### PR TITLE
FPGA codegen, fix error message for different veclen to same memory

### DIFF
--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -368,7 +368,7 @@ class FPGACodeGen(TargetCodeGenerator):
                                 "Vector length on memlet {} ({}) doesn't "
                                 "match vector length of {} ({})".format(
                                     edge.data, edge.data.veclen, node.data,
-                                    nodedesc.veclen))
+                                   node.desc(sdfg).veclen))
                         memory_widths[key] = edge.data.veclen
                     else:
                         if (memory_widths[key] is not None


### PR DESCRIPTION
The variable `nodedesc` was not initialized in this scope and threw an error.