### PR TITLE
WIP: New Memlet interface and typed connectors

### DIFF
--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -9,7 +9,7 @@ from .frontend.operations import *
 from .config import Config
 from .sdfg import SDFG, SDFGState, InterstateEdge, nodes
 from .sdfg.propagation import propagate_memlets_sdfg, propagate_memlet
-from .memlet import Memlet, EmptyMemlet
+from .memlet import Memlet
 from .symbolic import symbol
 
 # Run Jupyter notebook code

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -822,7 +822,7 @@ void __dace_alloc_{location}(uint32_t size, dace::GPUStream<{type}, {is_pow2}>& 
                         + '{dststrides}, {is_async}>{accum}({args});').format(
                             func=funcname,
                             type=dst_node.desc(sdfg).dtype.ctype,
-                            veclen=memlet.veclen,
+                            veclen='1',#memlet.veclen,
                             bdims=', '.join(_topy(self._block_dims)),
                             dststrides=', '.join(_topy(dst_strides)),
                             is_async='false'
@@ -833,12 +833,13 @@ void __dace_alloc_{location}(uint32_t size, dace::GPUStream<{type}, {is_pow2}>& 
                                            _topy(copy_shape))), sdfg, state_id,
                                           [src_node, dst_node])
                 else:
+                    # TODO: Use connector type
                     callsite_stream.write((
                         '    {func}<dace::vec<{type}, {veclen}>, {bdims}, {copysize}, '
                         + '{dststrides}, {is_async}>{accum}({args});').format(
                             func=funcname,
                             type=dst_node.desc(sdfg).dtype.ctype,
-                            veclen=memlet.veclen,
+                            veclen='1',#memlet.veclen,
                             bdims=', '.join(_topy(self._block_dims)),
                             copysize=', '.join(_topy(copy_shape)),
                             dststrides=', '.join(_topy(dst_strides)),

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -373,7 +373,7 @@ class FPGACodeGen(TargetCodeGenerator):
                     key = alias[key]
                 name = key[0]
                 for edge in state.all_edges(node):
-                    if (isinstance(edge.data, dace.memlet.EmptyMemlet)
+                    if (edge.data.is_empty()
                             or edge.data.data is None):
                         continue
                     if (isinstance(edge.src, dace.sdfg.nodes.AccessNode) and

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -80,9 +80,9 @@ class FPGACodeGen(TargetCodeGenerator):
             self,
             predicate=lambda sdfg, state: len(state.data_nodes()) > 0 and all([
                 n.desc(sdfg).storage in [
-                    dace.dtypes.StorageType.FPGA_Global, dace.dtypes.
-                    StorageType.FPGA_Local, dace.dtypes.StorageType.
-                    FPGA_Registers, dace.dtypes.StorageType.FPGA_ShiftRegister
+                    dace.dtypes.StorageType.FPGA_Global, dace.dtypes.StorageType
+                    .FPGA_Local, dace.dtypes.StorageType.FPGA_Registers, dace.
+                    dtypes.StorageType.FPGA_ShiftRegister
                 ] for n in state.data_nodes()
             ]))
 
@@ -98,8 +98,8 @@ class FPGACodeGen(TargetCodeGenerator):
         self._dispatcher.register_array_dispatcher(fpga_storage, self)
 
         # Register permitted copies
-        for storage_from in itertools.chain(
-                fpga_storage, [dace.dtypes.StorageType.Register]):
+        for storage_from in itertools.chain(fpga_storage,
+                                            [dace.dtypes.StorageType.Register]):
             for storage_to in itertools.chain(
                     fpga_storage, [dace.dtypes.StorageType.Register]):
                 if (storage_from == dace.dtypes.StorageType.Register
@@ -233,8 +233,7 @@ class FPGACodeGen(TargetCodeGenerator):
             candidates = []  # type: List[Tuple[bool,str,Data]]
             # [(is an output, dataname string, data object)]
             for n in subgraph.source_nodes():
-                candidates += [(False, e.data.data,
-                                subsdfg.arrays[e.data.data])
+                candidates += [(False, e.data.data, subsdfg.arrays[e.data.data])
                                for e in state.in_edges(n)]
             for n in subgraph.sink_nodes():
                 candidates += [(True, e.data.data, subsdfg.arrays[e.data.data])
@@ -270,14 +269,14 @@ class FPGACodeGen(TargetCodeGenerator):
                         or isinstance(data, dace.data.Scalar)
                         or isinstance(data, dace.data.Stream)):
                     if data.storage == dace.dtypes.StorageType.FPGA_Global:
-                        subgraph_parameters[subgraph].append((is_output,
-                                                              dataname, data))
+                        subgraph_parameters[subgraph].append(
+                            (is_output, dataname, data))
                         if is_output:
-                            global_data_parameters.append((is_output, dataname,
-                                                           data))
+                            global_data_parameters.append(
+                                (is_output, dataname, data))
                         else:
-                            global_data_parameters.append((is_output, dataname,
-                                                           data))
+                            global_data_parameters.append(
+                                (is_output, dataname, data))
                         global_data_names.add(dataname)
                     elif (data.storage in (
                             dace.dtypes.StorageType.FPGA_Local,
@@ -302,8 +301,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 subgraph_parameters[subgraph])
 
         # Deduplicate
-        global_data_parameters = dace.dtypes.deduplicate(
-            global_data_parameters)
+        global_data_parameters = dace.dtypes.deduplicate(global_data_parameters)
         top_level_local_data = dace.dtypes.deduplicate(top_level_local_data)
         top_level_local_data = [data_to_node[n] for n in top_level_local_data]
 
@@ -320,13 +318,12 @@ class FPGACodeGen(TargetCodeGenerator):
                               function_stream, callsite_stream):
 
         for sg in subgraphs:
-            self._dispatcher.dispatch_subgraph(
-                sdfg,
-                sg,
-                sdfg.node_id(state),
-                function_stream,
-                callsite_stream,
-                skip_entry_node=False)
+            self._dispatcher.dispatch_subgraph(sdfg,
+                                               sg,
+                                               sdfg.node_id(state),
+                                               function_stream,
+                                               callsite_stream,
+                                               skip_entry_node=False)
 
     @staticmethod
     def detect_memory_widths(parent_sdfg):
@@ -373,12 +370,10 @@ class FPGACodeGen(TargetCodeGenerator):
                     key = alias[key]
                 name = key[0]
                 for edge in state.all_edges(node):
-                    if (edge.data.is_empty()
-                            or edge.data.data is None):
+                    if (edge.data.is_empty() or edge.data.data is None):
                         continue
                     if (isinstance(edge.src, dace.sdfg.nodes.AccessNode) and
-                            isinstance(edge.dst, dace.sdfg.nodes.AccessNode)
-                            and edge.data.veclen == 1):
+                            isinstance(edge.dst, dace.sdfg.nodes.AccessNode)):
                         # Consistent vectorization is not enforced for
                         # memcopies, but if this memory is not found anywhere
                         # else, we need to set it to 1 later. Or, if a
@@ -387,21 +382,25 @@ class FPGACodeGen(TargetCodeGenerator):
                         if key not in memory_widths:
                             memory_widths[key] = None
                         continue
-                    if (key not in memory_widths
-                            or memory_widths[key] is None):
-                        if (isinstance(desc, dace.data.Stream)
-                                and desc.veclen != edge.data.veclen):
-                            raise ValueError(
-                                "Vector length on memlet {} ({}) doesn't "
-                                "match vector length of {} ({})".format(
-                                    edge.data, edge.data.veclen, node.data,
-                                    node.desc(sdfg).veclen))
-                        memory_widths[key] = edge.data.veclen
+                    if (key not in memory_widths or memory_widths[key] is None):
+                        # TODO: Check connectors instead
+                        warnings.warn("not done here yet")
+                        # if (isinstance(desc, dace.data.Stream)
+                        #         and desc.veclen != edge.data.veclen):
+                        #     raise ValueError(
+                        #         "Vector length on memlet {} ({}) doesn't "
+                        #         "match vector length of {} ({})".format(
+                        #             edge.data, edge.data.veclen, node.data,
+                        #             node.desc(sdfg).veclen))
+                        # memory_widths[key] = edge.data.veclen
+                        memory_widths[key] = 1
                     else:
-                        if (memory_widths[key] is not None
-                                and memory_widths[key] != edge.data.veclen):
-                            # If the vector length is inconsistent, set it to 1
-                            memory_widths[key] = 1
+                        # TODO: Check connectors instead
+                        warnings.warn("not done here yet")
+                        # if (memory_widths[key] is not None
+                        #         and memory_widths[key] != edge.data.veclen):
+                        #     # If the vector length is inconsistent, set it to 1
+                        #     memory_widths[key] = 1
         # Inherit the parent memory width for all aliased nested arrays
         for key in alias:
             if key in memory_widths:
@@ -432,21 +431,19 @@ class FPGACodeGen(TargetCodeGenerator):
                            dfg_scope.source_nodes()[0], function_stream,
                            callsite_stream)
 
-        self._dispatcher.dispatch_subgraph(
-            sdfg,
-            dfg_scope,
-            state_id,
-            function_stream,
-            callsite_stream,
-            skip_entry_node=True)
+        self._dispatcher.dispatch_subgraph(sdfg,
+                                           dfg_scope,
+                                           state_id,
+                                           function_stream,
+                                           callsite_stream,
+                                           skip_entry_node=True)
 
     def allocate_array(self, sdfg, dfg, state_id, node, function_stream,
                        callsite_stream):
         result = StringIO()
         nodedesc = node.desc(sdfg)
         arrsize = nodedesc.total_size
-        is_dynamically_sized = dace.symbolic.issymbolic(
-            arrsize, sdfg.constants)
+        is_dynamically_sized = dace.symbolic.issymbolic(arrsize, sdfg.constants)
 
         dataname = node.data
 
@@ -511,8 +508,8 @@ class FPGACodeGen(TargetCodeGenerator):
                                     "must be an integer: {}".format(
                                         nodedesc.location["bank"]))
                             memory_bank_arg = (
-                                "hlslib::ocl::MemoryBank::bank{}, ".format(
-                                    bank))
+                                "hlslib::ocl::MemoryBank::bank{}, ".format(bank)
+                            )
                             # (memory type, bank id)
                             self._bank_assignments[(dataname,
                                                     sdfg)] = (MemoryType.DDR,
@@ -523,14 +520,14 @@ class FPGACodeGen(TargetCodeGenerator):
                             "auto {} = dace::fpga::_context->Get()."
                             "MakeBuffer<{}, hlslib::ocl::Access::readWrite>"
                             "({}{});".format(dataname, nodedesc.dtype.ctype,
-                                             memory_bank_arg,
-                                             sym2cpp(arrsize)))
+                                             memory_bank_arg, sym2cpp(arrsize)))
                         self._dispatcher.defined_vars.add(
                             dataname, DefinedType.Pointer)
 
-            elif (nodedesc.storage in (dace.dtypes.StorageType.FPGA_Local,
-                                       dace.dtypes.StorageType.FPGA_Registers,
-                                       dace.dtypes.StorageType.FPGA_ShiftRegister)):
+            elif (nodedesc.storage in (
+                    dace.dtypes.StorageType.FPGA_Local,
+                    dace.dtypes.StorageType.FPGA_Registers,
+                    dace.dtypes.StorageType.FPGA_ShiftRegister)):
 
                 if not self._in_device_code:
                     raise dace.codegen.codegen.CodegenError(
@@ -571,13 +568,14 @@ class FPGACodeGen(TargetCodeGenerator):
                     # Language-specific
                     if (nodedesc.storage ==
                             dace.dtypes.StorageType.FPGA_ShiftRegister):
-                        self.define_shift_register(
-                            dataname, nodedesc, arrsize_vec, veclen,
-                            function_stream, result, sdfg, state_id, node)
+                        self.define_shift_register(dataname, nodedesc,
+                                                   arrsize_vec, veclen,
+                                                   function_stream, result,
+                                                   sdfg, state_id, node)
                     else:
-                        self.define_local_array(
-                            dataname, nodedesc, arrsize_vec, veclen,
-                            function_stream, result, sdfg, state_id, node)
+                        self.define_local_array(dataname, nodedesc, arrsize_vec,
+                                                veclen, function_stream, result,
+                                                sdfg, state_id, node)
 
             else:
                 raise NotImplementedError("Unimplemented storage type " +
@@ -619,11 +617,10 @@ class FPGACodeGen(TargetCodeGenerator):
         data_to_data = (isinstance(src_node, dace.sdfg.nodes.AccessNode)
                         and isinstance(dst_node, dace.sdfg.nodes.AccessNode))
 
-        host_to_device = (data_to_data and src_storage in _CPU_STORAGE_TYPES
-                          and
+        host_to_device = (data_to_data and src_storage in _CPU_STORAGE_TYPES and
                           dst_storage == dace.dtypes.StorageType.FPGA_Global)
-        device_to_host = (data_to_data and
-                          src_storage == dace.dtypes.StorageType.FPGA_Global
+        device_to_host = (data_to_data
+                          and src_storage == dace.dtypes.StorageType.FPGA_Global
                           and dst_storage in _CPU_STORAGE_TYPES)
         device_to_device = (
             data_to_data and src_storage == dace.dtypes.StorageType.FPGA_Global
@@ -655,40 +652,39 @@ class FPGACodeGen(TargetCodeGenerator):
                 callsite_stream.write(
                     "{}.CopyFromHost({}, {}, {});".format(
                         dst_node.data, (offset if not outgoing_memlet else 0),
-                        copysize,
-                        src_node.data + (" + {}".format(offset)
-                                         if outgoing_memlet else "")), sdfg,
-                    state_id, [src_node, dst_node])
+                        copysize, src_node.data +
+                        (" + {}".format(offset) if outgoing_memlet else "")),
+                    sdfg, state_id, [src_node, dst_node])
 
             elif device_to_host:
 
                 callsite_stream.write(
                     "{}.CopyToHost({}, {}, {});".format(
-                        src_node.data, (offset
-                                        if outgoing_memlet else 0), copysize,
+                        src_node.data, (offset if outgoing_memlet else 0),
+                        copysize,
                         dst_node.data + (" + {}".format(offset)
-                                         if not outgoing_memlet else "")),
-                    sdfg, state_id, [src_node, dst_node])
+                                         if not outgoing_memlet else "")), sdfg,
+                    state_id, [src_node, dst_node])
 
             elif device_to_device:
 
                 callsite_stream.write(
                     "{}.CopyToDevice({}, {}, {}, {});".format(
-                        src_node.data, (offset
-                                        if outgoing_memlet else 0), copysize,
-                        dst_node.data, (offset if not outgoing_memlet else 0)),
-                    sdfg, state_id, [src_node, dst_node])
+                        src_node.data, (offset if outgoing_memlet else 0),
+                        copysize, dst_node.data,
+                        (offset if not outgoing_memlet else 0)), sdfg, state_id,
+                    [src_node, dst_node])
 
         # Reject copying to/from local memory from/to outside the FPGA
-        elif (data_to_data
-              and (((src_storage in (dace.dtypes.StorageType.FPGA_Local,
-                                     dace.dtypes.StorageType.FPGA_Registers,
-                                     dace.dtypes.StorageType.FPGA_ShiftRegister))
-                    and dst_storage not in _FPGA_STORAGE_TYPES) or
-                   ((dst_storage in (dace.dtypes.StorageType.FPGA_Local,
-                                     dace.dtypes.StorageType.FPGA_Registers,
-                                     dace.dtypes.StorageType.FPGA_ShiftRegister))
-                    and src_storage not in _FPGA_STORAGE_TYPES))):
+        elif (data_to_data and
+              (((src_storage in (dace.dtypes.StorageType.FPGA_Local,
+                                 dace.dtypes.StorageType.FPGA_Registers,
+                                 dace.dtypes.StorageType.FPGA_ShiftRegister))
+                and dst_storage not in _FPGA_STORAGE_TYPES) or
+               ((dst_storage in (dace.dtypes.StorageType.FPGA_Local,
+                                 dace.dtypes.StorageType.FPGA_Registers,
+                                 dace.dtypes.StorageType.FPGA_ShiftRegister))
+                and src_storage not in _FPGA_STORAGE_TYPES))):
             raise NotImplementedError(
                 "Copies between host memory and FPGA "
                 "local memory not supported: from {} to {}".format(
@@ -705,20 +701,20 @@ class FPGACodeGen(TargetCodeGenerator):
 
             # Try to turn into degenerate/strided ND copies
             copy_shape, src_strides, dst_strides, src_expr, dst_expr = (
-                memlet_copy_to_absolute_strides(
-                    self._dispatcher,
-                    sdfg,
-                    memlet,
-                    src_node,
-                    dst_node,
-                    packed_types=True))
+                memlet_copy_to_absolute_strides(self._dispatcher,
+                                                sdfg,
+                                                memlet,
+                                                src_node,
+                                                dst_node,
+                                                packed_types=True))
 
             ctype = src_node.desc(sdfg).dtype.ctype
 
             # For a single vector access, tolerate not having set a range
-            if copy_shape[-1] != 1:
-                # Adjust for vectorization length
-                copy_shape[-1] = copy_shape[-1] / memlet.veclen
+            # if copy_shape[-1] != 1:
+            #     # Adjust for vectorization length
+            #     copy_shape[-1] = copy_shape[-1] / memlet.veclen
+            # TODO: Handle veclen somehow
 
             if dst_storage == dace.dtypes.StorageType.FPGA_ShiftRegister:
                 if len(copy_shape) != 1:
@@ -726,11 +722,10 @@ class FPGACodeGen(TargetCodeGenerator):
                         "Only single-dimensional writes "
                         "to shift registers supported: {}{}".format(
                             dst_node.data, copy_shape))
-                if copy_shape[-1] > memlet.veclen:
-                    raise ValueError(
-                        "Only a single (vector) element can be "
-                        "written to a shift register: {}{}".format(
-                            dst_node.data, copy_shape[-1]))
+                # if copy_shape[-1] > memlet.veclen:
+                #     raise ValueError("Only a single (vector) element can be "
+                #                      "written to a shift register: {}{}".format(
+                #                          dst_node.data, copy_shape[-1]))
 
             # Check if we are copying between vectorized and non-vectorized
             # types
@@ -786,9 +781,9 @@ class FPGACodeGen(TargetCodeGenerator):
                                 dace.StorageType.FPGA_Registers
                             ]):
                         # Language-specific
-                        self.generate_no_dependence_pre(
-                            node.data, callsite_stream, sdfg, state_id,
-                            dst_node)
+                        self.generate_no_dependence_pre(node.data,
+                                                        callsite_stream, sdfg,
+                                                        state_id, dst_node)
 
             # Loop intro
             for i, copy_dim in enumerate(copy_shape):
@@ -803,8 +798,8 @@ class FPGACodeGen(TargetCodeGenerator):
                         state_id, dst_node)
                     if register_to_register:
                         # Language-specific
-                        self.generate_unroll_loop_post(
-                            callsite_stream, None, sdfg, state_id, dst_node)
+                        self.generate_unroll_loop_post(callsite_stream, None,
+                                                       sdfg, state_id, dst_node)
 
             # Pragmas
             if num_loops > 0:
@@ -852,22 +847,25 @@ class FPGACodeGen(TargetCodeGenerator):
             src_expr, src_index = sanitize_index(src_expr, src_index)
             dst_expr, dst_index = sanitize_index(dst_expr, dst_index)
 
+            # TODO: Use connector type
+            warnings.warn('not done here')
+            veclen = 1  # memlet.veclen
+
             # Language specific
             read_expr = self.make_read(src_def_type, ctype, src_node.label,
-                                       memlet.veclen, src_expr, src_index,
-                                       is_pack, packing_factor)
+                                       veclen, src_expr, src_index, is_pack,
+                                       packing_factor)
 
             # Language specific
             if dst_storage == dace.dtypes.StorageType.FPGA_ShiftRegister:
                 write_expr = self.make_shift_register_write(
-                    dst_def_type, ctype, dst_node.label, memlet.veclen,
-                    dst_expr, dst_index, read_expr, None, is_unpack,
-                    packing_factor)
+                    dst_def_type, ctype, dst_node.label, veclen, dst_expr,
+                    dst_index, read_expr, None, is_unpack, packing_factor)
             else:
                 write_expr = self.make_write(dst_def_type, ctype,
-                                             dst_node.label, memlet.veclen,
-                                             dst_expr, dst_index, read_expr,
-                                             None, is_unpack, packing_factor)
+                                             dst_node.label, veclen, dst_expr,
+                                             dst_index, read_expr, None,
+                                             is_unpack, packing_factor)
 
             callsite_stream.write(write_expr)
 
@@ -879,8 +877,8 @@ class FPGACodeGen(TargetCodeGenerator):
                             dace.StorageType.FPGA_Registers
                         ]):
                     # Language-specific
-                    self.generate_no_dependence_post(
-                        node.data, callsite_stream, sdfg, state_id, dst_node)
+                    self.generate_no_dependence_post(node.data, callsite_stream,
+                                                     sdfg, state_id, dst_node)
 
             # Loop outtro
             for _ in range(num_loops):
@@ -1055,8 +1053,7 @@ class FPGACodeGen(TargetCodeGenerator):
             if not isinstance(node, dace.sdfg.nodes.PipelineEntry):
 
                 if is_innermost and not fully_degenerate:
-                    self.generate_flatten_loop_pre(result, sdfg, state_id,
-                                                   node)
+                    self.generate_flatten_loop_pre(result, sdfg, state_id, node)
 
                 for i, r in enumerate(node.map.range):
                     var = node.map.params[i]
@@ -1127,8 +1124,8 @@ class FPGACodeGen(TargetCodeGenerator):
 
             if not fully_degenerate:
                 if node.map.unroll:
-                    self.generate_unroll_loop_post(result, None, sdfg,
-                                                   state_id, node)
+                    self.generate_unroll_loop_post(result, None, sdfg, state_id,
+                                                   node)
                 elif is_innermost:
                     self.generate_pipeline_loop_post(result, sdfg, state_id,
                                                      node)
@@ -1145,8 +1142,8 @@ class FPGACodeGen(TargetCodeGenerator):
             if child.data not in to_allocate or child.data in allocated:
                 continue
             allocated.add(child.data)
-            self._dispatcher.dispatch_allocate(sdfg, dfg, state_id, child,
-                                               None, result)
+            self._dispatcher.dispatch_allocate(sdfg, dfg, state_id, child, None,
+                                               result)
 
     def _generate_PipelineExit(self, *args, **kwargs):
         self._generate_MapExit(*args, **kwargs)
@@ -1176,8 +1173,8 @@ class FPGACodeGen(TargetCodeGenerator):
                         it=it, begin=r[0], end=r[1]))
             for it, r in zip(pipeline.params, pipeline.range):
                 callsite_stream.write(
-                    "}} else {{\n{it} += {step};\n}}\n".format(
-                        it=it, step=r[2]))
+                    "}} else {{\n{it} += {step};\n}}\n".format(it=it,
+                                                               step=r[2]))
             if len(cond) > 0:
                 callsite_stream.write("}\n")
             callsite_stream.write("}\n}\n")
@@ -1244,18 +1241,18 @@ class FPGACodeGen(TargetCodeGenerator):
             if len(labels) == 0:
                 labels = [n.label.replace(" ", "_") for n in access_nodes]
             if len(labels) == 0:
-                raise RuntimeError(
-                    "Expected at least one tasklet or data node")
+                raise RuntimeError("Expected at least one tasklet or data node")
             module_name = "_".join(labels)
             self.generate_module(
                 sdfg, state, module_name, subgraph,
                 subgraph_parameters[subgraph] + scalar_parameters,
                 symbol_parameters, module_stream, entry_stream, host_stream)
 
-    def generate_host_function_boilerplate(
-            self, sdfg, state, kernel_name, parameters, symbol_parameters,
-            nested_global_transients, host_code_stream, header_stream,
-            callsite_stream):
+    def generate_host_function_boilerplate(self, sdfg, state, kernel_name,
+                                           parameters, symbol_parameters,
+                                           nested_global_transients,
+                                           host_code_stream, header_stream,
+                                           callsite_stream):
 
         # Generates:
         # - Definition of wrapper function in caller code
@@ -1282,8 +1279,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 continue
             seen.add(arg)
             if not isinstance(arg, dace.data.Stream):
-                kernel_args_call_host.append(
-                    arg.signature(False, name=argname))
+                kernel_args_call_host.append(arg.signature(False, name=argname))
                 kernel_args_opencl.append(
                     FPGACodeGen.make_opencl_parameter(argname, arg))
 
@@ -1297,9 +1293,8 @@ class FPGACodeGen(TargetCodeGenerator):
             """\
 DACE_EXPORTED void {host_function_name}({kernel_args_opencl}) {{
   hlslib::ocl::Program program = dace::fpga::_context->Get().CurrentlyLoadedProgram();"""
-            .format(
-                host_function_name=host_function_name,
-                kernel_args_opencl=", ".join(kernel_args_opencl)))
+            .format(host_function_name=host_function_name,
+                    kernel_args_opencl=", ".join(kernel_args_opencl)))
 
         header_stream.write("\n\nDACE_EXPORTED void {}({});\n\n".format(
             host_function_name, ", ".join(kernel_args_opencl)))

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -6,6 +6,7 @@ import os
 import re
 from six import StringIO
 import numpy as np
+import warnings
 
 import dace
 from dace import registry, subsets, dtypes
@@ -1132,8 +1133,9 @@ class OpenCLDaceKeywordRemover(cpp.DaCeKeywordRemover):
 
         # The vector length tells us HOW MANY ELEMENTS ARE ASSIGNED, whereas
         # the memory width length tells us if its a VECTOR TYPE being assigned.
+        warnings.warn('we are not done here')
 
-        veclen_lhs = memlet.veclen
+        veclen_lhs = 1  #memlet.veclen
         try:
             memwidth_lhs = self.memory_widths[(memlet.data, self.sdfg)]
         except KeyError:
@@ -1141,7 +1143,7 @@ class OpenCLDaceKeywordRemover(cpp.DaCeKeywordRemover):
         try:
             # Detect vector width conversions in simple cases.
             # TODO: use type inference to detect this for arbitrary expressions
-            veclen_rhs = self.memlets[node.value.id][0].veclen
+            veclen_rhs = 1  #self.memlets[node.value.id][0].veclen
         except (AttributeError, KeyError):
             veclen_rhs = veclen_lhs  # Is not a data container
         if veclen_lhs != veclen_rhs:

--- a/dace/data.py
+++ b/dace/data.py
@@ -460,7 +460,7 @@ class Stream(Data):
     offset = ListProperty(element_type=symbolic.pystr_to_symbolic)
     buffer_size = SymbolicProperty(desc="Size of internal buffer.", default=0)
     veclen = Property(dtype=int,
-                      desc="Vector length. Memlets must adhere to this.")
+                      desc="Vector length. Connectors must adhere to this.")
 
     def __init__(self,
                  dtype,

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -635,8 +635,7 @@ class callback(typeclass):
                         non_symbolic_sizes.append(other_arguments[str(s)])
                     else:
                         non_symbolic_sizes.append(s)
-                list_of_other_inputs[i] = ptrtonumpy(other_inputs[i],
-                                                     data_type,
+                list_of_other_inputs[i] = ptrtonumpy(other_inputs[i], data_type,
                                                      non_symbolic_sizes)
             return orig_function(*list_of_other_inputs)
 
@@ -836,12 +835,12 @@ class DebugInfo:
         IDE and debugging purposes. """
     def __init__(self,
                  start_line,
-                 start_column,
-                 end_line,
-                 end_column,
+                 start_column=0,
+                 end_line=-1,
+                 end_column=0,
                  filename=None):
         self.start_line = start_line
-        self.end_line = end_line
+        self.end_line = end_line if end_line >= 0 else start_line
         self.start_column = start_column
         self.end_column = end_column
         self.filename = filename

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -138,9 +138,6 @@ SCOPEDEFAULT_SCHEDULE = {
     ScheduleType.FPGA_Device: ScheduleType.FPGA_Device,
 }
 
-# Identifier for dynamic number of Memlet accesses.
-DYNAMIC = -1
-
 # Translation of types to C types
 _CTYPES = {
     int: "int",

--- a/dace/frontend/octave/ast_arrayaccess.py
+++ b/dace/frontend/octave/ast_arrayaccess.py
@@ -111,8 +111,7 @@ class AST_ArrayAccess(AST_Node):
                         str(self))
             else:
                 raise NotImplementedError(
-                    "Non-constant array indexing not implemented: " +
-                    str(self))
+                    "Non-constant array indexing not implemented: " + str(self))
         ret = dace.subsets.Range(rangelist)
         return ret
 
@@ -140,13 +139,9 @@ class AST_ArrayAccess(AST_Node):
 
         if self.is_data_dependent_access() == False:
             msubset = self.make_range_from_accdims()
-            memlet = dace.memlet.Memlet(arrnode,
-                                        msubset.num_elements(),
-                                        msubset,
-                                        1,
-                                        None,
-                                        None,
-                                        debuginfo=self.context)
+            memlet = dace.memlet.Memlet.simple(arrnode,
+                                               msubset,
+                                               debuginfo=self.context)
             sdfg.nodes()[state].add_edge(arrnode, None, resnode, None, memlet)
         else:
             # add a map around the access and feed the access dims that are
@@ -204,12 +199,10 @@ class AST_ArrayAccess(AST_Node):
                 dace.memlet.Memlet.simple(arrnode, ','.join(access_dims)))
             s.add_edge(
                 tasklet, 'out', mex, None,
-                dace.memlet.Memlet.from_array(resnode.data,
-                                              resnode.desc(sdfg)))
+                dace.memlet.Memlet.from_array(resnode.data, resnode.desc(sdfg)))
             s.add_edge(
                 mex, None, resnode, None,
-                dace.memlet.Memlet.from_array(resnode.data,
-                                              resnode.desc(sdfg)))
+                dace.memlet.Memlet.from_array(resnode.data, resnode.desc(sdfg)))
 
         print("The result of " + str(self) + " will be stored in " + str(name))
 

--- a/dace/frontend/octave/ast_assign.py
+++ b/dace/frontend/octave/ast_assign.py
@@ -161,7 +161,7 @@ class AST_Assign(AST_Node):
                         dace.memlet.Memlet.simple(
                             self.lhs.arrayname.get_name(),
                             ','.join([str(d) for d in acc_dims])))
-                    s.add_edge(dn, None, mex, None, dace.memlet.EmptyMemlet())
+                    s.add_edge(dn, None, mex, None, dace.memlet.Memlet())
 
             else:
                 raise NotImplementedError("Assignment with lhs of type " +

--- a/dace/frontend/octave/ast_assign.py
+++ b/dace/frontend/octave/ast_assign.py
@@ -41,8 +41,8 @@ class AST_Assign(AST_Node):
         self.rhs.provide_parents(self)
 
     def __repr__(self):
-        return "AST_Assign(" + str(self.lhs) + ", " + str(
-            self.op) + ", " + str(self.rhs) + ")"
+        return "AST_Assign(" + str(self.lhs) + ", " + str(self.op) + ", " + str(
+            self.rhs) + ")"
 
     def print_nodes(self, state):
         for n in state.nodes():
@@ -64,10 +64,7 @@ class AST_Assign(AST_Node):
                 name = self.lhs.get_name()
 
                 if name not in sdfg.arrays:
-                    sdfg.add_array(name,
-                                   dims,
-                                   basetype,
-                                   debuginfo=self.context)
+                    sdfg.add_array(name, dims, basetype, debuginfo=self.context)
                 rhs_datanode = self.rhs.get_datanode(sdfg, state)
                 lhs_datanode = self.lhs.get_datanode(sdfg, state)
 
@@ -108,13 +105,10 @@ class AST_Assign(AST_Node):
 
                 if self.lhs.is_data_dependent_access() == False:
                     msubset = self.lhs.make_range_from_accdims()
-                    writem = dace.memlet.Memlet(self.lhs.arrayname.get_name(),
-                                                msubset.num_elements(),
-                                                msubset,
-                                                1,
-                                                None,
-                                                None,
-                                                debuginfo=self.context)
+                    writem = dace.memlet.Memlet.simple(
+                        self.lhs.arrayname.get_name(),
+                        msubset,
+                        debuginfo=self.context)
 
                     sdfg.nodes()[state].add_edge(rhs_datanode, None, dn, None,
                                                  writem)

--- a/dace/frontend/octave/ast_function.py
+++ b/dace/frontend/octave/ast_function.py
@@ -212,11 +212,11 @@ class AST_BuiltInFunCall(AST_Node):
             if self.funname.get_name() == "zeros":
                 tasklet = sdfg.nodes()[state].add_tasklet(
                     'zero', {}, {'out'}, "out=0")
-                s.add_edge(men, None, tasklet, None, dace.memlet.EmptyMemlet())
+                s.add_edge(men, None, tasklet, None, dace.memlet.Memlet())
             elif self.funname.get_name() == "rand":
                 tasklet = sdfg.nodes()[state].add_tasklet(
                     'rand', {}, {'out'}, "out=drand48()")
-                s.add_edge(men, None, tasklet, None, dace.memlet.EmptyMemlet())
+                s.add_edge(men, None, tasklet, None, dace.memlet.Memlet())
             elif self.funname.get_name() == "sqrt":
                 A = self.args[0].get_datanode(sdfg, state)
                 tasklet = sdfg.nodes()[state].add_tasklet(

--- a/dace/frontend/octave/ast_matrix.py
+++ b/dace/frontend/octave/ast_matrix.py
@@ -124,7 +124,7 @@ class AST_Matrix(AST_Node):
             me, mx = sdfg.nodes()[state].add_map('init',
                                                  dict(i='0:' + str(arrlen)))
             sdfg.nodes()[state].add_edge(me, None, tasklet, None,
-                                         dace.memlet.EmptyMemlet())
+                                         dace.memlet.Memlet())
             sdfg.nodes()[state].add_edge(
                 tasklet, "out", mx, None,
                 dace.memlet.Memlet.from_array(trans.data, trans.desc(sdfg)))

--- a/dace/frontend/python/decorators.py
+++ b/dace/frontend/python/decorators.py
@@ -18,6 +18,8 @@ def program(f, *args, **kwargs) -> parser.DaceProgram:
     return parser.DaceProgram(f, args, kwargs)
 
 
+function = program
+
 # Internal DaCe decorators, these are not actually run, but rewritten
 
 

--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -206,8 +206,7 @@ def parse_memlet(visitor, src: MemletType, dst: MemletType,
     else:
         expr = dstexpr
 
-    return localvar, Memlet(expr.name,
-                            expr.accesses,
-                            expr.subset,
-                            1,
-                            wcr=expr.wcr)
+    return localvar, Memlet.simple(expr.name,
+                                   expr.subset,
+                                   num_accesses=expr.accesses,
+                                   wcr_str=expr.wcr)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -873,10 +873,9 @@ class TaskletTransformer(ExtNodeTransformer):
                         memlet = dace.Memlet.simple(memlet.data, rng)
                     if self.nested and name in self.sdfg_outputs:
                         out_memlet = self.sdfg_outputs[name][0]
-                        out_memlet.num_accesses = memlet.num_accesses
-                        out_memlet.veclen = memlet.veclen
+                        out_memlet.volume = memlet.volume
                         out_memlet.wcr = memlet.wcr
-                        out_memlet.wcr_conflict = memlet.wcr_conflict
+                        out_memlet.wcr_nonatomic = memlet.wcr_nonatomic
                     if connector in self.inputs or connector in self.outputs:
                         raise DaceSyntaxError(
                             self, node,

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -474,8 +474,7 @@ def add_indirection_subgraph(sdfg: SDFG,
     fullRange = subsets.Range([(0, s - 1, 1) for s in array.shape])
     fullMemlet = Memlet.simple(memlet.data,
                                fullRange,
-                               num_accesses=memlet.num_accesses,
-                               veclen=memlet.veclen)
+                               num_accesses=memlet.num_accesses)
 
     if output:
         if isinstance(dst, nodes.ExitNode):
@@ -509,8 +508,7 @@ def add_indirection_subgraph(sdfg: SDFG,
 
     valueMemlet = Memlet.simple(tmp_name,
                                 indirectRange,
-                                num_accesses=1,
-                                veclen=memlet.veclen)
+                                num_accesses=1)
     if output:
         path = [src] + inp_base_path
         if isinstance(src, nodes.AccessNode):
@@ -1769,7 +1767,6 @@ class ProgramVisitor(ExtNodeVisitor):
                                                'w')][0]
                         inner_memlet = Memlet.simple(vname, str(irng))
                         inner_memlet.num_accesses = memlet.num_accesses
-                        inner_memlet.veclen = memlet.veclen
                     else:
                         name = memlet.data
                         vname = "{c}_out_of_{s}{n}".format(

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1305,7 +1305,7 @@ class ProgramVisitor(ExtNodeVisitor):
         internal_memlet = dace.Memlet.simple(ntrans, subsets.Indices([0]))
         external_memlet = dace.Memlet.simple(stream_name,
                                              subsets.Indices([0]),
-                                             num_accesses=dtypes.DYNAMIC)
+                                             num_accesses=-1)
 
         # Inject to internal tasklet
         if not dec.endswith('scope'):

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -385,7 +385,7 @@ def add_indirection_subgraph(sdfg: SDFG,
                 conn = 'index_%s_%d' % (arr_name, i)
             arr = sdfg.arrays[arrname]
             # Memlet to load the indirection index
-            indexMemlet = Memlet(arrname, 1, subsets.Indices(access), 1)
+            indexMemlet = Memlet.simple(arrname, subsets.Indices(access))
             input_index_memlets.append(indexMemlet)
             read_node = graph.add_read(arrname)
             if PVisitor.nested or not isinstance(src, nodes.EntryNode):
@@ -472,8 +472,10 @@ def add_indirection_subgraph(sdfg: SDFG,
 
     # Create memlet that depends on the full array that we look up in
     fullRange = subsets.Range([(0, s - 1, 1) for s in array.shape])
-    fullMemlet = Memlet(memlet.data, memlet.num_accesses, fullRange,
-                        memlet.veclen)
+    fullMemlet = Memlet.simple(memlet.data,
+                               fullRange,
+                               num_accesses=memlet.num_accesses,
+                               veclen=memlet.veclen)
 
     if output:
         if isinstance(dst, nodes.ExitNode):
@@ -500,15 +502,15 @@ def add_indirection_subgraph(sdfg: SDFG,
 
     # Memlet to store the final value into the transient, and to load it into
     # the tasklet that needs it
-    # indirectMemlet = Memlet('__' + local_name + '_value', memlet.num_accesses,
-    #                         indirectRange, memlet.veclen)
+    # indirectMemlet = Memlet.simple('__' + local_name + '_value',
+    #                         indirectRange, num_accesses=memlet.num_accesses,
+    #                         veclen=memlet.veclen)
     # graph.add_edge(tasklet, 'lookup', dataNode, None, indirectMemlet)
 
-    valueMemlet = Memlet(
-        tmp_name,
-        1,  # memlet.num_accesses,
-        indirectRange,
-        memlet.veclen)
+    valueMemlet = Memlet.simple(tmp_name,
+                                indirectRange,
+                                num_accesses=1,
+                                veclen=memlet.veclen)
     if output:
         path = [src] + inp_base_path
         if isinstance(src, nodes.AccessNode):
@@ -720,15 +722,15 @@ class TaskletTransformer(ExtNodeTransformer):
                 self.sdfg_inputs[var_name] = (dace.Memlet.from_array(
                     parent_name, parent_array), inner_indices)
             else:
-                self.sdfg_inputs[var_name] = (dace.Memlet(
-                    parent_name, rng.num_elements(), rng, 1), inner_indices)
+                self.sdfg_inputs[var_name] = (dace.Memlet.simple(
+                    parent_name, rng), inner_indices)
         else:
             if _subset_has_indirection(rng):
                 self.sdfg_outputs[var_name] = (dace.Memlet.from_array(
                     parent_name, parent_array), inner_indices)
             else:
-                self.sdfg_outputs[var_name] = (dace.Memlet(
-                    parent_name, rng.num_elements(), rng, 1), inner_indices)
+                self.sdfg_outputs[var_name] = (dace.Memlet.simple(
+                    parent_name, rng), inner_indices)
 
         return (var_name, squeezed_rng)
 
@@ -843,8 +845,7 @@ class TaskletTransformer(ExtNodeTransformer):
                                                      node.value.left,
                                                      self.sdfg.arrays)
                     if self.nested and _subset_has_indirection(rng):
-                        memlet = dace.Memlet(memlet.data, rng.num_elements(),
-                                             rng, 1)
+                        memlet = dace.Memlet.simple(memlet.data, rng)
                     if connector in self.inputs or connector in self.outputs:
                         raise DaceSyntaxError(
                             self, node,
@@ -869,8 +870,7 @@ class TaskletTransformer(ExtNodeTransformer):
                                                      node.value.right,
                                                      self.sdfg.arrays)
                     if self.nested and _subset_has_indirection(rng):
-                        memlet = dace.Memlet(memlet.data, rng.num_elements(),
-                                             rng, 1)
+                        memlet = dace.Memlet.simple(memlet.data, rng)
                     if self.nested and name in self.sdfg_outputs:
                         out_memlet = self.sdfg_outputs[name][0]
                         out_memlet.num_accesses = memlet.num_accesses
@@ -1302,9 +1302,10 @@ class ProgramVisitor(ExtNodeVisitor):
         # Inject element to internal SDFG arrays
         ntrans = sdfg.temp_data_name()
         sdfg.add_array(ntrans, [1], self.sdfg.arrays[stream_name].dtype)
-        internal_memlet = dace.Memlet(ntrans, 1, subsets.Indices([0]), 1)
-        external_memlet = dace.Memlet(stream_name, dtypes.DYNAMIC,
-                                      subsets.Indices([0]), 1)
+        internal_memlet = dace.Memlet.simple(ntrans, subsets.Indices([0]))
+        external_memlet = dace.Memlet.simple(stream_name,
+                                             subsets.Indices([0]),
+                                             num_accesses=dtypes.DYNAMIC)
 
         # Inject to internal tasklet
         if not dec.endswith('scope'):
@@ -1625,8 +1626,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     state.add_edge(v, conn, internal_node, conn,
                                    dace.Memlet.simple(new_scalar, '0'))
                     if entry_node is not None:
-                        state.add_edge(entry_node, None, v, None,
-                                       dace.Memlet())
+                        state.add_edge(entry_node, None, v, None, dace.Memlet())
                     continue
 
                 if isinstance(v, tuple):
@@ -2043,8 +2043,7 @@ class ProgramVisitor(ExtNodeVisitor):
             if op_subset.num_elements() != 1:
                 op1 = state.add_read(op_name)
                 op2 = state.add_write(target_name)
-                memlet = Memlet(target_name, target_subset.num_elements(),
-                                target_subset, 1)
+                memlet = Memlet.simple(target_name, target_subset)
                 memlet.other_subset = op_subset
                 state.add_nedge(op1, op2, memlet)
             else:
@@ -2139,8 +2138,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 else:
                     op1 = state.add_read(op_name)
                     op2 = state.add_write(wtarget_name)
-                    memlet = Memlet(wtarget_name, wtarget_subset.num_elements(),
-                                    wtarget_subset, 1)
+                    memlet = Memlet.simple(wtarget_name, wtarget_subset)
                     memlet.other_subset = op_subset
                     if op is not None:
                         memlet.wcr = LambdaProperty.from_string(
@@ -2248,13 +2246,11 @@ class ProgramVisitor(ExtNodeVisitor):
         inner_indices = set(non_squeezed)
 
         if access_type == 'r':
-            self.inputs[var_name] = (dace.Memlet(parent_name,
-                                                 rng.num_elements(), rng,
-                                                 1), inner_indices)
+            self.inputs[var_name] = (dace.Memlet.simple(parent_name,
+                                                        rng), inner_indices)
         else:
-            self.outputs[var_name] = (dace.Memlet(parent_name,
-                                                  rng.num_elements(), rng,
-                                                  1), inner_indices)
+            self.outputs[var_name] = (dace.Memlet.simple(parent_name,
+                                                         rng), inner_indices)
 
         return var_name
 
@@ -2899,11 +2895,11 @@ class ProgramVisitor(ExtNodeVisitor):
             wnode = state.add_write(dst_name)
             state.add_nedge(
                 rnode, wnode,
-                Memlet(src_name,
-                       src_expr.accesses,
-                       subsets.Range.from_array(self.sdfg.arrays[src_name]),
-                       1,
-                       wcr=dst_expr.wcr))
+                Memlet.simple(src_name,
+                              subsets.Range.from_array(
+                                  self.sdfg.arrays[src_name]),
+                              num_accesses=src_expr.accesses,
+                              wcr_str=dst_expr.wcr))
             return
 
         # Calling reduction or other SDFGs / functions
@@ -3196,7 +3192,10 @@ class ProgramVisitor(ExtNodeVisitor):
         self._add_state('slice_%s_%d' % (array, node.lineno))
         rnode = self.last_state.add_read(array)
         if _subset_has_indirection(expr.subset):
-            memlet = Memlet(array, expr.accesses, expr.subset, 1, expr.wcr)
+            memlet = Memlet.simple(array,
+                                   expr.subset,
+                                   num_accesses=expr.accesses,
+                                   wcr_str=expr.wcr)
             tmp = self.sdfg.temp_data_name()
             return add_indirection_subgraph(self.sdfg, self.last_state, rnode,
                                             None, memlet, tmp, self)
@@ -3209,8 +3208,11 @@ class ProgramVisitor(ExtNodeVisitor):
             wnode = self.last_state.add_write(tmp)
             self.last_state.add_nedge(
                 rnode, wnode,
-                Memlet(array, expr.accesses, expr.subset, 1, expr.wcr,
-                       other_subset))
+                Memlet.simple(array,
+                              expr.subset,
+                              num_accesses=expr.accesses,
+                              wcr_str=expr.wcr,
+                              other_subset_str=other_subset))
             return tmp
 
     ##################################

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1626,7 +1626,7 @@ class ProgramVisitor(ExtNodeVisitor):
                                    dace.Memlet.simple(new_scalar, '0'))
                     if entry_node is not None:
                         state.add_edge(entry_node, None, v, None,
-                                       dace.EmptyMemlet())
+                                       dace.Memlet())
                     continue
 
                 if isinstance(v, tuple):
@@ -1727,7 +1727,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     state.add_edge(read_node, None, internal_node, conn, memlet)
         else:
             if entry_node is not None:
-                state.add_nedge(entry_node, internal_node, dace.EmptyMemlet())
+                state.add_nedge(entry_node, internal_node, dace.Memlet())
 
         # Parse internal node outputs
         if outputs:
@@ -1822,7 +1822,7 @@ class ProgramVisitor(ExtNodeVisitor):
                                    inner_memlet)
         else:
             if exit_node is not None:
-                state.add_nedge(internal_node, exit_node, dace.EmptyMemlet())
+                state.add_nedge(internal_node, exit_node, dace.Memlet())
 
     def _add_nested_symbols(self, nsdfg_node: nodes.NestedSDFG):
         """ 

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -107,8 +107,7 @@ def _reduce(sdfg: SDFG,
         input_subset = parse_memlet_subset(sdfg.arrays[inarr],
                                            ast.parse(in_array).body[0].value,
                                            {})
-        input_memlet = Memlet(inarr, input_subset.num_elements(), input_subset,
-                              1)
+        input_memlet = Memlet.simple(inarr, input_subset)
         output_shape = None
         if axis is None:
             output_shape = [1]
@@ -134,13 +133,11 @@ def _reduce(sdfg: SDFG,
         input_subset = parse_memlet_subset(sdfg.arrays[inarr],
                                            ast.parse(in_array).body[0].value,
                                            {})
-        input_memlet = Memlet(inarr, input_subset.num_elements(), input_subset,
-                              1)
+        input_memlet = Memlet.simple(inarr, input_subset)
         output_subset = parse_memlet_subset(sdfg.arrays[outarr],
                                             ast.parse(out_array).body[0].value,
                                             {})
-        output_memlet = Memlet(outarr, output_subset.num_elements(),
-                               output_subset, 1)
+        output_memlet = Memlet.simple(outarr, output_subset)
 
     # Create reduce subgraph
     inpnode = state.add_read(inarr)
@@ -342,8 +339,7 @@ def _conj(sdfg: SDFG, state: SDFGState, input: str):
 @oprepo.replaces('numpy.real')
 def _real(sdfg: SDFG, state: SDFGState, input: str):
     inptype = sdfg.arrays[input].dtype
-    return _simple_call(sdfg, state, input, 'real',
-                        _complex_to_scalar(inptype))
+    return _simple_call(sdfg, state, input, 'real', _complex_to_scalar(inptype))
 
 
 @oprepo.replaces('imag')
@@ -351,8 +347,7 @@ def _real(sdfg: SDFG, state: SDFGState, input: str):
 @oprepo.replaces('numpy.imag')
 def _imag(sdfg: SDFG, state: SDFGState, input: str):
     inptype = sdfg.arrays[input].dtype
-    return _simple_call(sdfg, state, input, 'imag',
-                        _complex_to_scalar(inptype))
+    return _simple_call(sdfg, state, input, 'imag', _complex_to_scalar(inptype))
 
 
 @oprepo.replaces('transpose')
@@ -404,31 +399,13 @@ def _min(sdfg: SDFG, state: SDFGState, a: str, axis=None):
 
 
 @oprepo.replaces('numpy.argmax')
-def _argmax(sdfg: SDFG,
-            state: SDFGState,
-            a: str,
-            axis,
-            result_type=dace.int32):
-    return _argminmax(sdfg,
-                      state,
-                      a,
-                      axis,
-                      func="max",
-                      result_type=result_type)
+def _argmax(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int32):
+    return _argminmax(sdfg, state, a, axis, func="max", result_type=result_type)
 
 
 @oprepo.replaces('numpy.argmin')
-def _argmin(sdfg: SDFG,
-            state: SDFGState,
-            a: str,
-            axis,
-            result_type=dace.int32):
-    return _argminmax(sdfg,
-                      state,
-                      a,
-                      axis,
-                      func="min",
-                      result_type=result_type)
+def _argmin(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int32):
+    return _argminmax(sdfg, state, a, axis, func="min", result_type=result_type)
 
 
 def _argminmax(sdfg: SDFG,
@@ -483,10 +460,8 @@ def _argminmax(sdfg: SDFG,
 
     nest.add_state().add_mapped_tasklet(
         name="_arg{}_reduce_".format(func),
-        map_ranges={
-            '__i%d' % i: '0:%s' % n
-            for i, n in enumerate(a_arr.shape)
-        },
+        map_ranges={'__i%d' % i: '0:%s' % n
+                    for i, n in enumerate(a_arr.shape)},
         inputs={
             '__in':
             Memlet.simple(
@@ -555,8 +530,7 @@ def _argminmax(sdfg: SDFG,
 ##############################################################################
 
 
-def _assignop(sdfg: SDFG, state: SDFGState, op1: str, opcode: str,
-              opname: str):
+def _assignop(sdfg: SDFG, state: SDFGState, op1: str, opcode: str, opname: str):
     """ Implements a general element-wise array assignment operator. """
     arr1 = sdfg.arrays[op1]
 
@@ -845,8 +819,9 @@ def _matmult(visitor, sdfg: SDFG, state: SDFGState, op1: str, op2: str):
     if len(arr1.shape) > 1 and len(arr2.shape) > 1:  # matrix * matrix
 
         if len(arr1.shape) > 3 or len(arr2.shape) > 3:
-            raise SyntaxError('Matrix multiplication of tensors of dimensions > 3 '
-                              'not supported')
+            raise SyntaxError(
+                'Matrix multiplication of tensors of dimensions > 3 '
+                'not supported')
 
         if arr1.shape[-1] != arr2.shape[-2]:
             raise SyntaxError('Matrix dimension mismatch %s != %s' %
@@ -871,7 +846,7 @@ def _matmult(visitor, sdfg: SDFG, state: SDFGState, op1: str, op2: str):
 
         output_shape = (arr1.shape[0], )
 
-    elif len(arr1.shape) == 1 and len(arr2.shape) == 1: # vector * vector
+    elif len(arr1.shape) == 1 and len(arr2.shape) == 1:  # vector * vector
 
         if arr1.shape[0] != arr2.shape[0]:
             raise SyntaxError("Vectors in vector product must have same size: "
@@ -897,11 +872,8 @@ def _matmult(visitor, sdfg: SDFG, state: SDFGState, op1: str, op2: str):
 
     tasklet = MatMul('_MatMult_', restype)
     state.add_node(tasklet)
-    state.add_edge(acc1, None, tasklet, '_a',
-                   dace.Memlet.from_array(op1, arr1))
-    state.add_edge(acc2, None, tasklet, '_b',
-                   dace.Memlet.from_array(op2, arr2))
-    state.add_edge(tasklet, '_c', acc3, None,
-                   dace.Memlet.from_array(op3, arr3))
+    state.add_edge(acc1, None, tasklet, '_a', dace.Memlet.from_array(op1, arr1))
+    state.add_edge(acc2, None, tasklet, '_b', dace.Memlet.from_array(op2, arr2))
+    state.add_edge(tasklet, '_c', acc3, None, dace.Memlet.from_array(op3, arr3))
 
     return op3

--- a/dace/frontend/tensorflow/tensorflow.py
+++ b/dace/frontend/tensorflow/tensorflow.py
@@ -11,7 +11,7 @@ import math
 from typing import Any, List
 
 import dace
-from dace.memlet import Memlet, EmptyMemlet
+from dace.memlet import Memlet
 from dace import SDFG, SDFGState, dtypes
 from dace.data import Scalar
 from dace.sdfg.nodes import Tasklet, NestedSDFG

--- a/dace/libraries/blas/nodes/dot.py
+++ b/dace/libraries/blas/nodes/dot.py
@@ -18,13 +18,13 @@ class ExpandDotPure(ExpandTransformation):
 
         ((edge_x, outer_array_x, shape_x, _), (edge_y, outer_array_y, shape_y,
                                                _),
-         (_, outer_array_result, shape_result, _)) = _get_matmul_operands(
-             node,
-             parent_state,
-             parent_sdfg,
-             name_lhs="_x",
-             name_rhs="_y",
-             name_out="_result")
+         (_, outer_array_result, shape_result,
+          _)) = _get_matmul_operands(node,
+                                     parent_state,
+                                     parent_sdfg,
+                                     name_lhs="_x",
+                                     name_rhs="_y",
+                                     name_out="_result")
 
         dtype_x = outer_array_x.dtype.type
         dtype_y = outer_array_y.dtype.type
@@ -41,7 +41,9 @@ class ExpandDotPure(ExpandTransformation):
 
         _, array_x = sdfg.add_array("_x", shape_x, dtype_x, storage=storage)
         _, array_y = sdfg.add_array("_y", shape_y, dtype_y, storage=storage)
-        _, array_result = sdfg.add_array("_result", [1], dtype_result, storage=storage)
+        _, array_result = sdfg.add_array("_result", [1],
+                                         dtype_result,
+                                         storage=storage)
 
         mul_program = "__out = __x * __y"
 
@@ -53,13 +55,15 @@ class ExpandDotPure(ExpandTransformation):
 
         # Initialization map
         init_write = init_state.add_write("_result")
-        init_tasklet = init_state.add_tasklet(
-            "dot_init", {}, {"_out"}, "_out = 0", location=node.location)
-        init_state.add_memlet_path(
-            init_tasklet,
-            init_write,
-            src_conn="_out",
-            memlet=dace.Memlet.simple(init_write.data, "0", num_accesses=1))
+        init_tasklet = init_state.add_tasklet("dot_init", {}, {"_out"},
+                                              "_out = 0",
+                                              location=node.location)
+        init_state.add_memlet_path(init_tasklet,
+                                   init_write,
+                                   src_conn="_out",
+                                   memlet=dace.Memlet.simple(init_write.data,
+                                                             "0",
+                                                             num_accesses=1))
 
         # Multiplication map
         state.add_mapped_tasklet(
@@ -183,17 +187,13 @@ class Dot(dace.sdfg.nodes.LibraryNode):
             raise ValueError("Expected exactly one output from dot product")
         out_memlet = out_edges[0].data
         size = in_memlets[0].subset.size()
-        veclen = in_memlets[0].veclen
         if len(size) != 1:
             raise ValueError(
                 "dot product only supported on 1-dimensional arrays")
         if size != in_memlets[1].subset.size():
             raise ValueError("Inputs to dot product must have equal size")
-        if out_memlet.subset.num_elements() != 1 or out_memlet.veclen != 1:
+        if out_memlet.subset.num_elements() != 1:
             raise ValueError("Output of dot product must be a single element")
-        if veclen != in_memlets[1].veclen:
-            raise ValueError(
-                "Vector lengths of inputs to dot product must be identical")
         if (in_memlets[0].wcr is not None or in_memlets[1].wcr is not None
                 or out_memlet.wcr is not None):
             raise ValueError("WCR on dot product memlets not supported")

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -310,8 +310,8 @@ class ExpandReduceCUDADevice(pm.ExpandTransformation):
                                                node=node_id)
 
         output_memlet = output_edge.data
-        output_type = 'dace::vec<%s, %s>' % (
-            sdfg.arrays[output_memlet.data].dtype.ctype, output_memlet.veclen)
+        output_type = 'dace::vec<%s, 1>' % (
+            sdfg.arrays[output_memlet.data].dtype.ctype)
 
         if node.identity is None:
             raise ValueError('For device reduce nodes, initial value must be '
@@ -529,8 +529,8 @@ class ExpandReduceCUDABlock(pm.ExpandTransformation):
         # Obtain some SDFG-related information
         input_memlet = input_edge.data
         output_memlet = output_edge.data
-        output_type = 'dace::vec<%s, %s>' % (
-            sdfg.arrays[output_memlet.data].dtype.ctype, output_memlet.veclen)
+        output_type = 'dace::vec<%s, 1>' % (
+            sdfg.arrays[output_memlet.data].dtype.ctype)
 
         if node.identity is None:
             raise ValueError('For device reduce nodes, initial value must be '

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -14,8 +14,8 @@ from dace.sdfg import graph
 from dace.frontend.python.astutils import unparse
 from dace.properties import (Property, CodeProperty, LambdaProperty,
                              RangeProperty, DebugInfoProperty, SetProperty,
-                             make_properties, indirect_properties,
-                             DataProperty, SymbolicProperty, ListProperty,
+                             make_properties, indirect_properties, DataProperty,
+                             SymbolicProperty, ListProperty,
                              SDFGReferenceProperty, DictProperty,
                              LibraryImplementationProperty)
 from dace.frontend.operations import detect_reduction_type
@@ -185,8 +185,7 @@ class ExpandReduceOpenMP(pm.ExpandTransformation):
         # Get reduction type for OpenMP
         redtype = detect_reduction_type(node.wcr, openmp=True)
         if redtype not in ExpandReduceOpenMP._REDUCTION_TYPE_TO_OPENMP:
-            raise ValueError('Reduction type not supported for "%s"' %
-                             node.wcr)
+            raise ValueError('Reduction type not supported for "%s"' % node.wcr)
         omptype, expr = ExpandReduceOpenMP._REDUCTION_TYPE_TO_OPENMP[redtype]
 
         # Standardize axes
@@ -362,8 +361,7 @@ class ExpandReduceCUDADevice(pm.ExpandTransformation):
         if (not reduce_all_axes) and (not reduce_last_axes):
             raise NotImplementedError(
                 'Multiple axis reductions not supported on GPUs. Please use '
-                'the pure expansion or make reduce axes the last in the array.'
-            )
+                'the pure expansion or make reduce axes the last in the array.')
 
         # Verify that data is on the GPU
         if input_data.storage not in [
@@ -405,8 +403,7 @@ class ExpandReduceCUDADevice(pm.ExpandTransformation):
             segment_size = ' * '.join([symstr(s) for s in reduce_axes])
 
             reduce_type = 'DeviceSegmentedReduce'
-            iterator = 'dace::stridedIterator({size})'.format(
-                size=segment_size)
+            iterator = 'dace::stridedIterator({size})'.format(size=segment_size)
             reduce_range = '{num}, {it}, {it} + 1'.format(num=num_segments,
                                                           it=iterator)
             reduce_range_def = 'size_t num_segments, size_t segment_size'
@@ -489,8 +486,8 @@ DACE_EXPORTED void __dace_reduce_{id}({intype} *input, {outtype} *output, {reduc
 
         # HACK: Workaround to avoid issues with code generator inferring reads
         # and writes when it shouldn't.
-        input_edge.data.num_accesses = dtypes.DYNAMIC
-        output_edge.data.num_accesses = dtypes.DYNAMIC
+        input_edge.data.dynamic = True
+        output_edge.data.dynamic = True
 
         return tnode
 
@@ -628,8 +625,8 @@ class ExpandReduceCUDABlock(pm.ExpandTransformation):
 
         # HACK: Workaround to avoid issues with code generator inferring reads
         # and writes when it shouldn't.
-        input_edge.data.num_accesses = dtypes.DYNAMIC
-        output_edge.data.num_accesses = dtypes.DYNAMIC
+        input_edge.data.dynamic = True
+        output_edge.data.dynamic = True
 
         return tnode
 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -163,7 +163,11 @@ class Memlet(object):
     @staticmethod
     def from_json(json_obj, context=None):
         ret = Memlet()
-        dace.serialize.set_properties_from_json(ret, json_obj, context=context)
+        dace.serialize.set_properties_from_json(
+            ret,
+            json_obj,
+            context=context,
+            ignore_properties={'data', 'subset', 'other_subset'})
         if context:
             ret._sdfg = context['sdfg']
             ret._state = context['sdfg_state']
@@ -461,9 +465,11 @@ class Memlet(object):
                 return self._data
             if isinstance(path_src, AccessNode):
                 self._data = path_src.data
+                self._is_data_src = True
                 return self._data
             elif isinstance(path_dst, AccessNode):
                 self._data = path_dst.data
+                self._is_data_src = False
                 return self._data
         return None
 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -166,8 +166,8 @@ class Memlet(object):
         dace.serialize.set_properties_from_json(ret, json_obj, context=context)
         if context:
             ret._sdfg = context['sdfg']
-            ret._state = context['state']
-            ret._edge = context['edge']
+            ret._state = context['sdfg_state']
+        ret._initialized = True
         return ret
 
     def is_empty(self) -> bool:
@@ -369,7 +369,7 @@ class Memlet(object):
             :type datadesc: Data
         """
         rng = subsets.Range.from_array(datadesc)
-        return Memlet.simple(dataname, rng, wcr=wcr)
+        return Memlet.simple(dataname, rng, wcr_str=wcr)
 
     def __hash__(self):
         return hash(

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -71,8 +71,7 @@ class Memlet(object):
                         AccessNode.
             :param num_accesses: The number of times that the moved data
                                  will be subsequently accessed. If
-                                 `dace.dtypes.DYNAMIC` (-1),
-                                 designates that the number of accesses is
+                                 -1, designates that the number of accesses is
                                  unknown at compile time.
             :param subset: The subset of `data` that is going to be accessed.
             :param vector_length: The length of a single unit of access to
@@ -163,8 +162,7 @@ class Memlet(object):
                                  information from the SDFG.
             :param num_accesses: The number of times that the moved data
                                  will be subsequently accessed. If
-                                 `dace.dtypes.DYNAMIC` (-1),
-                                 designates that the number of accesses is
+                                 -1, designates that the number of accesses is
                                  unknown at compile time.
             :param debuginfo: Source-code information (e.g., line, file)
                               used for debugging.

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -139,7 +139,7 @@ class Memlet(object):
                debuginfo=None):
         """ Constructs a Memlet from string-based expressions.
             :param data: The data object or name to access. B{Note:} this
-                         parameter will soon be deprecated.
+                         parameter is deprecated.
             :type data: Either a string of the data descriptor name or an
                         AccessNode.
             :param subset_str: The subset of `data` that is going to

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -176,7 +176,7 @@ class Memlet(object):
         primarily used for connecting nodes to scopes without transferring 
         data to them. 
         """
-        return (self.data is None and self.src_subset is None
+        return (self._data is None and self.src_subset is None
                 and self.dst_subset is None)
 
     @property
@@ -206,7 +206,7 @@ class Memlet(object):
             :param subset_str: The subset of `data` that is going to
                                be accessed in string format. Example: '0:N'.
             :param veclen: The length of a single unit of access to
-                           the data (used for vectorization optimizations).
+                           the data (UNUSED).
             :param wcr_str: A lambda function (as a string) specifying
                             how write-conflicts are resolved. The syntax
                             of the lambda function receives two elements:
@@ -410,6 +410,18 @@ class Memlet(object):
             return self.src_subset if self._is_data_src else self.dst_subset
         return self.src_subset
 
+    @subset.setter
+    def subset(self, value):
+        if not self._initialized:
+            self._subset = value
+        elif self._is_data_src is not None:
+            if self._is_data_src:
+                self.src_subset = value
+            else:
+                self.dst_subset = value
+        else:
+            self.src_subset = value
+
     @property
     def other_subset(self):
         if not self._initialized:
@@ -417,6 +429,18 @@ class Memlet(object):
         elif self._is_data_src is not None:
             return self.dst_subset if self._is_data_src else self.src_subset
         return self.dst_subset
+
+    @other_subset.setter
+    def other_subset(self, value):
+        if not self._initialized:
+            self._other_subset = value
+        elif self._is_data_src is not None:
+            if self._is_data_src:
+                self.dst_subset = value
+            else:
+                self.src_subset = value
+        else:
+            self.dst_subset = value
 
     @property
     def data(self):

--- a/dace/runtime/include/dace/types.h
+++ b/dace/runtime/include/dace/types.h
@@ -73,7 +73,6 @@ namespace dace
 
     enum NumAccesses
     {
-        NA_DYNAMIC = -1, // Dynamic number of accesses
         NA_RUNTIME = 0, // Given at runtime
     };
 

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -40,7 +40,7 @@ class Edge(object):
         yield self._data
 
     def to_json(self, parent_graph):
-        memlet_ret = self.data.to_json(parent_graph)
+        memlet_ret = self.data.to_json()
         ret = {
             'type': type(self).__name__,
             'attributes': {

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -105,8 +105,7 @@ class MultiConnectorEdge(MultiEdge):
         sdfg = context['sdfg_state']
         if sdfg is None:
             raise Exception("parent_graph must be defined for this method")
-        data = dace.serialize.from_json(json_obj['attributes']['data'],
-                                        context)
+        data = dace.serialize.from_json(json_obj['attributes']['data'], context)
         src_nid = json_obj['src']
         dst_nid = json_obj['dst']
 
@@ -119,6 +118,7 @@ class MultiConnectorEdge(MultiEdge):
         # Auto-create key (used when uniquely identifying networkx multigraph
         # edges)
         ret = MultiConnectorEdge(src, src_conn, dst, dst_conn, data, None)
+        data._edge = ret
 
         return ret
 
@@ -324,8 +324,7 @@ class Graph(object):
                     e = next(children)
                     if e.dst not in visited:
                         visited.add(e.dst)
-                        if condition is None or condition(
-                                e.src, e.dst, e.data):
+                        if condition is None or condition(e.src, e.dst, e.data):
                             yield e
                             stack.append(
                                 (e.dst, self.out_edges(e.dst).__iter__()))
@@ -579,11 +578,9 @@ class MultiDiConnectorGraph(MultiDiGraph):
     @staticmethod
     def _from_nx(edge):
         return MultiConnectorEdge(edge[0], edge[3]["src_conn"], edge[1],
-                                  edge[3]["dst_conn"], edge[3]["data"],
-                                  edge[2])
+                                  edge[3]["dst_conn"], edge[3]["data"], edge[2])
 
-    def add_edge(self, source, src_connector, destination, dst_connector,
-                 data):
+    def add_edge(self, source, src_connector, destination, dst_connector, data):
         key = self._nx.add_edge(source,
                                 destination,
                                 data=data,

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -85,7 +85,7 @@ class Node(object):
     def __repr__(self):
         return type(self).__name__ + ' (' + self.__str__() + ')'
 
-    def add_in_connector(self, connector_name: str):
+    def add_in_connector(self, connector_name: str, dtype=None):
         """ Adds a new input connector to the node. The operation will fail if
             a connector (either input or output) with the same name already
             exists in the node.

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -64,8 +64,7 @@ class SeparableMemlet(MemletPattern):
                          expr[dim][1].approx if isinstance(
                              expr[dim][1], symbolic.SymExpr) else expr[dim][1],
                          expr[dim][2].approx if isinstance(
-                             expr[dim][2],
-                             symbolic.SymExpr) else expr[dim][2]))
+                             expr[dim][2], symbolic.SymExpr) else expr[dim][2]))
                 else:
                     dexprs.append(expr[dim])
 
@@ -134,13 +133,6 @@ class AffineSMemlet(SeparableMemletPattern):
         self.constant_min = None
         self.constant_max = None
 
-        # Obtain vector length
-        self.veclen = None
-        if dim_index == total_dims - 1:
-            for e in orig_edges:
-                self.veclen = e.veclen
-        if self.veclen is None:
-            self.veclen = 1
         ######################
 
         # Special case: Get the total internal access range
@@ -256,7 +248,7 @@ class AffineSMemlet(SeparableMemletPattern):
         # This should be using sympy.floor
         memlet_start_pts = ((re - rt + 1 - rb) / rs) + 1
         memlet_rlen = memlet_start_pts.expand() * rt
-        interval_len = (result_end - result_begin + 1) * self.veclen
+        interval_len = (result_end - result_begin + 1) * 1  # self.veclen
         num_elements = node_rlen * memlet_rlen
 
         if (interval_len == num_elements
@@ -266,8 +258,8 @@ class AffineSMemlet(SeparableMemletPattern):
             result_tile = 1
         else:
             if rt == 1:
-                result_skip = (result_end - result_begin - re +
-                               rb) / (node_re - node_rb)
+                result_skip = (result_end - result_begin - re + rb) / (node_re -
+                                                                       node_rb)
                 try:
                     if result_skip < 1:
                         result_skip = 1

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -248,7 +248,7 @@ class AffineSMemlet(SeparableMemletPattern):
         # This should be using sympy.floor
         memlet_start_pts = ((re - rt + 1 - rb) / rs) + 1
         memlet_rlen = memlet_start_pts.expand() * rt
-        interval_len = (result_end - result_begin + 1) * 1  # self.veclen
+        interval_len = (result_end - result_begin + 1)
         num_elements = node_rlen * memlet_rlen
 
         if (interval_len == num_elements
@@ -689,6 +689,7 @@ def propagate_memlet(dfg_state,
             [symbolic.pystr_to_symbolic(p) for p in mapnode.params]
         ]
 
+        # TODO: Rewrite for src/dst_subset
         new_subset = None
         for md in aggdata:
             tmp_subset = None

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -8,7 +8,7 @@ import sympy
 import warnings
 
 from dace import registry, subsets, symbolic, dtypes
-from dace.memlet import EmptyMemlet, Memlet
+from dace.memlet import Memlet
 from dace.sdfg import nodes
 
 
@@ -624,8 +624,8 @@ def _propagate_node(dfg_state, node):
         ]
 
     for edge in external_edges:
-        if isinstance(edge.data, EmptyMemlet):
-            new_memlet = EmptyMemlet()
+        if edge.data.is_empty():
+            new_memlet = Memlet()
         else:
             internal_edge = next(e for e in internal_edges
                                  if e.data.data == edge.data.data)
@@ -658,8 +658,8 @@ def propagate_memlet(dfg_state,
         neighboring_edges = dfg_state.in_edges(scope_node)
     else:
         raise TypeError('Trying to propagate through a non-scope node')
-    if isinstance(memlet, EmptyMemlet):
-        return EmptyMemlet()
+    if memlet.is_empty():
+        return Memlet()
 
     sdfg = dfg_state.parent
     scope_node_symbols = set(conn for conn in entry_node.in_connectors

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -44,7 +44,7 @@ def replace(subgraph: 'dace.sdfg.state.StateGraphView', name: str,
     # Replace in memlets
     for edge in subgraph.edges():
         if edge.data.data == name:
-            edge.data.data = new_name
+            edge.data._data = new_name
         edge.data.subset = _replsym(edge.data.subset, symrepl)
         edge.data.other_subset = _replsym(edge.data.other_subset, symrepl)
         edge.data.num_accesses = _replsym(edge.data.num_accesses, symrepl)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1873,7 +1873,7 @@ def _get_optimizer_class(class_override):
     if class_override is None:
         clazz = Config.get("optimizer", "interface")
 
-    if clazz == "" or clazz is False:
+    if clazz.strip() == "" or clazz is False:
         return None
 
     result = locate(clazz)

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -747,8 +747,9 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
         for e in edges:
             eret = serialize.loads(serialize.dumps(e), context=rec_ci)
 
-            ret.add_edge(eret.src, eret.src_conn, eret.dst, eret.dst_conn,
-                         eret.data)
+            new_edge = ret.add_edge(eret.src, eret.src_conn, eret.dst,
+                                    eret.dst_conn, eret.data)
+            eret.data._edge = new_edge
 
         # Fix potentially broken scopes
         for n in nodes:

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -90,7 +90,8 @@ class StateGraphView(object):
         state = self._graph
 
         # If empty memlet, return itself as the path
-        if edge.src_conn is None and edge.dst_conn is None and edge.data.data is None:
+        if (edge.src_conn is None and edge.dst_conn is None
+                and edge.data.is_empty()):
             return result
 
         # Prepend incoming edges until reaching the source node

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1463,6 +1463,9 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
                     if propagate:
                         cur_memlet = propagate_memlet(self, cur_memlet, snode,
                                                       True)
+        # Retry to initialize edges
+        for edge in edges:
+            edge.data.try_initialize(self.parent, self, edge)
 
     # DEPRECATED FUNCTIONS
     ######################################

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -659,8 +659,10 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
                             str(type(memlet)))
 
         self._clear_scopedict_cache()
-        return super(SDFGState, self).add_edge(u, u_connector, v, v_connector,
-                                               memlet)
+        result = super(SDFGState, self).add_edge(u, u_connector, v, v_connector,
+                                                 memlet)
+        memlet.try_initialize(self.parent, self, result)
+        return result
 
     def remove_edge(self, edge):
         self._clear_scopedict_cache()

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1122,7 +1122,7 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
 
         # If there are no inputs, add empty memlet
         if len(inputs) == 0:
-            self.add_edge(map_entry, None, tasklet, None, mm.EmptyMemlet())
+            self.add_edge(map_entry, None, tasklet, None, mm.Memlet())
 
         if external_edges:
             for inp, inpnode in inpdict.items():
@@ -1155,7 +1155,7 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
 
         # If there are no outputs, add empty memlet
         if len(outputs) == 0:
-            self.add_edge(tasklet, None, map_exit, None, mm.EmptyMemlet())
+            self.add_edge(tasklet, None, map_exit, None, mm.Memlet())
 
         if external_edges:
             for out, outnode in outdict.items():
@@ -1385,7 +1385,7 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
         # Add edges first so that scopes can be understood
         edges = [
             self.add_edge(path_nodes[i], None, path_nodes[i + 1], None,
-                          mm.EmptyMemlet()) for i in range(len(path_nodes) - 1)
+                          mm.Memlet()) for i in range(len(path_nodes) - 1)
         ]
 
         if not isinstance(memlet, mm.Memlet):
@@ -1401,15 +1401,13 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
         cur_memlet = memlet
 
         # Verify that connectors exist
-        if (not isinstance(memlet, mm.EmptyMemlet)
-                and hasattr(edges[0].src, "out_connectors")
+        if (not memlet.is_empty() and hasattr(edges[0].src, "out_connectors")
                 and isinstance(edges[0].src, nd.CodeNode)
                 and not isinstance(edges[0].src, nd.LibraryNode) and
             (src_conn is None or src_conn not in edges[0].src.out_connectors)):
             raise ValueError("Output connector {} does not exist in {}".format(
                 src_conn, edges[0].src.label))
-        if (not isinstance(memlet, mm.EmptyMemlet)
-                and hasattr(edges[-1].dst, "in_connectors")
+        if (not memlet.is_empty() and hasattr(edges[-1].dst, "in_connectors")
                 and isinstance(edges[-1].dst, nd.CodeNode)
                 and not isinstance(edges[-1].dst, nd.LibraryNode) and
             (dst_conn is None or dst_conn not in edges[-1].dst.in_connectors)):
@@ -1431,7 +1429,7 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
                 dconn = dst_conn if i == 0 else ("IN_" +
                                                  edge.dst.last_connector())
 
-            if isinstance(cur_memlet, mm.EmptyMemlet):
+            if cur_memlet.is_empty():
                 if propagate_forward:
                     sconn = src_conn if i == 0 else None
                     dconn = dst_conn if i == len(edges) - 1 else None
@@ -1459,7 +1457,7 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
             # Propagate current memlet to produce the next one
             if i < len(edges) - 1:
                 snode = edge.dst if propagate_forward else edge.src
-                if not isinstance(cur_memlet, mm.EmptyMemlet):
+                if not cur_memlet.is_empty():
                     if propagate:
                         cur_memlet = propagate_memlet(self, cur_memlet, snode,
                                                       True)

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -749,7 +749,6 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
 
             new_edge = ret.add_edge(eret.src, eret.src_conn, eret.dst,
                                     eret.dst_conn, eret.data)
-            eret.data._edge = new_edge
 
         # Fix potentially broken scopes
         for n in nodes:

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -159,9 +159,8 @@ class Range(Subset):
         return Range(tuples)
 
     @staticmethod
-    def from_array(array):
-        """ Constructs a range that covers the full array given as input.
-            @type array: dace.data.Data """
+    def from_array(array: 'dace.data.Data'):
+        """ Constructs a range that covers the full array given as input. """
         return Range([(0, s - 1, 1) for s in array.shape])
 
     def __hash__(self):
@@ -577,8 +576,8 @@ class Range(Subset):
         return Range.ndslice_to_string_list(self.ranges, self.tile_sizes)
 
     def replace(self, repl_dict):
-        for i, ((rb, re, rs),
-                ts) in enumerate(zip(self.ranges, self.tile_sizes)):
+        for i, ((rb, re, rs), ts) in enumerate(zip(self.ranges,
+                                                   self.tile_sizes)):
             self.ranges[i] = (
                 rb.subs(repl_dict) if symbolic.issymbolic(rb) else rb,
                 re.subs(repl_dict) if symbolic.issymbolic(re) else re,

--- a/dace/transformation/dataflow/map_fission.py
+++ b/dace/transformation/dataflow/map_fission.py
@@ -317,10 +317,16 @@ class MapFission(pattern_matching.Transformation):
                     sbs.offset([r[0] for r in outer_map.range], True)
                     state.add_edge(
                         edge.src, edge.src_conn, anode, None,
-                        mm.Memlet(name, outer_map.range.num_elements(), sbs, 1))
+                        mm.Memlet.simple(
+                            name,
+                            sbs,
+                            num_accesses=outer_map.range.num_elements()))
                     state.add_edge(
                         anode, None, edge.dst, edge.dst_conn,
-                        mm.Memlet(name, outer_map.range.num_elements(), sbs, 1))
+                        mm.Memlet.simple(
+                            name,
+                            sbs,
+                            num_accesses=outer_map.range.num_elements()))
                     state.remove_edge(edge)
 
             # Add extra maps around components
@@ -354,8 +360,7 @@ class MapFission(pattern_matching.Transformation):
                     state.remove_edge(e)
                 # Empty memlet edge in nested SDFGs
                 if state.in_degree(component_in) == 0:
-                    state.add_edge(me, None, component_in, None,
-                                   mm.Memlet())
+                    state.add_edge(me, None, component_in, None, mm.Memlet())
 
                 for e in state.out_edges(component_out):
                     state.add_edge(e.src, e.src_conn, mx, None, dcpy(e.data))
@@ -370,8 +375,7 @@ class MapFission(pattern_matching.Transformation):
                     state.remove_edge(e)
                 # Empty memlet edge in nested SDFGs
                 if state.out_degree(component_out) == 0:
-                    state.add_edge(component_out, None, mx, None,
-                                   mm.Memlet())
+                    state.add_edge(component_out, None, mx, None, mm.Memlet())
             # Connect other sources/sinks not in components (access nodes)
             # directly to external nodes
             if self.expr_index == 0:

--- a/dace/transformation/dataflow/map_fission.py
+++ b/dace/transformation/dataflow/map_fission.py
@@ -355,7 +355,7 @@ class MapFission(pattern_matching.Transformation):
                 # Empty memlet edge in nested SDFGs
                 if state.in_degree(component_in) == 0:
                     state.add_edge(me, None, component_in, None,
-                                   mm.EmptyMemlet())
+                                   mm.Memlet())
 
                 for e in state.out_edges(component_out):
                     state.add_edge(e.src, e.src_conn, mx, None, dcpy(e.data))
@@ -371,7 +371,7 @@ class MapFission(pattern_matching.Transformation):
                 # Empty memlet edge in nested SDFGs
                 if state.out_degree(component_out) == 0:
                     state.add_edge(component_out, None, mx, None,
-                                   mm.EmptyMemlet())
+                                   mm.Memlet())
             # Connect other sources/sinks not in components (access nodes)
             # directly to external nodes
             if self.expr_index == 0:

--- a/dace/transformation/dataflow/mapreduce.py
+++ b/dace/transformation/dataflow/mapreduce.py
@@ -145,7 +145,6 @@ class MapReduceFusion(pm.Transformation):
             Memlet.simple(array_edge.data.data,
                           array_edge.data.subset,
                           num_accesses=array_edge.data.num_accesses,
-                          veclen=array_edge.data.veclen,
                           wcr_str=reduce_node.wcr))
 
         # Add initialization state as necessary

--- a/dace/transformation/dataflow/mapreduce.py
+++ b/dace/transformation/dataflow/mapreduce.py
@@ -23,11 +23,10 @@ class MapReduceFusion(pm.Transformation):
         between the map and the reduction is not used anywhere else.
     """
 
-    no_init = Property(
-        dtype=bool,
-        default=False,
-        desc='If enabled, does not create initialization states '
-        'for reduce nodes with identity')
+    no_init = Property(dtype=bool,
+                       default=False,
+                       desc='If enabled, does not create initialization states '
+                       'for reduce nodes with identity')
 
     _tasklet = nodes.Tasklet('_')
     _tmap_exit = nodes.MapExit(nodes.Map("", [], []))
@@ -137,16 +136,17 @@ class MapReduceFusion(pm.Transformation):
         # Modify edge from tasklet to map exit
         memlet_edge.data.data = out_array.data
         memlet_edge.data.wcr = reduce_node.wcr
-        memlet_edge.data.subset = type(
-            memlet_edge.data.subset)(filtered_subset)
+        memlet_edge.data.subset = type(memlet_edge.data.subset)(filtered_subset)
 
         # Add edge from map exit to output array
         graph.add_edge(
             memlet_edge.dst, 'OUT_' + memlet_edge.dst_conn[3:], array_edge.dst,
             array_edge.dst_conn,
-            Memlet(array_edge.data.data, array_edge.data.num_accesses,
-                   array_edge.data.subset, array_edge.data.veclen,
-                   reduce_node.wcr))
+            Memlet.simple(array_edge.data.data,
+                          array_edge.data.subset,
+                          num_accesses=array_edge.data.num_accesses,
+                          veclen=array_edge.data.veclen,
+                          wcr_str=reduce_node.wcr))
 
         # Add initialization state as necessary
         if reduce_node.identity is not None:

--- a/dace/transformation/dataflow/merge_arrays.py
+++ b/dace/transformation/dataflow/merge_arrays.py
@@ -25,9 +25,9 @@ class MergeArrays(pattern_matching.Transformation):
         g.add_node(MergeArrays._array2)
         g.add_node(MergeArrays._map_entry)
         g.add_edge(MergeArrays._array1, None, MergeArrays._map_entry, None,
-                   memlet.EmptyMemlet())
+                   memlet.Memlet())
         g.add_edge(MergeArrays._array2, None, MergeArrays._map_entry, None,
-                   memlet.EmptyMemlet())
+                   memlet.Memlet())
         return [g]
 
     @staticmethod

--- a/dace/transformation/dataflow/vectorization.py
+++ b/dace/transformation/dataflow/vectorization.py
@@ -46,6 +46,9 @@ class Vectorization(pattern_matching.Transformation):
         param = symbolic.pystr_to_symbolic(map_entry.map.params[-1])
         found = False
 
+        warnings.warn("REDO")
+        return False
+
         # Check if all edges, adjacent to the tasklet,
         # use the parameter in their last dimension.
         for _src, _, _dest, _, memlet in graph.all_edges(tasklet):
@@ -62,7 +65,7 @@ class Vectorization(pattern_matching.Transformation):
 
             try:
                 subset = memlet.subset
-                veclen = memlet.veclen
+                veclen = 1  #memlet.veclen
             except AttributeError:
                 return False
 
@@ -103,8 +106,7 @@ class Vectorization(pattern_matching.Transformation):
         tasklet = candidate[Vectorization._tasklet]
         map_exit = candidate[Vectorization._map_exit]
 
-        return ' -> '.join(
-            str(node) for node in [map_entry, tasklet, map_exit])
+        return ' -> '.join(str(node) for node in [map_entry, tasklet, map_exit])
 
     def apply(self, sdfg):
         graph = sdfg.nodes()[self.state_id]
@@ -121,8 +123,7 @@ class Vectorization(pattern_matching.Transformation):
         if self.strided_map:
             map_entry.map.range[-1] = (dim_from, dim_to, vector_size)
         else:
-            map_entry.map.range[-1] = (dim_from,
-                                       (dim_to + 1) / vector_size - 1,
+            map_entry.map.range[-1] = (dim_from, (dim_to + 1) / vector_size - 1,
                                        dim_step)
 
         # TODO: Postamble and/or preamble non-vectorized map

--- a/dace/transformation/dataflow/vectorization.py
+++ b/dace/transformation/dataflow/vectorization.py
@@ -4,6 +4,7 @@ from dace.sdfg import nodes
 from dace.sdfg import utils as sdutil
 from dace.transformation import pattern_matching
 from dace.properties import Property, make_properties
+import warnings
 
 
 @registry.autoregister_params(singlestate=True)

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from dace.sdfg import nodes
 from dace.sdfg.graph import SubgraphView, MultiConnectorEdge
 from dace.sdfg import SDFG, SDFGState
-from dace.memlet import EmptyMemlet, Memlet
+from dace.memlet import Memlet
 
 
 def nest_state_subgraph(sdfg: SDFG,
@@ -212,13 +212,13 @@ def nest_state_subgraph(sdfg: SDFG,
     for name in input_arrays:
         node = state.add_read(name)
         if entry is not None:
-            state.add_nedge(entry, node, EmptyMemlet())
+            state.add_nedge(entry, node, Memlet())
         state.add_edge(node, None, nested_sdfg, name,
                        Memlet.from_array(name, sdfg.arrays[name]))
     for name in output_arrays:
         node = state.add_write(name)
         if exit is not None:
-            state.add_nedge(node, exit, EmptyMemlet())
+            state.add_nedge(node, exit, Memlet())
         state.add_edge(nested_sdfg, name, node, None,
                        Memlet.from_array(name, sdfg.arrays[name]))
 

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -241,7 +241,8 @@ def unsqueeze_memlet(internal_memlet: Memlet, external_memlet: Memlet):
         :return: Offset Memlet to set on the resulting graph.
     """
     result = copy.deepcopy(internal_memlet)
-    result.data = external_memlet.data
+    # TODO: Remove
+    result._data = external_memlet.data
 
     shape = external_memlet.subset.size()
     if len(internal_memlet.subset) < len(external_memlet.subset):

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -97,8 +97,7 @@ class FPGATransformState(pattern_matching.Transformation):
             # Map schedules that are disallowed to transform to FPGAs
             if (candidate_map.schedule == dtypes.ScheduleType.MPI
                     or candidate_map.schedule == dtypes.ScheduleType.GPU_Device
-                    or
-                    candidate_map.schedule == dtypes.ScheduleType.FPGA_Device
+                    or candidate_map.schedule == dtypes.ScheduleType.FPGA_Device
                     or candidate_map.schedule ==
                     dtypes.ScheduleType.GPU_ThreadBlock):
                 return False
@@ -189,8 +188,7 @@ class FPGATransformState(pattern_matching.Transformation):
                 pre_node = pre_state.add_read(node.data)
                 pre_fpga_node = pre_state.add_write('fpga_' + node.data)
                 full_range = subsets.Range([(0, s - 1, 1) for s in desc.shape])
-                mem = memlet.Memlet(node.data, full_range.num_elements(),
-                                    full_range, 1)
+                mem = memlet.Memlet.simple(node.data, full_range)
                 pre_state.add_edge(pre_node, None, pre_fpga_node, None, mem)
 
                 if node not in wcr_input_nodes:
@@ -234,8 +232,7 @@ class FPGATransformState(pattern_matching.Transformation):
                 post_node = post_state.add_write(node.data)
                 post_fpga_node = post_state.add_read('fpga_' + node.data)
                 full_range = subsets.Range([(0, s - 1, 1) for s in desc.shape])
-                mem = memlet.Memlet('fpga_' + node.data,
-                                    full_range.num_elements(), full_range, 1)
+                mem = memlet.Memlet, simple('fpga_' + node.data, full_range)
                 post_state.add_edge(post_fpga_node, None, post_node, None, mem)
 
                 fpga_node = state.add_write('fpga_' + node.data)

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -255,7 +255,8 @@ class FPGATransformState(pattern_matching.Transformation):
                         if isinstance(n, dace.sdfg.nodes.AccessNode
                                       ) and n.data == dst_conn:
                             # assuming all memlets have the same vector length
-                            veclen_ = inner_state.all_edges(n)[0].data.veclen
+                            #veclen_ = inner_state.all_edges(n)[0].data.veclen
+                            pass
             if isinstance(src, dace.sdfg.nodes.NestedSDFG):
                 # this edge is coming from the nested SDFG
                 for inner_state in src.sdfg.states():
@@ -263,7 +264,8 @@ class FPGATransformState(pattern_matching.Transformation):
                         if isinstance(n, dace.sdfg.nodes.AccessNode
                                       ) and n.data == src_conn:
                             # assuming all memlets have the same vector length
-                            veclen_ = inner_state.all_edges(n)[0].data.veclen
+                            #veclen_ = inner_state.all_edges(n)[0].data.veclen
+                            pass
 
             if mem.data is not None and mem.data in fpga_data:
                 mem.data = 'fpga_' + mem.data

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -296,7 +296,7 @@ class GPUTransformSDFG(pattern_matching.Transformation):
 
                 # Map without inputs
                 if len(in_edges) == 0:
-                    state.add_nedge(me, gcode, memlet.EmptyMemlet())
+                    state.add_nedge(me, gcode, memlet.Memlet())
         #######################################################
         # Step 6: Change all top-level maps and library nodes to GPU schedule
 

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -6,7 +6,7 @@ import networkx as nx
 from typing import Dict, List, Set, Optional
 import warnings
 
-from dace import memlet, registry, sdfg as sd, Memlet, EmptyMemlet
+from dace import memlet, registry, sdfg as sd, Memlet
 from dace.sdfg import nodes
 from dace.sdfg.graph import MultiConnectorEdge, SubgraphView
 from dace.sdfg import SDFG, SDFGState
@@ -326,10 +326,10 @@ class InlineSDFG(pattern_matching.Transformation):
             for node in subgraph.nodes():
                 if state.in_degree(node) == 0:
                     state.add_edge(nsdfg_scope_entry, None, node, None,
-                                   EmptyMemlet())
+                                   Memlet())
                 if state.out_degree(node) == 0:
                     state.add_edge(node, None, nsdfg_scope_exit, None,
-                                   EmptyMemlet())
+                                   Memlet())
 
         # Replace nested SDFG parents with new SDFG
         for node in nstate.nodes():

--- a/samples/fpga/filter_fpga.py
+++ b/samples/fpga/filter_fpga.py
@@ -159,15 +159,14 @@ def make_loop_body(sdfg):
                    dace.memlet.Memlet.simple(ratio, "0"))
     state.add_edge(
         tasklet, "b", B, None,
-        dace.memlet.Memlet(B, dace.symbolic.pystr_to_symbolic("-1"),
-                           dace.subsets.Range.from_array(B.desc(sdfg)), 1))
+        dace.memlet.Memlet.simple(B,
+                                  dace.subsets.Range.from_array(B.desc(sdfg)),
+                                  num_accesses=-1))
     state.add_edge(outsize_buffer_in, None, tasklet, "write_index",
                    dace.memlet.Memlet.simple(outsize_buffer_in, "0"))
     state.add_edge(
         tasklet, "size_out", outsize_buffer_out, None,
-        dace.memlet.Memlet(outsize_buffer_out,
-                           dace.symbolic.pystr_to_symbolic("-1"),
-                           dace.properties.SubsetProperty.from_string("0"), 1))
+        dace.memlet.Memlet.simple(outsize_buffer_out, "0", num_accesses=-1))
 
     return state
 
@@ -205,8 +204,7 @@ def make_sdfg(specialize):
 
     sdfg.add_edge(copy_to_device_state, compute_state,
                   dace.sdfg.InterstateEdge())
-    sdfg.add_edge(compute_state, copy_to_host_state,
-                  dace.sdfg.InterstateEdge())
+    sdfg.add_edge(compute_state, copy_to_host_state, dace.sdfg.InterstateEdge())
 
     return sdfg
 
@@ -255,8 +253,8 @@ if __name__ == "__main__":
 
     if len(filtered) != outsize[0]:
         print(
-            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)"
-            % (outsize[0], len(filtered)))
+            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)" %
+            (outsize[0], len(filtered)))
         totalitems = min(outsize[0], N.get())
         print('DaCe:', B[:totalitems].view(type=np.ndarray))
         print('Regression:', filtered.view(type=np.ndarray))

--- a/samples/fpga/filter_fpga_vectorized.py
+++ b/samples/fpga/filter_fpga_vectorized.py
@@ -288,11 +288,10 @@ def make_read_sdfg():
 
     state.add_memlet_path(A,
                           A_pipe,
-                          memlet=Memlet(A_pipe,
-                                        1,
-                                        Indices(["0"]),
-                                        W.get(),
-                                        other_subset=Indices(["i"])))
+                          memlet=Memlet.simple(A_pipe,
+                                               '0',
+                                               other_subset_str='i',
+                                               veclen=W.get()))
 
     return sdfg
 
@@ -449,14 +448,13 @@ def make_main_state(sdfg):
                                          {"_A_pipe"})
 
     compute_sdfg = make_compute_sdfg()
-    compute_tasklet = state.add_nested_sdfg(
-        compute_sdfg, sdfg, {"_A_pipe", "ratio_nested"},
-        {"_B_pipe", "_valid_pipe", "count"})
+    compute_tasklet = state.add_nested_sdfg(compute_sdfg, sdfg,
+                                            {"_A_pipe", "ratio_nested"},
+                                            {"_B_pipe", "_valid_pipe", "count"})
 
     write_sdfg = make_write_sdfg()
     write_tasklet = state.add_nested_sdfg(write_sdfg, sdfg,
-                                          {"_B_pipe", "_valid_pipe"},
-                                          {"B_mem"})
+                                          {"_B_pipe", "_valid_pipe"}, {"B_mem"})
 
     state.add_memlet_path(A,
                           read_tasklet,
@@ -540,8 +538,7 @@ def make_sdfg(specialize):
 
     sdfg.add_edge(copy_to_device_state, compute_state,
                   dace.sdfg.InterstateEdge())
-    sdfg.add_edge(compute_state, copy_to_host_state,
-                  dace.sdfg.InterstateEdge())
+    sdfg.add_edge(compute_state, copy_to_host_state, dace.sdfg.InterstateEdge())
 
     return sdfg
 
@@ -602,8 +599,8 @@ if __name__ == "__main__":
 
     if len(filtered) != outsize[0]:
         print(
-            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)"
-            % (outsize[0], len(filtered)))
+            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)" %
+            (outsize[0], len(filtered)))
         totalitems = min(outsize[0], N.get())
         print('DaCe:', B[:totalitems].view(type=np.ndarray))
         print('Regression:', filtered.view(type=np.ndarray))

--- a/samples/fpga/gemm_fpga_pipelined.py
+++ b/samples/fpga/gemm_fpga_pipelined.py
@@ -79,7 +79,7 @@ def make_sdfg(specialized):
     m_entry, m_exit = state.add_map(
         "Map_M", {"m": "0:M"}, schedule=dace.dtypes.ScheduleType.FPGA_Device)
 
-    state.add_nedge(n_entry, C_buffer_in, dace.memlet.EmptyMemlet())
+    state.add_nedge(n_entry, C_buffer_in, dace.memlet.Memlet())
 
     ###########################################################################
     # Nested SDFG

--- a/samples/fpga/gemm_fpga_systolic.py
+++ b/samples/fpga/gemm_fpga_systolic.py
@@ -785,22 +785,22 @@ def make_fpga_state(sdfg):
     # Bring data nodes into scope
     state.add_memlet_path(compute_entry,
                           A_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(compute_entry,
                           B_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(compute_entry,
                           C_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(A_pipe_out,
                           compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(B_pipe_out,
                           compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(C_pipe_out,
                           compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
 
     # Connect data nodes
     state.add_memlet_path(

--- a/samples/fpga/gemm_fpga_systolic.py
+++ b/samples/fpga/gemm_fpga_systolic.py
@@ -136,16 +136,10 @@ def make_read_A_sdfg():
                                 dace.float32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        mem,
-        pipe,
-        memlet=dace.memlet.Memlet(
-            pipe,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string(
-                "n0 * P + n1, k")))
+    loop_body.add_memlet_path(mem,
+                              pipe,
+                              memlet=dace.memlet.Memlet.simple(
+                                  pipe, "0", other_subset_str="n0 * P + n1, k"))
 
     return sdfg
 
@@ -222,15 +216,10 @@ def make_read_B_sdfg():
                                 dace.float32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        mem,
-        pipe,
-        memlet=dace.memlet.Memlet(
-            pipe,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("k, m")))
+    loop_body.add_memlet_path(mem,
+                              pipe,
+                              memlet=dace.memlet.Memlet.simple(
+                                  pipe, "0", other_subset_str="k, m"))
 
     return sdfg
 
@@ -289,15 +278,10 @@ def make_write_C_sdfg():
                                 dace.float32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        pipe,
-        mem,
-        memlet=dace.memlet.Memlet(
-            mem,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("n, m"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("0")))
+    loop_body.add_memlet_path(pipe,
+                              mem,
+                              memlet=dace.memlet.Memlet.simple(
+                                  mem, "n, m", other_subset_str="0"))
 
     return sdfg
 
@@ -448,9 +432,7 @@ def make_compute_sdfg():
 
     # Scalar buffer for A
     A_pipe_in = buffer_a_state.add_stream(
-        "A_stream_in",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        "A_stream_in", dace.float32, storage=dace.dtypes.StorageType.FPGA_Local)
     A_pipe_out = buffer_a_state.add_stream(
         "A_stream_out",
         dace.float32,
@@ -468,27 +450,21 @@ def make_compute_sdfg():
         "\nelse:"
         "\n\tif p < P - 1:"
         "\n\t\ta_out = a_input")
-    buffer_a_state.add_memlet_path(
-        A_pipe_in,
-        buffer_a_tasklet,
-        memlet=dace.memlet.Memlet(
-            A_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        dst_conn="a_in")
-    buffer_a_state.add_memlet_path(
-        buffer_a_tasklet,
-        A_reg_out,
-        memlet=dace.memlet.Memlet(
-            A_reg_out, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="a_reg")
-    buffer_a_state.add_memlet_path(
-        buffer_a_tasklet,
-        A_pipe_out,
-        memlet=dace.memlet.Memlet(
-            A_pipe_out, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="a_out")
+    buffer_a_state.add_memlet_path(A_pipe_in,
+                                   buffer_a_tasklet,
+                                   memlet=dace.memlet.Memlet.simple(
+                                       A_pipe_in, "0", num_accesses=-1),
+                                   dst_conn="a_in")
+    buffer_a_state.add_memlet_path(buffer_a_tasklet,
+                                   A_reg_out,
+                                   memlet=dace.memlet.Memlet.simple(
+                                       A_reg_out, "0", num_accesses=-1),
+                                   src_conn="a_reg")
+    buffer_a_state.add_memlet_path(buffer_a_tasklet,
+                                   A_pipe_out,
+                                   memlet=dace.memlet.Memlet.simple(
+                                       A_pipe_out, "0", num_accesses=-1),
+                                   src_conn="a_out")
 
     ###########################################################################
     # Nested SDFG
@@ -577,13 +553,11 @@ def make_compute_sdfg():
                                   compute_tasklet,
                                   memlet=dace.memlet.Memlet.simple(B_in, "0"),
                                   dst_conn="b_in")
-    compute_state.add_memlet_path(
-        compute_tasklet,
-        B_out,
-        memlet=dace.memlet.Memlet(
-            B_out, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="b_out")
+    compute_state.add_memlet_path(compute_tasklet,
+                                  B_out,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      B_out, "0", num_accesses=-1),
+                                  src_conn="b_out")
     compute_state.add_memlet_path(C_val_in,
                                   compute_tasklet,
                                   memlet=dace.memlet.Memlet.simple(
@@ -617,26 +591,21 @@ def make_compute_sdfg():
 
     state.add_memlet_path(B_pipe_in,
                           tasklet,
-                          memlet=dace.memlet.Memlet(
-                              B_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(B_pipe_in,
+                                                           "0",
+                                                           num_accesses=-1),
                           dst_conn="B_in")
     state.add_memlet_path(tasklet,
                           B_pipe_out,
-                          memlet=dace.memlet.Memlet(
-                              B_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(B_pipe_out,
+                                                           "0",
+                                                           num_accesses=-1),
                           src_conn="B_out")
     state.add_memlet_path(C_buffer_in,
                           tasklet,
-                          memlet=dace.memlet.Memlet(
-                              C_buffer_in,
-                              dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("m"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(C_buffer_in,
+                                                           "m",
+                                                           num_accesses=-1),
                           dst_conn="C_in")
     state.add_memlet_path(tasklet,
                           C_buffer_out,
@@ -644,19 +613,16 @@ def make_compute_sdfg():
                           src_conn="C_out")
     state.add_memlet_path(A_reg_in,
                           tasklet,
-                          memlet=dace.memlet.Memlet(
-                              A_reg_in, dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(A_reg_in,
+                                                           "0",
+                                                           num_accesses=-1),
                           dst_conn="A_val_in")
 
     ###########################################################################
     # Write back state
 
     C_pipe_in = write_c_state.add_stream(
-        "C_stream_in",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        "C_stream_in", dace.float32, storage=dace.dtypes.StorageType.FPGA_Local)
     C_pipe_out = write_c_state.add_stream(
         "C_stream_out",
         dace.float32,
@@ -672,27 +638,21 @@ def make_compute_sdfg():
         "\nelse:"
         "\n\tif p > 0:"
         "\n\t\tc_out = forward_in")
-    write_c_state.add_memlet_path(
-        C_buffer_write,
-        write_c_tasklet,
-        memlet=dace.memlet.Memlet(
-            C_buffer_in, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("m"), 1),
-        dst_conn="buffer_in")
-    write_c_state.add_memlet_path(
-        C_pipe_in,
-        write_c_tasklet,
-        memlet=dace.memlet.Memlet(
-            C_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        dst_conn="forward_in")
-    write_c_state.add_memlet_path(
-        write_c_tasklet,
-        C_pipe_out,
-        memlet=dace.memlet.Memlet(
-            C_pipe_out, dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="c_out")
+    write_c_state.add_memlet_path(C_buffer_write,
+                                  write_c_tasklet,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      C_buffer_in, "m", num_accesses=-1),
+                                  dst_conn="buffer_in")
+    write_c_state.add_memlet_path(C_pipe_in,
+                                  write_c_tasklet,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      C_pipe_in, "0", num_accesses=-1),
+                                  dst_conn="forward_in")
+    write_c_state.add_memlet_path(write_c_tasklet,
+                                  C_pipe_out,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      C_pipe_out, "0"),
+                                  src_conn="c_out")
 
     return sdfg
 
@@ -783,121 +743,105 @@ def make_fpga_state(sdfg):
         unroll=True)
 
     # Bring data nodes into scope
-    state.add_memlet_path(compute_entry,
-                          A_pipe_in,
-                          memlet=dace.memlet.Memlet())
-    state.add_memlet_path(compute_entry,
-                          B_pipe_in,
-                          memlet=dace.memlet.Memlet())
-    state.add_memlet_path(compute_entry,
-                          C_pipe_in,
-                          memlet=dace.memlet.Memlet())
-    state.add_memlet_path(A_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.Memlet())
-    state.add_memlet_path(B_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.Memlet())
-    state.add_memlet_path(C_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.Memlet())
+    state.add_memlet_path(compute_entry, A_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(compute_entry, B_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(compute_entry, C_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(A_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(B_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(C_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
 
     # Connect data nodes
-    state.add_memlet_path(
-        A_pipe_in,
-        compute_sdfg_node,
-        dst_conn="A_stream_in",
-        memlet=dace.memlet.Memlet(
-            A_pipe_in,
-            dace.symbolic.pystr_to_symbolic("(N / P) * K * (P - p)"),
-            dace.properties.SubsetProperty.from_string("p"), 1))
-    state.add_memlet_path(B_pipe_in,
+    state.add_memlet_path(A_pipe_in,
                           compute_sdfg_node,
-                          dst_conn="B_stream_in",
-                          memlet=dace.memlet.Memlet(
-                              B_pipe_in,
-                              dace.symbolic.pystr_to_symbolic("N * K * M / P"),
-                              dace.properties.SubsetProperty.from_string("p"),
-                              1))
+                          dst_conn="A_stream_in",
+                          memlet=dace.memlet.Memlet.simple(
+                              A_pipe_in,
+                              'p',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(N / P) * K * (P - p)")))
+    state.add_memlet_path(
+        B_pipe_in,
+        compute_sdfg_node,
+        dst_conn="B_stream_in",
+        memlet=dace.memlet.Memlet.simple(
+            B_pipe_in,
+            'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N * K * M / P")))
     state.add_memlet_path(
         C_pipe_in,
         compute_sdfg_node,
         dst_conn="C_stream_in",
-        memlet=dace.memlet.Memlet(
-            C_pipe_in, dace.symbolic.pystr_to_symbolic("(N / P) * M * p"),
-            dace.properties.SubsetProperty.from_string("p"), 1))
-    state.add_memlet_path(
-        compute_sdfg_node,
-        A_pipe_out,
-        src_conn="A_stream_out",
-        memlet=dace.memlet.Memlet(
-            A_pipe_out,
-            dace.symbolic.pystr_to_symbolic("(N / P) * K * (P - p - 1)"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
-    state.add_memlet_path(
-        compute_sdfg_node,
-        B_pipe_out,
-        src_conn="B_stream_out",
-        memlet=dace.memlet.Memlet(
-            B_pipe_out,
-            dace.symbolic.pystr_to_symbolic(
-                "(p // (P - 1)) * (N / P) * K * M"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
-    state.add_memlet_path(
-        compute_sdfg_node,
-        C_pipe_out,
-        src_conn="C_stream_out",
-        memlet=dace.memlet.Memlet(
-            C_pipe_out,
-            dace.symbolic.pystr_to_symbolic("(N / P) * M * (p + 1)"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
-
-    state.add_memlet_path(
-        A,
-        read_A_sdfg_node,
-        dst_conn="mem",
-        memlet=dace.memlet.Memlet(
-            A, dace.symbolic.pystr_to_symbolic("N * K"),
-            dace.properties.SubsetProperty.from_string("0:N, 0:K"), 1))
-    state.add_memlet_path(read_A_sdfg_node,
-                          A_pipe_read,
-                          src_conn="pipe",
-                          memlet=dace.memlet.Memlet(
+        memlet=dace.memlet.Memlet.simple(
+            C_pipe_in,
+            'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * M * p")))
+    state.add_memlet_path(compute_sdfg_node,
+                          A_pipe_out,
+                          src_conn="A_stream_out",
+                          memlet=dace.memlet.Memlet.simple(
                               A_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("N * K"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1))
+                              'p + 1',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(N / P) * K * (P - p - 1)")))
+    state.add_memlet_path(compute_sdfg_node,
+                          B_pipe_out,
+                          src_conn="B_stream_out",
+                          memlet=dace.memlet.Memlet.simple(
+                              B_pipe_out,
+                              'p + 1',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(p // (P - 1)) * (N / P) * K * M")))
+    state.add_memlet_path(compute_sdfg_node,
+                          C_pipe_out,
+                          src_conn="C_stream_out",
+                          memlet=dace.memlet.Memlet.simple(
+                              C_pipe_out,
+                              'p + 1',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(N / P) * M * (p + 1)")))
+
+    state.add_memlet_path(A,
+                          read_A_sdfg_node,
+                          dst_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(A, '0:N, 0:K'))
+    state.add_memlet_path(
+        read_A_sdfg_node,
+        A_pipe_read,
+        src_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_out,
+            '0',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N * K")))
 
     state.add_memlet_path(
         B,
         read_B_sdfg_node,
         dst_conn="mem",
-        memlet=dace.memlet.Memlet(
-            B, dace.symbolic.pystr_to_symbolic("(N / P) * K * M"),
-            dace.properties.SubsetProperty.from_string("0:K, 0:M"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            B,
+            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * K * M"),
+            subset_str="0:K, 0:M"))
     state.add_memlet_path(
         read_B_sdfg_node,
         B_pipe_read,
         src_conn="pipe",
-        memlet=dace.memlet.Memlet(
-            B_pipe_out, dace.symbolic.pystr_to_symbolic("(N / P) * K * M"),
-            dace.properties.SubsetProperty.from_string("0"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            B_pipe_out,
+            '0',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * K * M")))
 
-    state.add_memlet_path(C_pipe_write,
-                          write_C_sdfg_node,
-                          dst_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              C_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("N * M"),
-                              dace.properties.SubsetProperty.from_string("P"),
-                              1))
     state.add_memlet_path(
+        C_pipe_write,
         write_C_sdfg_node,
-        C,
-        src_conn="mem",
-        memlet=dace.memlet.Memlet(
-            C, dace.symbolic.pystr_to_symbolic("N * M"),
-            dace.properties.SubsetProperty.from_string("0:N, 0:M"), 1))
+        dst_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            C_pipe_out,
+            'P',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N * M")))
+    state.add_memlet_path(write_C_sdfg_node,
+                          C,
+                          src_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(C, "N * M"))
 
     return state
 

--- a/samples/fpga/histogram_fpga.py
+++ b/samples/fpga/histogram_fpga.py
@@ -101,7 +101,7 @@ def make_init_buffer_state(sdfg):
 
     entry, exit = state.add_map("init_map", {"i": "0:num_bins"})
     tasklet = state.add_tasklet("zero", {}, {"out"}, "out = 0")
-    state.add_nedge(entry, tasklet, dace.memlet.EmptyMemlet())
+    state.add_nedge(entry, tasklet, dace.memlet.Memlet())
     state.add_memlet_path(tasklet,
                           exit,
                           hist_buffer,

--- a/samples/fpga/jacobi_fpga_systolic.py
+++ b/samples/fpga/jacobi_fpga_systolic.py
@@ -29,15 +29,13 @@ def make_init_state(sdfg):
     tmp0 = add_tmp(state)
     state.add_memlet_path(a0,
                           tmp0,
-                          memlet=dace.memlet.Memlet.simple(
-                              tmp0, "0, 0:H, 0:W"))
+                          memlet=dace.memlet.Memlet.simple(tmp0, "0, 0:H, 0:W"))
 
     a1 = state.add_array("A", (H, W), dtype)
     tmp1 = add_tmp(state)
     state.add_memlet_path(a1,
                           tmp1,
-                          memlet=dace.memlet.Memlet.simple(
-                              tmp1, "1, 0:H, 0:W"))
+                          memlet=dace.memlet.Memlet.simple(tmp1, "1, 0:H, 0:W"))
 
     return state
 
@@ -189,29 +187,25 @@ if (y >= 3 and x >= 3 and y < H - 1 and x < W - 1) or (y >= 2 and x >= 2):
                                   window_compute_in, "0:3, 0:3"))
 
     # Output result (conditional write)
-    out_memlet = dace.memlet.Memlet(
-        stream_out, dace.symbolic.pystr_to_symbolic("-1"),
-        dace.properties.SubsetProperty.from_string("0"), 1)
+    out_memlet = dace.memlet.Memlet.simple(stream_out, "0", num_accesses=-1)
     loop_body.add_memlet_path(tasklet,
                               stream_out,
                               src_conn="result",
                               memlet=out_memlet)
 
     # Read row buffer
-    read_row_memlet = dace.memlet.Memlet(
-        rows_in,
-        dace.symbolic.pystr_to_symbolic("2"),
-        dace.properties.SubsetProperty.from_string("0:2, x"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0:2, 2"))
+    read_row_memlet = dace.memlet.Memlet.simple(rows_in,
+                                                "0:2, x",
+                                                num_accesses=2,
+                                                other_subset_str="0:2, 2")
     pre_shift.add_memlet_path(rows_in,
                               window_buffer_out,
                               memlet=read_row_memlet)
 
     # Read from memory
-    read_memory_memlet = dace.memlet.Memlet(
-        stream_in, dace.symbolic.pystr_to_symbolic("-1"),
-        dace.properties.SubsetProperty.from_string("0"), 1)
+    read_memory_memlet = dace.memlet.Memlet.simple(stream_in,
+                                                   "0",
+                                                   num_accesses=-1)
     read_memory_tasklet = pre_shift.add_tasklet(
         "skip_last", {"read"}, {"window_buffer"},
         "if y < H - 1 and x < W - 1:\n\twindow_buffer = read")
@@ -226,23 +220,17 @@ if (y >= 3 and x >= 3 and y < H - 1 and x < W - 1) or (y >= 2 and x >= 2):
                               src_conn="window_buffer")
 
     # Shift window
-    shift_window_memlet = dace.memlet.Memlet(
-        window_shift_in,
-        dace.symbolic.pystr_to_symbolic("6"),
-        dace.properties.SubsetProperty.from_string("0:3, 1:3"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0:3, 0:2"))
+    shift_window_memlet = dace.memlet.Memlet.simple(window_shift_in,
+                                                    '0:3, 1:3',
+                                                    other_subset_str='0:3, 0:2')
     post_shift.add_memlet_path(window_shift_in,
                                window_shift_out,
                                memlet=shift_window_memlet)
 
     # To row buffer
-    write_row_memlet = dace.memlet.Memlet(
-        window_buffer_in,
-        dace.symbolic.pystr_to_symbolic("2"),
-        dace.properties.SubsetProperty.from_string("1:3, 2"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0:2, x"))
+    write_row_memlet = dace.memlet.Memlet.simple(window_buffer_in,
+                                                 '1:3, 2',
+                                                 other_subset_str='0:2, x')
     post_shift.add_memlet_path(window_buffer_in,
                                rows_out,
                                memlet=write_row_memlet)
@@ -322,12 +310,9 @@ def make_read_sdfg():
                                 storage=dace.dtypes.StorageType.FPGA_Global)
 
     # Read from memory
-    read_memory_memlet = dace.memlet.Memlet(
-        mem_read,
-        dace.symbolic.pystr_to_symbolic("1"),
-        dace.properties.SubsetProperty.from_string("t%2, y, x"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0"))
+    read_memory_memlet = dace.memlet.Memlet.simple(mem_read,
+                                                   "t%2, y, x",
+                                                   other_subset_str="0")
     loop_body.add_memlet_path(mem_read, pipe, memlet=read_memory_memlet)
 
     return sdfg
@@ -400,19 +385,13 @@ def make_write_sdfg():
                                 dtype,
                                 1,
                                 storage=dace.dtypes.StorageType.FPGA_Global)
-    mem_write = loop_body.add_array(
-        "mem_write", (2, H, W),
-        dtype,
-        storage=dace.dtypes.StorageType.FPGA_Global)
+    mem_write = loop_body.add_array("mem_write", (2, H, W),
+                                    dtype,
+                                    storage=dace.dtypes.StorageType.FPGA_Global)
 
     # Read from memory
-    write_memory_memlet = dace.memlet.Memlet(
-        pipe,
-        dace.symbolic.pystr_to_symbolic("1"),
-        dace.properties.SubsetProperty.from_string("0"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string(
-            "1 - t%2, y, x"))
+    write_memory_memlet = dace.memlet.Memlet.simple(
+        pipe, '0', other_subset_str="1 - t%2, y, x")
     loop_body.add_memlet_path(pipe, mem_write, memlet=write_memory_memlet)
 
     return sdfg
@@ -453,8 +432,8 @@ def make_outer_compute_state(sdfg):
     read_sdfg_node = state.add_nested_sdfg(read_sdfg, sdfg, {"mem_read"},
                                            {"pipe"})
     compute_sdfg = make_compute_sdfg()
-    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg,
-                                              {"stream_in"}, {"stream_out"})
+    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg, {"stream_in"},
+                                              {"stream_out"})
     write_sdfg = make_write_sdfg()
     write_sdfg_node = state.add_nested_sdfg(write_sdfg, sdfg, {"pipe"},
                                             {"mem_write"})
@@ -466,14 +445,14 @@ def make_outer_compute_state(sdfg):
                           dst_conn="mem_read",
                           memlet=dace.memlet.Memlet.simple(
                               tmp_in, "0:2, 0:H, 0:W"))
-    state.add_memlet_path(read_sdfg_node,
-                          pipes_memory_write,
-                          src_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              pipes_memory_write,
-                              dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1))
+    state.add_memlet_path(
+        read_sdfg_node,
+        pipes_memory_write,
+        src_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            pipes_memory_write,
+            '0',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
 
     compute_entry, compute_exit = state.add_map(
         "unroll_compute", {"p": "0:P"},
@@ -482,33 +461,34 @@ def make_outer_compute_state(sdfg):
     state.add_memlet_path(compute_entry,
                           pipes_read,
                           memlet=dace.memlet.Memlet())
-    state.add_memlet_path(pipes_read,
-                          compute_sdfg_node,
-                          dst_conn="stream_in",
-                          memlet=dace.memlet.Memlet(
-                              pipes_read,
-                              dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-                              dace.properties.SubsetProperty.from_string("p"),
-                              1))
+    state.add_memlet_path(
+        pipes_read,
+        compute_sdfg_node,
+        dst_conn="stream_in",
+        memlet=dace.memlet.Memlet.simple(
+            pipes_read,
+            'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
     state.add_memlet_path(
         compute_sdfg_node,
         pipes_write,
         src_conn="stream_out",
-        memlet=dace.memlet.Memlet(
-            pipes_write, dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            pipes_write,
+            'p + 1',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
     state.add_memlet_path(pipes_write,
                           compute_exit,
                           memlet=dace.memlet.Memlet())
 
-    state.add_memlet_path(pipes_memory_read,
-                          write_sdfg_node,
-                          dst_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              pipes_memory_read,
-                              dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-                              dace.properties.SubsetProperty.from_string("P"),
-                              1))
+    state.add_memlet_path(
+        pipes_memory_read,
+        write_sdfg_node,
+        dst_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            pipes_memory_read,
+            'P',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
     state.add_memlet_path(write_sdfg_node,
                           tmp_out,
                           src_conn="mem_write",
@@ -627,8 +607,7 @@ if __name__ == "__main__":
                                                    H.get() * W.get()))
         print("Highest difference: {}".format(highest_diff))
         print("** Result:\n", A[:min(6, H.get()), :min(6, W.get())])
-        print("** Reference:\n",
-              regression[:min(4, H.get()), :min(4, W.get())])
+        print("** Reference:\n", regression[:min(4, H.get()), :min(4, W.get())])
         print("Type \"debug\" to enter debugger, "
               "or any other string to quit (timeout in 10 seconds)")
         read, _, _ = select.select([sys.stdin], [], [], 10)

--- a/samples/fpga/jacobi_fpga_systolic.py
+++ b/samples/fpga/jacobi_fpga_systolic.py
@@ -481,7 +481,7 @@ def make_outer_compute_state(sdfg):
         unroll=True)
     state.add_memlet_path(compute_entry,
                           pipes_read,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(pipes_read,
                           compute_sdfg_node,
                           dst_conn="stream_in",
@@ -499,7 +499,7 @@ def make_outer_compute_state(sdfg):
             dace.properties.SubsetProperty.from_string("p + 1"), 1))
     state.add_memlet_path(pipes_write,
                           compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
 
     state.add_memlet_path(pipes_memory_read,
                           write_sdfg_node,

--- a/samples/fpga/spmv_fpga.py
+++ b/samples/fpga/spmv_fpga.py
@@ -250,31 +250,21 @@ def make_main_state(sdfg):
         {"row_begin", "row_end", "A_val_read", "A_col_read", "x_read"},
         {"b_write"})
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowptr,
-        memlet=dace.memlet.Memlet(
-            rowptr,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowptr,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowptr, "0", other_subset_str="i"))
     state.add_memlet_path(rowptr,
                           nested_sdfg_tasklet,
                           dst_conn="row_begin",
                           memlet=dace.memlet.Memlet.simple(rowptr, "0"))
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowend,
-        memlet=dace.memlet.Memlet(
-            rowend,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i + 1")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowend,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowend, "0", other_subset_str="i + 1"))
     state.add_memlet_path(rowend,
                           nested_sdfg_tasklet,
                           dst_conn="row_end",

--- a/samples/fpga/spmv_fpga_stream.py
+++ b/samples/fpga/spmv_fpga_stream.py
@@ -279,8 +279,7 @@ def make_compute_nested_sdfg():
                                        dtype,
                                        storage=StorageType.FPGA_Registers)
     else_tasklet = else_state.add_tasklet("b_wcr", {"_b_in", "b_prev"},
-                                          {"_b_out"},
-                                          "_b_out = b_prev + _b_in")
+                                          {"_b_out"}, "_b_out = b_prev + _b_in")
     else_state.add_memlet_path(b_tmp_else_in,
                                else_tasklet,
                                dst_conn="_b_in",
@@ -333,8 +332,10 @@ def make_compute_sdfg():
                          src_conn="b_out",
                          memlet=Memlet.simple(b_buffer_out, "0"))
 
-    b_buffer_post_in = post_state.add_scalar(
-        "b_buffer", dtype, transient=True, storage=StorageType.FPGA_Registers)
+    b_buffer_post_in = post_state.add_scalar("b_buffer",
+                                             dtype,
+                                             transient=True,
+                                             storage=StorageType.FPGA_Registers)
     b_pipe = post_state.add_stream("b_pipe",
                                    dtype,
                                    storage=StorageType.FPGA_Local)
@@ -767,31 +768,21 @@ def make_nested_compute_state(sdfg):
         {"row_begin", "row_end", "A_val_read", "A_col_read", "x_read"},
         {"b_write"})
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowptr,
-        memlet=dace.memlet.Memlet(
-            rowptr,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowptr,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowptr, "0", other_subset_str="i"))
     state.add_memlet_path(rowptr,
                           nested_sdfg_tasklet,
                           dst_conn="row_begin",
                           memlet=dace.memlet.Memlet.simple(rowptr, "0"))
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowend,
-        memlet=dace.memlet.Memlet(
-            rowend,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i + 1")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowend,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowend, '0', other_subset_str='i + 1'))
     state.add_memlet_path(rowend,
                           nested_sdfg_tasklet,
                           dst_conn="row_end",

--- a/samples/graph/bfs_bsp.py
+++ b/samples/graph/bfs_bsp.py
@@ -64,8 +64,7 @@ def create_reset_state(state, frontier_index):
                               'ofsz = 0')
     state.add_edge(
         rtask, 'ofsz', frontiersize, None,
-        dp.Memlet.from_array('fsz%d' % frontier_index,
-                             frontiersize.desc(sdfg)))
+        dp.Memlet.from_array('fsz%d' % frontier_index, frontiersize.desc(sdfg)))
 
 
 create_reset_state(rst0, 0)
@@ -75,8 +74,7 @@ create_reset_state(rst1, 1)
 # Computation state
 
 
-def create_computation_state(dstate, in_frontier, out_frontier,
-                             frontier_index):
+def create_computation_state(dstate, in_frontier, out_frontier, frontier_index):
     frontiersize = dstate.add_scalar('fsz%d' % frontier_index,
                                      dtype=dp.uint32,
                                      storage=storage,
@@ -106,8 +104,7 @@ def create_computation_state(dstate, in_frontier, out_frontier,
     # Map inputs
     dstate.add_edge(
         frontiersize, None, me, 'fsz%d' % frontier_index,
-        dp.Memlet.from_array('fsz%d' % frontier_index,
-                             frontiersize.desc(sdfg)))
+        dp.Memlet.from_array('fsz%d' % frontier_index, frontiersize.desc(sdfg)))
     dstate.add_edge(
         in_frontier, None, me, 'IN_F',
         dp.Memlet.from_array(in_frontier.data, in_frontier.desc(sdfg)))
@@ -134,8 +131,9 @@ def create_computation_state(dstate, in_frontier, out_frontier,
                     dp.Memlet.simple(in_frontier, 'f'))
     dstate.add_edge(
         me, 'OUT_R', indirection, 'in_row',
-        dp.Memlet('G_row', 2, dp.subsets.Range.from_array(G_row.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('G_row',
+                         dp.subsets.Range.from_array(G_row.desc(sdfg)),
+                         num_accesses=2))
     dstate.add_edge(
         indirection, 'ob', rowb, None,
         dp.Memlet.from_array('rowb%d' % frontier_index, rowb.desc(sdfg)))
@@ -182,42 +180,46 @@ if d < dep:
     # Internal inputs
     dstate.add_edge(
         nme, 'OUT_C', ctask, 'in_col',
-        dp.Memlet('G_col', -1, dp.subsets.Range.from_array(G_col.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('G_col',
+                         dp.subsets.Range.from_array(G_col.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         nme, 'OUT_D', ctask, 'in_depth',
-        dp.Memlet('depth', -1, dp.subsets.Range.from_array(depth.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('depth',
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
 
     # Internal outputs
     dstate.add_edge(
         ctask, 'out_depth', nmx, 'IN_D',
-        dp.Memlet('depth', -1, dp.subsets.Range.from_array(depth.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('depth',
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         ctask, 'out_fsz', nmx, 'IN_FSZ',
-        dp.Memlet(out_frontiersize,
-                  -1,
-                  dp.subsets.Indices([0]),
-                  1,
-                  wcr='lambda a,b: a+b'))
+        dp.Memlet.simple(out_frontiersize,
+                         dp.subsets.Indices([0]),
+                         num_accesses=-1,
+                         wcr_str='lambda a,b: a+b'))
     dstate.add_edge(
         ctask, 'out_frontier', nmx, 'IN_F',
-        dp.Memlet(out_frontier_stream, -1,
-                  dp.subsets.Range.from_array(out_frontier_stream.desc(sdfg)),
-                  1))
+        dp.Memlet.simple(out_frontier_stream,
+                         dp.subsets.Range.from_array(
+                             out_frontier_stream.desc(sdfg)),
+                         num_accesses=-1))
 
     # Internal neighbor map outputs
     dstate.add_edge(
         nmx, 'OUT_D', mx, 'IN_D',
-        dp.Memlet(depth, -1, dp.subsets.Range.from_array(depth.desc(sdfg)), 1))
+        dp.Memlet.simple(depth,
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         nmx, 'OUT_FSZ', mx, 'IN_FSZ',
-        dp.Memlet(out_frontiersize,
-                  -1,
-                  dp.subsets.Indices([0]),
-                  1,
-                  wcr='lambda a,b: a+b'))
+        dp.Memlet.simple(out_frontiersize,
+                         dp.subsets.Indices([0]),
+                         num_accesses=-1,
+                         wcr_str='lambda a,b: a+b'))
     dstate.add_edge(
         nmx, 'OUT_F', mx, 'IN_F',
         dp.Memlet.from_array(out_frontier_stream.data,
@@ -226,14 +228,15 @@ if d < dep:
     # Map outputs
     dstate.add_edge(
         mx, 'OUT_D', out_depth, None,
-        dp.Memlet(depth, -1, dp.subsets.Range.from_array(depth.desc(sdfg)), 1))
+        dp.Memlet.simple(depth,
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         mx, 'OUT_FSZ', out_frontiersize, None,
-        dp.Memlet(out_frontiersize,
-                  -1,
-                  dp.subsets.Indices([0]),
-                  1,
-                  wcr='lambda a,b: a+b'))
+        dp.Memlet.simple(out_frontiersize,
+                         dp.subsets.Indices([0]),
+                         num_accesses=-1,
+                         wcr_str='lambda a,b: a+b'))
     dstate.add_edge(
         mx, 'OUT_F', out_frontier_stream, None,
         dp.Memlet.from_array(out_frontier_stream.data,
@@ -246,15 +249,11 @@ if d < dep:
 
 
 frontier = dstate.add_transient('frontier', [V], dtype=vtype, storage=storage)
-frontier2 = dstate.add_transient('frontier2', [V],
-                                 dtype=vtype,
-                                 storage=storage)
+frontier2 = dstate.add_transient('frontier2', [V], dtype=vtype, storage=storage)
 create_computation_state(dstate, frontier, frontier2, 0)
 
 frontier = estate.add_transient('frontier', [V], dtype=vtype, storage=storage)
-frontier2 = estate.add_transient('frontier2', [V],
-                                 dtype=vtype,
-                                 storage=storage)
+frontier2 = estate.add_transient('frontier2', [V], dtype=vtype, storage=storage)
 create_computation_state(estate, frontier2, frontier, 1)
 
 if __name__ == "__main__":

--- a/tests/blockreduce_cudatest.py
+++ b/tests/blockreduce_cudatest.py
@@ -28,7 +28,7 @@ state.add_edge(tA, None, red, None, Memlet.simple(tA, '0:2'))
 state.add_edge(red, None, tB, None, Memlet.simple(tB, '0'))
 state.add_edge(tB, None, write_tasklet, 'inp', Memlet.simple(tB, '0'))
 state.add_edge(write_tasklet, 'out', mxi, None,
-               Memlet('B', -1, dace.subsets.Indices(['bi']), 1))
+               Memlet.simple('B', 'bi', num_accesses=-1))
 state.add_edge(mxi, None, mx, None, Memlet.simple(B, 'bi'))
 state.add_edge(mx, None, B, None, Memlet.simple(B, '0:2'))
 sdfg.fill_scope_connectors()

--- a/tests/intel_fpga/simple_systolic_array.py
+++ b/tests/intel_fpga/simple_systolic_array.py
@@ -83,15 +83,10 @@ def make_read_A_sdfg():
                                 dace.int32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        mem,
-        pipe,
-        memlet=dace.memlet.Memlet(
-            pipe,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("n")))
+    loop_body.add_memlet_path(mem,
+                              pipe,
+                              memlet=dace.memlet.Memlet.simple(
+                                  pipe, '0', other_subset_str='n'))
 
     return sdfg
 
@@ -132,15 +127,10 @@ def make_write_A_sdfg():
                                 dace.int32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        pipe,
-        mem,
-        memlet=dace.memlet.Memlet(
-            mem,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("n"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("0")))
+    loop_body.add_memlet_path(pipe,
+                              mem,
+                              memlet=dace.memlet.Memlet.simple(
+                                  mem, 'n', other_subset_str='0'))
 
     return sdfg
 
@@ -188,18 +178,15 @@ def make_compute_sdfg():
 
     state.add_memlet_path(A_pipe_in,
                           compute_tasklet,
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(A_pipe_in,
+                                                           '0',
+                                                           num_accesses=-1),
                           dst_conn="a_in")
     state.add_memlet_path(compute_tasklet,
                           A_pipe_out,
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(A_pipe_out,
+                                                           '0',
+                                                           num_accesses=-1),
                           src_conn="a_out")
 
     return sdfg
@@ -215,8 +202,7 @@ def make_fpga_state(sdfg):
 
     compute_sdfg = make_compute_sdfg()
     compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg,
-                                              {"A_stream_in"},
-                                              {"A_stream_out"})
+                                              {"A_stream_in"}, {"A_stream_out"})
 
     write_A_sdfg = make_write_A_sdfg()
     write_A_sdfg_node = state.add_nested_sdfg(write_A_sdfg, sdfg, {"pipe"},
@@ -257,59 +243,47 @@ def make_fpga_state(sdfg):
         unroll=True)
 
     # Bring data nodes into scope
-    state.add_memlet_path(compute_entry,
-                          A_pipe_in,
-                          memlet=dace.memlet.Memlet())
-    state.add_memlet_path(A_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.Memlet())
+    state.add_memlet_path(compute_entry, A_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(A_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
 
     # Connect data nodes
-    state.add_memlet_path(A_pipe_in,
-                          compute_sdfg_node,
-                          dst_conn="A_stream_in",
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_in,
-                              dace.symbolic.pystr_to_symbolic("N/P"),
-                              dace.properties.SubsetProperty.from_string("p"),
-                              1))
+    state.add_memlet_path(
+        A_pipe_in,
+        compute_sdfg_node,
+        dst_conn="A_stream_in",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_in, 'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N/P")))
     state.add_memlet_path(
         compute_sdfg_node,
         A_pipe_out,
         src_conn="A_stream_out",
-        memlet=dace.memlet.Memlet(
-            A_pipe_out, dace.symbolic.pystr_to_symbolic("N/P"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_out,
+            'p + 1',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N/P")))
 
+    state.add_memlet_path(A_IN,
+                          read_A_sdfg_node,
+                          dst_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(A_IN, "0:N"))
     state.add_memlet_path(
-        A_IN,
         read_A_sdfg_node,
-        dst_conn="mem",
-        memlet=dace.memlet.Memlet(
-            A_IN, dace.symbolic.pystr_to_symbolic("N"),
-            dace.properties.SubsetProperty.from_string("0:N"), 1))
-    state.add_memlet_path(read_A_sdfg_node,
-                          A_pipe_read,
-                          src_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_in, dace.symbolic.pystr_to_symbolic("N"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1))
+        A_pipe_read,
+        src_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_in, '0', num_accesses=dace.symbolic.pystr_to_symbolic("N")))
 
-    state.add_memlet_path(A_pipe_write,
-                          write_A_sdfg_node,
-                          dst_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_out, dace.symbolic.pystr_to_symbolic("N"),
-                              dace.properties.SubsetProperty.from_string("P"),
-                              1))
     state.add_memlet_path(
+        A_pipe_write,
         write_A_sdfg_node,
-        A_OUT,
-        src_conn="mem",
-        memlet=dace.memlet.Memlet(
-            A_OUT, dace.symbolic.pystr_to_symbolic("N"),
-            dace.properties.SubsetProperty.from_string("0:N"), 1))
+        dst_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_out, 'P', num_accesses=dace.symbolic.pystr_to_symbolic("N")))
+    state.add_memlet_path(write_A_sdfg_node,
+                          A_OUT,
+                          src_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(A_OUT, "0:N"))
 
     return state
 

--- a/tests/intel_fpga/simple_systolic_array.py
+++ b/tests/intel_fpga/simple_systolic_array.py
@@ -259,10 +259,10 @@ def make_fpga_state(sdfg):
     # Bring data nodes into scope
     state.add_memlet_path(compute_entry,
                           A_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
     state.add_memlet_path(A_pipe_out,
                           compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
 
     # Connect data nodes
     state.add_memlet_path(A_pipe_in,

--- a/tests/mapfission_test.py
+++ b/tests/mapfission_test.py
@@ -33,7 +33,7 @@ def mapfission_sdfg():
     wnode = state.add_write('B')
 
     # Edges
-    state.add_nedge(ome, scalar, dace.EmptyMemlet())
+    state.add_nedge(ome, scalar, dace.Memlet())
     state.add_memlet_path(rnode,
                           ome,
                           t1,
@@ -240,7 +240,7 @@ class MapFissionTest(unittest.TestCase):
         nstate.add_edge(t, 'out', a, None, dace.Memlet.simple('a', '0'))
         nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'a'})
 
-        state.add_edge(me, None, nsdfg_node, None, dace.EmptyMemlet())
+        state.add_edge(me, None, nsdfg_node, None, dace.Memlet())
         anode = state.add_write('A')
         state.add_memlet_path(nsdfg_node,
                               mx,

--- a/tests/properties_test.py
+++ b/tests/properties_test.py
@@ -67,14 +67,7 @@ class PropertyTests(unittest.TestCase):
         sdfg.add_array("arr2", (16, 16), dace.dtypes.float32)
         state1.add_node(dace.sdfg.nodes.AccessNode('arr2'))
 
-        memlet = dace.memlet.Memlet('arr2', 1, "0:N", 1)
-
-        with self.assertRaises(TypeError):
-            # Must pass SDFG as second argument
-            memlet = dace.memlet.Memlet(
-                dace.memlet.Memlet.__properties__["data"].from_string("arr0"),
-                None, 1, "i", 1)
-
+        memlet = dace.memlet.Memlet.simple('arr2', '0:N', num_accesses=1)
         memlet.data = 'arr0'
 
         self.assertEqual(sdfg.arrays[memlet.data], arr0)

--- a/tests/sdfg/free_symbols_test.py
+++ b/tests/sdfg/free_symbols_test.py
@@ -42,8 +42,8 @@ def test_state_subgraph():
     nsdfg = state.add_nested_sdfg(nsdfg,
                                   None, {}, {},
                                   symbol_mapping=dict(l=L / 2, i='i'))
-    state.add_nedge(me, nsdfg, dace.EmptyMemlet())
-    state.add_nedge(nsdfg, mx, dace.EmptyMemlet())
+    state.add_nedge(me, nsdfg, dace.Memlet())
+    state.add_nedge(nsdfg, mx, dace.Memlet())
 
     # Entire graph
     assert state.free_symbols == {'L', 'N'}

--- a/tests/sdfg_validate_scopes_test.py
+++ b/tests/sdfg_validate_scopes_test.py
@@ -17,7 +17,7 @@ class ScopeValidationTests(unittest.TestCase):
             state.add_edge(A, None, me, 'IN_a',
                            dace.Memlet.from_array(A.data, A.desc(sdfg)))
             state.add_edge(me, 'OUT_b', T, 'a', dace.Memlet.simple(A, '0'))
-            state.add_edge(T, None, mx, None, dace.EmptyMemlet())
+            state.add_edge(T, None, mx, None, dace.Memlet())
 
             sdfg.validate()
             self.fail('Failed to detect invalid SDFG')

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -32,7 +32,7 @@ state.add_memlet_path(matr,
                       tasklet,
                       dst_conn='mat_in',
                       memlet=dace.Memlet.simple('sparsemats_in', 'i'))
-# state.add_nedge(tasklet, omx, dace.EmptyMemlet())
+# state.add_nedge(tasklet, omx, dace.Memlet())
 state.add_memlet_path(tasklet,
                       omx,
                       matw,

--- a/tests/threadlocal_stream_test.py
+++ b/tests/threadlocal_stream_test.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import dace as dp
 from dace.sdfg import SDFG
-from dace.memlet import Memlet, EmptyMemlet
+from dace.memlet import Memlet
 
 N = dp.symbol('N')
 sdfg = SDFG('tlstream')
@@ -18,7 +18,7 @@ globalarr = state.add_array('ga', [N], dp.float32)
 me, mx = state.add_map('par', dict(i='0:N'))
 tasklet = state.add_tasklet('arange', set(), {'a'}, 'a = i')
 
-state.add_nedge(me, tasklet, EmptyMemlet())
+state.add_nedge(me, tasklet, Memlet())
 state.add_edge(tasklet, 'a', localstream, None,
                Memlet.from_array(localstream.data, localstream.desc(sdfg)))
 state.add_nedge(localstream, localarr,


### PR DESCRIPTION
- [x] Remove EmptyMemlet
- [x] New memlet properties
    - [x] dynamic num_accesses is a flag on the memlet
- [ ] Memlet interface and contents
    - [x] string-based memlet interface in constructor
    - [x] no data needed, src/dst_subset represented internally
    - [x] deprecate using data+subset
    - [ ] Allow memlet.data to be None for code->code (#201)
- [ ] Modify memlet propagation for src/dst subset
- [x] remove wcr_identity (#262)
- [ ] Connector types
    - [ ] veclen becomes a typeclass `dace.vector(type, veclen)`
    - [ ] Adapt Vectorization transformation