### PR TITLE
Fail if kernel name is too long

### DIFF
--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -508,10 +508,15 @@ DACE_EXPORTED void __dace_exit_intel_fpga({signature}) {{
                 kernel_args_call.append(pname)
 
         module_function_name = "module_" + name
-        if len(module_function_name) > 61:
+
+        # The official limit suggested by Intel is 61. However, the compiler
+        # can also append text to the module. Longest seen so far is
+        # "_cra_slave_inst", which is 15 characters, so we restrict to
+        # 61 - 15 = 46, and round down to 42 to be conservative.
+        if len(module_function_name) > 42:
             raise NameTooLongError(
                 "Due to a bug in the Intel FPGA OpenCL compiler, "
-                "kernel names cannot be longer than 61 characters:\n\t{}".
+                "kernel names cannot be longer than 42 characters:\n\t{}".
                 format(module_function_name))
 
         # Unrolling processing elements: if there first scope of the subgraph

--- a/tests/intel_fpga/name_too_long.py
+++ b/tests/intel_fpga/name_too_long.py
@@ -1,0 +1,22 @@
+import dace
+from simple_systolic_array import P, make_sdfg
+from dace.config import Config
+
+KERNEL_NAME = ("_this_is_a_very_long_kernel_name_that_does_not_fit_"
+               "in_the_61_character_limit")
+
+if __name__ == "__main__":
+
+    Config.set("compiler", "fpga_vendor", value="intel_fpga")
+
+    sdfg = make_sdfg("name_too_long")
+    for node, _ in sdfg.all_nodes_recursive():
+        if isinstance(node, dace.graph.nodes.CodeNode):
+            node.label += KERNEL_NAME
+    sdfg.specialize({"P": 4})
+    try:
+        code = sdfg.generate_code()
+    except dace.codegen.targets.intel_fpga.NameTooLongError:
+        pass
+    else:
+        raise RuntimeError("No exception thrown.")

--- a/tests/intel_fpga_test.sh
+++ b/tests/intel_fpga_test.sh
@@ -59,6 +59,9 @@ run_all() {
     run_sample intel_fpga/vec_sum vec_sum "FPGATransformSDFG\$0\nVectorization\$0(propagate_parent=True)\n"
     # Vectorization 3: TODO non vectorizable N
 
+    # Throw error when kernel names are too long
+    run_sample intel_fpga/name_too_long name_too_long "\n"
+
     # ### MAP TILING ####
     # First tile then transform
     run_sample intel_fpga/dot dot "MapTiling\$0\nFPGATransformSDFG\$0\n"


### PR DESCRIPTION
Intel FPGA OpenCL doesn't allow kernel names longer than 61 characters. Fail in DaCe with an explicit error when this occurs in practice.

https://www.intel.com/content/www/us/en/programmable/documentation/bhg1517418195706.html#dhf1517418905976