### PR TITLE
Store node instead of index for starting state

### DIFF
--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -649,7 +649,7 @@ class SDFG(OrderedDiGraph):
             raise TypeError("Expected SDFGState, got " + str(type(node)))
         super(SDFG, self).add_node(node)
         if is_start_state == True:
-            self.start_state = len(self.nodes())
+            self.start_state = len(self.nodes()) - 1
 
     def add_edge(self, u, v, edge):
         """ Adds a new edge to the SDFG. Must be an InterstateEdge or a

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -647,12 +647,9 @@ class SDFG(OrderedDiGraph):
         """
         if not isinstance(node, SDFGState):
             raise TypeError("Expected SDFGState, got " + str(type(node)))
-
-        # If no start state has been defined, define to be the first state
+        super(SDFG, self).add_node(node)
         if is_start_state == True:
             self.start_state = len(self.nodes())
-
-        return super(SDFG, self).add_node(node)
 
     def add_edge(self, u, v, edge):
         """ Adds a new edge to the SDFG. Must be an InterstateEdge or a

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -413,7 +413,9 @@ class SDFG(OrderedDiGraph):
             return source_nodes[0]
         if self._start_state is None:
             raise ValueError('Ambiguous or undefined starting state for SDFG')
-
+        if self._start_state not in source_nodes:
+            raise ValueError("Start state {} not found in source nodes".format(
+                self._start_state))
         return self._start_state
 
     @start_state.setter

--- a/tests/sdfg_validate_names_test.py
+++ b/tests/sdfg_validate_names_test.py
@@ -25,9 +25,10 @@ class NameValidationTests(unittest.TestCase):
     def test_state_duplication(self):
         try:
             sdfg = dace.SDFG('ok')
-            sdfg.add_state('also_ok')
+            s1 = sdfg.add_state('also_ok')
             s2 = sdfg.add_state('also_ok')
             s2.set_label('also_ok')
+            sdfg.add_edge(s1, s2, dace.InterstateEdge())
             sdfg.validate()
             self.fail('Failed to detect duplicate state')
         except dace.sdfg.InvalidSDFGError as ex:
@@ -111,8 +112,8 @@ class NameValidationTests(unittest.TestCase):
                            dace.Memlet.from_array(A.data, A.desc(sdfg)))
             state.add_edge(t, 'b', B, None,
                            dace.Memlet.from_array(B.data, B.desc(sdfg)))
-            sdfg.add_edge(
-                state, state, dace.InterstateEdge(assignments={'%5': '1'}))
+            sdfg.add_edge(state, state,
+                          dace.InterstateEdge(assignments={'%5': '1'}))
             sdfg.validate()
             self.fail('Failed to detect invalid interstate edge')
         except dace.sdfg.InvalidSDFGInterstateEdgeError as ex:


### PR DESCRIPTION
There was a bug where `sdfg._start_state` was stored as an index, but read as a node. I've changed it to be stored as a node, since this is more robust to the SDFG changing.