### PR TITLE
Double argument in Xilinx kernels

### DIFF
--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -1,3 +1,5 @@
+import collections
+import itertools
 import os
 import re
 
@@ -286,10 +288,12 @@ DACE_EXPORTED int __dace_init_xilinx({signature}) {{
             if kernel_arg:
                 kernel_args.append(kernel_arg)
 
+        scalar_parameters = collections.OrderedDict(scalar_parameters)
+        symbol_parameters.update(scalar_parameters)
         kernel_args += ([
             arg.signature(with_types=True, name=argname)
-            for argname, arg in scalar_parameters
-        ] + symbol_params)
+            for argname, arg in symbol_parameters.items()
+        ])
 
         # Write kernel signature
         kernel_stream.write(
@@ -326,11 +330,15 @@ DACE_EXPORTED int __dace_init_xilinx({signature}) {{
                                     symbol_parameters, kernel_stream):
 
         # Just collect all variable names for calling the kernel function
-        kernel_args = [
-            p.signature(False, name=name) for is_output, name, p in parameters
-        ]
-
-        kernel_args += symbol_parameters.keys()
+        added = set()
+        kernel_args = []
+        for _, name, p in itertools.chain(
+                parameters,
+            [(False, k, v) for k, v in symbol_parameters.items()]):
+            if not isinstance(p, dace.data.Array) and name in added:
+                continue
+            added.add(name)
+            kernel_args.append(p.signature(False, name=name))
 
         kernel_function_name = kernel_name
         kernel_file_name = "{}.xclbin".format(kernel_name)
@@ -353,18 +361,13 @@ DACE_EXPORTED int __dace_init_xilinx({signature}) {{
         state_id = sdfg.node_id(state)
         dfg = sdfg.nodes()[state_id]
 
-        # Treat scalars and symbols the same, assuming there are no scalar
-        # outputs
-        symbol_sigs = [
-            v.signature(with_types=True, name=k)
-            for k, v in symbol_parameters.items()
-        ]
-        symbol_names = symbol_parameters.keys()
         kernel_args_call = []
         kernel_args_module = []
         added = set()
 
-        for is_output, pname, p in parameters:
+        for is_output, pname, p in itertools.chain(
+                parameters,
+            [(False, k, v) for k, v in symbol_parameters.items()]):
             if isinstance(p, dace.data.Array):
                 arr_name = "{}_{}".format(pname, "out" if is_output else "in")
                 kernel_args_call.append(arr_name)
@@ -393,8 +396,6 @@ DACE_EXPORTED int __dace_init_xilinx({signature}) {{
                         p.signature(with_types=False, name=pname))
                     kernel_args_module.append(
                         p.signature(with_types=True, name=pname))
-        kernel_args_call += symbol_names
-        kernel_args_module += symbol_sigs
         module_function_name = "module_" + name
         # Unrolling processing elements: if there first scope of the subgraph
         # is an unrolled map, generate a processing element for each iteration
@@ -622,7 +623,9 @@ DACE_EXPORTED int __dace_init_xilinx({signature}) {{
         kernel_args = []
 
         seen = set()
-        for is_output, name, arg in parameters:
+        for is_output, name, arg in itertools.chain(
+                parameters,
+            [(False, k, v) for k, v in symbol_parameters.items()]):
             if isinstance(arg, dace.data.Array):
                 kernel_args.append(
                     arg.signature(with_types=True,
@@ -633,11 +636,6 @@ DACE_EXPORTED int __dace_init_xilinx({signature}) {{
                     continue
                 seen.add(name)
                 kernel_args.append(arg.signature(with_types=True, name=name))
-
-        kernel_args += [
-            v.signature(with_types=True, name=k)
-            for k, v in symbol_parameters.items()
-        ]
 
         host_code_stream.write(
             """\


### PR DESCRIPTION
When creating Xilinx OpenCL kernels, we were concatenating scalar arguments with symbol arguments. It seems symbol arguments sometimes include scalar arguments despite the `include_scalar_arguments` flag being set to `False` (and/or the other way around).

Work around this by deduplicating arguments in the Xilinx codegen.