### PR TITLE
Remove frontend implementation functionality

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -627,22 +627,6 @@ required:
                             Enables analysis of gcc vectorization information. Only gcc/g++ is supported.
 
     #############################################
-    # Frontend settings
-
-    frontend:
-        type: dict
-        title: Frontend
-        description: Python frontend preferences
-        required:
-            implementation:
-                type: str
-                default: "sdfg"
-                title: Default operator implementation
-                description: >
-                    Sets the default operator implementation when parsing Python code into
-                    subgraphs or tasklets (can be sdfg, mkl, cublas).
-
-    #############################################
     # General settings
     debugprint:
         type: bool

--- a/dace/frontend/common/op_repository.py
+++ b/dace/frontend/common/op_repository.py
@@ -11,37 +11,30 @@ class Replacements(object):
     _oprep = {}
 
     @staticmethod
-    def get(name, implementation='sdfg'):
+    def get(name):
         """ Returns an implementation of a function. """
-        if (name, implementation) not in Replacements._rep:
+        if name not in Replacements._rep:
             return None
-        return Replacements._rep[(name, implementation)]
+        return Replacements._rep[name]
 
     @staticmethod
-    def getop(classname: str,
-              optype: str,
-              implementation='sdfg',
-              otherclass: str = None):
+    def getop(classname: str, optype: str, otherclass: str = None):
         """ Returns an implementation of an operator. """
         if otherclass is None:
             otherclass = classname
-        if (classname, otherclass, optype,
-                implementation) not in Replacements._oprep:
+        if (classname, otherclass, optype) not in Replacements._oprep:
             return None
-        return Replacements._oprep[(classname, otherclass, optype,
-                                    implementation)]
+        return Replacements._oprep[(classname, otherclass, optype)]
 
 
 @paramdec
-def replaces(func: Callable[..., Tuple[str]], name: str,
-             implementation='sdfg'):
+def replaces(func: Callable[..., Tuple[str]], name: str):
     """ Registers a replacement sub-SDFG generator for a function.
         :param func: A function that receives an SDFG, SDFGState, and the original function
                      arguments, returning a tuple of array names to connect to the outputs.
         :param name: Full name (pydoc-compliant, including package) of function to replace.
-        :param implementation: The default implementation to replace the SDFG with.
     """
-    Replacements._rep[(name, implementation)] = func
+    Replacements._rep[name] = func
     return func
 
 
@@ -49,18 +42,16 @@ def replaces(func: Callable[..., Tuple[str]], name: str,
 def replaces_operator(func: Callable[[Any, Any, str, str], Tuple[str]],
                       classname: str,
                       optype: str,
-                      implementation='sdfg',
                       otherclass: str = None):
     """ Registers a replacement sub-SDFG generator for an operator.
         :param func: A function that receives an SDFG, SDFGState, and the two operand array names,
                      returning a tuple of array names to connect to the outputs.
         :param classname: The name of the class to implement the operator for (extends dace.Data).
         :param optype: The type (as string) of the operator to replace (extends ast.operator).
-        :param implementation: The default implementation to replace the SDFG with.
         :param otherclass: Optional argument defining operators for a second class that
                            differs from the first.
     """
     if otherclass is None:
         otherclass = classname
-    Replacements._oprep[(classname, otherclass, optype, implementation)] = func
+    Replacements._oprep[(classname, otherclass, optype)] = func
     return func

--- a/dacelibs/blas/nodes/matmul.py
+++ b/dacelibs/blas/nodes/matmul.py
@@ -1,4 +1,5 @@
 from copy import deepcopy as dc
+import numpy as np
 from dace.config import Config
 from dace.frontend.common.op_impl import gpu_transform_tasklet
 import dace.library
@@ -8,26 +9,83 @@ from dace.transformation.pattern_matching import ExpandTransformation
 from .. import environments
 
 
+def _get_matmul_inputs(node, state, sdfg):
+    """Returns the matrix multiplication input edges, arrays, and shape."""
+    res_a = None
+    res_b = None
+    for edge in state.in_edges(node):
+        if edge.dst_conn in ["_a", "_b"]:
+            subset = dc(edge.data.subset)
+            subset.squeeze()
+            size = subset.size()
+            outer_array = sdfg.data(
+                dace.sdfg.find_input_arraynode(state, edge).data)
+            res = edge, outer_array, (size[0], size[1])
+            if edge.dst_conn == "_a":
+                res_a = res
+            else:
+                res_b = res
+    if res_a is None or res_b is None:
+        raise ValueError("Matrix multiplication input connectors \"_a\" and "
+                         "\"_b\" not found.")
+    return res_a, res_b
+
+
 @dace.library.expansion
 class ExpandMatMulPure(ExpandTransformation):
 
     environments = []
 
     @staticmethod
-    def make_sdfg(dtype):
+    def make_sdfg(node, parent_state, parent_sdfg):
 
-        m = dace.symbol("m")
-        n = dace.symbol("n")
-        k = dace.symbol("k")
+        sdfg = dace.SDFG(node.label + "_sdfg")
+        state = sdfg.add_state(node.label + "_state")
 
-        @dace.program
-        def matmul(_a: dtype[m, k], _b: dtype[k, n], _c: dtype[m, n]):
-            _c[:] = _a @ _b
+        ((edge_a, outer_array_a, shape_a),
+         (edge_b, outer_array_b, shape_b)) = _get_matmul_inputs(
+             node, parent_state, parent_sdfg)
 
-        default_implementation = Config.get('frontend', 'implementation')
-        Config.set('frontend', 'implementation', value='sdfg')
-        sdfg = matmul.to_sdfg()
-        Config.set('frontend', 'implementation', value=default_implementation)
+        if (len(shape_a) != 2 or len(shape_b) != 2
+                or shape_a[1] != shape_b[0]):
+            raise SyntaxError('Matrix sizes must match')
+        shape_c = (shape_a[0], shape_b[1])
+
+        dtype_a = outer_array_a.dtype.type
+        dtype_b = outer_array_b.dtype.type
+        dtype_c = dace.DTYPE_TO_TYPECLASS[np.result_type(dtype_a,
+                                                         dtype_b).type]
+
+        if outer_array_a.storage != outer_array_b.storage:
+            raise ValueError("Input matrices must have same storage")
+        storage = outer_array_a.storage
+
+        _, array_a = sdfg.add_array("_a", shape_a, dtype_a, storage=storage)
+        _, array_b = sdfg.add_array("_b", shape_b, dtype_b, storage=storage)
+        _, array_c = sdfg.add_array("_c", shape_c, dtype_c, storage=storage)
+
+        state.add_mapped_tasklet(
+            '_MatMult_', {
+                '__i%d' % i: '0:%s' % s
+                for i, s in enumerate(
+                    [array_a.shape[0], array_b.shape[1], array_a.shape[1]])
+            }, {
+                '__a': dace.Memlet.simple("_a", '__i0, __i2'),
+                '__b': dace.Memlet.simple("_b", '__i2, __i1')
+            },
+            '__c = __a * __b', {
+                '__c':
+                dace.Memlet.simple(
+                    "_c",
+                    '__i0, __i1',
+                    wcr_str='lambda x, y: x + y',
+                    wcr_identity=0)
+            },
+            external_edges=True)
+
+        sdfg.parent = parent_sdfg
+        sdfg.parent_sdfg = parent_sdfg
+
         return sdfg
 
     @staticmethod
@@ -36,7 +94,7 @@ class ExpandMatMulPure(ExpandTransformation):
         if node.dtype is None:
             raise ValueError("Data type must be set to expand " + str(node) +
                              ".")
-        return ExpandMatMulPure.make_sdfg(node.dtype)
+        return ExpandMatMulPure.make_sdfg(node, state, sdfg)
 
 
 @dace.library.expansion
@@ -67,18 +125,7 @@ class ExpandMatMulOpenBLAS(ExpandTransformation):
         else:
             raise ValueError("Unsupported type for BLAS dot product: " +
                              str(dtype))
-        for _, _, _, dst_conn, memlet in state.in_edges(node):
-            if dst_conn == '_a':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                m = size[0]
-                k = size[1]
-            if dst_conn == '_b':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                n = size[1]
+        (_, _, (m, k)), (_, _, (_, n)) = _get_matmul_inputs(node, state, sdfg)
         code = ("cblas_{f}(CblasRowMajor, CblasNoTrans, CblasNoTrans, "
                 "{m}, {n}, {k}, {a}, _a, {k}, _b, {n}, {b}, _c, {n});").format(
                     f=func, m=m, n=n, k=k, a=alpha, b=beta)
@@ -133,18 +180,7 @@ class ExpandMatMulCuBLAS(ExpandTransformation):
         else:
             raise ValueError("Unsupported type for cuBLAS dot product: " +
                              str(dtype))
-        for _, _, _, dst_conn, memlet in state.in_edges(node):
-            if dst_conn == '_a':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                m = size[0]
-                k = size[1]
-            if dst_conn == '_b':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                n = size[1]
+        (_, _, (m, k)), (_, _, (_, n)) = _get_matmul_inputs(node, state, sdfg)
         code = (environments.cublas.cuBLAS.handle_setup_code(node) +
                 "cublasStatus_t _result = cublas{f}(__dace_cublas_handle, "
                 "CUBLAS_OP_N, CUBLAS_OP_N, {m}, {n}, {k}, {a}, {c}_a, {m}, "
@@ -174,19 +210,28 @@ class ExpandMatMulCuBLAS(ExpandTransformation):
         trans_a = Transpose('_Transpose_a', dtype)
         trans_b = Transpose('_Transpose_b', dtype)
         trans_c = Transpose('_Transpose_c', dtype)
-        nested_state.add_edge(acc1, None, trans_a, '_inp', dace.Memlet.from_array('_a', A))
-        nested_state.add_edge(trans_a, '_out', acc4, None, dace.Memlet.from_array('_aT', AT))
-        nested_state.add_edge(acc2, None, trans_b, '_inp', dace.Memlet.from_array('_b', B))
-        nested_state.add_edge(trans_b, '_out', acc5, None, dace.Memlet.from_array('_bT', BT))
-        nested_state.add_edge(acc6, None, trans_c, '_inp', dace.Memlet.from_array('_cT', CT))
-        nested_state.add_edge(trans_c, '_out', acc3, None, dace.Memlet.from_array('_c', C))
-        nested_state.add_edge(acc4, None, tasklet, '_a', dace.Memlet.from_array('_aT', AT))
-        nested_state.add_edge(acc5, None, tasklet, '_b', dace.Memlet.from_array('_bT', BT))
-        nested_state.add_edge(tasklet, '_c', acc6, None, dace.Memlet.from_array('_cT', CT))
-        nested_node = dace.graph.nodes.NestedSDFG('_cuBLAS_MatMul_', nested_sdfg, {'_a', '_b'}, {'_c'})
+        nested_state.add_edge(acc1, None, trans_a, '_inp',
+                              dace.Memlet.from_array('_a', A))
+        nested_state.add_edge(trans_a, '_out', acc4, None,
+                              dace.Memlet.from_array('_aT', AT))
+        nested_state.add_edge(acc2, None, trans_b, '_inp',
+                              dace.Memlet.from_array('_b', B))
+        nested_state.add_edge(trans_b, '_out', acc5, None,
+                              dace.Memlet.from_array('_bT', BT))
+        nested_state.add_edge(acc6, None, trans_c, '_inp',
+                              dace.Memlet.from_array('_cT', CT))
+        nested_state.add_edge(trans_c, '_out', acc3, None,
+                              dace.Memlet.from_array('_c', C))
+        nested_state.add_edge(acc4, None, tasklet, '_a',
+                              dace.Memlet.from_array('_aT', AT))
+        nested_state.add_edge(acc5, None, tasklet, '_b',
+                              dace.Memlet.from_array('_bT', BT))
+        nested_state.add_edge(tasklet, '_c', acc6, None,
+                              dace.Memlet.from_array('_cT', CT))
+        nested_node = dace.graph.nodes.NestedSDFG(
+            '_cuBLAS_MatMul_', nested_sdfg, {'_a', '_b'}, {'_c'})
         gpu_transform_tasklet(nested_sdfg, nested_state, tasklet)
         return nested_node
-
 
 
 @dace.library.node

--- a/dacelibs/blas/nodes/transpose.py
+++ b/dacelibs/blas/nodes/transpose.py
@@ -1,3 +1,4 @@
+import functools
 from copy import deepcopy as dc
 from dace.config import Config
 from dace.frontend.common.op_impl import gpu_transform_tasklet
@@ -8,34 +9,83 @@ from dace.transformation.pattern_matching import ExpandTransformation
 from .. import environments
 
 
+def _get_transpose_input(node, state, sdfg):
+    """Returns the transpose input edge, array, and shape."""
+    for edge in state.in_edges(node):
+        if edge.dst_conn == "_inp":
+            subset = dc(edge.data.subset)
+            subset.squeeze()
+            size = subset.size()
+            outer_array = sdfg.data(
+                dace.sdfg.find_input_arraynode(state, edge).data)
+            return edge, outer_array, (size[0], size[1])
+    raise ValueError("Transpose input connector \"_inp\" not found.")
+
+
 @dace.library.expansion
 class ExpandTransposePure(ExpandTransformation):
 
     environments = []
 
     @staticmethod
-    def make_sdfg(dtype):
+    def make_sdfg(node, parent_state, parent_sdfg):
 
-        m = dace.symbol("m")
-        n = dace.symbol("n")
+        in_edge, outer_array, in_shape = _get_transpose_input(
+            node, parent_state, parent_sdfg)
+        out_shape = (in_shape[1], in_shape[0])
+        dtype = node.dtype
 
-        @dace.program
-        def _transpose(_inp: dtype[m, n], _out: dtype[n, m]):
-            _out[:] = transpose(_inp)
+        sdfg = dace.SDFG(node.label + "_sdfg")
+        state = sdfg.add_state(node.label + "_state")
 
-        default_implementation = Config.get('frontend', 'implementation')
-        Config.set('frontend', 'implementation', value='sdfg')
-        sdfg = _transpose.to_sdfg()
-        Config.set('frontend', 'implementation', value=default_implementation)
+        _, in_array = sdfg.add_array(
+            "_inp", in_shape, dtype, storage=outer_array.storage)
+        _, out_array = sdfg.add_array(
+            "_out", out_shape, dtype, storage=outer_array.storage)
+
+        num_elements = functools.reduce(lambda x, y: x * y, in_array.shape)
+        if num_elements == 1:
+            inp = state.add_read("_inp")
+            out = state.add_write("_out")
+            tasklet = state.add_tasklet("transpose", {"__inp"}, {"__out"},
+                                        "__out = __inp")
+            state.add_edge(inp, None, tasklet, "__inp",
+                           dace.memlet.Memlet.from_array("_inp", in_array))
+            state.add_edge(tasklet, "__out", out, None,
+                           dace.memlet.Memlet.from_array("_out", outarr))
+        else:
+            state.add_mapped_tasklet(
+                name="transpose",
+                map_ranges={
+                    "__i%d" % i: "0:%s" % n
+                    for i, n in enumerate(in_array.shape)
+                },
+                inputs={
+                    "__inp":
+                    dace.memlet.Memlet.simple(
+                        "_inp", ",".join(
+                            ["__i%d" % i for i in range(len(in_array.shape))]))
+                },
+                code="__out = __inp",
+                outputs={
+                    "__out":
+                    dace.memlet.Memlet.simple(
+                        "_out", ",".join([
+                            "__i%d" % i
+                            for i in range(len(in_array.shape) - 1, -1, -1)
+                        ]))
+                },
+                external_edges=True)
+
+        sdfg.parent = parent_sdfg
+        sdfg.parent_sdfg = parent_sdfg
+
         return sdfg
 
     @staticmethod
     def expansion(node, state, sdfg):
         node.validate(sdfg, state)
-        if node.dtype is None:
-            raise ValueError("Data type must be set to expand " + str(node) +
-                             ".")
-        return ExpandTransposePure.make_sdfg(node.dtype)
+        return ExpandTransposePure.make_sdfg(node, state, sdfg)
 
 
 @dace.library.expansion
@@ -47,6 +97,7 @@ class ExpandTransposeOpenBLAS(ExpandTransformation):
     def expansion(node, state, sdfg):
         node.validate(sdfg, state)
         dtype = node.dtype
+
         if dtype == dace.float32:
             func = "somatcopy"
             alpha = "1.0f"
@@ -62,15 +113,11 @@ class ExpandTransposeOpenBLAS(ExpandTransformation):
         else:
             raise ValueError("Unsupported type for OpenBLAS omatcopy: " +
                              str(dtype))
-        for _, _, _, dst_conn, memlet in state.in_edges(node):
-            if dst_conn == '_inp':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                m = size[0]
-                n = size[1]
+
+        _, _, (m, n) = _get_transpose_input(node, state, sdfg)
         code = ("cblas_{f}(CblasRowMajor, CblasTrans, {m}, {n}, {a}, _inp, "
-                "{n}, _out, {m});").format(f=func, m=m, n=n, a=alpha)
+                "{n}, _out, {m});").format(
+                    f=func, m=m, n=n, a=alpha)
         tasklet = dace.graph.nodes.Tasklet(
             node.name,
             node.in_connectors,
@@ -104,15 +151,10 @@ class ExpandTransposeMKL(ExpandTransformation):
         else:
             raise ValueError("Unsupported type for MKL omatcopy extension: " +
                              str(dtype))
-        for _, _, _, dst_conn, memlet in state.in_edges(node):
-            if dst_conn == '_inp':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                m = size[0]
-                n = size[1]
+        _, _, (m, n) = _get_transpose_input(node, state, sdfg)
         code = ("mkl_{f}('R', 'T', {m}, {n}, {a}, _inp, "
-                "{n}, _out, {m});").format(f=func, m=m, n=n, a=alpha)
+                "{n}, _out, {m});").format(
+                    f=func, m=m, n=n, a=alpha)
         tasklet = dace.graph.nodes.Tasklet(
             node.name,
             node.in_connectors,
@@ -152,15 +194,8 @@ class ExpandTransposeCuBLAS(ExpandTransformation):
             alpha = "dacelib::blas::CublasConstants::Get(__dace_cuda_device).Complex128Pone()"
             beta = "dacelib::blas::CublasConstants::Get(__dace_cuda_device).Complex128Zero()"
         else:
-            raise ValueError("Unsupported type for cuBLAS geam: " +
-                             str(dtype))
-        for _, _, _, dst_conn, memlet in state.in_edges(node):
-            if dst_conn == '_inp':
-                subset = dc(memlet.subset)
-                subset.squeeze()
-                size = subset.size()
-                m = size[0]
-                n = size[1]
+            raise ValueError("Unsupported type for cuBLAS geam: " + str(dtype))
+        _, _, (m, n) = _get_transpose_input(node, state, sdfg)
         code = (environments.cublas.cuBLAS.handle_setup_code(node) +
                 "cublasStatus_t _result = cublas{f}(__dace_cublas_handle, "
                 "CUBLAS_OP_T, CUBLAS_OP_N, {m}, {n}, {a}, {c}_inp, {n}, "
@@ -191,12 +226,7 @@ class Transpose(dace.graph.nodes.LibraryNode):
     }
     default_implementation = "pure"
 
-    # Object fields
     dtype = dace.properties.TypeClassProperty(allow_none=True)
-    # location = dace.properties.Property(
-    #     dtype=str,
-    #     desc="Execution location descriptor (e.g., GPU identifier)",
-    #     allow_none=True)
 
     def __init__(self, name, dtype=None, location=None):
         super().__init__(
@@ -220,14 +250,12 @@ class Transpose(dace.graph.nodes.LibraryNode):
                 "Expected exactly one output from transpose operation")
         out_memlet = out_edges[0].data
         if len(in_size) != 2:
-            raise ValueError(
-                "Transpose operation only supported on matrices")
+            raise ValueError("Transpose operation only supported on matrices")
         out_subset = dc(out_memlet.subset)
         out_subset.squeeze()
         out_size = out_subset.size()
         if len(out_size) != 2:
-            raise ValueError(
-                "Transpose operation only supported on matrices")
+            raise ValueError("Transpose operation only supported on matrices")
         if list(out_size) != [in_size[1], in_size[0]]:
             raise ValueError(
                 "Output to transpose operation must agree in the m and n dimensions"


### PR DESCRIPTION
The frontend implementation functionality has been replaced by library nodes.

Remove this functionality, and port the "pure" expansion of transpose and matmul to the library nodes interface.