### PR TITLE
Fix Nesting Transformation

### DIFF
--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -50,58 +50,35 @@ class NestSDFG(pattern_matching.Transformation):
         transients = {}
 
         for state in nested_sdfg.nodes():
-
-            for node in nxutil.find_source_nodes(state):
+            #  Input and output nodes are added as input and output nodes of the nested SDFG
+            for node in state.nodes():
                 if (isinstance(node, nodes.AccessNode)
                         and not node.desc(nested_sdfg).transient):
-                    arrname = node.data
-                    if arrname not in inputs:
-                        arrobj = nested_sdfg.arrays[arrname]
-                        nested_sdfg.arrays[arrname + '_in'] = arrobj
-                        outer_sdfg.arrays[arrname] = dc(arrobj)
-                        inputs[arrname] = arrname + '_in'
-                    node.data = arrname + '_in'
-
-            for node in nxutil.find_sink_nodes(state):
-                if (isinstance(node, nodes.AccessNode)
-                        and not node.desc(nested_sdfg).transient):
-                    arrname = node.data
-                    if arrname not in outputs:
-                        arrobj = nested_sdfg.arrays[arrname]
-                        nested_sdfg.arrays[arrname + '_out'] = arrobj
+                    if (state.out_degree(node) > 0):      # input node
+                        arrname = node.data
                         if arrname not in inputs:
+                            arrobj = nested_sdfg.arrays[arrname]
+                            nested_sdfg.arrays[arrname + '_in'] = arrobj
                             outer_sdfg.arrays[arrname] = dc(arrobj)
-                        outputs[arrname] = arrname + '_out'
-
-                        # TODO: Is this needed any longer ?
-                        # # WCR Fix
-                        # if self.promote_global_trans:
-                        #     for edge in state.in_edges(node):
-                        #         if state.memlet_path(edge)[0].data.wcr:
-                        #             if node.data not in input_data:
-                        #                 input_orig.update({
-                        #                     node.data + '_in':
-                        #                     node.data
-                        #                 })
-                        #                 input_nodes.update({
-                        #                     node.data + '_in':
-                        #                     dc(node)
-                        #                 })
-                        #                 new_data = dc(node.desc(sdfg))
-                        #                 sdfg.arrays.update({
-                        #                     node.data + '_in':
-                        #                     new_data
-                        #                 })
-                        #                 input_data.add(node.data + '_in')
-                        #             break
-
-                    node.data = arrname + '_out'
+                            inputs[arrname] = arrname + '_in'
+                        node_data_name = arrname + '_in'
+                    if (state.in_degree(node) > 0): # output node
+                        arrname = node.data
+                        if arrname not in outputs:
+                            arrobj = nested_sdfg.arrays[arrname]
+                            nested_sdfg.arrays[arrname + '_out'] = arrobj
+                            if arrname not in inputs:
+                                outer_sdfg.arrays[arrname] = dc(arrobj)
+                            outputs[arrname] = arrname + '_out'
+                        node_data_name = arrname + '_out'
+                    node.data = node_data_name
 
             if self.promote_global_trans:
                 scope_dict = state.scope_dict()
                 for node in state.nodes():
                     if (isinstance(node, nodes.AccessNode)
                             and node.desc(nested_sdfg).transient):
+
                         arrname = node.data
                         if arrname not in transients and not scope_dict[node]:
                             arrobj = nested_sdfg.arrays[arrname]
@@ -117,24 +94,25 @@ class NestSDFG(pattern_matching.Transformation):
         for oldarrname, newarrname in transients.items():
             nested_sdfg.arrays.pop(oldarrname)
             nested_sdfg.arrays[newarrname].transient = False
-            outer_sdfg.arrays[oldarrname].transient = False
+            outer_sdfg.arrays[oldarrname].transient = True
         outputs.update(transients)
 
+        # Update memlets
         for state in nested_sdfg.nodes():
             for _, edge in enumerate(state.edges()):
                 _, _, _, _, mem = edge
                 src = state.memlet_path(edge)[0].src
                 dst = state.memlet_path(edge)[-1].dst
                 if isinstance(src, nodes.AccessNode):
-                    if (mem.data in inputs.keys()
-                            and src.data == inputs[mem.data]):
+                    if (mem.data in inputs.keys() and
+                            src.data == inputs[mem.data]):
                         mem.data = inputs[mem.data]
-                    elif (mem.data in outputs.keys()
-                          and src.data == outputs[mem.data]):
+                    elif (mem.data in outputs.keys() and
+                          src.data == outputs[mem.data]):
                         mem.data = outputs[mem.data]
-                elif (isinstance(dst, nodes.AccessNode)
-                      and mem.data in outputs.keys()
-                      and dst.data == outputs[mem.data]):
+                elif (isinstance(dst, nodes.AccessNode) and
+                      mem.data in outputs.keys() and
+                      dst.data == outputs[mem.data]):
                     mem.data = outputs[mem.data]
 
         outer_state = outer_sdfg.add_state(outer_sdfg.label)

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -94,7 +94,6 @@ class NestSDFG(pattern_matching.Transformation):
         for oldarrname, newarrname in transients.items():
             nested_sdfg.arrays.pop(oldarrname)
             nested_sdfg.arrays[newarrname].transient = False
-            outer_sdfg.arrays[oldarrname].transient = True
         outputs.update(transients)
 
         # Update memlets


### PR DESCRIPTION
Fix for nesting transformation:
- previously only source and sink node in the SDFG were considered and moved to the nested one. Now all the input/output node are considered
- change of transient property if an array has been moved to a Nested SDFG