### PR TITLE
Avoid allocation of variable-length arrays if allocated on the stack

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -241,9 +241,12 @@ class CPUCodeGen(TargetCodeGenerator):
             callsite_stream.write(definition, sdfg, state_id, node)
             self._dispatcher.defined_vars.add(name, DefinedType.Stream)
 
+        # TODO: immaterial arrays should not allocate memory
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or nodedesc.storage == dtypes.StorageType.Immaterial
-              ):  # TODO: immaterial arrays should not allocate memory
+              or (nodedesc.storage in [
+                  dtypes.StorageType.CPU_Stack, dtypes.StorageType.Register
+              ] and symbolic.issymbolic(arrsize, sdfg.constants))):
             callsite_stream.write(
                 "%s *%s = new %s DACE_ALIGN(64)[%s];\n" %
                 (nodedesc.dtype.ctype, name, nodedesc.dtype.ctype,
@@ -345,11 +348,15 @@ class CPUCodeGen(TargetCodeGenerator):
     def deallocate_array(self, sdfg, dfg, state_id, node, function_stream,
                          callsite_stream):
         nodedesc = node.desc(sdfg)
+        arrsize = nodedesc.total_size
         if isinstance(nodedesc, data.Scalar):
             return
         elif isinstance(nodedesc, data.Stream):
             return
-        elif nodedesc.storage == dtypes.StorageType.CPU_Heap:
+        elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
+              or (nodedesc.storage in [
+                  dtypes.StorageType.CPU_Stack, dtypes.StorageType.Register
+              ] and symbolic.issymbolic(arrsize, sdfg.constants))):
             callsite_stream.write("delete[] %s;\n" % node.data, sdfg, state_id,
                                   node)
         else:

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -4,6 +4,7 @@ import functools
 import itertools
 import sympy as sp
 from six import StringIO
+import warnings
 
 from dace.codegen import cppunparse
 
@@ -247,6 +248,15 @@ class CPUCodeGen(TargetCodeGenerator):
               or (nodedesc.storage in [
                   dtypes.StorageType.CPU_Stack, dtypes.StorageType.Register
               ] and symbolic.issymbolic(arrsize, sdfg.constants))):
+
+            if nodedesc.storage in [
+                    dtypes.StorageType.CPU_Stack, dtypes.StorageType.Register
+            ]:
+                warnings.warn(
+                    'Variable-length array %s with size %s '
+                    'detected and was allocated on heap instead of '
+                    '%s' % (name, sym2cpp(arrsize), nodedesc.storage))
+
             callsite_stream.write(
                 "%s *%s = new %s DACE_ALIGN(64)[%s];\n" %
                 (nodedesc.dtype.ctype, name, nodedesc.dtype.ctype,

--- a/tests/vla_test.py
+++ b/tests/vla_test.py
@@ -1,0 +1,40 @@
+""" Tries to allocate a symbolically-sized array on a register and makes
+    sure that it is allocated on the heap instead.
+"""
+import dace
+import numpy as np
+import warnings
+
+N = dace.symbol('N')
+
+sdfg = dace.SDFG('vla_test')
+sdfg.add_array('A', [N], dace.float32)
+sdfg.add_transient('tmp', [N], dace.float32, storage=dace.StorageType.Register)
+sdfg.add_array('B', [N], dace.float32)
+state = sdfg.add_state()
+A = state.add_read('A')
+tmp = state.add_access('tmp')
+B = state.add_write('B')
+
+state.add_nedge(A, tmp, dace.Memlet.simple('A', '0:N'))
+state.add_nedge(tmp, B, dace.Memlet.simple('tmp', '0:N'))
+
+if __name__ == '__main__':
+    N.set(12)
+    A = np.random.rand(12).astype(np.float32)
+    B = np.random.rand(12).astype(np.float32)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sdfg(A=A, B=B, N=N)
+
+        if not w:
+            print('FAIL: No warnings caught')
+            exit(2)
+        if not any('Variable-length' in warn.message.args[0] for warn in w):
+            print('FAIL: No VLA warnings caught')
+            exit(3)
+
+    diff = np.linalg.norm(A - B)
+    print('Difference:', diff)
+    exit(0 if diff < 1e-5 else 1)


### PR DESCRIPTION
This fixes an issue where symbolically-sized arrays are allocated on the stack. Instead of potentially overflowing the stack, a warning is emitted and the memory goes to the heap.