### PR TITLE
Order FPGA Arguments

### DIFF
--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -1290,8 +1290,7 @@ class FPGACodeGen(TargetCodeGenerator):
             key=lambda t: t[1])
         scalars = [t for t in parameters if isinstance(t[2], dace.data.Scalar)]
         scalars += ((False, k, v) for k, v in symbol_parameters.items())
-        scalars = dace.dtypes.deduplicate(
-            list(sorted(scalars, key=lambda t: t[1])))
+        scalars = list(sorted(scalars, key=lambda t: t[1]))
         for is_output, argname, arg in itertools.chain(arrays, scalars):
             # Only pass each array once from the host code
             if arg in seen:
@@ -1302,6 +1301,9 @@ class FPGACodeGen(TargetCodeGenerator):
                                                            name=argname))
                 kernel_args_opencl.append(
                     FPGACodeGen.make_opencl_parameter(argname, arg))
+
+        kernel_args_call_host = dace.dtypes.deduplicate(kernel_args_call_host)
+        kernel_args_opencl = dace.dtypes.deduplicate(kernel_args_opencl)
 
         host_function_name = "__dace_runkernel_{}".format(kernel_name)
 

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -477,20 +477,20 @@ DACE_EXPORTED void __dace_exit_intel_fpga({signature}) {{
         state_id = sdfg.node_id(state)
         dfg = sdfg.nodes()[state_id]
 
-        # Treat scalars and symbols the same, assuming there are no scalar
-        # outputs
-        symbol_sigs = [
-            v.signature(with_types=True, name=k)
-            for k, v in symbol_parameters.items()
-        ]
-        symbol_names = symbol_parameters.keys()
-
         kernel_args_opencl = []
         kernel_args_host = []
         kernel_args_call = []
         added = set()
-        for is_output, pname, p in parameters:
-            # Don't make duplicate arguments for other types than arrays
+        # Split into arrays and scalars
+        arrays = sorted([
+            t for t in parameters if not isinstance(t[2], dace.data.Scalar)
+        ], key=lambda t: t[1])
+        scalars = [
+            t for t in parameters if isinstance(t[2], dace.data.Scalar)
+        ]
+        scalars += [(False, k, v) for k, v in symbol_parameters.items()]
+        scalars = list(sorted(scalars, key=lambda t: t[1]))
+        for is_output, pname, p in itertools.chain(arrays, scalars):
             if pname in added:
                 continue
             added.add(pname)
@@ -504,10 +504,6 @@ DACE_EXPORTED void __dace_exit_intel_fpga({signature}) {{
                 kernel_args_opencl.append(arg)
                 kernel_args_host.append(p.signature(True, name=pname))
                 kernel_args_call.append(pname)
-
-        kernel_args_opencl += symbol_sigs
-        kernel_args_host += symbol_sigs
-        kernel_args_call += symbol_names
 
         module_function_name = "module_" + name
 

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -284,7 +284,7 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
         ]
         arrays = list(sorted(global_data_parameters, key=lambda t: t[1]))
         scalars = scalar_parameters + list(symbol_parameters.items())
-        scalars = list(sorted(scalars, key=lambda t: t[1]))
+        scalars = list(sorted(scalars, key=lambda t: t[0]))
 
         # Build kernel signature
         kernel_args = []

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -282,22 +282,21 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
             v.signature(with_types=True, name=k)
             for k, v in symbol_parameters.items()
         ]
+        arrays = list(sorted(global_data_parameters, key=lambda t: t[1]))
+        scalars = (scalar_parameters + [(False, k, v)
+                                        for k, v in symbol_parameters.items()])
+        scalars = list(sorted(scalars, key=lambda t: t[1]))
 
         # Build kernel signature
         kernel_args = []
-        for is_output, dataname, data in global_data_parameters:
+        for is_output, dataname, data in arrays:
             kernel_arg = self.make_kernel_argument(
                 data, dataname, self._memory_widths[(dataname, sdfg)],
                 is_output, True)
             if kernel_arg:
                 kernel_args.append(kernel_arg)
-
-        scalar_parameters = collections.OrderedDict(scalar_parameters)
-        symbol_parameters.update(scalar_parameters)
-        kernel_args += ([
-            arg.signature(with_types=True, name=argname)
-            for argname, arg in symbol_parameters.items()
-        ])
+        kernel_args += (v.signature(with_types=True, name=k)
+                        for _, k, v in scalars)
 
         # Write kernel signature
         kernel_stream.write(
@@ -335,10 +334,17 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
 
         # Just collect all variable names for calling the kernel function
         added = set()
+        arrays = list(
+            sorted([
+                p
+                for p in parameters if not isinstance(p[2], dace.data.Scalar)
+            ],
+                   key=lambda t: t[1]))
+        scalars = [p for p in parameters if isinstance(p[2], dace.data.Scalar)]
+        scalars += ((False, k, v) for k, v in symbol_parameters.items())
+        scalars = dace.dtypes.deduplicate(sorted(scalars, key=lambda t: t[1]))
         kernel_args = []
-        for _, name, p in itertools.chain(
-                parameters,
-            [(False, k, v) for k, v in symbol_parameters.items()]):
+        for _, name, p in itertools.chain(arrays, scalars):
             if not isinstance(p, dace.data.Array) and name in added:
                 continue
             added.add(name)
@@ -369,9 +375,14 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
         kernel_args_module = []
         added = set()
 
-        for is_output, pname, p in itertools.chain(
-                parameters,
-            [(False, k, v) for k, v in symbol_parameters.items()]):
+        parameters = list(sorted(parameters, key=lambda t: t[1]))
+        arrays = [
+            p for p in parameters if not isinstance(p[2], dace.data.Scalar)
+        ]
+        scalars = [p for p in parameters if isinstance(p[2], dace.data.Scalar)]
+        scalars += ((False, k, v) for k, v in symbol_parameters.items())
+        scalars = dace.dtypes.deduplicate(sorted(scalars, key=lambda t: t[1]))
+        for is_output, pname, p in itertools.chain(parameters, scalars):
             if isinstance(p, dace.data.Array):
                 arr_name = "{}_{}".format(pname, "out" if is_output else "in")
                 kernel_args_call.append(arr_name)
@@ -624,12 +635,18 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
     def generate_host_header(self, sdfg, kernel_function_name, parameters,
                              symbol_parameters, host_code_stream):
 
+        arrays = [
+            p for p in parameters if not isinstance(p[2], dace.data.Scalar)
+        ]
+        arrays = list(sorted(arrays, key=lambda t: t[1]))
+        scalars = [p for p in parameters if isinstance(p[2], dace.data.Scalar)]
+        scalars += ((False, k, v) for k, v in symbol_parameters.items())
+        scalars = list(sorted(scalars, key=lambda t: t[1]))
+
         kernel_args = []
 
         seen = set()
-        for is_output, name, arg in itertools.chain(
-                parameters,
-            [(False, k, v) for k, v in symbol_parameters.items()]):
+        for is_output, name, arg in itertools.chain(arrays, scalars):
             if isinstance(arg, dace.data.Array):
                 kernel_args.append(
                     arg.signature(with_types=True,

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -297,6 +297,8 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
         kernel_args += (v.signature(with_types=True, name=k)
                         for k, v in scalars)
 
+        kernel_args = dace.dtypes.deduplicate(kernel_args)
+
         # Write kernel signature
         kernel_stream.write(
             "DACE_EXPORTED void {}({}) {{\n".format(kernel_name,

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -352,7 +352,6 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
 
         kernel_function_name = kernel_name
         kernel_file_name = "{}.xclbin".format(kernel_name)
-        host_function_name = "__dace_runkernel_{}".format(kernel_name)
 
         kernel_stream.write(
             """\

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -283,8 +283,7 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
             for k, v in symbol_parameters.items()
         ]
         arrays = list(sorted(global_data_parameters, key=lambda t: t[1]))
-        scalars = (scalar_parameters + [(False, k, v)
-                                        for k, v in symbol_parameters.items()])
+        scalars = scalar_parameters + list(symbol_parameters.items())
         scalars = list(sorted(scalars, key=lambda t: t[1]))
 
         # Build kernel signature
@@ -296,7 +295,7 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
             if kernel_arg:
                 kernel_args.append(kernel_arg)
         kernel_args += (v.signature(with_types=True, name=k)
-                        for _, k, v in scalars)
+                        for k, v in scalars)
 
         # Write kernel signature
         kernel_stream.write(


### PR DESCRIPTION
We've had indeterminism in the FPGA code generators, which leads to recompiling when it's not necessary, and which could potentially lead to sporadic behavior.

I've now made sure to reorder all arguments according to their name.

The reason why this is not done centrally is because the arguments can vary depending on the context, and there might sometimes be mixes between array and scalar arguments.

It could be prettier, but it's better than before :-)