### PR TITLE
WIP: Automatic differentiation of SDFGs

### DIFF
--- a/dace/autodiff/__init__.py
+++ b/dace/autodiff/__init__.py
@@ -1,1 +1,1 @@
-from .autodiff import BackwardPassGenerator
+from .autodiff import BackwardPassGenerator, AutoDiffException

--- a/dace/autodiff/__init__.py
+++ b/dace/autodiff/__init__.py
@@ -1,1 +1,1 @@
-from .autodiff import *
+from .autodiff import BackwardPassGenerator

--- a/dace/autodiff/__init__.py
+++ b/dace/autodiff/__init__.py
@@ -1,0 +1,1 @@
+from .autodiff import *

--- a/dace/autodiff/autodiff.py
+++ b/dace/autodiff/autodiff.py
@@ -596,7 +596,7 @@ class BackwardPassGenerator:
             _, argminmax_input_arr = forward_sdfg.add_array(
                 "IN", shape=input_array.shape, dtype=input_array.dtype)
 
-            _, (argminmax_output, minmax_output) = _argminmax(
+            _, (minmax_output, argminmax_output) = _argminmax(
                 forward_sdfg,
                 state,
                 "IN",
@@ -677,7 +677,7 @@ class BackwardPassGenerator:
                 {"_reduce_out_grad"})
 
             tmp, _ = self.sdfg.add_temp_transient(output_array.shape,
-                                                  dtype=dace.int64)
+                                                  dtype=dace.int32)
             tmp_access = self.state.add_access(tmp)
 
             self.state.add_edge(new_node, argminmax_output, tmp_access, None,

--- a/dace/autodiff/autodiff.py
+++ b/dace/autodiff/autodiff.py
@@ -1,0 +1,269 @@
+import dace
+from dace import Memlet
+from dace.graph import dot, graph
+import dace.graph.nodes as nd
+
+import ast
+import itertools
+from collections import deque
+from copy import deepcopy as dc
+from typing import Iterator, Tuple, Deque
+
+import sympy as sp
+from sympy.parsing.sympy_parser import parse_expr
+from astunparse import unparse
+
+
+def symbolically_diff_tasklet(tasklet: nd.Tasklet, x: str) -> nd.Tasklet:
+    """Symbolically differentiate the value of an assignment tasklet with respect to a given
+       in_connector.
+    """
+
+    if len(tasklet.code) != 1 or type(tasklet.code[0]) is not ast.Assign:
+        raise ValueError(
+            "Differentiating tasklets more complex than assign statements is not supported"
+        )
+    assign: ast.Assign = tasklet.code[0]
+    if len(assign.targets) != 1:
+        raise ValueError(
+            "Expected assignment statement with at most one target")
+    target = assign.targets[0].id
+
+    input_vars = set(tasklet.in_connectors)
+    if x not in input_vars:
+        raise ValueError("Unknown connector {}".format(x))
+
+    sp_expr: sp.Expr = parse_expr(unparse(assign.value))
+
+    def symbs_to_strings(symbs):
+        return {str(symb) for symb in symbs}
+
+    free_symbs = symbs_to_strings(sp_expr.free_symbols)
+
+    if target in free_symbs:
+        raise ValueError("Inplace operations are currently not supported")
+
+    if input_vars != free_symbs:
+        print(input_vars)
+        print(sp_expr.free_symbols)
+        raise ValueError(
+            "Expected all in_connectors to be used in the tasklet code")
+
+    diff_expr = sp_expr.diff(sp.symbols(x))
+
+    return nd.Tasklet(
+        tasklet.label + "_backward",
+        inputs=symbs_to_strings(diff_expr.free_symbols) | {target + "_grad"},
+        outputs={x + "_grad"},
+        code=x + "_grad = {}_grad * ({})".format(
+            target, str(diff_expr))  # this should be valid python code
+    )
+
+
+def _check_volume_one(memlet: dace.Memlet):
+    elems = memlet.subset.num_elements()
+
+    if len(elems.free_symbols) > 0 or int(memlet.subset.num_elements()) != 1:
+        raise ValueError(
+            "Autodiff only supported for tasklets that operate on memlets with volume 1"
+        )
+
+
+def diff_mapped_tasklet(sdfg: dace.SDFG, forward_state: dace.SDFGState,
+                        backward_state: dace.SDFGState, map_entry: nd.MapEntry,
+                        map_exit: nd.MapExit, tasklet: nd.Tasklet, target: str,
+                        X: str):
+
+    in_arrays = set()
+    out_arrays = set()
+
+    # input checking
+    ########################################
+
+    X_conn = None
+    for _, _, map_tasklet, conn, memlet in forward_state.out_edges(map_entry):
+        if map_tasklet is not tasklet:
+            raise ValueError(
+                "Expected tasklet to be connected directly to the map exit and entry"
+            )
+        _check_volume_one(memlet)
+
+        if memlet.data in in_arrays:
+            raise ValueError(
+                "Using the same array for multiple memlets is not supported")
+
+        in_arrays.add(memlet.data)
+
+        if memlet.data == X:
+            X_conn = conn
+
+    if len(forward_state.out_edges(tasklet)) != 1:
+        raise ValueError(
+            "Tasklets with more than one output are not supported")
+
+    target_conn = None
+    target_memlet: Memlet = None
+    for map_tasklet, conn, _, _, memlet in forward_state.in_edges(map_exit):
+        if map_tasklet is not tasklet:
+            raise ValueError(
+                "Expected tasklet to be connected directly to the map exit and entry"
+            )
+        _check_volume_one(memlet)
+
+        if memlet.data in in_arrays:
+            raise ValueError("Inplace operations are not supported")
+
+        out_arrays.add(memlet.data)
+
+        if memlet.data == target:
+            target_conn = conn
+            target_memlet = dc(memlet)
+
+    if target_conn is None:
+        raise ValueError(
+            "target ({}) not found in tasklet outputs".format(target))
+
+    if X_conn is None:
+        raise ValueError("X_array ({}) not found in tasklet inputs".format(X))
+
+    target_grad = sdfg.arrays[target + "_grad"]
+
+    # allocate an array for the gradient of x
+    X_arr = sdfg.arrays[X]
+    if X_arr.dtype not in [dace.float16, dace.float32, dace.float64]:
+        raise ValueError("Expected dtype of x to be float, got {}".format(
+            X_arr.dtype.to_string()))
+
+    # TODO @orausch grad arrays should be zero at the start of execution; how should that be handled?
+    _, X_grad_arr = sdfg.add_array(X + "_grad",
+                                   shape=X_arr.shape,
+                                   dtype=X_arr.dtype)
+
+    # HACK @orausch ask how to do this properly
+    ndrange = dict(
+        zip(map_entry.map.params,
+            str(map_entry.map.range).split(", ")))
+
+    diff_map_entry, diff_map_exit = backward_state.add_map(
+        X + "_diff", ndrange)
+
+    diff_tasklet = symbolically_diff_tasklet(tasklet, X_conn)
+    backward_state.add_node(diff_tasklet)
+
+    diff_map_entry.add_in_connector("IN_1")
+    diff_map_entry.add_out_connector("OUT_1")
+
+    target_memlet.data = target + "_grad"
+    target_memlet.wcr = None
+    # connect the target's gradient
+    backward_state.add_edge(
+        backward_state.add_read(target + "_grad"), None, diff_map_entry,
+        "IN_1",
+        Memlet.from_array(target + "_grad", sdfg.arrays[target + "_grad"]))
+    backward_state.add_edge(diff_map_entry, "OUT_1", diff_tasklet,
+                            target_conn + "_grad", target_memlet)
+
+    i = 2
+    X_memlet: Memlet = None
+
+    # connect the inputs from the forward pass
+    for _, _, _, conn, memlet in forward_state.in_edges(tasklet):
+
+        if conn in diff_tasklet.in_connectors:
+            access = backward_state.add_read(memlet.data)
+            arr = sdfg.arrays[memlet.data]
+            diff_map_entry.add_in_connector("IN_" + str(i))
+            diff_map_entry.add_out_connector("OUT_" + str(i))
+            backward_state.add_edge(access, None, diff_map_entry,
+                                    "IN_" + str(i),
+                                    Memlet.from_array(memlet.data, arr))
+            backward_state.add_edge(diff_map_entry, "OUT_" + str(i),
+                                    diff_tasklet, conn, dc(memlet))
+            i += 1
+
+        if conn == X_conn:
+            X_memlet = dc(memlet)
+
+    if X_memlet is None:
+        raise ValueError("X_array ({}) not found in tasklet inputs".format(X))
+
+    # TODO @orausch this isn't always necessary; maybe we can add a transform to remove this if possible?
+    X_memlet.wcr = "lambda x, y: x + y"
+    X_memlet.data = X + "_grad"
+
+    diff_map_exit.add_in_connector("IN_1")
+    diff_map_exit.add_out_connector("OUT_1")
+    backward_state.add_edge(diff_tasklet, X_conn + "_grad", diff_map_exit,
+                            "IN_1", X_memlet)
+    backward_state.add_edge(
+        diff_map_exit, "OUT_1", backward_state.add_write(X + "_grad"), None,
+        Memlet.from_array(X + "_grad", X_grad_arr, wcr="lambda x, y: x + y"))
+
+
+def add_backward_pass(sdfg: dace.SDFG, forward_state: dace.SDFGState,
+                      target: dace.nodes.AccessNode):
+    """Generate the backward pass wrt. target.
+    """
+
+    # This is currently a bit ugly due to the constrains on graph structure.
+
+    target_arr = sdfg.arrays[target.data]
+    if target_arr.dtype not in [dace.float16, dace.float32, dace.float64]:
+        raise ValueError("Expected dtype of x to be float, got {}".format(
+            target_arr.dtype.to_string()))
+
+    if len(target_arr.total_size.free_symbols) > 0 or int(
+            target_arr.total_size) != 1:
+        raise ValueError("Targets with more than one element are unsupported")
+
+    target_grad, target_grad_arr = sdfg.add_array(target.data + "_grad",
+                                                  target_arr.shape,
+                                                  target_arr.dtype)
+
+    def getpred(state: dace.SDFGState, node: nd.Node):
+        in_edges = state.in_edges(node)
+        preds = {edge.src for edge in in_edges}
+        if len(preds) > 1:
+            raise ValueError("Unsupported graph structure")
+        return next(iter(preds))
+
+    # this is a breath first search along collapsed maps
+    queue: Deque[Tuple[nd.AccessNode, dace.SDFGState]] = deque([target])
+    prev_state = forward_state
+    while queue:
+        current = queue.popleft()
+
+        if type(current) is not nd.AccessNode:
+            raise ValueError("Unsupported graph structure")
+
+        try:
+            map_x = getpred(forward_state, current)
+            task = getpred(forward_state, map_x)
+            map_e = getpred(forward_state, task)
+
+            if (type(map_e) is not nd.MapEntry or  #
+                    type(task) is not nd.Tasklet or  #
+                    type(map_x) is not nd.MapExit):
+                raise ValueError("Unsupported graph structure")
+
+            input_edges = forward_state.in_edges(map_e)
+            inputs = list({edge.src for edge in input_edges})
+            for inp in inputs:
+                if type(inp) is not nd.AccessNode:
+                    raise ValueError("Unsupported graph structure")
+                # generate the backward pass for this map
+                backward_state = sdfg.add_state()
+                diff_mapped_tasklet(sdfg, forward_state, backward_state, map_e,
+                                    map_x, task, current.data, inp.data)
+
+                # add interstate edges
+                sdfg.add_edge(prev_state, backward_state,
+                              dace.InterstateEdge())
+                prev_state = backward_state
+
+                # recursively generate backward pass for inp
+                if len(forward_state.in_edges(inp)) > 0:
+                    queue.append(inp)
+
+        except StopIteration:
+            raise ValueError("Unsupported graph structure")

--- a/dace/autodiff/autodiff.py
+++ b/dace/autodiff/autodiff.py
@@ -1,20 +1,29 @@
+"""Automatic Differentiation of SDFGStates.
+
+   This module exposes the add_backward_pass method that can be used to add a backward pass to an
+   SDFGState.
+"""
 import dace
-from dace import Memlet
-from dace.graph import dot, graph
+from dace import Memlet, SDFG, SDFGState
 import dace.graph.nodes as nd
+from dace.sdfg import ScopeSubgraphView
+from dace.graph.nxutil import dfs_topological_sort
+from dace.frontend.operations import detect_reduction_type
 
 import ast
 import itertools
-from collections import deque
+from collections import deque, defaultdict
 from copy import deepcopy as dc
-from typing import Iterator, Tuple, Deque, Dict, Set
+from typing import Iterator, Tuple, Deque, Dict, Set, List
 
+import aenum
 import sympy as sp
 from sympy.parsing.sympy_parser import parse_expr
 from astunparse import unparse
 
 
 class AutoDiffException(Exception):
+    """Base class for all exceptions related to automatic differentiation"""
     pass
 
 
@@ -89,274 +98,287 @@ def symbolic_execution({}):
             .format(cleaned_code, code_fn)) from e
 
 
-def symbolically_diff_tasklet(tasklet: nd.Tasklet, target: str,
-                              x: str) -> nd.Tasklet:
-    """Symbolically differentiate the value of an output of a tasklet (target) with respect to an
-       input x.
+def _check_one(value):
+    if type(value) is int:
+        return value == 1
+
+    if len(value.free_symbols) > 0 or int(value) != 1:
+        raise AutoDiffException("Expected value one, got {}".format(value))
+
+
+def _invert_access(access: dace.AccessType) -> dace.AccessType:
+    if access == dace.AccessType.ReadOnly:
+        return dace.AccessType.WriteOnly
+    elif access == dace.AccessType.WriteOnly:
+        return dace.AccessType.ReadOnly
+    return access
+
+
+def _has_inplace_operation(state: dace.SDFGState,
+                           target: nd.AccessNode) -> bool:
+    """Returns true if state has any inplace operations before target"""
+
+    seen_accesses: Set[str] = set()
+    for src, _, dst, _, _ in state.bfs_edges(target):
+        if type(src) is nd.AccessNode:
+            if src.data in seen_accesses:
+                return True
+            seen_accesses.add(src.data)
+        if type(dst) is nd.AccessNode:
+            if dst.data in seen_accesses:
+                return True
+            seen_accesses.add(dst.data)
+    return False
+
+
+class BackwardPassGenerator:
+    """Signatures:
+       Generate the backward pass for the node.
+
+       :param node: the node to generate a backward pass for.
+       :param output_grads: the nodes that produce the gradients for the outputs. This is a map from
+                            output_connector to Tuple[Node, input_connector].
+       :param required_grads: the list of input connectors that gradients need to be generated
+                              for. For each of these, there should be an output on the reverse node
+                              with the suffix _grad.
+       :return: the reversed node
+
     """
+    def __init__(self, sdfg: SDFG, state: SDFGState, required_grads: Set[str], target: nd.AccessNode):
+        """Generate the backward pass for a state wrt. a `target` scalar.
 
-    if tasklet.language is not dace.dtypes.Language.Python:
-        raise AutoDiffException(
-            "Expected tasklet with language Python, got language {}".format(
-                tasklet.language))
+           :param sdfg: the `SDFG` to differentiate
+           :param forward_state: the `SDFGState` to differentiate
+           :param required_grads: the names of all arrays that gradients should be calculated for
+           :param target: the `AccessNode` in `state` to generate the backward pass for. This
+                          should be an array with one element.
+        """
+        self.sdfg = sdfg
+        self.state = state
+        self.required_grads = required_grads
+        self.target = target
 
-    code_str = tasklet.code
-    if type(code_str) is ast.Module:
-        # unparse the tree
-        code_str = unparse(code_str)
+    def backward(
+        self
+    ):
 
-    if x not in tasklet.in_connectors:
-        raise AutoDiffException("Unknown connector {}".format(x))
+        target_arr = self.sdfg.arrays[self.target.data]
+        try:
+            _check_one(target_arr.total_size)
+        except AutoDiffException as e:
+            raise AutoDiffException("Expected scalar target") from e
 
-    if target not in tasklet.out_connectors:
-        raise AutoDiffException("Unknown connector {}".format(x))
-
-    output_exprs = code_to_exprs(code_str, tasklet.in_connectors,
-                                 tasklet.out_connectors)
-
-    target_expr = output_exprs[target]
-
-    free_symbs = _symbols_to_strings(target_expr.free_symbols)
-
-    if target in free_symbs:
-        raise AutoDiffException(
-            "Inplace operations are currently not supported for autodiff")
-
-    diff_expr = target_expr.diff(sp.symbols(x))
-
-    if diff_expr.atoms(sp.Derivative):
-        # the final result contains a call to sp.Derivative
-        raise AutoDiffException(
-            "Unable to differentiate expression: {}".format(diff_expr.expr))
-
-    return nd.Tasklet(
-        "_" + tasklet.label + "_backward_",
-        inputs=_symbols_to_strings(diff_expr.free_symbols)
-        | {target + "_grad"},
-        outputs={x + "_grad"},
-        code=x + "_grad = {}_grad * ({})".format(
-            target, str(diff_expr))  # this should be valid python code
-    )
-
-
-def _check_volume_one(memlet: dace.Memlet):
-    elems = memlet.subset.num_elements()
-
-    if len(elems.free_symbols) > 0 or int(memlet.subset.num_elements()) != 1:
-        raise AutoDiffException(
-            "Autodiff only supported for scalar tasklets (tasklets with input memlets with volume 1)"
-        )
-
-
-def diff_mapped_tasklet(sdfg: dace.SDFG, forward_state: dace.SDFGState,
-                        backward_state: dace.SDFGState, map_entry: nd.MapEntry,
-                        map_exit: nd.MapExit, tasklet: nd.Tasklet, target: str,
-                        X: str):
-
-    in_arrays = set()
-    out_arrays = set()
-
-    # input checking
-    ########################################
-
-    X_conn = None
-    for _, _, map_tasklet, conn, memlet in forward_state.out_edges(map_entry):
-        if map_tasklet is not tasklet:
+        self.reverse_map = {}
+        if self.required_grads.difference(
+                node.data for node in self.state.nodes() 
+                if type(node) is nd.AccessNode):
             raise AutoDiffException(
-                "Expected tasklet to be connected directly to the map exit and entry"
-            )
-        _check_volume_one(memlet)
+                "Could not find AccessNode nodes in {} with the following data {}".
+                format(
+                    self.sdfg,
+                    self.required_grads.difference(
+                        node.data for node in self.state.nodes()
+                        if type(node) is nd.AccessNode)))
 
-        if memlet.data in in_arrays:
-            raise AutoDiffException(
-                "Using the same array for multiple memlets is currently not supported in autodiff"
-            )
-
-        in_arrays.add(memlet.data)
-
-        if memlet.data == X:
-            X_conn = conn
-
-    if len(forward_state.out_edges(tasklet)) != 1:
-        raise AutoDiffException(
-            "Tasklets with more than one output are not supported")
-
-    target_conn = None
-    target_memlet: Memlet = None
-    for map_tasklet, conn, _, _, memlet in forward_state.in_edges(map_exit):
-        if map_tasklet is not tasklet:
-            raise AutoDiffException(
-                "Expected tasklet to be connected directly to the map exit and entry"
-            )
-        _check_volume_one(memlet)
-
-        if memlet.data in in_arrays:
+        # check for inplace operations (i.e. duplicated access nodes)
+        if _has_inplace_operation(self.state, self.target):
             raise AutoDiffException(
                 "Inplace operations are currently not supported in autodiff")
 
-        out_arrays.add(memlet.data)
+        source_nodes = [
+            node for node in self.state.source_nodes()
+            if node.data in self.required_grads
+        ]
 
-        if memlet.data == target:
-            target_conn = conn
-            target_memlet = dc(memlet)
+        required_nodes: Set[nd.Node] = set()
 
-    if target_conn is None:
-        raise AutoDiffException(
-            "target ({}) not found in tasklet outputs".format(target))
+        # determine which nodes we need to reverse
+        required_nodes = set()
+        for src, _, dst, _, _ in self.state.bfs_edges(source_nodes):
+            required_nodes |= {src, dst}
+            if dst is self.target:
+                break
+        else:
+            raise AutoDiffException(
+                "target node {} was not reachable from source nodes {}".format(
+                    self.target, required_grads))
 
-    if X_conn is None:
-        raise AutoDiffException(
-            "X_array ({}) not found in tasklet inputs".format(X))
+        self.grad_memlets: Dict[str, List[Memlet]] = defaultdict(list)
+        self._reverse_subgraph(
+            ScopeSubgraphView(self.state, list(required_nodes)))
 
-    target_grad = sdfg.arrays[target + "_grad"]
+    def append_grad(self, conn):
+        if conn is None:
+            return None
+        else:
+            return conn + "_grad"
 
-    # allocate an array for the gradient of x
-    X_arr = sdfg.arrays[X]
-    if X_arr.dtype not in [dace.float16, dace.float32, dace.float64]:
-        raise AutoDiffException(
-            "Expected dtype of x to be float, got {}".format(
-                X_arr.dtype.to_string()))
+    def _reverse_subgraph(self, subgraph: ScopeSubgraphView):
 
-    # TODO @orausch grad arrays should be zero at the start of execution; how should that be handled?
-    _, X_grad_arr = sdfg.add_array(X + "_grad",
-                                   shape=X_arr.shape,
-                                   dtype=X_arr.dtype)
+        nodes_to_skip = set()
+        # all memlets that write to grads
+        # a reversed topological sort is a topological sort on the reverse graph
+        for node in reversed(
+                list(dfs_topological_sort(subgraph, subgraph.source_nodes(), target=self.target))):
+            if type(node) is nd.MapExit:
+                # TODO handle scopes
+                raise AutoDiffException("TODO")
+            else:
+                output_grads = {
+                    edge.src_conn:
+                    (self.reverse_map[edge.dst], edge.dst_conn, edge.data)
+                    for edge in subgraph.out_edges(node)
+                }
+                required_grads = list(edge.dst_conn
+                                      for edge in subgraph.in_edges(node))
 
-    # HACK @orausch ask how to do this properly
-    ndrange = dict(
-        zip(map_entry.map.params,
-            str(map_entry.map.range).split(", ")))
+                rev: nd.Node = getattr(self, '_reverse_' +
+                                       type(node).__name__)(node, output_grads,
+                                                            required_grads)
+                # add rev to the graph and hook up the edges
+                self.reverse_map[node] = rev
+                subgraph.graph.add_node(rev)
 
-    diff_map_entry, diff_map_exit = backward_state.add_map(
-        X + "_diff", ndrange)
+                # connect the gradients of the outputs (as inputs)
+                for output_conn, (dest_node, input_conn,
+                                  memlet) in output_grads.items():
+                    if detect_reduction_type(memlet.wcr) not in [
+                            None, dace.dtypes.ReductionType.Sum
+                    ]:
+                        raise AutoDiffException(
+                            "Unsupported reduction type {}".format(
+                                detect_reduction_type(memlet.wcr)))
 
-    diff_tasklet = symbolically_diff_tasklet(
-        tasklet,
-        target_conn,
-        X_conn,
-    )
-    backward_state.add_node(diff_tasklet)
+                    memlet = dc(memlet)
 
-    diff_map_entry.add_in_connector("IN_1")
-    diff_map_entry.add_out_connector("OUT_1")
+                    if memlet.data not in self.grad_memlets:
+                        # this grad hasn't been written before: initialize it
+                        array = self.state.parent.arrays[memlet.data]
 
-    target_memlet.data = target + "_grad"
-    target_memlet.wcr = None
-    # connect the target's gradient
-    backward_state.add_edge(
-        backward_state.add_read(target + "_grad"), None, diff_map_entry,
-        "IN_1",
-        Memlet.from_array(target + "_grad", sdfg.arrays[target + "_grad"]))
-    backward_state.add_edge(diff_map_entry, "OUT_1", diff_tasklet,
-                            target_conn + "_grad", target_memlet)
+                        # this can clearly fail if someone chooses annoying array names; let's
+                        # ignore this for now
+                        if type(array) is dace.data.Scalar:
+                            self.sdfg.add_scalar(memlet.data + "_grad",
+                                                 array.dtype,
+                                                 storage=array.storage,
+                                                 transient=array.transient,
+                                                 toplevel=array.toplevel)
+                        elif type(array) is dace.data.Array:
+                            self.state.parent.add_array(
+                                memlet.data + "_grad",
+                                array.shape,
+                                array.dtype,
+                                storage=array.storage,
+                                materialize_func=array.materialize_func,
+                                transient=array.transient,
+                                strides=array.strides,
+                                offset=array.offset,
+                                toplevel=array.toplevel,
+                                allow_conflicts=array.allow_conflicts,
+                                total_size=array.total_size)
+                        else:
+                            raise AutoDiffException(
+                                "Unsupported data descriptor {}".format(array))
 
-    i = 2
-    X_memlet: Memlet = None
+                    self.grad_memlets[memlet.data].append(memlet)
+                    memlet.data = memlet.data + "_grad"
+                    subgraph.graph.add_edge(dest_node,
+                                            self.append_grad(input_conn), rev,
+                                            self.append_grad(output_conn),
+                                            memlet)
 
-    # connect the inputs from the forward pass
-    for _, _, _, conn, memlet in forward_state.in_edges(tasklet):
+                if isinstance(node, nd.AccessNode):
+                    # this means we are writing out a grad to an array. In this case, we need to set
+                    # all incoming memlets to WCR Sum
+                    # TODO @orausch there could be an intersection check here
+                    for edge in subgraph.graph.in_edges(rev):
+                        for path_edge in subgraph.graph.memlet_path(edge):
+                            path_edge.data.wcr = "lambda x, y: x + y"
 
-        if conn in diff_tasklet.in_connectors:
-            access = backward_state.add_read(memlet.data)
-            arr = sdfg.arrays[memlet.data]
-            diff_map_entry.add_in_connector("IN_" + str(i))
-            diff_map_entry.add_out_connector("OUT_" + str(i))
-            backward_state.add_edge(access, None, diff_map_entry,
-                                    "IN_" + str(i),
-                                    Memlet.from_array(memlet.data, arr))
-            backward_state.add_edge(diff_map_entry, "OUT_" + str(i),
-                                    diff_tasklet, conn, dc(memlet))
-            i += 1
+                # connect any required inputs from the forward pass
+                required_inputs = rev.in_connectors.difference(
+                    self.append_grad(output_conn)
+                    for output_conn in output_grads)
+                for src, src_conn, dst, dst_conn, memlet in subgraph.graph.in_edges(
+                        node):
+                    if dst_conn in required_inputs:
+                        subgraph.graph.add_edge(src, src_conn, rev, dst_conn,
+                                                memlet)
 
-        if conn == X_conn:
-            X_memlet = dc(memlet)
+    def _reverse_AccessNode(self, node: nd.AccessNode,
+                            output_grads: Dict[str, Tuple[nd.Node, str,
+                                                          Memlet]],
+                            required_grads: List[str]):
 
-    if X_memlet is None:
-        raise AutoDiffException(
-            "X_array ({}) not found in tasklet inputs".format(X))
+        return nd.AccessNode(node.data + "_grad",
+                             access=_invert_access(node.access))
 
-    # TODO @orausch this isn't always necessary; maybe we can add a transform to remove this if possible?
-    X_memlet.wcr = "lambda x, y: x + y"
-    X_memlet.data = X + "_grad"
+    def _reverse_Tasklet(self, tasklet: nd.Tasklet,
+                         output_grads: Dict[str, Tuple[nd.Node, str, Memlet]],
+                         required_grads: List[str]) -> nd.Tasklet:
 
-    diff_map_exit.add_in_connector("IN_1")
-    diff_map_exit.add_out_connector("OUT_1")
-    backward_state.add_edge(diff_tasklet, X_conn + "_grad", diff_map_exit,
-                            "IN_1", X_memlet)
-    backward_state.add_edge(
-        diff_map_exit, "OUT_1", backward_state.add_write(X + "_grad"), None,
-        Memlet.from_array(X + "_grad", X_grad_arr, wcr="lambda x, y: x + y"))
+        if tasklet.language is not dace.dtypes.Language.Python:
+            raise AutoDiffException(
+                "Expected tasklet with language Python, got language {}".
+                format(tasklet.language))
 
-
-def add_backward_pass(sdfg: dace.SDFG, forward_state: dace.SDFGState,
-                      target: dace.nodes.AccessNode):
-    """Generate the backward pass wrt. target.
-    """
-
-    # This is currently a bit ugly due to the constrains on graph structure.
-
-    target_arr = sdfg.arrays[target.data]
-    if target_arr.dtype not in [dace.float16, dace.float32, dace.float64]:
-        raise AutoDiffException(
-            "Expected dtype of x to be float, got {}".format(
-                target_arr.dtype.to_string()))
-
-    if len(target_arr.total_size.free_symbols) > 0 or int(
-            target_arr.total_size) != 1:
-        raise AutoDiffException(
-            "Targets with more than one element are currently unsupported in autodiff"
-        )
-
-    target_grad, target_grad_arr = sdfg.add_array(target.data + "_grad",
-                                                  target_arr.shape,
-                                                  target_arr.dtype)
-
-    def getpred(state: dace.SDFGState, node: nd.Node):
-        in_edges = state.in_edges(node)
-        preds = {edge.src for edge in in_edges}
-        if len(preds) > 1:
-            raise AutoDiffException("Unsupported graph structure for autodiff")
-        return next(iter(preds))
-
-    # this is a breath first search along collapsed maps
-    queue: Deque[Tuple[nd.AccessNode, dace.SDFGState]] = deque([target])
-    prev_state = forward_state
-    while queue:
-        current = queue.popleft()
-
-        if type(current) is not nd.AccessNode:
-            raise AutoDiffException("Unsupported graph structure for autodiff")
-
-        try:
-            map_x = getpred(forward_state, current)
-            task = getpred(forward_state, map_x)
-            map_e = getpred(forward_state, task)
-
-            if (type(map_e) is not nd.MapEntry or  #
-                    type(task) is not nd.Tasklet or  #
-                    type(map_x) is not nd.MapExit):
+        # tasklets should have scalar inputs
+        for _, _, _, _, memlet in self.state.in_edges(tasklet):
+            try:
+                _check_one(memlet.subset.num_elements())
+            except AutoDiffException as e:
                 raise AutoDiffException(
-                    "Unsupported graph structure for autodiff")
+                    "Autodiff only supported for scalar tasklets (tasklets with input memlets with volume 1)"
+                ) from e
 
-            input_edges = forward_state.in_edges(map_e)
-            inputs = list({edge.src for edge in input_edges})
-            for inp in inputs:
-                if type(inp) is not nd.AccessNode:
+        code_str = tasklet.code
+        if type(code_str) is ast.Module:
+            # unparse the tree
+            code_str = unparse(code_str)
+
+        output_exprs = code_to_exprs(code_str, tasklet.in_connectors,
+                                     tasklet.out_connectors)
+        rev_code = []
+
+        # the outputs of the reversed nodes are the grads of inputs of the original node
+        rev_outputs = set()
+        rev_inputs = set()
+
+        for output_conn, (dest_node, input_conn,
+                          memlet) in output_grads.items():
+            # tasklets should have scalar outputs
+            _check_one(memlet.subset.num_elements())
+            # for each output_conn...
+            for inp in required_grads:
+                # ...add the code to generate {inp}_grad
+                rev_outputs.add(inp + "_grad")
+
+                output_expr = output_exprs[output_conn]
+
+                # symbolically differentiate the output by inp
+                diff_expr = output_expr.diff(sp.symbols(inp))
+
+                if diff_expr.atoms(sp.Derivative):
+                    # the final result contains a call to sp.Derivative
                     raise AutoDiffException(
-                        "Unsupported graph structure for autodiff")
-                # generate the backward pass for this map
-                backward_state = sdfg.add_state()
-                diff_mapped_tasklet(sdfg, forward_state, backward_state, map_e,
-                                    map_x, task, current.data, inp.data)
+                        "Unable to symbolically differentiate expression: {}".
+                        format(diff_expr.expr))
 
-                # add interstate edges
-                sdfg.add_edge(prev_state, backward_state,
-                              dace.InterstateEdge())
-                prev_state = backward_state
+                rev_inputs |= _symbols_to_strings(
+                    diff_expr.free_symbols) | {output_conn + "_grad"}
 
-                # recursively generate backward pass for inp
-                if len(forward_state.in_edges(inp)) > 0:
-                    queue.append(inp)
+                rev_code.append(
+                    "{input}_grad = {output}_grad * ({diff_expr})".format(
+                        input=inp,
+                        output=output_conn,
+                        diff_expr=str(diff_expr)))
 
-        except StopIteration:
-            raise AutoDiffException("Unsupported graph structure")
+        return nd.Tasklet("_" + tasklet.label + "_reverse_",
+                          inputs=rev_inputs,
+                          outputs=rev_outputs,
+                          code="\n".join(rev_code))
+
+    def _reverse_MapExit(self, node: nd.Tasklet,
+                         output_grads: Dict[str, Tuple[nd.Node, str]],
+                         required_grads: List[str]):
+        pass

--- a/dace/autodiff/autodiff.py
+++ b/dace/autodiff/autodiff.py
@@ -5,6 +5,7 @@
 """
 import dace
 from dace import Memlet, SDFG, SDFGState
+from dace.graph.graph import MultiConnectorEdge
 import dace.graph.nodes as nd
 from dace.sdfg import ScopeSubgraphView
 from dace.graph.nxutil import dfs_topological_sort
@@ -15,7 +16,7 @@ import ast
 import itertools
 from collections import deque, defaultdict
 from copy import deepcopy as dc
-from typing import Iterator, Tuple, Deque, Dict, Set, List
+from typing import Iterator, Tuple, Deque, Dict, Set, List, Union
 
 import aenum
 import sympy as sp
@@ -115,6 +116,26 @@ def _invert_access(access: dace.AccessType) -> dace.AccessType:
     return access
 
 
+def _add_through_connector(node: Union[nd.MapEntry, nd.MapExit]):
+    i = 1
+    while "IN_{}".format(i) in node.in_connectors or "OUT_{}".format(
+            i) in node.out_connectors:
+        i += 1
+    node.add_in_connector("IN_{}".format(i))
+    node.add_out_connector("OUT_{}".format(i))
+    return "IN_{}".format(i), "OUT_{}".format(i)
+
+
+def _invert_map_connector(conn):
+    if conn[:2] == "IN":
+        return "OUT" + conn[2:]
+    elif conn[:3] == "OUT":
+        return "IN" + conn[3:]
+    else:
+        raise AutoDiffException(
+            "Could not parse map connector {}".format(conn))
+
+
 def _has_inplace_operation(state: dace.SDFGState,
                            target: nd.AccessNode) -> bool:
     """Returns true if state has any inplace operations
@@ -145,6 +166,19 @@ def _has_inplace_operation(state: dace.SDFGState,
                 return True
             seen_scalars.add(memlet_data)
     return False
+
+
+def _get_matching_entry(state: SDFGState, map_exit: nd.MapExit) -> nd.MapEntry:
+    """Get the matching `MapEntry` for a `MapExit`"""
+    cands = [
+        node for node in state.nodes()
+        if isinstance(node, nd.MapEntry) and node.map is map_exit.map
+    ]
+
+    if len(cands) != 1:
+        raise AutoDiffException(
+            "More than one map entry found for map {}".format(map_exit.map))
+    return cands[0]
 
 
 class BackwardPassGenerator:
@@ -183,6 +217,7 @@ class BackwardPassGenerator:
         except AutoDiffException as e:
             raise AutoDiffException("Expected scalar target") from e
 
+        # this is a mapping from forward node -> backward node, and forward map -> backward map
         self.reverse_map = {}
         if self.required_grads.difference(node.data
                                           for node in self.state.nodes()
@@ -223,7 +258,9 @@ class BackwardPassGenerator:
         self._reverse_subgraph(
             ScopeSubgraphView(self.state, list(required_nodes)))
 
-    def append_grad(self, conn):
+    def append_grad(self, conn, node):
+        if type(node) in [nd.MapExit, nd.MapEntry]:
+            return _invert_map_connector(conn)
         if conn is None:
             return None
         else:
@@ -239,97 +276,200 @@ class BackwardPassGenerator:
                     dfs_topological_sort(subgraph,
                                          subgraph.source_nodes(),
                                          target=self.target))):
-            if type(node) is nd.MapExit:
-                # TODO handle scopes
-                raise AutoDiffException("TODO")
-            else:
-                output_grads = [edge for edge in subgraph.out_edges(node)]
-                required_grads = [
-                    edge.dst_conn for edge in subgraph.in_edges(node)
-                ]
+            output_grads = [edge for edge in subgraph.out_edges(node)]
+            required_grads = [
+                edge.dst_conn for edge in subgraph.in_edges(node)
+            ]
 
-                rev: nd.Node = getattr(self, '_reverse_' +
-                                       type(node).__name__)(node, output_grads,
-                                                            required_grads)
-                # add rev to the graph and hook up the edges
-                self.reverse_map[node] = rev
-                subgraph.graph.add_node(rev)
+            if not hasattr(self, '_reverse_' + type(node).__name__):
+                raise AutoDiffException("Unsupported node type {}".format(
+                    type(node)))
 
-                # connect the gradients of the outputs (as inputs)
-                for _, output_conn, dest_node, input_conn, memlet in output_grads:
-                    dest_node = self.reverse_map[dest_node]
-                    if detect_reduction_type(memlet.wcr) not in [
-                            None, dace.dtypes.ReductionType.Sum
-                    ]:
+            rev: nd.Node = getattr(self, '_reverse_' + type(node).__name__)(
+                node, output_grads, required_grads)
+            # add rev to the graph and hook up the edges
+            self.reverse_map[node] = rev
+            subgraph.graph.add_node(rev)
+
+            # connect the gradients of the outputs (as inputs)
+            for _, output_conn, dest_node, input_conn, memlet in output_grads:
+                dest_node = self.reverse_map[dest_node]
+                if detect_reduction_type(memlet.wcr) not in [
+                        None, dace.dtypes.ReductionType.Sum
+                ]:
+                    raise AutoDiffException(
+                        "Unsupported reduction type {}".format(
+                            detect_reduction_type(memlet.wcr)))
+
+                memlet = dc(memlet)
+
+                # remove the WCR since these are now read edges
+                memlet.wcr = None
+
+                if memlet.data not in self.grad_memlets:
+                    # this grad hasn't been written before: initialize it
+                    array = self.state.parent.arrays[memlet.data]
+
+                    # this can clearly fail if someone chooses annoying array names; let's
+                    # ignore this for now
+                    if type(array) is dace.data.Scalar:
+                        self.sdfg.add_scalar(memlet.data + "_grad",
+                                             array.dtype,
+                                             storage=array.storage,
+                                             transient=array.transient,
+                                             toplevel=array.toplevel)
+                    elif type(array) is dace.data.Array:
+                        self.state.parent.add_array(
+                            memlet.data + "_grad",
+                            array.shape,
+                            array.dtype,
+                            storage=array.storage,
+                            materialize_func=array.materialize_func,
+                            transient=array.transient,
+                            strides=array.strides,
+                            offset=array.offset,
+                            toplevel=array.toplevel,
+                            allow_conflicts=array.allow_conflicts,
+                            total_size=array.total_size)
+                    else:
                         raise AutoDiffException(
-                            "Unsupported reduction type {}".format(
-                                detect_reduction_type(memlet.wcr)))
+                            "Unsupported data descriptor {}".format(array))
 
-                    memlet = dc(memlet)
+                self.grad_memlets[memlet.data].append(memlet)
+                memlet.data = memlet.data + "_grad"
+                subgraph.graph.add_edge(
+                    dest_node, self.append_grad(input_conn, dest_node), rev,
+                    self.append_grad(output_conn, rev), memlet)
 
-                    if memlet.data not in self.grad_memlets:
-                        # this grad hasn't been written before: initialize it
-                        array = self.state.parent.arrays[memlet.data]
+            if isinstance(node, nd.AccessNode):
+                # this means we are writing out a grad to an array. In this case, we need to set
+                # all incoming memlets to WCR Sum
+                # TODO @orausch there could be an intersection check here
+                for edge in subgraph.graph.in_edges(rev):
+                    for path_edge in subgraph.graph.memlet_tree(edge):
+                        path_edge.data.wcr = "lambda x, y: x + y"
 
-                        # this can clearly fail if someone chooses annoying array names; let's
-                        # ignore this for now
-                        if type(array) is dace.data.Scalar:
-                            self.sdfg.add_scalar(memlet.data + "_grad",
-                                                 array.dtype,
-                                                 storage=array.storage,
-                                                 transient=array.transient,
-                                                 toplevel=array.toplevel)
-                        elif type(array) is dace.data.Array:
-                            self.state.parent.add_array(
-                                memlet.data + "_grad",
-                                array.shape,
-                                array.dtype,
-                                storage=array.storage,
-                                materialize_func=array.materialize_func,
-                                transient=array.transient,
-                                strides=array.strides,
-                                offset=array.offset,
-                                toplevel=array.toplevel,
-                                allow_conflicts=array.allow_conflicts,
-                                total_size=array.total_size)
-                        else:
+            # connect any required inputs from the forward pass
+            required_inputs = rev.in_connectors.difference(
+                self.append_grad(edge.src_conn, node) for edge in output_grads)
+
+            for edge in subgraph.graph.in_edges(node):
+                if edge.dst_conn in required_inputs:
+
+                    path = subgraph.graph.memlet_path(edge)
+                    conn_map = dict()
+
+                    # TODO subgraph.graph or state here?
+                    for i, traversed_edge in enumerate(path):
+                        throw = False
+                        src = None
+                        dst = None
+                        src_conn = traversed_edge.src_conn
+                        dst_conn = traversed_edge.dst_conn
+
+                        if i == 0:
+                            # the start of the path should be in the forward pass
+                            src = traversed_edge.src
+                            throw |= type(
+                                traversed_edge.dst) is not nd.MapEntry
+
+                        if i == len(path) - 1:
+                            # the end of the path should be in the backward pass
+                            dst = self.reverse_map[traversed_edge.dst]
+                            throw |= type(
+                                traversed_edge.src) is not nd.MapEntry
+
+                        if i != 0 and i != len(path) - 1:
+                            throw |= type(
+                                traversed_edge.src) is not nd.MapEntry
+                            throw |= type(
+                                traversed_edge.dst) is not nd.MapEntry
+
+                        if len(path) == 1:
+                            # if len path == 1, throw will be true because the ends are not maps
+                            # however, this is fine in this case as long as we have code -> code or access -> code
+                            throw = not (
+                                (isinstance(traversed_edge.src, nd.CodeNode)
+                                 and isinstance(traversed_edge.dst,
+                                                nd.CodeNode)) or
+                                (isinstance(traversed_edge.src, nd.AccessNode)
+                                 and isinstance(traversed_edge.dst,
+                                                nd.CodeNode)))
+                        if throw:
                             raise AutoDiffException(
-                                "Unsupported data descriptor {}".format(array))
+                                "Unexpected graph structure")
 
-                    self.grad_memlets[memlet.data].append(memlet)
-                    memlet.data = memlet.data + "_grad"
-                    subgraph.graph.add_edge(dest_node,
-                                            self.append_grad(input_conn), rev,
-                                            self.append_grad(output_conn),
-                                            memlet)
+                        if dst is None:
+                            dst = self._find_backward_entry_node_for_map_entry(
+                                subgraph.graph, traversed_edge.dst)
+                            dst_conn, _src_conn = _add_through_connector(dst)
+                            conn_map[dst] = _src_conn
 
-                if isinstance(node, nd.AccessNode):
-                    # this means we are writing out a grad to an array. In this case, we need to set
-                    # all incoming memlets to WCR Sum
-                    # TODO @orausch there could be an intersection check here
-                    for edge in subgraph.graph.in_edges(rev):
-                        for path_edge in subgraph.graph.memlet_path(edge):
-                            path_edge.data.wcr = "lambda x, y: x + y"
+                        if src is None:
+                            src = self._find_backward_entry_node_for_map_entry(
+                                subgraph.graph, traversed_edge.src)
+                            src_conn = conn_map[src]
 
-                # connect any required inputs from the forward pass
-                required_inputs = rev.in_connectors.difference(
-                    self.append_grad(edge.src_conn) for edge in output_grads)
-                for src, src_conn, dst, dst_conn, memlet in subgraph.graph.in_edges(
-                        node):
-                    if dst_conn in required_inputs:
-                        subgraph.graph.add_edge(src, src_conn, rev, dst_conn,
-                                                memlet)
+                        subgraph.graph.add_edge(src, src_conn, dst, dst_conn,
+                                                traversed_edge.data)
+
+    def _find_backward_entry_node_for_map_entry(
+            self, graph, entry_node: nd.MapEntry) -> nd.ExitNode:
+        """Find the entry node in the backward pass corresponding to the exit node opened by
+           `entry_node` (where `entry_node` is a node from the forward pass).
+        """
+        src_candidates = [
+            node for node in graph.nodes() if type(node) is nd.MapEntry
+            and node.map == self.reverse_map[entry_node.map]
+        ]
+        if len(src_candidates) != 1:
+            # this shouldn't happen; if we are within a scope, the exit nodes
+            # for the scope should already exist in the backward pass
+            raise AutoDiffException("Invalid graph")
+
+        return src_candidates[0]
 
     def _reverse_AccessNode(self, node: nd.AccessNode,
-                            output_grads: Dict[str, Tuple[nd.Node, str,
-                                                          Memlet]],
+                            output_grads: List[MultiConnectorEdge],
                             required_grads: List[str]):
 
         return nd.AccessNode(node.data + "_grad",
                              access=_invert_access(node.access))
 
+    def _reverse_MapEntry(
+        self,
+        node: nd.MapEntry,
+        output_grads: List[MultiConnectorEdge],
+        required_grads: List[str],
+    ):
+        rev = nd.MapExit(self.reverse_map[node.map])
+
+        for conn in node.in_connectors:
+            rev.add_in_connector(conn)
+
+        for conn in node.out_connectors:
+            rev.add_out_connector(conn)
+
+        return rev
+
+    def _reverse_MapExit(
+        self,
+        node: nd.MapExit,
+        output_grads: List[MultiConnectorEdge],
+        required_grads: List[str],
+    ):
+        self.reverse_map[node.map] = dc(node.map)
+
+        rev = nd.MapEntry(self.reverse_map[node.map])
+        for conn in node.in_connectors:
+            rev.add_in_connector(conn)
+
+        for conn in node.out_connectors:
+            rev.add_out_connector(conn)
+        return rev
+
     def _reverse_Tasklet(self, tasklet: nd.Tasklet,
-                         output_grads: Dict[str, Tuple[nd.Node, str, Memlet]],
+                         output_grads: List[MultiConnectorEdge],
                          required_grads: List[str]) -> nd.Tasklet:
 
         if tasklet.language is not dace.dtypes.Language.Python:
@@ -343,7 +483,7 @@ class BackwardPassGenerator:
                 _check_one(memlet.subset.num_elements())
             except AutoDiffException as e:
                 raise AutoDiffException(
-                    "Autodiff only supported for scalar tasklets (tasklets with input memlets with volume 1)"
+                    "Autodiff only supported for tasklets with scalar inputs and outputs"
                 ) from e
 
         code_str = tasklet.code
@@ -391,8 +531,3 @@ class BackwardPassGenerator:
                           inputs=rev_inputs,
                           outputs=rev_outputs,
                           code="\n".join(rev_code))
-
-    def _reverse_MapExit(self, node: nd.Tasklet,
-                         output_grads: Dict[str, Tuple[nd.Node, str]],
-                         required_grads: List[str]):
-        pass

--- a/dace/autodiff/autodiff.py
+++ b/dace/autodiff/autodiff.py
@@ -23,7 +23,6 @@ import sympy as sp
 from sympy.parsing.sympy_parser import parse_expr
 from astunparse import unparse
 
-
 class AutoDiffException(Exception):
     """Base class for all exceptions related to automatic differentiation"""
     pass
@@ -586,7 +585,8 @@ class BackwardPassGenerator:
         #        dtypes.ReductionType.Max, dtypes.ReductionType.Min
         #]:
         #    # in this case we need to modify the forward pass and add an argmin/argmax
-        #    # TODO
+        #    
+        #    
         #    pass
         else:
             raise AutoDiffException(
@@ -619,6 +619,9 @@ class BackwardPassGenerator:
         output_exprs = code_to_exprs(code_str, tasklet.in_connectors,
                                      tasklet.out_connectors)
 
+        # for each output that an input is used in, there will be an entry for the expression of the
+        # grad in this list in the final code snippet. When we generate the final code for the
+        # reverse tasklet, we need to add them all up.
         rev_code = defaultdict(list)
 
         # the outputs of the reversed nodes are the grads of inputs of the original node

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -196,6 +196,58 @@ _BYTES = {
     numpy.complex128: 16,
 }
 
+# Translation of types to C types
+_CTYPES = {
+    int: "int",
+    float: "float",
+    bool: "bool",
+    numpy.bool: "bool",
+    numpy.int8: "char",
+    numpy.int16: "short",
+    numpy.int32: "int",
+    numpy.int64: "long long",
+    numpy.uint8: "unsigned char",
+    numpy.uint16: "unsigned short",
+    numpy.uint32: "unsigned int",
+    numpy.uint64: "unsigned long long",
+    numpy.float16: "dace::float16",
+    numpy.float32: "float",
+    numpy.float64: "double",
+    numpy.complex64: "dace::complex64",
+    numpy.complex128: "dace::complex128",
+}
+
+_LIMITS = {
+    'int': "INT_{}",
+    'float': "FLT_{}",
+    'char': "CHAR_{}",
+    'short': "SHRT_{}",
+    'long long': "LLONG_{}",
+    'unsigned char': "UCHAR_{}",
+    'unsigned short': "USHRT_{}",
+    'unsigned int': "UINT_{}",
+    'unsigned long long': "ULLONG_{}",
+    'double': "DBL_{}",
+    #'dace::float16': numpy.float16,
+}
+
+
+def max_value(dtype):
+    """Get a max value literal for `dtype`."""
+    ctype = dtype.ctype
+    if ctype == "bool":
+        return "true"
+    else:
+        return _LIMITS[ctype].format("MAX")
+
+def min_value(dtype):
+    """Get a max value literal for `dtype`."""
+    ctype = dtype.ctype
+    if ctype == "bool":
+        return "false"
+    else:
+        return _LIMITS[ctype].format("MIN")
+
 
 class typeclass(object):
     """ An extension of types that enables their use in DaCe.

--- a/dace/frontend/python/nested_call.py
+++ b/dace/frontend/python/nested_call.py
@@ -25,8 +25,11 @@ class NestedCall():
 
     def __call__(self, func):
         def nested(*args, **kwargs):
-            result = func(self.sdfg, self.add_state(func.__name__), *args,
-                          **kwargs)
+            result = func(
+                self.sdfg,
+                self.add_state("{}_nested_call_{}_{}".format(
+                    self.state.label, self.count, func.__name__)), *args,
+                **kwargs)
             if isinstance(result, tuple) and type(result[0]) is NestedCall:
                 self.last_state = result[0].last_state
                 result = result[1]
@@ -34,10 +37,9 @@ class NestedCall():
 
         return nested
 
-    def add_state(self, func_name):
+    def add_state(self, label=None):
         self.count += 1
-        state = self.sdfg.add_state("{}_nested_call_{}_{}".format(
-            self.state.label, self.count, func_name))
+        state = self.sdfg.add_state(label=label)
         self.sdfg.add_edge(self.last_state, state, dace.InterstateEdge())
         self.last_state = state
         return state

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -386,7 +386,7 @@ def _max(sdfg: SDFG, state: SDFGState, a: str, axis=None):
                    "lambda x, y: max(x, y)",
                    a,
                    axis=axis,
-                   identity=-9999999999999)
+                   identity=dtypes.min_value(sdfg.arrays[a].dtype))
 
 
 @oprepo.replaces('numpy.min')
@@ -397,7 +397,7 @@ def _min(sdfg: SDFG, state: SDFGState, a: str, axis=None):
                    "lambda x, y: min(x, y)",
                    a,
                    axis=axis,
-                   identity=999999999999)
+                   identity=dtypes.max_value(sdfg.arrays[a].dtype))
 
 
 @oprepo.replaces('numpy.argmax')
@@ -433,7 +433,8 @@ def _argminmax(sdfg: SDFG,
                a: str,
                axis,
                func,
-               result_type=dace.int32):
+               result_type=dace.int32,
+               return_both=False):
     nest = NestedCall(sdfg, state)
 
     assert func in ['min', 'max']
@@ -452,58 +453,98 @@ def _argminmax(sdfg: SDFG,
 
     val_and_idx = dace.struct('_val_and_idx', val=a_arr.dtype, idx=result_type)
 
-    # convert to array of structs
-    structs, structs_arr = sdfg.add_temp_transient(a_arr.shape, val_and_idx)
-
     # HACK: at the time of writing, the reduce op on structs doesn't work unless we init the output
-    # array for that reason we will init the output array with (-1, -inf) in the loop. This should
+    # array for that reason we will init the output array with (-1, +-inf) in the loop. This should
     # be removed once the issue is resolved
     reduced_structs, reduced_struct_arr = sdfg.add_temp_transient(
         reduced_shape, val_and_idx)
 
-    code = ("__out = _val_and_idx(val=__in, idx=__i{})\n".format(axis) +
-            "__init = _val_and_idx(val={}1e38, idx=-1)".format('-' if func ==
-                                                               'max' else ''))
+    code = "__init = _val_and_idx(val={}, idx=-1)".format(
+        dtypes.min_value(a_arr.dtype) if func ==
+        'max' else dtypes.max_value(a_arr.dtype))
 
-    state.add_mapped_tasklet(
+    nest.add_state().add_mapped_tasklet(
         name="_arg{}_convert_".format(func),
         map_ranges={
             '__i%d' % i: '0:%s' % n
-            for i, n in enumerate(a_arr.shape)
+            for i, n in enumerate(a_arr.shape) if i != axis
         },
-        inputs={
-            "__in":
-            Memlet.simple(
-                a, ','.join('__i%d' % i for i in range(len(a_arr.shape))))
-        },
+        inputs={},
         code=code,
         outputs={
             '__init':
             Memlet.simple(
                 reduced_structs, ','.join('__i%d' % i
                                           for i in range(len(a_arr.shape))
-                                          if i != axis)),
-            '__out':
-            Memlet.simple(
-                structs,
-                ','.join('__i%d' % i for i in range(len(a_arr.shape))))
+                                          if i != axis))
         },
         external_edges=True)
 
-    # reduce array of structs
-    nest(_reduce)(  # comment for yapf
-        "lambda x, y: _val_and_idx(val={}(x.val, y.val), idx=(x.idx if x.val {} y.val else y.idx))"
-        .format(func, '>' if func == 'max' else '<'),
-        structs,
-        out_array=reduced_structs,
-        axis=axis)
+    nest.add_state().add_mapped_tasklet(
+        name="_arg{}_reduce_".format(func),
+        map_ranges={
+            '__i%d' % i: '0:%s' % n
+            for i, n in enumerate(a_arr.shape)
+        },
+        inputs={
+            '__in':
+            Memlet.simple(
+                a, ','.join('__i%d' % i for i in range(len(a_arr.shape))))
+        },
+        code="__out = _val_and_idx(idx={}, val=__in)".format("__i%d" % axis),
+        outputs={
+            '__out':
+            Memlet.simple(
+                reduced_structs,
+                ','.join('__i%d' % i for i in range(len(a_arr.shape))
+                         if i != axis),
+                wcr_str=("lambda x, y:"
+                         "_val_and_idx(val={}(x.val, y.val), "
+                         "idx=(y.idx if x.val {} y.val else x.idx))").format(
+                             func, '<' if func == 'max' else '>'))
+        },
+        external_edges=True)
 
-    # map to int64
-    out, outarr = sdfg.add_temp_transient(sdfg.arrays[reduced_structs].shape,
-                                          dace.int64)
-    nest(_elementwise)("lambda x: x.idx", reduced_structs, out_array=out)
+    if return_both:
+        outidx, outidxarr = sdfg.add_temp_transient(
+            sdfg.arrays[reduced_structs].shape, result_type)
+        outval, outvalarr = sdfg.add_temp_transient(
+            sdfg.arrays[reduced_structs].shape, a_arr.dtype)
 
-    return nest, out
+        nest.add_state().add_mapped_tasklet(
+            name="_arg{}_extract_".format(func),
+            map_ranges={
+                '__i%d' % i: '0:%s' % n
+                for i, n in enumerate(a_arr.shape) if i != axis
+            },
+            inputs={
+                '__in':
+                Memlet.simple(
+                    reduced_structs, ','.join('__i%d' % i for i in range(len(a_arr.shape)) if i != axis))
+            },
+            code="__out_val = __in.val\n__out_idx = __in.idx",
+            outputs={
+                '__out_val':
+                Memlet.simple(
+                    outval,
+                    ','.join('__i%d' % i for i in range(len(a_arr.shape))
+                             if i != axis)),
+                '__out_idx':
+                Memlet.simple(
+                    outidx,
+                    ','.join('__i%d' % i for i in range(len(a_arr.shape))
+                             if i != axis))
+            },
+            external_edges=True)
+
+        return nest, (outval, outidx)
+
+    else:
+        # map to result_type
+        out, outarr = sdfg.add_temp_transient(
+            sdfg.arrays[reduced_structs].shape, result_type)
+        nest(_elementwise)("lambda x: x.idx", reduced_structs, out_array=out)
+        return nest, out
 
 
 ##############################################################################

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -506,9 +506,9 @@ def _argminmax(sdfg: SDFG,
         external_edges=True)
 
     if return_both:
-        outidx, outidxarr = sdfg.add_temp_transient(
+        outidx, outidxarr = sdfg.add_transient("__" + sdfg.temp_data_name(),
             sdfg.arrays[reduced_structs].shape, result_type)
-        outval, outvalarr = sdfg.add_temp_transient(
+        outval, outvalarr = sdfg.add_transient("__" + sdfg.temp_data_name(),
             sdfg.arrays[reduced_structs].shape, a_arr.dtype)
 
         nest.add_state().add_mapped_tasklet(

--- a/dace/frontend/torch_replacements.py
+++ b/dace/frontend/torch_replacements.py
@@ -69,4 +69,4 @@ def _softmax(sdfg: SDFG, state: SDFGState, inpname: str, dim: int):
                 out_name,
                 ','.join("__i" + str(i) for i in range(len(inparr.shape))))
         }, external_edges=True)
-    return out_name
+    return nest, out_name

--- a/dace/frontend/torch_replacements.py
+++ b/dace/frontend/torch_replacements.py
@@ -1,0 +1,72 @@
+"""Deep Learning ops. Functions should be similar to torch.nn.functional"""
+
+from typing import Dict, Union, Tuple, List
+
+import numpy as np
+import dace
+from dace.memlet import Memlet
+from dace.sdfg import SDFG, SDFGState
+from dace.frontend.common import op_repository as oprepo
+from dace.frontend.python.replacements import _reduce, _max, _sum
+import dace.graph.nodes as nd
+from dace.frontend.python.nested_call import NestedCall
+
+@oprepo.replaces('torch.nn.functional.softmax')
+def _softmax(sdfg: SDFG, state: SDFGState, inpname: str, dim: int):
+
+    nest = NestedCall(sdfg, state)
+    inparr = sdfg.arrays[inpname]
+
+    tmp_max = nest(_max)(inpname, axis=dim)
+
+    out_tmp_name, out_tmp_arr = sdfg.add_temp_transient(inparr.shape, inparr.dtype)
+    nest.add_state().add_mapped_tasklet(
+        "_softmax_exp_",
+        map_ranges={
+            "__i" + str(i): "0:" + str(shape)
+            for i, shape in enumerate(inparr.shape)
+        },
+        inputs={
+            '__max':
+            Memlet.simple(
+                tmp_max, ','.join("__i" + str(i) for i in range(len(inparr.shape))
+                                  if i != dim)),
+            '__x':
+            Memlet.simple(
+                inpname, ','.join("__i" + str(i) for i in range(len(inparr.shape))))
+        },
+        code='__out = exp(__x - __max)',
+        outputs={
+            '__out':
+            Memlet.simple(
+                out_tmp_name,
+                ','.join("__i" + str(i) for i in range(len(inparr.shape))))
+        },
+        external_edges=True)
+
+    tmp_sum = nest(_sum)(out_tmp_name, axis=dim)
+
+    out_name, out_arr = sdfg.add_temp_transient(inparr.shape, inparr.dtype)
+    nest.add_state().add_mapped_tasklet(
+        "_softmax_div_",
+        map_ranges={
+            "__i" + str(i): "0:" + str(shape)
+            for i, shape in enumerate(inparr.shape)
+        },
+        inputs={
+            '__sum':
+            Memlet.simple(
+                tmp_sum, ','.join("__i" + str(i) for i in range(len(inparr.shape))
+                                  if i != dim)),
+            '__exp':
+            Memlet.simple(
+                out_tmp_name, ','.join("__i" + str(i) for i in range(len(inparr.shape))))
+        },
+        code='__out = __exp / __sum',
+        outputs={
+            '__out':
+            Memlet.simple(
+                out_name,
+                ','.join("__i" + str(i) for i in range(len(inparr.shape))))
+        }, external_edges=True)
+    return out_name

--- a/dace/graph/graph.py
+++ b/dace/graph/graph.py
@@ -40,6 +40,9 @@ class Edge(object):
         yield self._dst
         yield self._data
 
+    def __repr__(self):
+        return str(list(self))
+
     def to_json(self, parent_graph):
         # Slight hack to preserve the old format (attributes should not behave like this)
         memlet_ret = self.data.to_json(parent_graph)

--- a/dace/graph/graph.py
+++ b/dace/graph/graph.py
@@ -305,28 +305,30 @@ class Graph(object):
                     queue.append(next_node)
                 yield e
 
-    def dfs_edges(G, source, condition=None):
+    def dfs_edges(G, source, condition=None, reverse=False):
         """Traverse a graph (DFS) with an optional condition to filter out nodes
         """
         if isinstance(source, list): nodes = source
         else: nodes = [source]
         visited = set()
+        edge_getter = G.out_edges if not reverse else G.in_edges
         for start in nodes:
             if start in visited:
                 continue
             visited.add(start)
-            stack = [(start, G.out_edges(start).__iter__())]
+            stack = [(start, edge_getter(start).__iter__())]
             while stack:
                 parent, children = stack[-1]
                 try:
                     e = next(children)
-                    if e.dst not in visited:
+                    next_node = e.dst if not reverse else e.src
+                    if next_node not in visited:
                         visited.add(e.dst)
                         if condition is None or condition(
                                 e.src, e.dst, e.data):
                             yield e
                             stack.append(
-                                (e.dst, G.out_edges(e.dst).__iter__()))
+                                (next_node, edge_getter(next_node).__iter__()))
                 except StopIteration:
                     stack.pop()
 

--- a/dace/graph/nxutil.py
+++ b/dace/graph/nxutil.py
@@ -102,7 +102,7 @@ def depth_limited_dfs_iter(source, depth):
             stack.pop()
 
 
-def dfs_topological_sort(G, sources=None, condition=None):
+def dfs_topological_sort(G, sources=None, condition=None, target=None):
     """ Produce nodes in a depth-first topological ordering.
 
     The function produces nodes in a depth-first topological ordering
@@ -114,6 +114,7 @@ def dfs_topological_sort(G, sources=None, condition=None):
     :param sources: (optional) node or list of nodes that
                     specify starting point(s) for depth-first search and return
                     edges in the component reachable from source.
+    :param target: (optional) A target node in `G`. The search will stop when this node is reached.
     :return: A generator of edges in the lastvisit depth-first-search.
 
     @note: Based on http://www.ics.uci.edu/~eppstein/PADS/DFS.py
@@ -157,6 +158,8 @@ def dfs_topological_sort(G, sources=None, condition=None):
                     visited.add(child)
                     if condition is None or condition(parent, child):
                         yield child
+                        if target is not None and child is target:
+                            break
                         stack.append((child, iter(G.neighbors(child))))
             except StopIteration:
                 stack.pop()

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -194,6 +194,7 @@ class Memlet(object):
             :param datadesc: The data descriptor object.
             :param wcr: The conflict resolution lambda.
             @type datadesc: Data.
+            :param wcr: The write conflict resolution lambda.
         """
         range = subsets.Range.from_array(datadesc)
         return Memlet(dataname, range.num_elements(), range, 1, wcr=wcr)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'numpy', 'networkx >= 2.2', 'astunparse', 'sympy', 'pyyaml', 'ply',
         'websockets', 'requests', 'flask', 'scikit-build', 'cmake', 'aenum'
     ],
-    extras_require={'testing': ['coverage', 'scipy', 'absl-py', 'opt_einsum']},
+    extras_require={'testing': ['coverage', 'scipy', 'absl-py', 'opt_einsum', 'torch']},
     entry_points={
         'console_scripts': [
             'dacelab = dace.frontend.octave.dacelab:main',

--- a/tests/autodiff/torch_test.py
+++ b/tests/autodiff/torch_test.py
@@ -1,0 +1,179 @@
+import torch
+import numpy as np
+import dace
+import dace.graph.nodes as nd
+from dace.autodiff import add_backward_pass
+from dace.libraries.blas import ExpandGemmPure
+from dace.transformation import optimizer
+
+all_tests = []
+
+
+def correctness_test(func):
+    all_tests.append(func)
+    return func
+
+
+class SDFGBackwardRunner:
+    def __init__(self, sdfg, target, required_grads=None):
+        self.sdfg = sdfg
+        self.target = target
+        self.required_grads = required_grads
+        state = sdfg.nodes()[0]
+
+        matches = [
+            node for node in state.nodes()
+            if type(node) is nd.AccessNode and node.data == target
+        ]
+        if len(matches) > 1:
+            raise ValueError(
+                "Found more than one accessnode with data {}".format(target))
+
+        add_backward_pass(sdfg, state, matches[0])
+        self.sdfg.apply_strict_transformations()
+
+    def run(self, **inputs):
+        # zero out all arrays
+        intermediate_arrs = {
+            name: np.zeros(arr.shape, dtype=getattr(np, arr.dtype.to_string()))
+            for name, arr in self.sdfg.arrays.items()
+            if name != self.target + "_grad" if not name.startswith("__")
+            if name not in inputs if not arr.transient
+        }
+        inputs.update(intermediate_arrs)
+        inputs[self.target + "_grad"] = np.ones(
+            (1, ),
+            dtype=getattr(np, self.sdfg.arrays[self.target].dtype.to_string()))
+        self.sdfg.save("out.sdfg")
+        self.sdfg(**inputs)
+
+        results = {
+            name: arr
+            for name, arr in inputs.items()
+            if name.endswith("_grad") and name != self.target + "_grad"
+            if self.required_grads is None or name in self.required_grads
+        }
+        return results
+
+
+def check_correctness(runner: SDFGBackwardRunner, pytorch_func, inputs):
+    sdfg_dict = {name: arr.copy() for name, arr in inputs.items()}
+    torch_dict = {
+        name: torch.tensor(arr.copy(), requires_grad=True)
+        for name, arr in inputs.items()
+    }
+
+    sdfg_results = runner.run(**sdfg_dict)
+    torch_results = pytorch_func(**torch_dict)
+
+    for k, v in torch_results.items():
+        v = v.detach().numpy()
+        diff = np.linalg.norm(sdfg_results[k] - v) / (v.shape[0] * v.shape[1])
+        assert diff < 1e-5
+
+
+@correctness_test
+def test_gemm():
+    def torch_gemm(*, X, Y):
+        Z = X @ Y
+        S = Z.sum()
+        S.backward()
+        return dict(X_grad=X.grad, Y_grad=Y.grad)
+
+    @dace.program
+    def dace_gemm(X: dace.float32[5, 4], Y: dace.float32[4, 3],
+                  Z: dace.float32[5, 3], S: dace.float32[1]):
+
+        Z[:] = X @ Y
+
+        @dace.map(_[0:5, 0:3])
+        def summap(i, j):
+            s >> S(1, lambda x, y: x + y)[0]
+            z << Z[i, j]
+            s = z
+
+    sdfg = dace_gemm.to_sdfg()
+    state = sdfg.nodes()[0]
+    sdfg.expand_library_nodes()
+    sdfg.apply_strict_transformations()
+
+    return SDFGBackwardRunner(sdfg, "S"), torch_gemm, dict(
+        X=np.random.rand(5, 4).astype(np.float32),
+        Y=np.random.rand(4, 3).astype(np.float32))
+
+
+@correctness_test
+def test_sum():
+    def torch_sum(*, X, Y):
+        Z = X + Y
+        Z = Z * Z
+        S = Z.sum()
+        S.backward()
+        return dict(X_grad=X.grad, Y_grad=Y.grad)
+
+    @dace.program
+    def dace_sum(X: dace.float32[3, 3], Y: dace.float32[3, 3],
+                 Z: dace.float32[3, 3], S: dace.float32[1]):
+
+        Z[:] = X + Y
+
+        @dace.map(_[0:3, 0:3])
+        def summap(i, j):
+            s >> S(1, lambda x, y: x + y)[0]
+            z << Z[i, j]
+            s = z * z
+
+    sdfg = dace_sum.to_sdfg()
+    state = sdfg.nodes()[0]
+
+    return SDFGBackwardRunner(sdfg, "S"), torch_sum, dict(
+        X=np.random.rand(3, 3).astype(np.float32),
+        Y=np.random.rand(3, 3).astype(np.float32))
+
+
+@correctness_test
+def test_add_mmul_transpose_log():
+    def torch_func(*, X, Y, W):
+
+        Xt = X.T
+        YW = W * Y
+        Z = Xt @ YW
+        Zl = torch.log(Z)
+
+        S = Zl.sum()
+        S.backward()
+        return dict(X_grad=X.grad, Y_grad=Y.grad)
+
+    @dace.program
+    def dace_func(X: dace.float32[4, 5], Y: dace.float32[4, 3],
+                  W: dace.float32[4, 3], Z: dace.float32[5, 3],
+                  S: dace.float32[1]):
+
+        Xt[:] = np.transpose(X)
+        YW[:] = W * Y
+        Z[:] = Xt @ YW
+
+        @dace.map(_[0:5, 0:3])
+        def summap(i, j):
+            s >> S(1, lambda x, y: x + y)[0]
+            z << Z[i, j]
+            s = log(z)
+
+    sdfg = dace_func.to_sdfg()
+    state = sdfg.nodes()[0]
+    sdfg.expand_library_nodes()
+    sdfg.apply_strict_transformations()
+
+    return SDFGBackwardRunner(sdfg, "S"), torch_func, dict(
+        X=np.random.rand(4, 5).astype(np.float32),
+        W=np.random.rand(4, 3).astype(np.float32),
+        Y=np.random.rand(4, 3).astype(np.float32))
+
+
+def test_all():
+    for test in all_tests:
+        check_correctness(*test())
+
+
+if __name__ == "__main__":
+    test_all()

--- a/tests/autodiff/torch_test.py
+++ b/tests/autodiff/torch_test.py
@@ -28,6 +28,7 @@ def correctness_test(func):
             v = v.detach().numpy()
             diff = np.linalg.norm(sdfg_results[k] - v) / reduce(
                 lambda x, y: x * y, v.shape)
+            print("Difference:", diff)
             assert diff < 1e-5
 
     all_tests.append(check_correctness)
@@ -476,4 +477,6 @@ def test_reduce_node_1_axis_and_none_axis():
 
 if __name__ == "__main__":
     for test in all_tests:
+        print("START: {}".format(test.__name__))
         test()
+        print("END: {}".format(test.__name__))

--- a/tests/autodiff/torch_test.py
+++ b/tests/autodiff/torch_test.py
@@ -374,20 +374,12 @@ def test_add_mmul_transpose_log():
 
         S = Zl.sum()
         S.backward()
-        return dict(X=X,
-                    Y=Y,
-                    W=W,
-                    YW=YW,
-                    Z=Z,
-                    X_grad=X.grad,
-                    Y_grad=Y.grad)
-    
+        return dict(X_grad=X.grad, Y_grad=Y.grad, W_grad=W.grad)
+
     @dace.program
     def dace_func(X: dace.float32[4, 5], Y: dace.float32[4, 3],
                   W: dace.float32[4, 3], Z: dace.float32[5, 3],
-                  YW: dace.float32[4, 3],
-                  Xt: dace.float32[5, 4],
-                  S: dace.float32[1]):
+                  YW: dace.float32[4, 3], S: dace.float32[1]):
 
         Xt[:] = np.transpose(X)
         YW[:] = W * Y
@@ -400,16 +392,13 @@ def test_add_mmul_transpose_log():
             s = log(z + 1)
 
     sdfg = dace_func.to_sdfg()
-    
+
     return SDFGBackwardRunner(sdfg, "S"), torch_func, dict(
         X=np.random.rand(4, 5).astype(np.float32),
         W=np.random.rand(4, 3).astype(np.float32),
         Y=np.random.rand(4, 3).astype(np.float32))
 
 
-#def test_all():
-#    for test in all_tests:
-#        test()
-
-#if __name__ == "__main__":
-#    test_all()
+if __name__ == "__main__":
+    for test in all_tests:
+        test()

--- a/tests/numpy/reductions_test.py
+++ b/tests/numpy/reductions_test.py
@@ -30,6 +30,26 @@ def test_min_1(A: dace.float64[10, 5, 3]):
 
 
 @compare_numpy_output
+def test_min_int32(A: dace.int32[10, 5, 3]):
+    return np.min(A, axis=1)
+
+
+@compare_numpy_output
+def test_min_int64(A: dace.int64[10, 5, 3]):
+    return np.min(A, axis=1)
+
+
+@compare_numpy_output
+def test_max_int32(A: dace.int32[10, 5, 3]):
+    return np.max(A, axis=1)
+
+
+@compare_numpy_output
+def test_max_int64(A: dace.int64[10, 5, 3]):
+    return np.max(A, axis=1)
+
+
+@compare_numpy_output
 def test_max_1(A: dace.float64[10, 5, 3]):
     return np.max(A, axis=1)
 
@@ -44,6 +64,53 @@ def test_argmin_1(A: dace.float64[10, 5, 3]):
     return np.argmin(A, axis=1)
 
 
+@compare_numpy_output
+def test_argmin_1_int32(A: dace.int32[10, 5, 3]):
+    return np.argmin(A, axis=1)
+
+
+@compare_numpy_output
+def test_argmin_1_int64(A: dace.int64[10, 5, 3]):
+    return np.argmin(A, axis=1)
+
+
+@compare_numpy_output
+def test_argmax_1_int32(A: dace.int32[10, 5, 3]):
+    return np.argmax(A, axis=1)
+
+
+@compare_numpy_output
+def test_argmax_1_int64(A: dace.int64[10, 5, 3]):
+    return np.argmax(A, axis=1)
+
+
+def test_return_both():
+    from dace.frontend.python.replacements import _argminmax
+
+    sdfg = dace.SDFG("test_return_both")
+    state = sdfg.add_state()
+
+    sdfg.add_array("IN", [10, 5, 3], dace.float64)
+
+    _, (outval, outidx) = _argminmax(sdfg, state, "IN", 1, "min", return_both=True)
+
+    IN = np.random.rand(10, 5, 3)
+    OUT_IDX = np.zeros((10, 3), dtype=np.int32)
+    OUT_VAL = np.zeros((10, 3), dtype=np.float64)
+
+
+    sdfg.arrays[outval].transient = False
+    sdfg.arrays[outidx].transient = False
+
+    sdfg(**{"IN": IN.copy(), outval: OUT_VAL, outidx: OUT_IDX})
+
+    breakpoint()
+
+    np.allclose(OUT_IDX, np.argmin(IN.copy(), axis=1))
+    np.allclose(OUT_VAL, np.min(IN.copy(), axis=1))
+
+    
+    
 def test_argmin_result_type():
     @dace.program
     def test_argmin_result(A: dace.float64[10, 5, 3]):
@@ -52,14 +119,32 @@ def test_argmin_result_type():
     res = test_argmin_result(np.random.rand(10, 5, 3))
     assert res.dtype == np.int64
 
+    @dace.program
+    def test_argmin_result(A: dace.float64[10, 5, 3]):
+        return np.argmin(A, axis=1)
+
+    res = test_argmin_result(np.random.rand(10, 5, 3))
+    assert res.dtype == np.int32
+
 
 if __name__ == '__main__':
+
+    # generated with cat tests/numpy/reductions_test.py | grep -oP '(?<=^def ).*(?=\()' | awk '{print $0 "()"}'
     test_sum()
     test_sum_1()
-    test_max()
-    test_max_1()
     test_min()
+    test_max()
     test_min_1()
+    test_min_int32()
+    test_min_int64()
+    test_max_int32()
+    test_max_int64()
+    test_max_1()
     test_argmax_1()
     test_argmin_1()
+    test_argmin_1_int32()
+    test_argmin_1_int64()
+    test_argmax_1_int32()
+    test_argmax_1_int64()
+    test_return_both()
     test_argmin_result_type()

--- a/tests/torch/softmax_test.py
+++ b/tests/torch/softmax_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+
 def compare_function(torch_name, kwargs, inputs):
     def decorator(func):
         def test():
@@ -19,7 +20,9 @@ def compare_function(torch_name, kwargs, inputs):
             dace_result = func(dace_input)
 
             assert np.allclose(torch_result, dace_result)
+
         return test
+
     return decorator
 
 
@@ -33,6 +36,13 @@ def test_softmax_1(X: dace.float64[10, 9]):
 @dace.program
 def test_softmax_0(X: dace.float64[10, 9]):
     return F.softmax(X, 0)
+
+
+# currently fails
+@compare_function("softmax", dict(dim=0), np.random.rand(10, 9))
+@dace.program
+def test_softmax_full_path(X: dace.float64[10, 9]):
+    return torch.nn.functional.softmax(X, 0)
 
 
 if __name__ == "__main__":

--- a/tests/torch/softmax_test.py
+++ b/tests/torch/softmax_test.py
@@ -1,0 +1,40 @@
+import dace
+from copy import deepcopy as dc
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+def compare_function(torch_name, kwargs, inputs):
+    def decorator(func):
+        def test():
+            dace_input = dc(inputs)
+
+            if type(inputs) is list:
+                torch_input = [torch.tensor(inp) for inp in dc(inputs)]
+            else:
+                torch_input = torch.tensor(dc(inputs))
+
+            torch_result = getattr(F, torch_name)(torch_input, **kwargs)
+            dace_result = func(dace_input)
+
+            assert np.allclose(torch_result, dace_result)
+        return test
+    return decorator
+
+
+@compare_function("softmax", dict(dim=1), np.random.rand(10, 9))
+@dace.program
+def test_softmax_1(X: dace.float64[10, 9]):
+    return F.softmax(X, 1)
+
+
+@compare_function("softmax", dict(dim=0), np.random.rand(10, 9))
+@dace.program
+def test_softmax_0(X: dace.float64[10, 9]):
+    return F.softmax(X, 0)
+
+
+if __name__ == "__main__":
+    test_softmax_0()
+    test_softmax_1()


### PR DESCRIPTION
Add autodiff support to SDFGs.

~~Currently, only SDFGs consisting of consecutive mapped tasklets are supported.~~
The other constraints are:
- The tasklets should input and output scalar quantities
- Inplace operations aren't supported
- ~~Tasklet code should be a single assignment statement, assigning a symbolically differentiable expression~~


TODO:
- [x] add a feature similar to `requires_grad` from pytorch
  - [x] handle multi-output tasklets
- [x] add some more pytorch tests
- [x] handle more complex expressions using stuff from `detect_reduction_type`
- [x] visitor pattern rewrite 
    - [x] `AccessNode`
    - [x] `Tasklet`
    - [x] `MapExit`, `MapEntry`
    - [ ] `Reduce`
      - [x] `Sum`
      - [ ] `Max` and `Min`
- [ ] test more complex scopes, like in spmv
  -  [ ] add support for multidimensional inputs to tasklets
- [ ] test memlet trees (jacobi)
- [ ] add addition nodes when grads sum
  - [ ] intersection checks on when adding WCR add?
- [ ] handle library nodes without expansion
- [x] clean up code (use some methods from codegen, I didn't know these existed when I wrote the code)
  - [x] clean up https://github.com/spcl/dace/pull/192/files#diff-ad6c8cfe5abaa9957c361bcade6ab123R231 using `scope_subgraph`