### PR TITLE
Fix nested SDFG size-1 connectors

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -746,8 +746,8 @@ class CPUCodeGen(TargetCodeGenerator):
 
                 could_be_scalar = True
                 if isinstance(node, nodes.NestedSDFG):
-                    could_be_scalar = isinstance(node.sdfg.arrays[uconn],
-                                                 data.Scalar)
+                    could_be_scalar = not isinstance(node.sdfg.arrays[uconn],
+                                                     data.Array)
 
                 try:
                     positive_accesses = bool(memlet.num_accesses >= 0)
@@ -916,7 +916,7 @@ class CPUCodeGen(TargetCodeGenerator):
                           local_name: str,
                           conntype: data.Data = None,
                           allow_shadowing=False):
-        could_be_scalar = not conntype or isinstance(conntype, data.Scalar)
+        could_be_scalar = not conntype or not isinstance(conntype, data.Array)
         result = ("auto __%s = " % local_name +
                   self.memlet_ctor(sdfg, memlet, output) + ";\n")
 

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1990,18 +1990,8 @@ for (int {mapname}_iter = 0; {mapname}_iter < {mapname}_rng.size(); ++{mapname}_
 
             # Store back tmpout into the true output
             if i == end_braces - 1 and use_tmpout:
-                # TODO: This is a targeted fix that has to be generalized when
-                # refactoring code generation. The issue is related to an
-                # inconsistency on whether an output connector generates a tmp
-                # scalar variable to be used with __write or a pointer to the
-                # output array.
-                scalar_output = True
-                for r in output_subset:
-                    if r != 0 and r != (0, 0, 1):
-                        scalar_output = False
-                        break
-                arr = sdfg.arrays[output_memlet.data]
-                if scalar_output and sdfg.parent_sdfg and not arr.transient:
+                if (self._dispatcher.defined_vars.get(
+                        output_memlet.data) == DefinedType.Scalar):
                     out_var = output_memlet.data
                 else:
                     out_var = cpp_array_expr(sdfg, output_memlet)

--- a/tests/nested_sdfg_scalar_test.py
+++ b/tests/nested_sdfg_scalar_test.py
@@ -1,0 +1,38 @@
+import dace
+import numpy as np
+
+
+def _construct_sdfg():
+    sdfg = dace.SDFG('nsstest')
+    sdfg.add_array('A', [2], dace.float64)
+    state = sdfg.add_state()
+
+    nsdfg = dace.SDFG('nested')
+    nsdfg.add_array('a', [1], dace.float64)
+    nsdfg.add_array('b', [1], dace.float64)
+    nstate = nsdfg.add_state()
+    nstate.add_mapped_tasklet('m',
+                              dict(i='0'),
+                              dict(inp=dace.Memlet.simple('a', 'i')),
+                              'out = inp * 5.0',
+                              dict(out=dace.Memlet.simple('b', 'i')),
+                              external_edges=True)
+
+    r = state.add_read('A')
+    n = state.add_nested_sdfg(nsdfg, None, {'a'}, {'b'})
+    w = state.add_write('A')
+    state.add_edge(r, None, n, 'a', dace.Memlet.simple('A', '1'))
+    state.add_edge(n, 'b', w, None, dace.Memlet.simple('A', '0'))
+
+    return sdfg
+
+
+def test_nss():
+    sdfg = _construct_sdfg()
+    A = np.random.rand(2)
+    sdfg(A=A)
+    assert A[0] == A[1] * 5
+
+
+if __name__ == '__main__':
+    test_nss()


### PR DESCRIPTION
Now obeying SDFG semantics - if the internal node is an array, generate a pointer. If it's a scalar, generate a scalar.