### PR TITLE
WIP: Fix covered nested accesses

### DIFF
--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -488,7 +488,7 @@ class Range(Subset):
     def compose(self, other):
         if not isinstance(other, Subset):
             raise TypeError("Cannot compose ranges with non-subsets")
-        if self.data_dims() != other.dims():
+        if self.data_dims() != other.dims() and self.dims() != other.dims():
             raise ValueError("Dimension mismatch in composition")
         new_subset = []
         idx = 0

--- a/tests/numpy/nested_superrange_test.py
+++ b/tests/numpy/nested_superrange_test.py
@@ -1,0 +1,104 @@
+import dace
+import numpy as np
+
+
+@dace.program
+def nested_superrange(A: dace.float32[2, 3, 4], B: dace.float32[3, 4]):
+    tmp = dace.define_local([3, 4, 2, 1, 1], dace.float32)
+    for i, j in dace.map[0:3, 0:4]:
+        tmp[i, j] = A[:, i, j]
+        B[i, j] = tmp[i, j, 0] + tmp[i, j, 1]
+
+
+@dace.program
+def subrange1(A: dace.float32[2, 3, 4], B: dace.float32[3, 4]):
+    B[:] = A[0, :, :] + A[1, :, :]
+
+
+@dace.program
+def subrange2(A: dace.float32[2, 3, 4], B: dace.float32[3, 4]):
+    tmp0 = A[0, :, :]
+    tmp1 = A[1, :, :]
+    for i, j in dace.map[0:3, 0:4]:
+        B[i, j] = tmp0[i, j] + tmp1[i, j]
+
+
+@dace.program
+def subrange3(A: dace.float32[2, 3, 4], B: dace.float32[3, 4]):
+    B[:] = A[0] + A[1, :, :]
+
+
+@dace.program
+def subrange_of_subrange(A: dace.float32[2, 3, 4, 5], B: dace.float32[4]):
+    B[:] = A[:, 0, :, 0][0, :]
+
+
+@dace.program
+def subrange_of_subrange_nested(A: dace.float32[2, 3, 4, 5],
+                                B: dace.float32[4]):
+    for i, j, k in dace.map[0:3, 0:5, 0:2]:
+        B[:] = A[:, i, :, j][k, :]
+
+
+def onetest(program):
+    A = np.random.rand(2, 3, 4).astype(np.float32)
+    expected = A[0, :, :] + A[1, :, :]
+    B = np.random.rand(3, 4).astype(np.float32)
+
+    sdfg = program.to_sdfg()
+    sdfg(A=A, B=B)
+
+    diff = np.linalg.norm(expected - B)
+    print('Difference:', diff)
+    assert diff < 1e-5
+
+
+def onetest_subrange_of_subrange(program):
+    A = np.random.rand(2, 3, 4, 5).astype(np.float32)
+    expected = A[0, 0, :, 0]
+    for i in range(2):
+        for j in range(3):
+            for k in range(5):
+                A[i, j, :, k] = expected
+
+    B = np.random.rand(4).astype(np.float32)
+
+    sdfg = program.to_sdfg()
+    sdfg(A=A, B=B)
+
+    diff = np.linalg.norm(expected - B)
+    print('Difference:', diff)
+    assert diff < 1e-5
+
+
+def test_nested_superrange():
+    onetest(nested_superrange)
+
+
+def test_subrange1():
+    onetest(subrange1)
+
+
+def test_subrange2():
+    onetest(subrange2)
+
+
+def test_subrange3():
+    onetest(subrange3)
+
+
+def test_subrange_of_subrange():
+    onetest_subrange_of_subrange(subrange_of_subrange)
+
+
+def test_subrange_of_subrange_nested():
+    onetest_subrange_of_subrange(subrange_of_subrange_nested)
+
+
+if __name__ == '__main__':
+    test_nested_superrange()
+    # test_subrange1()
+    # test_subrange2()
+    # test_subrange3()
+    # test_subrange_of_subrange()
+    # test_subrange_of_subrange_nested()


### PR DESCRIPTION
In DaCe we still don't have the required tools to detect overlapped accesses in a generalized manner. Because of this, the python frontend always generates new accesses for data, even if there is already another access to the same data, unless the access ranges match exactly. This causes issues when an access is re-used in the same scope. For example:
```python
@dace.program
def nested_superrange(A: dace.float32[2, 3, 4], B: dace.float32[3, 4]):
    tmp = dace.define_local([3, 4, 2, 1, 1], dace.float32)
    for i, j in dace.map[0:3, 0:4]:
        tmp[i, j] = A[:, i, j]
        B[i, j] = tmp[i, j, 0] + tmp[i, j, 1]
```

There is an access to tmp (tmp[i, j]) that is subsequently re-used (tmp[i, j, 0] and tmp[i, j, 1]). The python frontend in master will generate new accesses for tmp[i, j, 0] and tmp[i, j, 1] instead of re-using the access for tmp[i, j]. Due to this, the result of the program execution will be wrong.

It is possible for DaCe to support the above case, because the re-used accesses are **covered** by the first access. We already have a suitable method to detect this, dace.subsets.Subset.covers. The purpose of this branch is to amend the frontend and any other core-files necessary to support re-use of covered nested accesses properly.