### PR TITLE
Bugfix: duplicate map code produced

### DIFF
--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -188,14 +188,15 @@ class Memlet(object):
                       debuginfo=debuginfo)
 
     @staticmethod
-    def from_array(dataname, datadesc):
+    def from_array(dataname, datadesc, wcr=None):
         """ Constructs a Memlet that transfers an entire array's contents.
             :param dataname: The name of the data descriptor in the SDFG.
             :param datadesc: The data descriptor object.
+            :param wcr: The conflict resolution lambda.
             @type datadesc: Data.
         """
         range = subsets.Range.from_array(datadesc)
-        return Memlet(dataname, range.num_elements(), range, 1)
+        return Memlet(dataname, range.num_elements(), range, 1, wcr=wcr)
 
     def __hash__(self):
         return hash((self.data, self.num_accesses, self.subset, self.veclen,

--- a/dace/sdfg.py
+++ b/dace/sdfg.py
@@ -4214,14 +4214,22 @@ def concurrent_subgraphs(graph):
                     to_search.append(e.dst)
         # If this component overlaps with any previously determined components,
         # fuse them
-        for other in subgraphs:
+        to_delete = []
+        for i, other in enumerate(subgraphs):
             if len(other & seen) > 0:
-                # Add both traversed node and potential data source nodes
-                other |= seen | components[start_node]
-                break
-        else:
+                to_delete.append(i)
+        if len(to_delete) == 0:
             # If there was no overlap, this is a concurrent subgraph
             subgraphs.append(seen | components[start_node])
+        else:
+            # Merge overlapping subgraphs
+            new_subgraph = seen | components[start_node]
+
+            for i, index in enumerate(reversed(to_delete)):
+                new_subgraph |= subgraphs.pop(index - i)
+
+            subgraphs.append(new_subgraph)
+
     # Now stick each of the found components in a ScopeSubgraphView and return
     # them. Sort according to original order of nodes
     all_nodes = graph.nodes()

--- a/tests/codegen/concurrent_subgraph_test.py
+++ b/tests/codegen/concurrent_subgraph_test.py
@@ -1,0 +1,79 @@
+import dace
+from dace import Memlet
+import numpy as np
+
+
+def test_duplicate_codegen():
+
+    # Unfortunately I have to generate this graph manually, as doing it with the python
+    # frontend wouldn't result in the node ordering that we want
+
+    sdfg = dace.SDFG("dup")
+    state = sdfg.add_state()
+
+    c_task = state.add_tasklet("c_task",
+                               inputs={"c"},
+                               outputs={"d"},
+                               code='d = c')
+    e_task = state.add_tasklet("e_task",
+                               inputs={"a", "d"},
+                               outputs={"e"},
+                               code="e = a + d")
+    f_task = state.add_tasklet("f_task",
+                               inputs={"b", "d"},
+                               outputs={"f"},
+                               code="f = b + d")
+
+    _, A_arr = sdfg.add_array("A", [
+        1,
+    ], dace.float32)
+    _, B_arr = sdfg.add_array("B", [
+        1,
+    ], dace.float32)
+    _, C_arr = sdfg.add_array("C", [
+        1,
+    ], dace.float32)
+    _, D_arr = sdfg.add_array("D", [
+        1,
+    ], dace.float32)
+    _, E_arr = sdfg.add_array("E", [
+        1,
+    ], dace.float32)
+    _, F_arr = sdfg.add_array("F", [
+        1,
+    ], dace.float32)
+    A = state.add_read("A")
+    B = state.add_read("B")
+    C = state.add_read("C")
+    D = state.add_access("D")
+    E = state.add_write("E")
+    F = state.add_write("F")
+
+    state.add_edge(C, None, c_task, "c", Memlet.from_array("C", C_arr))
+    state.add_edge(c_task, "d", D, None, Memlet.from_array("D", D_arr))
+
+    state.add_edge(A, None, e_task, "a", Memlet.from_array("A", A_arr))
+    state.add_edge(B, None, f_task, "b", Memlet.from_array("B", B_arr))
+    state.add_edge(D, None, f_task, "d", Memlet.from_array("D", D_arr))
+    state.add_edge(D, None, e_task, "d", Memlet.from_array("D", D_arr))
+
+    state.add_edge(e_task, "e", E, None,
+                   Memlet.from_array("E", E_arr, wcr="lambda x, y: x + y"))
+    state.add_edge(f_task, "f", F, None,
+                   Memlet.from_array("F", F_arr, wcr="lambda x, y: x + y"))
+
+    A = np.array([1], dtype=np.float32)
+    B = np.array([1], dtype=np.float32)
+    C = np.array([1], dtype=np.float32)
+    D = np.array([1], dtype=np.float32)
+    E = np.zeros_like(A)
+    F = np.zeros_like(A)
+
+    sdfg(A=A, B=B, C=C, D=D, E=E, F=F)
+
+    assert E[0] == 2
+    assert F[0] == 2
+
+
+if __name__ == "__main__":
+    test_duplicate_codegen()


### PR DESCRIPTION
This fixes a bug in `concurrent_subgraphs` that would result in code for subgraphs being generated more than once.
