### PR TITLE
Nested Symbols

### DIFF
--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -198,7 +198,9 @@ class CompiledSDFG(object):
                     (atype.dtype.ctype, a))
             if not isinstance(atype, dt.Array) and not isinstance(
                     atype.dtype, dace.callback) and not isinstance(
-                        arg, atype.dtype.type):
+                        arg, atype.dtype.type) and not (
+                            isinstance(arg, symbolic.symbol)
+                            and arg.dtype == atype.dtype):
                 print('WARNING: Casting scalar argument "%s" from %s to %s' %
                       (a, type(arg).__name__, atype.dtype.type))
 

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -315,7 +315,12 @@ class ASTFindReplace(ast.NodeTransformer):
     def __init__(self, repldict: Dict[str, str]):
         self.repldict = repldict
 
-    def visit_Name(self, node):
+    def visit_Name(self, node: ast.Name):
         if node.id in self.repldict:
             node.id = self.repldict[node.id]
         return node
+
+    def visit_keyword(self, node: ast.keyword):
+        if node.arg in self.repldict:
+            node.arg = self.repldict[node.arg]
+        return self.generic_visit(node)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3238,11 +3238,12 @@ class ProgramVisitor(ExtNodeVisitor):
             from dace.frontend.python.parser import infer_symbols_from_shapes
 
             # Map internal SDFG symbols by adding keyword arguments
-            symbols = sdfg.undefined_symbols(False)
             mapping = infer_symbols_from_shapes(sdfg, {
                 k: self.sdfg.arrays[v]
                 for k, v in args if v in self.sdfg.arrays
             })
+            if len(mapping) == 0:  # Default to same-symbol mapping
+                mapping = None
 
             # Argument checks
             for arg in node.keywords:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3263,10 +3263,14 @@ class ProgramVisitor(ExtNodeVisitor):
             for arrname, array in arrays_before:
                 if array.transient and arrname[:5] == '__tmp':
                     if int(arrname[5:]) < self.sdfg._temp_transients:
-                        new_name = sdfg.temp_data_name()
+                        if self.sdfg._temp_transients > sdfg._temp_transients:
+                            new_name = self.sdfg.temp_data_name()
+                        else:
+                            new_name = sdfg.temp_data_name()
                         sdfg.replace(arrname, new_name)
             self.sdfg._temp_transients = max(self.sdfg._temp_transients,
                                              sdfg._temp_transients)
+            sdfg._temp_transients = self.sdfg._temp_transients
 
             # TODO: This workaround needs to be formalized (pass-by-assignment)
             slice_state = None

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3226,7 +3226,8 @@ class ProgramVisitor(ExtNodeVisitor):
 
                 sdfg = func.to_sdfg(*({
                     **self.defined,
-                    **self.sdfg.arrays
+                    **self.sdfg.arrays,
+                    **self.sdfg.symbols
                 }[arg] if isinstance(arg, str) else arg
                                       for aname, arg in args))
 
@@ -3285,7 +3286,7 @@ class ProgramVisitor(ExtNodeVisitor):
             # by an access.
             for i, (aname, arg) in enumerate(args):
                 if arg not in self.sdfg.arrays:
-                    if isinstance(arg, str):
+                    if isinstance(arg, str) and arg in self.scope_arrays:
                         newarg = self._add_read_access(
                             arg,
                             subsets.Range.from_array(self.scope_arrays[arg]),
@@ -3514,6 +3515,9 @@ class ProgramVisitor(ExtNodeVisitor):
             return _inner_eval_ast(self.globals, node)
 
         if name in self.sdfg.arrays:
+            return name
+
+        if name in self.sdfg.symbols:
             return name
 
         if name not in self.scope_vars:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2542,6 +2542,9 @@ class ProgramVisitor(ExtNodeVisitor):
         elif iterator == 'range':
             # Add an initial loop state with a None last_state (so as to not
             # create an interstate edge)
+            # TODO(later): Take range start/skip into account as well
+            self.sdfg.symbols[indices[0]] = self.sdfg.symbols.get(
+                ranges[0][1], dace.int32)
             laststate, first_loop_state, last_loop_state = \
                 self._recursive_visit(node.body, 'for', node.lineno)
             end_loop_state = self.last_state

--- a/dace/graph/nodes.py
+++ b/dace/graph/nodes.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, Set
 from dace.graph import dot, graph
 from dace.frontend.python.astutils import unparse
 from dace.properties import (
-    Property, CodeProperty, LambdaProperty, RangeProperty,
-    DebugInfoProperty, SetProperty, make_properties, indirect_properties,
-    DataProperty, SymbolicProperty, ListProperty, SDFGReferenceProperty)
+    Property, CodeProperty, LambdaProperty, RangeProperty, DebugInfoProperty,
+    SetProperty, make_properties, indirect_properties, DataProperty,
+    SymbolicProperty, ListProperty, SDFGReferenceProperty, DictProperty)
 from dace.frontend.operations import detect_reduction_type
 from dace import data, subsets as sbs, dtypes
 
@@ -374,12 +374,11 @@ class NestedSDFG(CodeNode):
         from_string=lambda x: dtypes.ScheduleType[x],
         default=dtypes.ScheduleType.Default)
     location = Property(dtype=str, desc="SDFG execution location descriptor")
-    symbol_mapping = Property(
-        dtype=dict,
-        desc="Mapping between internal "
-        "symbols and their values, "
-        "expressed as symbolic "
-        "expressions")
+    symbol_mapping = DictProperty(
+        key_type=str,
+        value_type=dace.symbolic.pystr_to_symbolic,
+        desc="Mapping between internal symbols and their values, expressed as "
+        "symbolic expressions")
     debuginfo = DebugInfoProperty()
     is_collapsed = Property(
         dtype=bool,
@@ -616,8 +615,7 @@ class Map(object):
 
     # List of (editable) properties
     label = Property(dtype=str, desc="Label of the map")
-    params = ListProperty(element_type=str,
-                          desc="Mapped parameters")
+    params = ListProperty(element_type=str, desc="Mapped parameters")
     range = RangeProperty(
         desc="Ranges of map parameters", default=sbs.Range([]))
     schedule = Property(

--- a/dace/graph/nodes.py
+++ b/dace/graph/nodes.py
@@ -457,10 +457,10 @@ class NestedSDFG(CodeNode):
                                 'SDFG connectors' % dname)
 
         # Validate undefined symbols
-        symbols = self.sdfg.undefined_symbols(False)
-        missing_symbols = [
-            s for s in symbols.keys() if s not in self.symbol_mapping
-        ]
+        symbols = set(
+            k for k in self.sdfg.undefined_symbols(False).keys()
+            if k not in connectors)
+        missing_symbols = [s for s in symbols if s not in self.symbol_mapping]
         if missing_symbols:
             raise ValueError(
                 'Missing symbols on nested SDFG: %s' % (missing_symbols))

--- a/dace/graph/nodes.py
+++ b/dace/graph/nodes.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Set
 from dace.graph import dot, graph
 from dace.frontend.python.astutils import unparse
 from dace.properties import (
-    Property, CodeProperty, LambdaProperty, ParamsProperty, RangeProperty,
+    Property, CodeProperty, LambdaProperty, RangeProperty,
     DebugInfoProperty, SetProperty, make_properties, indirect_properties,
     DataProperty, SymbolicProperty, ListProperty, SDFGReferenceProperty)
 from dace.frontend.operations import detect_reduction_type
@@ -616,7 +616,8 @@ class Map(object):
 
     # List of (editable) properties
     label = Property(dtype=str, desc="Label of the map")
-    params = ParamsProperty(desc="Mapped parameters")
+    params = ListProperty(element_type=str,
+                          desc="Mapped parameters")
     range = RangeProperty(
         desc="Ranges of map parameters", default=sbs.Range([]))
     schedule = Property(

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -537,9 +537,11 @@ class ListProperty(Property):
         # Otherwise, convert to strings
         return list(map(str, l))
 
-    @staticmethod
-    def from_string(s):
-        return list(s)
+    def from_string(self, s):
+        if s.startswith('[') and s.endswith(']'):
+            return [self.element_type(d.strip()) for d in s[1:-1].split(',')]
+        else:
+            return list(s)
 
     def from_json(self, data, sdfg=None):
         if data is None:

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -662,31 +662,6 @@ class DebugInfoProperty(Property):
         return di
 
 
-class ParamsProperty(Property):
-    """ Property for list of parameters, such as parameters for a Map. """
-
-    @property
-    def dtype(self):
-        return list
-
-    @staticmethod
-    def to_string(l):
-        return "[{}]".format(", ".join(map(str, l)))
-
-    @staticmethod
-    def from_string(s):
-        return [
-            sp.Symbol(m.group(0))
-            for m in re.finditer("[a-zA-Z_][a-zA-Z0-9_]*", s)
-        ]
-
-    def to_json(self, l):
-        return l
-
-    def from_json(self, l, sdfg=None):
-        return l
-
-
 class SetProperty(Property):
     """Property for a set of elements of one type, e.g., connectors. """
 

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -580,6 +580,11 @@ class DictProperty(Property):
             val = ast.literal_eval(val)
         elif isinstance(val, (tuple, list)):
             val = {k[0]: k[1] for k in val}
+        elif isinstance(val, dict):
+            val = {
+                self.key_type(k): self.value_type(v)
+                for k, v in val.items()
+            }
         super(DictProperty, self).__set__(obj, val)
 
     @staticmethod

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -2709,7 +2709,6 @@ class SDFGState(OrderedMultiDiConnectorGraph, MemletTrackingView):
         if name is None:
             name = sdfg.label
         debuginfo = getdebuginfo(debuginfo)
-        symbol_mapping = symbol_mapping or {}
 
         sdfg.parent = self
         sdfg._parent_sdfg = self.parent

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -284,7 +284,7 @@ class SDFG(OrderedDiGraph):
             parent=context_info['sdfg'])
 
         dace.serialize.set_properties_from_json(
-            ret, json_obj, ignore_properties={'constants_prop'})
+            ret, json_obj, ignore_properties={'constants_prop', 'name'})
 
         for n in nodes:
             nci = copy.deepcopy(context_info)
@@ -309,9 +309,6 @@ class SDFG(OrderedDiGraph):
         ret.validate()
 
         return ret
-
-        # Counter to make it easy to create temp transients
-        self._temp_transients = 0
 
     @property
     def arrays(self):

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -300,7 +300,7 @@ class SDFG(OrderedDiGraph):
         # Redefine symbols
         for k, v in json_obj['undefined_symbols']:
             v = dace.serialize.from_json(v)
-            symbolic.symbol(k, v.dtype, override_dtype=True)
+            ret.add_symbol(k, v.dtype, override_dtype=True)
 
         for k, v in json_obj['scalar_parameters']:
             v = dace.serialize.from_json(v)

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -4071,8 +4071,8 @@ def data_symbols(dfg):
 def undefined_symbols(sdfg, obj, include_scalar_data):
     """ Returns all symbols used in this object that are undefined, and thus
         must be given as input parameters. """
-    scalar_arguments = sdfg.scalar_parameters(False)
     if include_scalar_data:
+        scalar_arguments = sdfg.scalar_parameters(False)
         symbols = collections.OrderedDict(
             (name, data) for name, data in scalar_arguments)
     else:
@@ -4086,15 +4086,9 @@ def undefined_symbols(sdfg, obj, include_scalar_data):
     symbols.update(used)
     iteration_variables, subset_symbols = obj.scope_symbols()
     symbols.update(subset_symbols)
-    if sdfg.parent is not None:
-        # Find parent Nested SDFG node
-        parent_node = next(
-            n for n in sdfg.parent.nodes()
-            if isinstance(n, nd.NestedSDFG) and n.sdfg.name == sdfg.name)
-        defined |= sdfg._parent_sdfg.symbols_defined_at(
-            parent_node, sdfg.parent).keys()
+
     # Don't include iteration variables
-    # (TODO: this is too lenient; take scope into account)
+    # TODO: this is too lenient; take scope into account
     defined |= iteration_variables.keys()
     defined |= {
         n.data

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -300,7 +300,7 @@ class SDFG(OrderedDiGraph):
         # Redefine symbols
         for k, v in json_obj['undefined_symbols']:
             v = dace.serialize.from_json(v)
-            ret.add_symbol(k, v.dtype, override_dtype=True)
+            symbolic.symbol(k, v.dtype, override_dtype=True)
 
         for k, v in json_obj['scalar_parameters']:
             v = dace.serialize.from_json(v)

--- a/dace/serialize.py
+++ b/dace/serialize.py
@@ -203,9 +203,11 @@ def set_properties_from_json(object_with_properties,
 
         setattr(object_with_properties, prop_name, val)
 
-    if len(source_properties) > 0:
+    remaining_properties = source_properties - ignore_properties
+    # Ignore all metadata "properties" saved for DIODE
+    remaining_properties = set(
+        prop for prop in remaining_properties if not prop.startswith('_meta'))
+    if len(remaining_properties) > 0:
         # TODO: elevate to error once #28 is fixed.
-        # raise KeyError("Unused properties: {}".format(", ".join(
-        #     sorted(source_properties))))
         print("WARNING: unused properties: {}".format(", ".join(
-            sorted(source_properties))))
+            sorted(remaining_properties))))

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -266,6 +266,10 @@ class InlineSDFG(pattern_matching.Transformation):
         #######################################################
         # Replace data on inlined SDFG nodes/edges
 
+        # Replace symbols using invocation symbol mapping
+        for symname, symvalue in nsdfg_node.symbol_mapping.items():
+            nsdfg.replace(symname, symvalue)
+
         # Replace data names with their top-level counterparts
         repldict = {}
         repldict.update(transients)

--- a/tests/local_inline_test.py
+++ b/tests/local_inline_test.py
@@ -23,7 +23,7 @@ def bla(AA, BB):
 
 
 @dace.program
-def prog(A, B, C):
+def prog(A: dace.float64[W], B: dace.float64[W], C: dace.float64[W]):
     bla(A, B)
     bla(B, C)
 
@@ -36,10 +36,10 @@ if __name__ == '__main__':
     C = dace.ndarray([W])
 
     A[:] = np.mgrid[0:W.get()]
-    B[:] = dace.float32(0.0)
-    C[:] = dace.float32(0.0)
+    B[:] = 0.0
+    C[:] = 0.0
 
-    prog(A, B, C, W=W)
+    prog(A, B, C)
 
     diff = np.linalg.norm((-(-A + 1) + 1) - C) / W.get()
     print("Difference:", diff)

--- a/tests/nested_symbol_partial_test.py
+++ b/tests/nested_symbol_partial_test.py
@@ -1,0 +1,30 @@
+import dace
+import numpy as np
+
+W = dace.symbol()
+
+
+@dace.program
+def nested(out: dace.float64[1]):
+    tmp = np.ndarray([W], dtype=np.float64)
+    for i in dace.map[0:W]:
+        with dace.tasklet:
+            o >> tmp[i]
+            o = i
+    dace.reduce(lambda a, b: a + b, tmp, out, identity=0)
+
+
+@dace.program
+def nested_symbol_partial(A: dace.float64[1]):
+    nested(A, W=W)
+
+
+def test_nested_symbol_partial():
+    expected = np.arange(0, 20, dtype=np.float64).sum()
+    out = np.ndarray([1], dtype=np.float64)
+    nested_symbol_partial(A=out, sym_0=20)
+    assert np.allclose(out, expected)
+
+
+if __name__ == '__main__':
+    test_nested_symbol_partial()

--- a/tests/nested_symbol_test.py
+++ b/tests/nested_symbol_test.py
@@ -1,5 +1,6 @@
 import dace
 import numpy as np
+import warnings
 
 N = dace.symbol('N')
 N.set(12345)
@@ -31,6 +32,11 @@ def test_nested_symbol():
 
 
 def test_nested_symbol_dynamic():
+    if not dace.Config.get_bool('optimizer',
+                                'automatic_strict_transformations'):
+        warnings.warn("Test disabled (missing allocation lifetime support)")
+        return
+
     A = np.random.rand(5)
     expected = A.copy()
     for i in range(5):

--- a/tests/nested_symbol_test.py
+++ b/tests/nested_symbol_test.py
@@ -1,0 +1,44 @@
+import dace
+import numpy as np
+
+N = dace.symbol('N')
+N.set(12345)
+
+
+@dace.program
+def nested(A: dace.float64[N], B: dace.float64[N], factor: dace.float64):
+    B[:] = A * factor
+
+
+@dace.program
+def nested_symbol(A: dace.float64[N], B: dace.float64[N]):
+    nested(A[0:5], B[0:5], 0.5)
+    nested(A=A[5:N], B=B[5:N], factor=2.0)
+
+
+@dace.program
+def nested_symbol_dynamic(A: dace.float64[N]):
+    for i in range(5):
+        nested(A[0:i], A[0:i], i)
+
+
+def test_nested_symbol():
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    nested_symbol(A, B)
+    assert np.allclose(B[0:5], A[0:5] / 2) and np.allclose(
+        B[5:20], A[5:20] * 2)
+
+
+def test_nested_symbol_dynamic():
+    A = np.random.rand(5)
+    expected = A.copy()
+    for i in range(5):
+        expected[0:i] *= i
+    nested_symbol_dynamic(A)
+    assert np.allclose(A, expected)
+
+
+if __name__ == '__main__':
+    test_nested_symbol()
+    test_nested_symbol_dynamic()

--- a/tests/properties_test.py
+++ b/tests/properties_test.py
@@ -12,9 +12,7 @@ class PropertyTests(unittest.TestCase):
     def test_indirect_properties(self):
 
         m = dace.graph.nodes.Map(
-            "test_map",
-            [sp.Symbol("i"), sp.Symbol("j"),
-             sp.Symbol("k")],
+            "test_map", ['i', 'j', 'k'],
             dace.subsets.Range([(0, 10, 1), (0, sp.Symbol("N"), 4),
                                 (0, sp.Symbol("M"), None)]))
 
@@ -23,13 +21,13 @@ class PropertyTests(unittest.TestCase):
         to_string = dace.graph.nodes.Map.__properties__["params"].to_string
         from_string = dace.graph.nodes.Map.__properties__["params"].from_string
 
-        self.assertTrue(to_string(m.params) == "[i, j, k]")
-        self.assertTrue(to_string(entry.params) == "[i, j, k]")
+        self.assertTrue(to_string(m.params) == "['i', 'j', 'k']")
+        self.assertTrue(to_string(entry.params) == "['i', 'j', 'k']")
 
         entry.params = from_string("[k, j, i]")
 
-        self.assertTrue(to_string(m.params) == "[k, j, i]")
-        self.assertTrue(to_string(entry.params) == "[k, j, i]")
+        self.assertTrue(to_string(m.params) == "['k', 'j', 'i']")
+        self.assertTrue(to_string(entry.params) == "['k', 'j', 'i']")
 
     def test_range_property(self):
 


### PR DESCRIPTION
Allow nested SDFGs to be written once and have different symbol values based on their invocation.

- [x] Add symbol mapping to `NestedSDFG` nodes
- [x] Adapt nested SDFG calling convention
    - [x] Frontend
    - [x] Code generation
- [x] Adapt `undefined_symbols` to look at `symbol_mapping` and ignore nested SDFGs
- [x] Adapt the `InlineSDFG` transformation to take nested symbols into account
