### PR TITLE
Ternary operation code generation

### DIFF
--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -95,18 +95,20 @@ _py2c_typeconversion = {
 }
 
 
-def interleave(inter, f, seq):
-    """Call f on each item in seq, calling inter() in between.
+def interleave(inter, f, seq, **kwargs):
+    """
+    Call f on each item in seq, calling inter() in between.
+    f can accept optional arguments (kwargs)
     """
     seq = iter(seq)
     try:
-        f(next(seq))
+        f(next(seq), **kwargs)
     except StopIteration:
         pass
     else:
         for x in seq:
             inter()
-            f(x)
+            f(x, **kwargs)
 
 
 class LocalScheme(object):
@@ -1052,7 +1054,7 @@ class CPPUnparser:
     def _BoolOp(self, t, infer_type=False):
         self.write("(", infer_type)
         s = " %s " % self.boolops[t.op.__class__]
-        interleave(lambda: self.write(s), self.dispatch, t.values)
+        interleave(lambda: self.write(s, infer_type), self.dispatch, t.values, infer_type=infer_type)
         self.write(")", infer_type)
         return dace.dtypes.typeclass(np.bool) if infer_type else None
 

--- a/tests/intel_fpga/type_inference.py
+++ b/tests/intel_fpga/type_inference.py
@@ -17,7 +17,7 @@ def type_inference(x: dace.float32[N], y: dace.float32[N]):
         # computes y[i]=(int)x[i] + ((int)y[i])*2.1
         var1 = int(in_x)
         var2: int = in_y
-        var3 = 2.1
+        var3 = 2.1 if (i>1 and i<10) else 2.1 # Just for the sake of testing
         res = var1 + var3 * var2
         out = res
 
@@ -27,10 +27,11 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("N", type=int, nargs="?", default=24)
-    parser.add_argument("--compile-only",
-                        default=False,
-                        action="store_true",
-                        dest="compile-only")
+    parser.add_argument(
+        "--compile-only",
+        default=False,
+        action="store_true",
+        dest="compile-only")
     args = vars(parser.parse_args())
     dace.config.Config.set("compiler", "intel_fpga", "mode", value="emulator")
 


### PR DESCRIPTION
There were errors in handling ternary operation (`cppunparse.py`).
The problem arises when the condition was expressed as a composition of boolean expression. The `__BoolOp` function was not properly handling the case in which type inference is requested.

I've slightly changed the `interleave` function.

Added test for intel_fpga.