### PR TITLE
Enable Override of CPUCodegen with custom extensions.

### DIFF
--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -100,7 +100,12 @@ def generate_code(sdfg) -> List[CodeObject]:
 
     # Instantiate CPU first (as it is used by the other code generators)
     # TODO: Refactor the parts used by other code generators out of CPU
-    targets = {'cpu': cpu.CPUCodeGen(frame, sdfg)}
+    default_target = cpu.CPUCodeGen
+    for k, v in target.TargetCodeGenerator.extensions().items():
+        # If another target has already been registered as CPU, use it instead
+        if v['name'] == 'cpu':
+            default_target = k
+    targets = {'cpu': default_target(frame, sdfg)}
 
     # Instantiate the rest of the targets
     targets.update({


### PR DESCRIPTION
if a target is already registered for CPU, use that as default instead of CPUCodegen, s.t. the code generator can be extended by users.