### PR TITLE
Enable/disable automatically building bitstreams

### DIFF
--- a/dace/codegen/CMakeLists.txt
+++ b/dace/codegen/CMakeLists.txt
@@ -8,6 +8,9 @@ set(DACE_FILES "" CACHE STRING "List of host code files relative to the root of 
 set(DACE_LIBS "" CACHE STRING "Extra libraries")
 set(HLSLIB_PART_NAME "${DACE_XILINX_PART_NAME}")
 
+# FPGA specific
+set(DACE_FPGA_AUTOBUILD_BITSTREAM OFF CACHE STRING "Automatically build bitstreams if they are not present.")
+
 # Allow passing flags to various stages of Xilinx compilation process
 set(DACE_XILINX_MODE "simulation" CACHE STRING "Type of compilation/execution [simulation/software_emulation/hardware_emulation/hardware].")
 set(DACE_XILINX_HOST_FLAGS "" CACHE STRING "Extra flags to host code")
@@ -500,7 +503,7 @@ if(DACE_ENABLE_INTELFPGA)
       add_custom_target(intelfpga_compile_${DACE_PROGRAM_NAME}_emulator
                         DEPENDS ${DACE_PROGRAM_NAME}_emulator.aocx)
   endif()
-  if(DACE_INTELFPGA_MODE STREQUAL "hardware")
+  if(DACE_INTELFPGA_MODE STREQUAL "hardware" AND DACE_FPGA_AUTOBUILD_BITSTREAM)
       add_custom_target(intelfpga_compile_${DACE_PROGRAM_NAME}_hardware
                         ALL DEPENDS ${DACE_PROGRAM_NAME}_hardware.aocx)
   else()
@@ -528,7 +531,7 @@ if(DACE_ENABLE_XILINX)
   endif()
   add_custom_target(xilinx_link_hardware_emulation DEPENDS
                     xilinx_link_${DACE_PROGRAM_NAME}_hardware_emulation)
-  if(DACE_XILINX_MODE STREQUAL "hardware")
+  if(DACE_XILINX_MODE STREQUAL "hardware" AND DACE_FPGA_AUTOBUILD_BITSTREAM)
       add_custom_target(xilinx_link_${DACE_PROGRAM_NAME}_hardware
                         ALL DEPENDS ${DACE_PROGRAM_NAME}_hw.xclbin) 
   else()

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -67,12 +67,15 @@ class IntelFPGACodeGen(fpga.FPGACodeGen):
         target_board = Config.get("compiler", "intel_fpga", "board")
         enable_debugging = ("ON" if Config.get_bool(
             "compiler", "intel_fpga", "enable_debugging") else "OFF")
+        autobuild = ("ON" if Config.get_bool(
+            "compiler", "autobuild_bitstreams") else "OFF")
         options = [
             "-DDACE_INTELFPGA_HOST_FLAGS=\"{}\"".format(host_flags),
             "-DDACE_INTELFPGA_KERNEL_FLAGS=\"{}\"".format(kernel_flags),
             "-DDACE_INTELFPGA_MODE={}".format(mode),
             "-DDACE_INTELFPGA_TARGET_BOARD=\"{}\"".format(target_board),
             "-DDACE_INTELFPGA_ENABLE_DEBUGGING={}".format(enable_debugging),
+            "-DDACE_FPGA_AUTOBUILD_BITSTREAM={}".format(autobuild)
         ]
         # Override Intel FPGA OpenCL installation directory
         if Config.get("compiler", "intel_fpga", "path"):

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -46,6 +46,8 @@ class XilinxCodeGen(fpga.FPGACodeGen):
         target_platform = Config.get("compiler", "xilinx", "platform")
         enable_debugging = ("ON" if Config.get_bool(
             "compiler", "xilinx", "enable_debugging") else "OFF")
+        autobuild = ("ON" if Config.get_bool(
+            "compiler", "autobuild_bitstreams") else "OFF")
         options = [
             "-DDACE_XILINX_HOST_FLAGS=\"{}\"".format(host_flags),
             "-DDACE_XILINX_SYNTHESIS_FLAGS=\"{}\"".format(synthesis_flags),
@@ -53,6 +55,7 @@ class XilinxCodeGen(fpga.FPGACodeGen):
             "-DDACE_XILINX_MODE={}".format(mode),
             "-DDACE_XILINX_TARGET_PLATFORM=\"{}\"".format(target_platform),
             "-DDACE_XILINX_ENABLE_DEBUGGING={}".format(enable_debugging),
+            "-DDACE_FPGA_AUTOBUILD_BITSTREAM={}".format(autobuild)
         ]
         # Override Vitis/SDx/SDAccel installation directory
         if Config.get("compiler", "xilinx", "path"):

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -128,7 +128,7 @@ required:
 
             autobuild_bitstreams:
                 type: bool
-                default: false
+                default: true
                 title: Automatically build bitstreams
                 description: >
                     If set to true, CMake will automatically build missing

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -125,6 +125,18 @@ required:
                 description: >
                     Target Xilinx ("xilinx") or Intel ("intel_fpga") FPGAs when
                     generating code. 
+
+            autobuild_bitstreams:
+                type: bool
+                default: false
+                title: Automatically build bitstreams
+                description: >
+                    If set to true, CMake will automatically build missing
+                    bitstreams when running an FPGA program. This can take a
+                    very long time, and users might want to do this manually.
+                    If set to false, the program will optimistically assume
+                    that the bitstream is present in the build directory, and
+                    will crash if this is not the case.
             #############################################
             # CPU compiler
             cpu:


### PR DESCRIPTION
Boolean flag in the config can enable/disable automatically building missing bitstreams for both Xilinx and Intel.