### PR TITLE
Python frontend: Try to replace transients with their assigned names

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1812,6 +1812,13 @@ class ProgramVisitor(ExtNodeVisitor):
         if len(self.sdfg.nodes()) == 0:
             self.sdfg.add_state("EmptyState")
 
+        # Try to replace transients with their python-assigned names
+        for pyname, arrname in self.variables.items():
+            if arrname in self.sdfg.arrays:
+                if self.sdfg.arrays[arrname].transient:
+                    if pyname not in self.sdfg.arrays:
+                        self.sdfg.replace(arrname, pyname)
+
         return self.sdfg, self.inputs, self.outputs
 
     @property

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1816,7 +1816,8 @@ class ProgramVisitor(ExtNodeVisitor):
         for pyname, arrname in self.variables.items():
             if arrname in self.sdfg.arrays:
                 if self.sdfg.arrays[arrname].transient:
-                    if pyname not in self.sdfg.arrays:
+                    if (pyname and data.validate_name(pyname)
+                            and pyname not in self.sdfg.arrays):
                         self.sdfg.replace(arrname, pyname)
 
         return self.sdfg, self.inputs, self.outputs

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -4447,6 +4447,8 @@ def replace(subgraph: Union[SDFGState, ScopeSubgraphView, SubgraphView],
             if isinstance(propclass, properties.RangeProperty):
                 setattr(node, pname, replsym(propval))
             if isinstance(propclass, properties.CodeProperty):
+                if propval is None:
+                    continue
                 if isinstance(propval['code_or_block'], str):
                     # TODO: C++ AST parsing for replacement?
                     if name != str(new_name):


### PR DESCRIPTION
This creates more meaningful transient array names in the most conservative way possible. 

Example 1 (softmax):
![image](https://user-images.githubusercontent.com/8348955/75296058-8025fd00-582c-11ea-8ae1-9f6bda823880.png)

Example 2 (dTGL_test):
![image](https://user-images.githubusercontent.com/8348955/75296205-d98e2c00-582c-11ea-9e58-5a041d91e72b.png)
