### PR TITLE
SDFV: Draggable graph elements

### DIFF
--- a/diode/webclient/renderer.js
+++ b/diode/webclient/renderer.js
@@ -231,6 +231,16 @@ class CanvasManager {
         if (target_y <= min_y && target_y >= max_y) dy = 0;
         */
 
+        if (el.data.type && el.data.type === 'Memlet') {
+            if (el.points[2]) {
+                // Only allow dragging, if the memlet is 'making a curve'
+                el.points[1].x += dx;
+                el.points[1].y += dy;
+            }
+            // Don't do any of the other stuff, it doesn't apply here
+            return;
+        }
+
         el.x += dx;
         el.y += dy;
 
@@ -244,6 +254,7 @@ class CanvasManager {
                 c.x += dx;
                 c.y += dy;
             });
+        console.log(el);
 
         // Allow recursive translation of nested SDFGs
         function translate_recursive(ng) {
@@ -271,15 +282,15 @@ class CanvasManager {
                         });
                 });
 
-                /*
                 g.edges().forEach(edge_id => {
                     const edge = g.edge(edge_id);
-                    console.log("Moving edge");
-                    console.log(edge);
                     edge.x += dx;
                     edge.y += dy;
+                    edge.points.forEach(point => {
+                        point.x += dx;
+                        point.y += dy;
+                    });
                 });
-                */
             });
         }
 
@@ -312,6 +323,16 @@ class CanvasManager {
                         c.x += dx;
                         c.y += dy;
                     });
+            });
+
+            graph.edges().forEach(edge_id => {
+                const edge = graph.edge(edge_id);
+                edge.x += dx;
+                edge.y += dy;
+                edge.points.forEach(point => {
+                    point.x += dx;
+                    point.y += dy;
+                });
             });
         }
     }

--- a/diode/webclient/renderer.js
+++ b/diode/webclient/renderer.js
@@ -279,8 +279,7 @@ class CanvasManager {
                 el.points[1].x += dx;
                 el.points[1].y += dy;
             }
-            // Don't do any of the other stuff.
-            // The rest of the method doesn't apply here
+            // The rest of the method doesn't apply to Edges
             return;
         }
 

--- a/diode/webclient/renderer.js
+++ b/diode/webclient/renderer.js
@@ -273,13 +273,14 @@ class CanvasManager {
             if (target_y <= min_y || target_y >= max_y) dy = 0;
         }
 
-        if (el.data.type && (el.data.type === 'Memlet' || el.data.type === 'InterstateEdge')) {
+        if (el instanceof Edge) {
             if (el.points[2]) {
                 // Only allow dragging, if the memlet is 'making a curve'
                 el.points[1].x += dx;
                 el.points[1].y += dy;
             }
-            // Don't do any of the other stuff, it doesn't apply here
+            // Don't do any of the other stuff.
+            // The rest of the method doesn't apply here
             return;
         }
 
@@ -1412,7 +1413,7 @@ class SDFGRenderer {
                 return false;
             } else {
                 this.drag_start = null;
-                if (event.buttons & 1 || event.buttons & 2)
+                if (event.buttons & 1 || event.buttons & 4)
                     return true; // Don't stop propagation
             }
         } else if (evtype === "touchmove") {


### PR DESCRIPTION
- Nodes and edges can both be dragged
- Moving/panning of the view was moved from primary mouse button to secondary mouse button (for now?)
- Movement of nodes is restricted to remain within their parent element, e.g. state or nested SDFG