### PR TITLE
Fix missing slash in fpga codegen

### DIFF
--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -71,7 +71,7 @@ class XilinxCodeGen(fpga.FPGACodeGen):
         except ValueError:
             sdaccel_dir = ''
 
-        kernel_file_name = "DACE_BINARY_DIR \"{}".format("/" + self._program_name)
+        kernel_file_name = "DACE_BINARY_DIR \"/{}".format(self._program_name)
         if execution_mode == "software_emulation":
             kernel_file_name += "_sw_emu.xclbin\""
             xcl_emulation_mode = "sw_emu"

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -71,7 +71,7 @@ class XilinxCodeGen(fpga.FPGACodeGen):
         except ValueError:
             sdaccel_dir = ''
 
-        kernel_file_name = "DACE_BINARY_DIR \"{}".format(self._program_name)
+        kernel_file_name = "DACE_BINARY_DIR \"{}".format("/" + self._program_name)
         if execution_mode == "software_emulation":
             kernel_file_name += "_sw_emu.xclbin\""
             xcl_emulation_mode = "sw_emu"


### PR DESCRIPTION
While compiling and running on Xilinx FPGA I ran into the following issue:
```
terminate called after throwing an instance of 'hlslib::ocl::ConfigurationError'
  what():  Failed to open program file "/home/burgerm/thesis_dace/tasks/blas/level1/axpy/.dacecache/saxpy_perf/buildsaxpy_perf_hw.xclbin".
```
There is a `/` missing between `...build` and `$PROGRAM_NAME` .The small change should fix it.