### PR TITLE
Memlet API revamp

### DIFF
--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -9,7 +9,7 @@ from .frontend.operations import *
 from .config import Config
 from .sdfg import SDFG, SDFGState, InterstateEdge, nodes
 from .sdfg.propagation import propagate_memlets_sdfg, propagate_memlet
-from .memlet import Memlet, EmptyMemlet
+from .memlet import Memlet
 from .symbolic import symbol
 
 # Run Jupyter notebook code

--- a/dace/codegen/instrumentation/papi.py
+++ b/dace/codegen/instrumentation/papi.py
@@ -656,10 +656,10 @@ class PAPIUtils(object):
         :param memlet: Memlet to return size in bytes.
         :return: The size as a symbolic expression.
         """
-        if memlet.num_accesses < 0:  # Ignoring dynamic accesses
+        if memlet.dynamic:  # Ignoring dynamic accesses
             return 0
         memdata = sdfg.arrays[memlet.data]
-        return memlet.num_accesses * memdata.dtype.bytes
+        return memlet.volume * memdata.dtype.bytes
 
     @staticmethod
     def get_out_memlet_costs(sdfg, state_id, node, dfg):

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -713,8 +713,10 @@ class CPUCodeGen(TargetCodeGenerator):
 
                 could_be_scalar = True
                 if isinstance(node, nodes.NestedSDFG):
-                    could_be_scalar = isinstance(node.sdfg.arrays[uconn],
-                                                 data.Scalar)
+                    could_be_scalar = (
+                        isinstance(node.sdfg.arrays[uconn], data.Scalar)
+                        or (isinstance(node.sdfg.arrays[uconn], data.Stream) and
+                            (memlet.volume == 1) == True))
 
                 if (memlet.subset.data_dims() == 0 and not memlet.dynamic
                         and could_be_scalar):

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -713,8 +713,8 @@ class CPUCodeGen(TargetCodeGenerator):
 
                 could_be_scalar = True
                 if isinstance(node, nodes.NestedSDFG):
-                    could_be_scalar = not isinstance(node.sdfg.arrays[uconn],
-                                                     data.Array)
+                    could_be_scalar = isinstance(node.sdfg.arrays[uconn],
+                                                 data.Scalar)
 
                 if (memlet.subset.data_dims() == 0 and not memlet.dynamic
                         and could_be_scalar):

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -80,9 +80,9 @@ class FPGACodeGen(TargetCodeGenerator):
             self,
             predicate=lambda sdfg, state: len(state.data_nodes()) > 0 and all([
                 n.desc(sdfg).storage in [
-                    dace.dtypes.StorageType.FPGA_Global, dace.dtypes.
-                    StorageType.FPGA_Local, dace.dtypes.StorageType.
-                    FPGA_Registers, dace.dtypes.StorageType.FPGA_ShiftRegister
+                    dace.dtypes.StorageType.FPGA_Global, dace.dtypes.StorageType
+                    .FPGA_Local, dace.dtypes.StorageType.FPGA_Registers, dace.
+                    dtypes.StorageType.FPGA_ShiftRegister
                 ] for n in state.data_nodes()
             ]))
 
@@ -98,8 +98,8 @@ class FPGACodeGen(TargetCodeGenerator):
         self._dispatcher.register_array_dispatcher(fpga_storage, self)
 
         # Register permitted copies
-        for storage_from in itertools.chain(
-                fpga_storage, [dace.dtypes.StorageType.Register]):
+        for storage_from in itertools.chain(fpga_storage,
+                                            [dace.dtypes.StorageType.Register]):
             for storage_to in itertools.chain(
                     fpga_storage, [dace.dtypes.StorageType.Register]):
                 if (storage_from == dace.dtypes.StorageType.Register
@@ -233,8 +233,7 @@ class FPGACodeGen(TargetCodeGenerator):
             candidates = []  # type: List[Tuple[bool,str,Data]]
             # [(is an output, dataname string, data object)]
             for n in subgraph.source_nodes():
-                candidates += [(False, e.data.data,
-                                subsdfg.arrays[e.data.data])
+                candidates += [(False, e.data.data, subsdfg.arrays[e.data.data])
                                for e in state.in_edges(n)]
             for n in subgraph.sink_nodes():
                 candidates += [(True, e.data.data, subsdfg.arrays[e.data.data])
@@ -270,14 +269,14 @@ class FPGACodeGen(TargetCodeGenerator):
                         or isinstance(data, dace.data.Scalar)
                         or isinstance(data, dace.data.Stream)):
                     if data.storage == dace.dtypes.StorageType.FPGA_Global:
-                        subgraph_parameters[subgraph].append((is_output,
-                                                              dataname, data))
+                        subgraph_parameters[subgraph].append(
+                            (is_output, dataname, data))
                         if is_output:
-                            global_data_parameters.append((is_output, dataname,
-                                                           data))
+                            global_data_parameters.append(
+                                (is_output, dataname, data))
                         else:
-                            global_data_parameters.append((is_output, dataname,
-                                                           data))
+                            global_data_parameters.append(
+                                (is_output, dataname, data))
                         global_data_names.add(dataname)
                     elif (data.storage in (
                             dace.dtypes.StorageType.FPGA_Local,
@@ -302,8 +301,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 subgraph_parameters[subgraph])
 
         # Deduplicate
-        global_data_parameters = dace.dtypes.deduplicate(
-            global_data_parameters)
+        global_data_parameters = dace.dtypes.deduplicate(global_data_parameters)
         top_level_local_data = dace.dtypes.deduplicate(top_level_local_data)
         top_level_local_data = [data_to_node[n] for n in top_level_local_data]
 
@@ -320,13 +318,12 @@ class FPGACodeGen(TargetCodeGenerator):
                               function_stream, callsite_stream):
 
         for sg in subgraphs:
-            self._dispatcher.dispatch_subgraph(
-                sdfg,
-                sg,
-                sdfg.node_id(state),
-                function_stream,
-                callsite_stream,
-                skip_entry_node=False)
+            self._dispatcher.dispatch_subgraph(sdfg,
+                                               sg,
+                                               sdfg.node_id(state),
+                                               function_stream,
+                                               callsite_stream,
+                                               skip_entry_node=False)
 
     @staticmethod
     def detect_memory_widths(parent_sdfg):
@@ -373,11 +370,10 @@ class FPGACodeGen(TargetCodeGenerator):
                     key = alias[key]
                 name = key[0]
                 for edge in state.all_edges(node):
-                    if (isinstance(edge.data, dace.memlet.EmptyMemlet)
-                            or edge.data.data is None):
+                    if edge.data.is_empty() or edge.data.data is None:
                         continue
-                    if (isinstance(edge.src, dace.sdfg.nodes.AccessNode) and
-                            isinstance(edge.dst, dace.sdfg.nodes.AccessNode)
+                    if (isinstance(edge.src, dace.sdfg.nodes.AccessNode)
+                            and isinstance(edge.dst, dace.sdfg.nodes.AccessNode)
                             and edge.data.veclen == 1):
                         # Consistent vectorization is not enforced for
                         # memcopies, but if this memory is not found anywhere
@@ -387,8 +383,7 @@ class FPGACodeGen(TargetCodeGenerator):
                         if key not in memory_widths:
                             memory_widths[key] = None
                         continue
-                    if (key not in memory_widths
-                            or memory_widths[key] is None):
+                    if (key not in memory_widths or memory_widths[key] is None):
                         if (isinstance(desc, dace.data.Stream)
                                 and desc.veclen != edge.data.veclen):
                             raise ValueError(
@@ -432,21 +427,19 @@ class FPGACodeGen(TargetCodeGenerator):
                            dfg_scope.source_nodes()[0], function_stream,
                            callsite_stream)
 
-        self._dispatcher.dispatch_subgraph(
-            sdfg,
-            dfg_scope,
-            state_id,
-            function_stream,
-            callsite_stream,
-            skip_entry_node=True)
+        self._dispatcher.dispatch_subgraph(sdfg,
+                                           dfg_scope,
+                                           state_id,
+                                           function_stream,
+                                           callsite_stream,
+                                           skip_entry_node=True)
 
     def allocate_array(self, sdfg, dfg, state_id, node, function_stream,
                        callsite_stream):
         result = StringIO()
         nodedesc = node.desc(sdfg)
         arrsize = nodedesc.total_size
-        is_dynamically_sized = dace.symbolic.issymbolic(
-            arrsize, sdfg.constants)
+        is_dynamically_sized = dace.symbolic.issymbolic(arrsize, sdfg.constants)
 
         dataname = node.data
 
@@ -511,8 +504,8 @@ class FPGACodeGen(TargetCodeGenerator):
                                     "must be an integer: {}".format(
                                         nodedesc.location["bank"]))
                             memory_bank_arg = (
-                                "hlslib::ocl::MemoryBank::bank{}, ".format(
-                                    bank))
+                                "hlslib::ocl::MemoryBank::bank{}, ".format(bank)
+                            )
                             # (memory type, bank id)
                             self._bank_assignments[(dataname,
                                                     sdfg)] = (MemoryType.DDR,
@@ -523,14 +516,14 @@ class FPGACodeGen(TargetCodeGenerator):
                             "auto {} = dace::fpga::_context->Get()."
                             "MakeBuffer<{}, hlslib::ocl::Access::readWrite>"
                             "({}{});".format(dataname, nodedesc.dtype.ctype,
-                                             memory_bank_arg,
-                                             sym2cpp(arrsize)))
+                                             memory_bank_arg, sym2cpp(arrsize)))
                         self._dispatcher.defined_vars.add(
                             dataname, DefinedType.Pointer)
 
-            elif (nodedesc.storage in (dace.dtypes.StorageType.FPGA_Local,
-                                       dace.dtypes.StorageType.FPGA_Registers,
-                                       dace.dtypes.StorageType.FPGA_ShiftRegister)):
+            elif (nodedesc.storage in (
+                    dace.dtypes.StorageType.FPGA_Local,
+                    dace.dtypes.StorageType.FPGA_Registers,
+                    dace.dtypes.StorageType.FPGA_ShiftRegister)):
 
                 if not self._in_device_code:
                     raise dace.codegen.codegen.CodegenError(
@@ -571,13 +564,14 @@ class FPGACodeGen(TargetCodeGenerator):
                     # Language-specific
                     if (nodedesc.storage ==
                             dace.dtypes.StorageType.FPGA_ShiftRegister):
-                        self.define_shift_register(
-                            dataname, nodedesc, arrsize_vec, veclen,
-                            function_stream, result, sdfg, state_id, node)
+                        self.define_shift_register(dataname, nodedesc,
+                                                   arrsize_vec, veclen,
+                                                   function_stream, result,
+                                                   sdfg, state_id, node)
                     else:
-                        self.define_local_array(
-                            dataname, nodedesc, arrsize_vec, veclen,
-                            function_stream, result, sdfg, state_id, node)
+                        self.define_local_array(dataname, nodedesc, arrsize_vec,
+                                                veclen, function_stream, result,
+                                                sdfg, state_id, node)
 
             else:
                 raise NotImplementedError("Unimplemented storage type " +
@@ -619,11 +613,10 @@ class FPGACodeGen(TargetCodeGenerator):
         data_to_data = (isinstance(src_node, dace.sdfg.nodes.AccessNode)
                         and isinstance(dst_node, dace.sdfg.nodes.AccessNode))
 
-        host_to_device = (data_to_data and src_storage in _CPU_STORAGE_TYPES
-                          and
+        host_to_device = (data_to_data and src_storage in _CPU_STORAGE_TYPES and
                           dst_storage == dace.dtypes.StorageType.FPGA_Global)
-        device_to_host = (data_to_data and
-                          src_storage == dace.dtypes.StorageType.FPGA_Global
+        device_to_host = (data_to_data
+                          and src_storage == dace.dtypes.StorageType.FPGA_Global
                           and dst_storage in _CPU_STORAGE_TYPES)
         device_to_device = (
             data_to_data and src_storage == dace.dtypes.StorageType.FPGA_Global
@@ -655,40 +648,39 @@ class FPGACodeGen(TargetCodeGenerator):
                 callsite_stream.write(
                     "{}.CopyFromHost({}, {}, {});".format(
                         dst_node.data, (offset if not outgoing_memlet else 0),
-                        copysize,
-                        src_node.data + (" + {}".format(offset)
-                                         if outgoing_memlet else "")), sdfg,
-                    state_id, [src_node, dst_node])
+                        copysize, src_node.data +
+                        (" + {}".format(offset) if outgoing_memlet else "")),
+                    sdfg, state_id, [src_node, dst_node])
 
             elif device_to_host:
 
                 callsite_stream.write(
                     "{}.CopyToHost({}, {}, {});".format(
-                        src_node.data, (offset
-                                        if outgoing_memlet else 0), copysize,
+                        src_node.data, (offset if outgoing_memlet else 0),
+                        copysize,
                         dst_node.data + (" + {}".format(offset)
-                                         if not outgoing_memlet else "")),
-                    sdfg, state_id, [src_node, dst_node])
+                                         if not outgoing_memlet else "")), sdfg,
+                    state_id, [src_node, dst_node])
 
             elif device_to_device:
 
                 callsite_stream.write(
                     "{}.CopyToDevice({}, {}, {}, {});".format(
-                        src_node.data, (offset
-                                        if outgoing_memlet else 0), copysize,
-                        dst_node.data, (offset if not outgoing_memlet else 0)),
-                    sdfg, state_id, [src_node, dst_node])
+                        src_node.data, (offset if outgoing_memlet else 0),
+                        copysize, dst_node.data,
+                        (offset if not outgoing_memlet else 0)), sdfg, state_id,
+                    [src_node, dst_node])
 
         # Reject copying to/from local memory from/to outside the FPGA
-        elif (data_to_data
-              and (((src_storage in (dace.dtypes.StorageType.FPGA_Local,
-                                     dace.dtypes.StorageType.FPGA_Registers,
-                                     dace.dtypes.StorageType.FPGA_ShiftRegister))
-                    and dst_storage not in _FPGA_STORAGE_TYPES) or
-                   ((dst_storage in (dace.dtypes.StorageType.FPGA_Local,
-                                     dace.dtypes.StorageType.FPGA_Registers,
-                                     dace.dtypes.StorageType.FPGA_ShiftRegister))
-                    and src_storage not in _FPGA_STORAGE_TYPES))):
+        elif (data_to_data and
+              (((src_storage in (dace.dtypes.StorageType.FPGA_Local,
+                                 dace.dtypes.StorageType.FPGA_Registers,
+                                 dace.dtypes.StorageType.FPGA_ShiftRegister))
+                and dst_storage not in _FPGA_STORAGE_TYPES) or
+               ((dst_storage in (dace.dtypes.StorageType.FPGA_Local,
+                                 dace.dtypes.StorageType.FPGA_Registers,
+                                 dace.dtypes.StorageType.FPGA_ShiftRegister))
+                and src_storage not in _FPGA_STORAGE_TYPES))):
             raise NotImplementedError(
                 "Copies between host memory and FPGA "
                 "local memory not supported: from {} to {}".format(
@@ -705,13 +697,12 @@ class FPGACodeGen(TargetCodeGenerator):
 
             # Try to turn into degenerate/strided ND copies
             copy_shape, src_strides, dst_strides, src_expr, dst_expr = (
-                memlet_copy_to_absolute_strides(
-                    self._dispatcher,
-                    sdfg,
-                    memlet,
-                    src_node,
-                    dst_node,
-                    packed_types=True))
+                memlet_copy_to_absolute_strides(self._dispatcher,
+                                                sdfg,
+                                                memlet,
+                                                src_node,
+                                                dst_node,
+                                                packed_types=True))
 
             ctype = src_node.desc(sdfg).dtype.ctype
 
@@ -727,10 +718,9 @@ class FPGACodeGen(TargetCodeGenerator):
                         "to shift registers supported: {}{}".format(
                             dst_node.data, copy_shape))
                 if copy_shape[-1] > memlet.veclen:
-                    raise ValueError(
-                        "Only a single (vector) element can be "
-                        "written to a shift register: {}{}".format(
-                            dst_node.data, copy_shape[-1]))
+                    raise ValueError("Only a single (vector) element can be "
+                                     "written to a shift register: {}{}".format(
+                                         dst_node.data, copy_shape[-1]))
 
             # Check if we are copying between vectorized and non-vectorized
             # types
@@ -786,9 +776,9 @@ class FPGACodeGen(TargetCodeGenerator):
                                 dace.StorageType.FPGA_Registers
                             ]):
                         # Language-specific
-                        self.generate_no_dependence_pre(
-                            node.data, callsite_stream, sdfg, state_id,
-                            dst_node)
+                        self.generate_no_dependence_pre(node.data,
+                                                        callsite_stream, sdfg,
+                                                        state_id, dst_node)
 
             # Loop intro
             for i, copy_dim in enumerate(copy_shape):
@@ -803,8 +793,8 @@ class FPGACodeGen(TargetCodeGenerator):
                         state_id, dst_node)
                     if register_to_register:
                         # Language-specific
-                        self.generate_unroll_loop_post(
-                            callsite_stream, None, sdfg, state_id, dst_node)
+                        self.generate_unroll_loop_post(callsite_stream, None,
+                                                       sdfg, state_id, dst_node)
 
             # Pragmas
             if num_loops > 0:
@@ -879,8 +869,8 @@ class FPGACodeGen(TargetCodeGenerator):
                             dace.StorageType.FPGA_Registers
                         ]):
                     # Language-specific
-                    self.generate_no_dependence_post(
-                        node.data, callsite_stream, sdfg, state_id, dst_node)
+                    self.generate_no_dependence_post(node.data, callsite_stream,
+                                                     sdfg, state_id, dst_node)
 
             # Loop outtro
             for _ in range(num_loops):
@@ -1055,8 +1045,7 @@ class FPGACodeGen(TargetCodeGenerator):
             if not isinstance(node, dace.sdfg.nodes.PipelineEntry):
 
                 if is_innermost and not fully_degenerate:
-                    self.generate_flatten_loop_pre(result, sdfg, state_id,
-                                                   node)
+                    self.generate_flatten_loop_pre(result, sdfg, state_id, node)
 
                 for i, r in enumerate(node.map.range):
                     var = node.map.params[i]
@@ -1127,8 +1116,8 @@ class FPGACodeGen(TargetCodeGenerator):
 
             if not fully_degenerate:
                 if node.map.unroll:
-                    self.generate_unroll_loop_post(result, None, sdfg,
-                                                   state_id, node)
+                    self.generate_unroll_loop_post(result, None, sdfg, state_id,
+                                                   node)
                 elif is_innermost:
                     self.generate_pipeline_loop_post(result, sdfg, state_id,
                                                      node)
@@ -1145,8 +1134,8 @@ class FPGACodeGen(TargetCodeGenerator):
             if child.data not in to_allocate or child.data in allocated:
                 continue
             allocated.add(child.data)
-            self._dispatcher.dispatch_allocate(sdfg, dfg, state_id, child,
-                                               None, result)
+            self._dispatcher.dispatch_allocate(sdfg, dfg, state_id, child, None,
+                                               result)
 
     def _generate_PipelineExit(self, *args, **kwargs):
         self._generate_MapExit(*args, **kwargs)
@@ -1176,8 +1165,8 @@ class FPGACodeGen(TargetCodeGenerator):
                         it=it, begin=r[0], end=r[1]))
             for it, r in zip(pipeline.params, pipeline.range):
                 callsite_stream.write(
-                    "}} else {{\n{it} += {step};\n}}\n".format(
-                        it=it, step=r[2]))
+                    "}} else {{\n{it} += {step};\n}}\n".format(it=it,
+                                                               step=r[2]))
             if len(cond) > 0:
                 callsite_stream.write("}\n")
             callsite_stream.write("}\n}\n")
@@ -1244,18 +1233,18 @@ class FPGACodeGen(TargetCodeGenerator):
             if len(labels) == 0:
                 labels = [n.label.replace(" ", "_") for n in access_nodes]
             if len(labels) == 0:
-                raise RuntimeError(
-                    "Expected at least one tasklet or data node")
+                raise RuntimeError("Expected at least one tasklet or data node")
             module_name = "_".join(labels)
             self.generate_module(
                 sdfg, state, module_name, subgraph,
                 subgraph_parameters[subgraph] + scalar_parameters,
                 symbol_parameters, module_stream, entry_stream, host_stream)
 
-    def generate_host_function_boilerplate(
-            self, sdfg, state, kernel_name, parameters, symbol_parameters,
-            nested_global_transients, host_code_stream, header_stream,
-            callsite_stream):
+    def generate_host_function_boilerplate(self, sdfg, state, kernel_name,
+                                           parameters, symbol_parameters,
+                                           nested_global_transients,
+                                           host_code_stream, header_stream,
+                                           callsite_stream):
 
         # Generates:
         # - Definition of wrapper function in caller code
@@ -1282,8 +1271,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 continue
             seen.add(arg)
             if not isinstance(arg, dace.data.Stream):
-                kernel_args_call_host.append(
-                    arg.signature(False, name=argname))
+                kernel_args_call_host.append(arg.signature(False, name=argname))
                 kernel_args_opencl.append(
                     FPGACodeGen.make_opencl_parameter(argname, arg))
 
@@ -1297,9 +1285,8 @@ class FPGACodeGen(TargetCodeGenerator):
             """\
 DACE_EXPORTED void {host_function_name}({kernel_args_opencl}) {{
   hlslib::ocl::Program program = dace::fpga::_context->Get().CurrentlyLoadedProgram();"""
-            .format(
-                host_function_name=host_function_name,
-                kernel_args_opencl=", ".join(kernel_args_opencl)))
+            .format(host_function_name=host_function_name,
+                    kernel_args_opencl=", ".join(kernel_args_opencl)))
 
         header_stream.write("\n\nDACE_EXPORTED void {}({});\n\n".format(
             host_function_name, ", ".join(kernel_args_opencl)))

--- a/dace/codegen/targets/immaterial.py
+++ b/dace/codegen/targets/immaterial.py
@@ -126,7 +126,7 @@ class ImmaterialCodeGen(TargetCodeGenerator):
         # Allocate variable type
         memlet_type = '    dace::vec<%s, %s>' % (
             sdfg.arrays[memlet.data].dtype.ctype, sym2cpp(memlet.veclen))
-        if memlet.subset.data_dims() == 0 and memlet.num_accesses >= 0:
+        if memlet.subset.data_dims() == 0 and not memlet.dynamic:
             result += memlet_type + ' ' + local_name
             if direction == "in":
                 result += ' = __%s;\n' % local_name

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -912,7 +912,7 @@ __kernel void \\
                     # The value will be written during the tasklet, and will be
                     # automatically written out after
                     result += write_expr
-                elif memlet.num_accesses == -1:
+                elif memlet.dynamic:
                     # Variable number of reads or writes
                     pass
                 else:
@@ -1018,7 +1018,8 @@ void unpack_{dtype}{veclen}(const {dtype}{veclen} value, {dtype} *const ptr) {{
             u, uconn, v, vconn, memlet = edge
             if u == node:
                 # this could be a wcr
-                memlets[uconn] = (memlet, edge.data.wcr_conflict, edge.data.wcr)
+                memlets[uconn] = (memlet, not edge.data.wcr_nonatomic,
+                                  edge.data.wcr)
             elif v == node:
                 memlets[vconn] = (memlet, False, None)
 

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -138,9 +138,6 @@ SCOPEDEFAULT_SCHEDULE = {
     ScheduleType.FPGA_Device: ScheduleType.FPGA_Device,
 }
 
-# Identifier for dynamic number of Memlet accesses.
-DYNAMIC = -1
-
 # Translation of types to C types
 _CTYPES = {
     int: "int",
@@ -635,8 +632,7 @@ class callback(typeclass):
                         non_symbolic_sizes.append(other_arguments[str(s)])
                     else:
                         non_symbolic_sizes.append(s)
-                list_of_other_inputs[i] = ptrtonumpy(other_inputs[i],
-                                                     data_type,
+                list_of_other_inputs[i] = ptrtonumpy(other_inputs[i], data_type,
                                                      non_symbolic_sizes)
             return orig_function(*list_of_other_inputs)
 
@@ -836,12 +832,12 @@ class DebugInfo:
         IDE and debugging purposes. """
     def __init__(self,
                  start_line,
-                 start_column,
-                 end_line,
-                 end_column,
+                 start_column=0,
+                 end_line=-1,
+                 end_column=0,
                  filename=None):
         self.start_line = start_line
-        self.end_line = end_line
+        self.end_line = end_line if end_line >= 0 else start_line
         self.start_column = start_column
         self.end_column = end_column
         self.filename = filename

--- a/dace/frontend/octave/ast_arrayaccess.py
+++ b/dace/frontend/octave/ast_arrayaccess.py
@@ -111,8 +111,7 @@ class AST_ArrayAccess(AST_Node):
                         str(self))
             else:
                 raise NotImplementedError(
-                    "Non-constant array indexing not implemented: " +
-                    str(self))
+                    "Non-constant array indexing not implemented: " + str(self))
         ret = dace.subsets.Range(rangelist)
         return ret
 
@@ -140,13 +139,9 @@ class AST_ArrayAccess(AST_Node):
 
         if self.is_data_dependent_access() == False:
             msubset = self.make_range_from_accdims()
-            memlet = dace.memlet.Memlet(arrnode,
-                                        msubset.num_elements(),
-                                        msubset,
-                                        1,
-                                        None,
-                                        None,
-                                        debuginfo=self.context)
+            memlet = dace.memlet.Memlet.simple(arrnode,
+                                               msubset,
+                                               debuginfo=self.context)
             sdfg.nodes()[state].add_edge(arrnode, None, resnode, None, memlet)
         else:
             # add a map around the access and feed the access dims that are
@@ -204,12 +199,10 @@ class AST_ArrayAccess(AST_Node):
                 dace.memlet.Memlet.simple(arrnode, ','.join(access_dims)))
             s.add_edge(
                 tasklet, 'out', mex, None,
-                dace.memlet.Memlet.from_array(resnode.data,
-                                              resnode.desc(sdfg)))
+                dace.memlet.Memlet.from_array(resnode.data, resnode.desc(sdfg)))
             s.add_edge(
                 mex, None, resnode, None,
-                dace.memlet.Memlet.from_array(resnode.data,
-                                              resnode.desc(sdfg)))
+                dace.memlet.Memlet.from_array(resnode.data, resnode.desc(sdfg)))
 
         print("The result of " + str(self) + " will be stored in " + str(name))
 

--- a/dace/frontend/octave/ast_assign.py
+++ b/dace/frontend/octave/ast_assign.py
@@ -41,8 +41,8 @@ class AST_Assign(AST_Node):
         self.rhs.provide_parents(self)
 
     def __repr__(self):
-        return "AST_Assign(" + str(self.lhs) + ", " + str(
-            self.op) + ", " + str(self.rhs) + ")"
+        return "AST_Assign(" + str(self.lhs) + ", " + str(self.op) + ", " + str(
+            self.rhs) + ")"
 
     def print_nodes(self, state):
         for n in state.nodes():
@@ -64,10 +64,7 @@ class AST_Assign(AST_Node):
                 name = self.lhs.get_name()
 
                 if name not in sdfg.arrays:
-                    sdfg.add_array(name,
-                                   dims,
-                                   basetype,
-                                   debuginfo=self.context)
+                    sdfg.add_array(name, dims, basetype, debuginfo=self.context)
                 rhs_datanode = self.rhs.get_datanode(sdfg, state)
                 lhs_datanode = self.lhs.get_datanode(sdfg, state)
 
@@ -108,13 +105,10 @@ class AST_Assign(AST_Node):
 
                 if self.lhs.is_data_dependent_access() == False:
                     msubset = self.lhs.make_range_from_accdims()
-                    writem = dace.memlet.Memlet(self.lhs.arrayname.get_name(),
-                                                msubset.num_elements(),
-                                                msubset,
-                                                1,
-                                                None,
-                                                None,
-                                                debuginfo=self.context)
+                    writem = dace.memlet.Memlet.simple(
+                        self.lhs.arrayname.get_name(),
+                        msubset,
+                        debuginfo=self.context)
 
                     sdfg.nodes()[state].add_edge(rhs_datanode, None, dn, None,
                                                  writem)
@@ -161,7 +155,7 @@ class AST_Assign(AST_Node):
                         dace.memlet.Memlet.simple(
                             self.lhs.arrayname.get_name(),
                             ','.join([str(d) for d in acc_dims])))
-                    s.add_edge(dn, None, mex, None, dace.memlet.EmptyMemlet())
+                    s.add_edge(dn, None, mex, None, dace.memlet.Memlet())
 
             else:
                 raise NotImplementedError("Assignment with lhs of type " +

--- a/dace/frontend/octave/ast_function.py
+++ b/dace/frontend/octave/ast_function.py
@@ -212,11 +212,11 @@ class AST_BuiltInFunCall(AST_Node):
             if self.funname.get_name() == "zeros":
                 tasklet = sdfg.nodes()[state].add_tasklet(
                     'zero', {}, {'out'}, "out=0")
-                s.add_edge(men, None, tasklet, None, dace.memlet.EmptyMemlet())
+                s.add_edge(men, None, tasklet, None, dace.memlet.Memlet())
             elif self.funname.get_name() == "rand":
                 tasklet = sdfg.nodes()[state].add_tasklet(
                     'rand', {}, {'out'}, "out=drand48()")
-                s.add_edge(men, None, tasklet, None, dace.memlet.EmptyMemlet())
+                s.add_edge(men, None, tasklet, None, dace.memlet.Memlet())
             elif self.funname.get_name() == "sqrt":
                 A = self.args[0].get_datanode(sdfg, state)
                 tasklet = sdfg.nodes()[state].add_tasklet(

--- a/dace/frontend/octave/ast_matrix.py
+++ b/dace/frontend/octave/ast_matrix.py
@@ -124,7 +124,7 @@ class AST_Matrix(AST_Node):
             me, mx = sdfg.nodes()[state].add_map('init',
                                                  dict(i='0:' + str(arrlen)))
             sdfg.nodes()[state].add_edge(me, None, tasklet, None,
-                                         dace.memlet.EmptyMemlet())
+                                         dace.memlet.Memlet())
             sdfg.nodes()[state].add_edge(
                 tasklet, "out", mx, None,
                 dace.memlet.Memlet.from_array(trans.data, trans.desc(sdfg)))

--- a/dace/frontend/python/decorators.py
+++ b/dace/frontend/python/decorators.py
@@ -18,6 +18,8 @@ def program(f, *args, **kwargs) -> parser.DaceProgram:
     return parser.DaceProgram(f, args, kwargs)
 
 
+function = program
+
 # Internal DaCe decorators, these are not actually run, but rewritten
 
 

--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -206,8 +206,7 @@ def parse_memlet(visitor, src: MemletType, dst: MemletType,
     else:
         expr = dstexpr
 
-    return localvar, Memlet(expr.name,
-                            expr.accesses,
-                            expr.subset,
-                            1,
-                            wcr=expr.wcr)
+    return localvar, Memlet.simple(expr.name,
+                                   expr.subset,
+                                   num_accesses=expr.accesses,
+                                   wcr_str=expr.wcr)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -476,6 +476,7 @@ def add_indirection_subgraph(sdfg: SDFG,
                                fullRange,
                                veclen=memlet.veclen,
                                num_accesses=memlet.num_accesses)
+    fullMemlet.dynamic = memlet.dynamic
 
     if output:
         if isinstance(dst, nodes.ExitNode):
@@ -875,6 +876,7 @@ class TaskletTransformer(ExtNodeTransformer):
                         out_memlet = self.sdfg_outputs[name][0]
                         out_memlet.veclen = memlet.veclen
                         out_memlet.volume = memlet.volume
+                        out_memlet.dynamic = memlet.dynamic
                         out_memlet.wcr = memlet.wcr
                         out_memlet.wcr_nonatomic = memlet.wcr_nonatomic
                     if connector in self.inputs or connector in self.outputs:
@@ -1770,6 +1772,7 @@ class ProgramVisitor(ExtNodeVisitor):
                                                'w')][0]
                         inner_memlet = Memlet.simple(vname, str(irng))
                         inner_memlet.num_accesses = memlet.num_accesses
+                        inner_memlet.dynamic = memlet.dynamic
                         inner_memlet.veclen = memlet.veclen
                     else:
                         name = memlet.data

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -385,7 +385,7 @@ def add_indirection_subgraph(sdfg: SDFG,
                 conn = 'index_%s_%d' % (arr_name, i)
             arr = sdfg.arrays[arrname]
             # Memlet to load the indirection index
-            indexMemlet = Memlet(arrname, 1, subsets.Indices(access), 1)
+            indexMemlet = Memlet.simple(arrname, subsets.Indices(access))
             input_index_memlets.append(indexMemlet)
             read_node = graph.add_read(arrname)
             if PVisitor.nested or not isinstance(src, nodes.EntryNode):
@@ -472,8 +472,10 @@ def add_indirection_subgraph(sdfg: SDFG,
 
     # Create memlet that depends on the full array that we look up in
     fullRange = subsets.Range([(0, s - 1, 1) for s in array.shape])
-    fullMemlet = Memlet(memlet.data, memlet.num_accesses, fullRange,
-                        memlet.veclen)
+    fullMemlet = Memlet.simple(memlet.data,
+                               fullRange,
+                               veclen=memlet.veclen,
+                               num_accesses=memlet.num_accesses)
 
     if output:
         if isinstance(dst, nodes.ExitNode):
@@ -500,15 +502,15 @@ def add_indirection_subgraph(sdfg: SDFG,
 
     # Memlet to store the final value into the transient, and to load it into
     # the tasklet that needs it
-    # indirectMemlet = Memlet('__' + local_name + '_value', memlet.num_accesses,
-    #                         indirectRange, memlet.veclen)
+    # indirectMemlet = Memlet.simple('__' + local_name + '_value',
+    #                         indirectRange, num_accesses=memlet.num_accesses,
+    #                         veclen=memlet.veclen)
     # graph.add_edge(tasklet, 'lookup', dataNode, None, indirectMemlet)
 
-    valueMemlet = Memlet(
-        tmp_name,
-        1,  # memlet.num_accesses,
-        indirectRange,
-        memlet.veclen)
+    valueMemlet = Memlet.simple(tmp_name,
+                                indirectRange,
+                                num_accesses=1,
+                                veclen=memlet.veclen)
     if output:
         path = [src] + inp_base_path
         if isinstance(src, nodes.AccessNode):
@@ -720,15 +722,15 @@ class TaskletTransformer(ExtNodeTransformer):
                 self.sdfg_inputs[var_name] = (dace.Memlet.from_array(
                     parent_name, parent_array), inner_indices)
             else:
-                self.sdfg_inputs[var_name] = (dace.Memlet(
-                    parent_name, rng.num_elements(), rng, 1), inner_indices)
+                self.sdfg_inputs[var_name] = (dace.Memlet.simple(
+                    parent_name, rng), inner_indices)
         else:
             if _subset_has_indirection(rng):
                 self.sdfg_outputs[var_name] = (dace.Memlet.from_array(
                     parent_name, parent_array), inner_indices)
             else:
-                self.sdfg_outputs[var_name] = (dace.Memlet(
-                    parent_name, rng.num_elements(), rng, 1), inner_indices)
+                self.sdfg_outputs[var_name] = (dace.Memlet.simple(
+                    parent_name, rng), inner_indices)
 
         return (var_name, squeezed_rng)
 
@@ -843,8 +845,7 @@ class TaskletTransformer(ExtNodeTransformer):
                                                      node.value.left,
                                                      self.sdfg.arrays)
                     if self.nested and _subset_has_indirection(rng):
-                        memlet = dace.Memlet(memlet.data, rng.num_elements(),
-                                             rng, 1)
+                        memlet = dace.Memlet.simple(memlet.data, rng)
                     if connector in self.inputs or connector in self.outputs:
                         raise DaceSyntaxError(
                             self, node,
@@ -869,14 +870,13 @@ class TaskletTransformer(ExtNodeTransformer):
                                                      node.value.right,
                                                      self.sdfg.arrays)
                     if self.nested and _subset_has_indirection(rng):
-                        memlet = dace.Memlet(memlet.data, rng.num_elements(),
-                                             rng, 1)
+                        memlet = dace.Memlet.simple(memlet.data, rng)
                     if self.nested and name in self.sdfg_outputs:
                         out_memlet = self.sdfg_outputs[name][0]
-                        out_memlet.num_accesses = memlet.num_accesses
                         out_memlet.veclen = memlet.veclen
+                        out_memlet.volume = memlet.volume
                         out_memlet.wcr = memlet.wcr
-                        out_memlet.wcr_conflict = memlet.wcr_conflict
+                        out_memlet.wcr_nonatomic = memlet.wcr_nonatomic
                     if connector in self.inputs or connector in self.outputs:
                         raise DaceSyntaxError(
                             self, node,
@@ -1302,9 +1302,10 @@ class ProgramVisitor(ExtNodeVisitor):
         # Inject element to internal SDFG arrays
         ntrans = sdfg.temp_data_name()
         sdfg.add_array(ntrans, [1], self.sdfg.arrays[stream_name].dtype)
-        internal_memlet = dace.Memlet(ntrans, 1, subsets.Indices([0]), 1)
-        external_memlet = dace.Memlet(stream_name, dtypes.DYNAMIC,
-                                      subsets.Indices([0]), 1)
+        internal_memlet = dace.Memlet.simple(ntrans, subsets.Indices([0]))
+        external_memlet = dace.Memlet.simple(stream_name,
+                                             subsets.Indices([0]),
+                                             num_accesses=-1)
 
         # Inject to internal tasklet
         if not dec.endswith('scope'):
@@ -1625,8 +1626,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     state.add_edge(v, conn, internal_node, conn,
                                    dace.Memlet.simple(new_scalar, '0'))
                     if entry_node is not None:
-                        state.add_edge(entry_node, None, v, None,
-                                       dace.EmptyMemlet())
+                        state.add_edge(entry_node, None, v, None, dace.Memlet())
                     continue
 
                 if isinstance(v, tuple):
@@ -1727,7 +1727,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     state.add_edge(read_node, None, internal_node, conn, memlet)
         else:
             if entry_node is not None:
-                state.add_nedge(entry_node, internal_node, dace.EmptyMemlet())
+                state.add_nedge(entry_node, internal_node, dace.Memlet())
 
         # Parse internal node outputs
         if outputs:
@@ -1822,7 +1822,7 @@ class ProgramVisitor(ExtNodeVisitor):
                                    inner_memlet)
         else:
             if exit_node is not None:
-                state.add_nedge(internal_node, exit_node, dace.EmptyMemlet())
+                state.add_nedge(internal_node, exit_node, dace.Memlet())
 
     def _add_nested_symbols(self, nsdfg_node: nodes.NestedSDFG):
         """ 
@@ -2043,8 +2043,7 @@ class ProgramVisitor(ExtNodeVisitor):
             if op_subset.num_elements() != 1:
                 op1 = state.add_read(op_name)
                 op2 = state.add_write(target_name)
-                memlet = Memlet(target_name, target_subset.num_elements(),
-                                target_subset, 1)
+                memlet = Memlet.simple(target_name, target_subset)
                 memlet.other_subset = op_subset
                 state.add_nedge(op1, op2, memlet)
             else:
@@ -2139,8 +2138,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 else:
                     op1 = state.add_read(op_name)
                     op2 = state.add_write(wtarget_name)
-                    memlet = Memlet(wtarget_name, wtarget_subset.num_elements(),
-                                    wtarget_subset, 1)
+                    memlet = Memlet.simple(wtarget_name, wtarget_subset)
                     memlet.other_subset = op_subset
                     if op is not None:
                         memlet.wcr = LambdaProperty.from_string(
@@ -2248,13 +2246,11 @@ class ProgramVisitor(ExtNodeVisitor):
         inner_indices = set(non_squeezed)
 
         if access_type == 'r':
-            self.inputs[var_name] = (dace.Memlet(parent_name,
-                                                 rng.num_elements(), rng,
-                                                 1), inner_indices)
+            self.inputs[var_name] = (dace.Memlet.simple(parent_name,
+                                                        rng), inner_indices)
         else:
-            self.outputs[var_name] = (dace.Memlet(parent_name,
-                                                  rng.num_elements(), rng,
-                                                  1), inner_indices)
+            self.outputs[var_name] = (dace.Memlet.simple(parent_name,
+                                                         rng), inner_indices)
 
         return var_name
 
@@ -2899,11 +2895,11 @@ class ProgramVisitor(ExtNodeVisitor):
             wnode = state.add_write(dst_name)
             state.add_nedge(
                 rnode, wnode,
-                Memlet(src_name,
-                       src_expr.accesses,
-                       subsets.Range.from_array(self.sdfg.arrays[src_name]),
-                       1,
-                       wcr=dst_expr.wcr))
+                Memlet.simple(src_name,
+                              subsets.Range.from_array(
+                                  self.sdfg.arrays[src_name]),
+                              num_accesses=src_expr.accesses,
+                              wcr_str=dst_expr.wcr))
             return
 
         # Calling reduction or other SDFGs / functions
@@ -3196,7 +3192,10 @@ class ProgramVisitor(ExtNodeVisitor):
         self._add_state('slice_%s_%d' % (array, node.lineno))
         rnode = self.last_state.add_read(array)
         if _subset_has_indirection(expr.subset):
-            memlet = Memlet(array, expr.accesses, expr.subset, 1, expr.wcr)
+            memlet = Memlet.simple(array,
+                                   expr.subset,
+                                   num_accesses=expr.accesses,
+                                   wcr_str=expr.wcr)
             tmp = self.sdfg.temp_data_name()
             return add_indirection_subgraph(self.sdfg, self.last_state, rnode,
                                             None, memlet, tmp, self)
@@ -3209,8 +3208,11 @@ class ProgramVisitor(ExtNodeVisitor):
             wnode = self.last_state.add_write(tmp)
             self.last_state.add_nedge(
                 rnode, wnode,
-                Memlet(array, expr.accesses, expr.subset, 1, expr.wcr,
-                       other_subset))
+                Memlet.simple(array,
+                              expr.subset,
+                              num_accesses=expr.accesses,
+                              wcr_str=expr.wcr,
+                              other_subset_str=other_subset))
             return tmp
 
     ##################################

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -107,8 +107,7 @@ def _reduce(sdfg: SDFG,
         input_subset = parse_memlet_subset(sdfg.arrays[inarr],
                                            ast.parse(in_array).body[0].value,
                                            {})
-        input_memlet = Memlet(inarr, input_subset.num_elements(), input_subset,
-                              1)
+        input_memlet = Memlet.simple(inarr, input_subset)
         output_shape = None
         if axis is None:
             output_shape = [1]
@@ -134,13 +133,11 @@ def _reduce(sdfg: SDFG,
         input_subset = parse_memlet_subset(sdfg.arrays[inarr],
                                            ast.parse(in_array).body[0].value,
                                            {})
-        input_memlet = Memlet(inarr, input_subset.num_elements(), input_subset,
-                              1)
+        input_memlet = Memlet.simple(inarr, input_subset)
         output_subset = parse_memlet_subset(sdfg.arrays[outarr],
                                             ast.parse(out_array).body[0].value,
                                             {})
-        output_memlet = Memlet(outarr, output_subset.num_elements(),
-                               output_subset, 1)
+        output_memlet = Memlet.simple(outarr, output_subset)
 
     # Create reduce subgraph
     inpnode = state.add_read(inarr)
@@ -342,8 +339,7 @@ def _conj(sdfg: SDFG, state: SDFGState, input: str):
 @oprepo.replaces('numpy.real')
 def _real(sdfg: SDFG, state: SDFGState, input: str):
     inptype = sdfg.arrays[input].dtype
-    return _simple_call(sdfg, state, input, 'real',
-                        _complex_to_scalar(inptype))
+    return _simple_call(sdfg, state, input, 'real', _complex_to_scalar(inptype))
 
 
 @oprepo.replaces('imag')
@@ -351,8 +347,7 @@ def _real(sdfg: SDFG, state: SDFGState, input: str):
 @oprepo.replaces('numpy.imag')
 def _imag(sdfg: SDFG, state: SDFGState, input: str):
     inptype = sdfg.arrays[input].dtype
-    return _simple_call(sdfg, state, input, 'imag',
-                        _complex_to_scalar(inptype))
+    return _simple_call(sdfg, state, input, 'imag', _complex_to_scalar(inptype))
 
 
 @oprepo.replaces('transpose')
@@ -404,31 +399,13 @@ def _min(sdfg: SDFG, state: SDFGState, a: str, axis=None):
 
 
 @oprepo.replaces('numpy.argmax')
-def _argmax(sdfg: SDFG,
-            state: SDFGState,
-            a: str,
-            axis,
-            result_type=dace.int32):
-    return _argminmax(sdfg,
-                      state,
-                      a,
-                      axis,
-                      func="max",
-                      result_type=result_type)
+def _argmax(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int32):
+    return _argminmax(sdfg, state, a, axis, func="max", result_type=result_type)
 
 
 @oprepo.replaces('numpy.argmin')
-def _argmin(sdfg: SDFG,
-            state: SDFGState,
-            a: str,
-            axis,
-            result_type=dace.int32):
-    return _argminmax(sdfg,
-                      state,
-                      a,
-                      axis,
-                      func="min",
-                      result_type=result_type)
+def _argmin(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int32):
+    return _argminmax(sdfg, state, a, axis, func="min", result_type=result_type)
 
 
 def _argminmax(sdfg: SDFG,
@@ -483,10 +460,8 @@ def _argminmax(sdfg: SDFG,
 
     nest.add_state().add_mapped_tasklet(
         name="_arg{}_reduce_".format(func),
-        map_ranges={
-            '__i%d' % i: '0:%s' % n
-            for i, n in enumerate(a_arr.shape)
-        },
+        map_ranges={'__i%d' % i: '0:%s' % n
+                    for i, n in enumerate(a_arr.shape)},
         inputs={
             '__in':
             Memlet.simple(
@@ -555,8 +530,7 @@ def _argminmax(sdfg: SDFG,
 ##############################################################################
 
 
-def _assignop(sdfg: SDFG, state: SDFGState, op1: str, opcode: str,
-              opname: str):
+def _assignop(sdfg: SDFG, state: SDFGState, op1: str, opcode: str, opname: str):
     """ Implements a general element-wise array assignment operator. """
     arr1 = sdfg.arrays[op1]
 
@@ -845,8 +819,9 @@ def _matmult(visitor, sdfg: SDFG, state: SDFGState, op1: str, op2: str):
     if len(arr1.shape) > 1 and len(arr2.shape) > 1:  # matrix * matrix
 
         if len(arr1.shape) > 3 or len(arr2.shape) > 3:
-            raise SyntaxError('Matrix multiplication of tensors of dimensions > 3 '
-                              'not supported')
+            raise SyntaxError(
+                'Matrix multiplication of tensors of dimensions > 3 '
+                'not supported')
 
         if arr1.shape[-1] != arr2.shape[-2]:
             raise SyntaxError('Matrix dimension mismatch %s != %s' %
@@ -871,7 +846,7 @@ def _matmult(visitor, sdfg: SDFG, state: SDFGState, op1: str, op2: str):
 
         output_shape = (arr1.shape[0], )
 
-    elif len(arr1.shape) == 1 and len(arr2.shape) == 1: # vector * vector
+    elif len(arr1.shape) == 1 and len(arr2.shape) == 1:  # vector * vector
 
         if arr1.shape[0] != arr2.shape[0]:
             raise SyntaxError("Vectors in vector product must have same size: "
@@ -897,11 +872,8 @@ def _matmult(visitor, sdfg: SDFG, state: SDFGState, op1: str, op2: str):
 
     tasklet = MatMul('_MatMult_', restype)
     state.add_node(tasklet)
-    state.add_edge(acc1, None, tasklet, '_a',
-                   dace.Memlet.from_array(op1, arr1))
-    state.add_edge(acc2, None, tasklet, '_b',
-                   dace.Memlet.from_array(op2, arr2))
-    state.add_edge(tasklet, '_c', acc3, None,
-                   dace.Memlet.from_array(op3, arr3))
+    state.add_edge(acc1, None, tasklet, '_a', dace.Memlet.from_array(op1, arr1))
+    state.add_edge(acc2, None, tasklet, '_b', dace.Memlet.from_array(op2, arr2))
+    state.add_edge(tasklet, '_c', acc3, None, dace.Memlet.from_array(op3, arr3))
 
     return op3

--- a/dace/frontend/tensorflow/tensorflow.py
+++ b/dace/frontend/tensorflow/tensorflow.py
@@ -11,7 +11,7 @@ import math
 from typing import Any, List
 
 import dace
-from dace.memlet import Memlet, EmptyMemlet
+from dace.memlet import Memlet
 from dace import SDFG, SDFGState, dtypes
 from dace.data import Scalar
 from dace.sdfg.nodes import Tasklet, NestedSDFG

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -489,8 +489,8 @@ DACE_EXPORTED void __dace_reduce_{id}({intype} *input, {outtype} *output, {reduc
 
         # HACK: Workaround to avoid issues with code generator inferring reads
         # and writes when it shouldn't.
-        input_edge.data.num_accesses = dtypes.DYNAMIC
-        output_edge.data.num_accesses = dtypes.DYNAMIC
+        input_edge.data.dynamic = True
+        output_edge.data.dynamic = True
 
         return tnode
 
@@ -628,8 +628,8 @@ class ExpandReduceCUDABlock(pm.ExpandTransformation):
 
         # HACK: Workaround to avoid issues with code generator inferring reads
         # and writes when it shouldn't.
-        input_edge.data.num_accesses = dtypes.DYNAMIC
-        output_edge.data.num_accesses = dtypes.DYNAMIC
+        input_edge.data.dynamic = True
+        output_edge.data.dynamic = True
 
         return tnode
 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -143,8 +143,14 @@ class Memlet(object):
         attrs = dace.serialize.all_properties_to_json(self)
 
         # Fill in new values
-        attrs['src_subset'] = self.src_subset
-        attrs['dst_subset'] = self.dst_subset
+        if self.src_subset is not None:
+            attrs['src_subset'] = self.src_subset.to_json()
+        else:
+            attrs['src_subset'] = None
+        if self.dst_subset is not None:
+            attrs['dst_subset'] = self.dst_subset.to_json()
+        else:
+            attrs['dst_subset'] = None
 
         return {"type": "Memlet", "attributes": attrs}
 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -155,7 +155,7 @@ class Memlet(object):
 
         # Fill in legacy (DEPRECATED) values for backwards compatibility
         attrs['num_accesses'] = \
-            self.volume.to_json() if not self.dynamic else -1
+            str(self.volume) if not self.dynamic else -1
 
         return {"type": "Memlet", "attributes": attrs}
 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -1,11 +1,12 @@
 import ast
 from functools import reduce
 import operator
-from typing import List, Set
+from typing import List, Set, Union
+import warnings
 
 import dace
 import dace.serialize
-from dace import subsets, dtypes
+from dace import subsets, dtypes, symbolic
 from dace.frontend.operations import detect_reduction_type
 from dace.frontend.python.astutils import unparse
 from dace.properties import (Property, make_properties, DataProperty,
@@ -22,90 +23,163 @@ class Memlet(object):
     """
 
     # Properties
+    volume = SymbolicProperty(default=0,
+                              desc='The exact number of elements moved '
+                              'using this memlet, or the maximum number '
+                              'if dynamic=True (with 0 as unbounded)')
+    dynamic = Property(default=False,
+                       desc='Is the number of elements moved determined at '
+                       'runtime (e.g., data dependent)')
+    subset = SubsetProperty(allow_none=True,
+                            desc='Subset of elements to move from the data '
+                            'attached to this edge.')
+    other_subset = SubsetProperty(
+        allow_none=True,
+        desc='Subset of elements after reindexing to the data not attached '
+        'to this edge (e.g., for offsets and reshaping).')
+    data = DataProperty(desc='Data descriptor attached to this memlet')
+    wcr = LambdaProperty(allow_none=True,
+                         desc='If set, defines a write-conflict resolution '
+                         'lambda function. The syntax of the lambda function '
+                         'receives two elements: `current` value and `new` '
+                         'value, and returns the value after resolution')
     veclen = Property(dtype=int, desc="Vector length", default=1)
-    num_accesses = SymbolicProperty(default=0)
-    subset = SubsetProperty(default=subsets.Range([]))
-    other_subset = SubsetProperty(allow_none=True)
-    data = DataProperty()
-    debuginfo = DebugInfoProperty()
-    wcr = LambdaProperty(allow_none=True)
-    wcr_conflict = Property(dtype=bool, default=True)
+
+    # Code generation and validation hints
+    debuginfo = DebugInfoProperty(desc='Line information to track source and '
+                                  'generated code')
+    wcr_nonatomic = Property(dtype=bool,
+                             default=False,
+                             desc='If True, always generates non-conflicting '
+                             '(non-atomic) writes in resulting code')
     allow_oob = Property(dtype=bool,
                          default=False,
                          desc='Bypass out-of-bounds validation')
 
     def __init__(self,
-                 data,
-                 num_accesses,
-                 subset,
-                 vector_length,
-                 wcr=None,
-                 other_subset=None,
-                 debuginfo=None,
-                 wcr_conflict=True):
-        """ Constructs a Memlet.
-            :param data: The data object or name to access. B{Note:} this
-                         parameter will soon be deprecated.
-            @type data: Either a string of the data descriptor name or an
-                        AccessNode.
-            :param num_accesses: The number of times that the moved data
-                                 will be subsequently accessed. If
-                                 `dace.dtypes.DYNAMIC` (-1),
-                                 designates that the number of accesses is
-                                 unknown at compile time.
-            :param subset: The subset of `data` that is going to be accessed.
-            :param vector_length: The length of a single unit of access to
-                                  the data (used for vectorization
-                                  optimizations).
-            :param wcr: A lambda function specifying how write-conflicts
-                        are resolved. The syntax of the lambda function receives two elements: `current` value and `new` value,
-                        and returns the value after resolution. For example,
-                        summation is `lambda cur, new: cur + new`.
-            :param other_subset: The reindexing of `subset` on the other
-                                 connected data.
-            :param debuginfo: Source-code information (e.g., line, file)
-                              used for debugging.
-            :param wcr_conflict: If False, forces non-locked conflict
-                                 resolution when generating code. The default
-                                 is to let the code generator infer this
-                                 information from the SDFG.
+                 expr: str = None,
+                 data: str = None,
+                 subset: Union[str, subsets.Subset] = None,
+                 other_subset: Union[str, subsets.Subset] = None,
+                 veclen: int = 1,
+                 volume: Union[int, str, symbolic.SymbolicType] = None,
+                 dynamic: bool = False,
+                 wcr: Union[str, ast.AST] = None,
+                 debuginfo: dtypes.DebugInfo = None,
+                 wcr_nonatomic: bool = False,
+                 allow_oob: bool = False):
+        """ 
+        Constructs a Memlet.
+        :param expr: A string expression of the this memlet, given as an ease
+                     of use API. Must follow one of the following forms:
+                     1. ``ARRAY``,
+                     2. ``ARRAY[SUBSET]``,
+                     3. ``ARRAY[SUBSET] -> OTHER_SUBSET``.
+        :param data: (DEPRECATED) Data descriptor name attached to this memlet.
+        :param subset: The subset to take from the data attached to the edge,
+                       represented either as a string or a Subset object.
+        :param other_subset: The subset to offset into the other side of the
+                             memlet, represented either as a string or a Subset 
+                             object.
+        :param volume: The exact number of elements moved using this
+                       memlet, or the maximum number of elements if
+                       ``dynamic`` is set to True. If dynamic and this
+                       value is set to zero, the number of elements moved
+                       is runtime-defined and unbounded.
+        :param dynamic: If True, the number of elements moved in this memlet
+                        is defined dynamically at runtime.
+        :param wcr: A lambda function (represented as a string or Python AST) 
+                    specifying how write-conflicts are resolved. The syntax
+                    of the lambda function receives two elements: ``current`` 
+                    value and `new` value, and returns the value after 
+                    resolution. For example, summation is represented by
+                    ``'lambda cur, new: cur + new'``.
+        :param debuginfo: Line information from the generating source code.
+        :param wcr_nonatomic: If True, overrides the automatic code generator 
+                              decision and treat all write-conflict resolution
+                              operations as non-atomic, which might cause race
+                              conditions in the general case.
+        :param allow_oob: If True, bypasses the checks in SDFG validation for
+                          out-of-bounds accesses in memlet subsets.
         """
 
-        # Properties
-        self.num_accesses = num_accesses  # type: sympy.expr.Expr
-        self.subset = subset  # type: subsets.Subset
-        self.veclen = vector_length  # type: int
-        if hasattr(data, 'data'):
-            data = data.data
-        self.data = data  # type: str
+        # Will be set once memlet is added into an SDFG (in try_initialize)
+        self._sdfg = None
+        self._state = None
+        self._edge = None
 
-        # Annotates memlet with _how_ writing is performed in case of conflict
+        # Field caching which subset belongs to source or destination of memlet
+        self._is_data_src = None
+
+        # Initialize first by string expression
+        self.data = None
+        self.subset = None
+        self.other_subset = None
+        if expr is not None:
+            self._parse_memlet_from_str(expr)
+
+        # Set properties
+        self.data = self.data or data
+        self.subset = self.subset or subset
+        self.other_subset = self.other_subset or other_subset
+
+        if volume is not None:
+            self.volume = volume
+        else:
+            if self.subset is not None:
+                self.volume = self.subset.num_elements()
+            elif self.other_subset is not None:
+                self.volume = self.other_subset.num_elements()
+            else:
+                self.volume = 1
+
+        self.dynamic = dynamic
         self.wcr = wcr
-        self.wcr_conflict = wcr_conflict
-
-        # The subset of the other endpoint we are copying from/to (note:
-        # carries the dimensionality of the other endpoint too!)
-        self.other_subset = other_subset
-
+        self.wcr_nonatomic = wcr_nonatomic
         self.debuginfo = debuginfo
+        self.veclen = veclen
 
-    def to_json(self, parent_graph=None):
+    def to_json(self):
         attrs = dace.serialize.all_properties_to_json(self)
 
-        retdict = {"type": "Memlet", "attributes": attrs}
+        # Fill in new values
+        attrs['src_subset'] = self.src_subset
+        attrs['dst_subset'] = self.dst_subset
 
-        return retdict
+        return {"type": "Memlet", "attributes": attrs}
 
     @staticmethod
     def from_json(json_obj, context=None):
-        if json_obj['type'] != "Memlet":
-            raise TypeError("Invalid data type")
-
-        # Create dummy object
-        ret = Memlet("", dace.dtypes.DYNAMIC, None, 1)
-        dace.serialize.set_properties_from_json(ret, json_obj, context=context)
-
+        ret = Memlet()
+        dace.serialize.set_properties_from_json(
+            ret,
+            json_obj,
+            context=context,
+            ignore_properties={'src_subset', 'dst_subset'})
+        if context:
+            ret._sdfg = context['sdfg']
+            ret._state = context['sdfg_state']
         return ret
+
+    def is_empty(self) -> bool:
+        """ 
+        Returns True if this memlet carries no data. Memlets without data are
+        primarily used for connecting nodes to scopes without transferring 
+        data to them. 
+        """
+        return (self.data is None and self.src_subset is None
+                and self.dst_subset is None)
+
+    @property
+    def num_accesses(self):
+        """ 
+        Returns the total memory movement volume (in elements) of this memlet.
+        """
+        return self.volume
+
+    @num_accesses.setter
+    def num_accesses(self, value):
+        self.volume = value
 
     @staticmethod
     def simple(data,
@@ -116,10 +190,9 @@ class Memlet(object):
                wcr_conflict=True,
                num_accesses=None,
                debuginfo=None):
-        """ Constructs a Memlet from string-based expressions.
-            :param data: The data object or name to access. B{Note:} this
-                         parameter will soon be deprecated.
-            @type data: Either a string of the data descriptor name or an
+        """ DEPRECATED: Constructs a Memlet from string-based expressions.
+            :param data: The data object or name to access. 
+            :type data: Either a string of the data descriptor name or an
                         AccessNode.
             :param subset_str: The subset of `data` that is going to
                                be accessed in string format. Example: '0:N'.
@@ -140,41 +213,121 @@ class Memlet(object):
                                  information from the SDFG.
             :param num_accesses: The number of times that the moved data
                                  will be subsequently accessed. If
-                                 `dace.dtypes.DYNAMIC` (-1),
-                                 designates that the number of accesses is
+                                 -1, designates that the number of accesses is
                                  unknown at compile time.
             :param debuginfo: Source-code information (e.g., line, file)
                               used for debugging.
 
         """
-        subset = SubsetProperty.from_string(subset_str)
-        if num_accesses is not None:
-            na = num_accesses
+        # warnings.warn(
+        #     'This function is deprecated, please use the Memlet '
+        #     'constructor instead', DeprecationWarning)
+
+        result = Memlet()
+
+        if isinstance(subset_str, subsets.Subset):
+            result.subset = subset_str
         else:
-            na = subset.num_elements()
+            result.subset = SubsetProperty.from_string(subset_str)
+
+        if num_accesses is not None:
+            if num_accesses == -1:
+                result.dynamic = True
+                result.volume = 0
+            else:
+                result.volume = num_accesses
+        else:
+            result.volume = result._subset.num_elements()
 
         if wcr_str is not None:
-            wcr = LambdaProperty.from_string(wcr_str)
-        else:
-            wcr = None
+            if isinstance(wcr_str, ast.AST):
+                result.wcr = wcr_str
+            else:
+                result.wcr = LambdaProperty.from_string(wcr_str)
 
         if other_subset_str is not None:
-            other_subset = SubsetProperty.from_string(other_subset_str)
+            if isinstance(other_subset_str, subsets.Subset):
+                result.other_subset = other_subset_str
+            else:
+                result.other_subset = SubsetProperty.from_string(
+                    other_subset_str)
         else:
-            other_subset = None
+            result.other_subset = None
 
         # If it is an access node or another memlet
         if hasattr(data, 'data'):
-            data = data.data
+            result.data = data.data
+        else:
+            result.data = data
 
-        return Memlet(data,
-                      na,
-                      subset,
-                      veclen,
-                      wcr=wcr,
-                      other_subset=other_subset,
-                      wcr_conflict=wcr_conflict,
-                      debuginfo=debuginfo)
+        result.wcr_nonatomic = not wcr_conflict
+        result.veclen = veclen
+
+        return result
+
+    def _parse_from_subexpr(self, expr: str):
+        if expr[-1] != ']':  # No subset given, try to use whole array
+            if not dtypes.validate_name(expr):
+                raise SyntaxError('Invalid memlet syntax "%s"' % expr)
+            return expr, None
+
+        # array[subset] syntax
+        arrname, subset_str = expr[:-1].split('[')
+        if not dtypes.validate_name(arrname):
+            raise SyntaxError('Invalid array name "%s" in memlet' % arrname)
+        return arrname, SubsetProperty.from_string(subset_str)
+
+    def _parse_memlet_from_str(self, expr: str):
+        """
+        Parses a memlet and fills in either the src_subset,dst_subset fields
+        or the _data,_subset fields.
+        :param expr: A string expression of the this memlet, given as an ease
+                of use API. Must follow one of the following forms:
+                1. ``ARRAY``,
+                2. ``ARRAY[SUBSET]``,
+                3. ``ARRAY[SUBSET] -> OTHER_SUBSET``.
+                Note that modes 2 and 3 are deprecated and will leave 
+                the memlet uninitialized until inserted into an SDFG.
+        """
+        expr = expr.strip()
+        if '->' not in expr:  # Options 1 and 2
+            self.data, self.subset = self._parse_from_subexpr(expr)
+            return
+
+        # Option 3
+        src_expr, dst_expr = expr.split('->')
+        src_expr = src_expr.strip()
+        dst_expr = dst_expr.strip()
+        if '[' not in src_expr and not dtypes.validate_name(src_expr):
+            raise SyntaxError('Expression without data name not yet allowed')
+
+        self.data, self.subset = self._parse_from_subexpr(src_expr)
+        self.other_subset = SubsetProperty.from_string(dst_expr)
+
+    def try_initialize(self, sdfg: 'dace.sdfg.SDFG',
+                       state: 'dace.sdfg.SDFGState',
+                       edge: 'dace.sdfg.graph.MultiConnectorEdge'):
+        """ 
+        Tries to initialize the internal fields of the memlet (e.g., src/dst 
+        subset) once it is added to an SDFG as an edge.
+        """
+        from dace.sdfg.nodes import AccessNode  # Avoid import loop
+        self._sdfg = sdfg
+        self._state = state
+        self._edge = edge
+
+        # Find source/destination of memlet
+        try:
+            path = state.memlet_path(edge)
+        except (ValueError, AssertionError, StopIteration):
+            # Cannot initialize yet
+            return
+
+        is_data_src = True
+        if isinstance(path[-1].dst, AccessNode):
+            if path[-1].dst.data == self._data:
+                is_data_src = False
+        self._is_data_src = is_data_src
 
     @staticmethod
     def from_array(dataname, datadesc, wcr=None):
@@ -182,25 +335,28 @@ class Memlet(object):
             :param dataname: The name of the data descriptor in the SDFG.
             :param datadesc: The data descriptor object.
             :param wcr: The conflict resolution lambda.
-            @type datadesc: Data.
+            :type datadesc: Data
         """
-        range = subsets.Range.from_array(datadesc)
-        return Memlet(dataname, range.num_elements(), range, 1, wcr=wcr)
+        rng = subsets.Range.from_array(datadesc)
+        return Memlet.simple(dataname, rng, wcr_str=wcr)
 
     def __hash__(self):
-        return hash((self.data, self.num_accesses, self.subset, self.veclen,
-                     str(self.wcr), self.other_subset))
+        return hash(
+            (self.volume, self.src_subset, self.dst_subset, str(self.wcr)))
 
     def __eq__(self, other):
         return all([
-            self.data == other.data, self.num_accesses == other.num_accesses,
-            self.subset == other.subset, self.veclen == other.veclen,
-            self.wcr == other.wcr, self.other_subset == other.other_subset
+            self.volume == other.volume, self.src_subset == other.src_subset,
+            self.dst_subset == other.dst_subset, self.wcr == other.wcr
         ])
 
     def num_elements(self):
         """ Returns the number of elements in the Memlet subset. """
-        return self.subset.num_elements()
+        if self.subset:
+            return self.subset.num_elements()
+        elif self.other_subset:
+            return self.other_subset.num_elements()
+        return 0
 
     def bounding_box_size(self):
         """ Returns a per-dimension upper bound on the maximum number of
@@ -208,7 +364,24 @@ class Memlet(object):
 
             This bound will be tight in the case of Range.
         """
-        return self.subset.bounding_box_size()
+        if self.src_subset:
+            return self.src_subset.bounding_box_size()
+        elif self.dst_subset:
+            return self.dst_subset.bounding_box_size()
+        return []
+
+    # New fields
+    @property
+    def src_subset(self):
+        if self._is_data_src is not None:
+            return self.subset if self._is_data_src else self.other_subset
+        return self.subset
+
+    @property
+    def dst_subset(self):
+        if self._is_data_src is not None:
+            return self.other_subset if self._is_data_src else self.subset
+        return self.other_subset
 
     def validate(self, sdfg, state):
         if self.data is not None and self.data not in sdfg.arrays:
@@ -217,13 +390,13 @@ class Memlet(object):
     @property
     def free_symbols(self) -> Set[str]:
         """ Returns a set of symbols used in this edge's properties. """
-        # Symbolic properties are in num_accesses, and the two subsets
+        # Symbolic properties are in volume, and the two subsets
         result = set()
-        result |= set(map(str, self.num_accesses.free_symbols))
-        if self.subset:
-            result |= self.subset.free_symbols
-        if self.other_subset:
-            result |= self.other_subset.free_symbols
+        result |= set(map(str, self.volume.free_symbols))
+        if self.src_subset:
+            result |= self.src_subset.free_symbols
+        if self.dst_subset:
+            result |= self.dst_subset.free_symbols
         return result
 
     def __label__(self, sdfg, state):
@@ -249,12 +422,10 @@ class Memlet(object):
             return result
 
         num_elements = self.subset.num_elements()
-        if self.num_accesses != num_elements:
-            if self.num_accesses == -1:
-                result += '(dyn) '
-            else:
-                result += '(%s) ' % SymbolicProperty.to_string(
-                    self.num_accesses)
+        if self.dynamic:
+            result += '(dyn) '
+        elif self.volume != num_elements:
+            result += '(%s) ' % SymbolicProperty.to_string(self.volume)
         arrayNotation = True
         try:
             if shape is not None and reduce(operator.mul, shape, 1) == 1:
@@ -283,13 +454,6 @@ class Memlet(object):
 
     def __repr__(self):
         return "Memlet (" + self.__str__() + ")"
-
-
-class EmptyMemlet(Memlet):
-    """ A memlet without data. Primarily used for connecting nodes to scopes
-        without transferring data to them. """
-    def __init__(self):
-        super(EmptyMemlet, self).__init__(None, 0, None, 1)
 
 
 class MemletTree(object):

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -348,7 +348,7 @@ class Memlet(object):
         Tries to initialize the internal fields of the memlet (e.g., src/dst 
         subset) once it is added to an SDFG as an edge.
         """
-        from dace.sdfg.nodes import AccessNode  # Avoid import loop
+        from dace.sdfg.nodes import AccessNode, CodeNode  # Avoid import loops
         self._sdfg = sdfg
         self._state = state
         self._edge = edge

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -1,4 +1,5 @@
 import ast
+from copy import deepcopy as dcpy
 from functools import reduce
 import operator
 from typing import List, Set, Union
@@ -166,6 +167,29 @@ class Memlet(object):
             ret._sdfg = context['sdfg']
             ret._state = context['sdfg_state']
         return ret
+
+    def __deepcopy__(self, memo):
+        node = object.__new__(Memlet)
+
+        # Set properties
+        node.volume = dcpy(self.volume, memo=memo)
+        node._dynamic = self._dynamic
+        node.subset = dcpy(self.subset, memo=memo)
+        node.other_subset = dcpy(self.other_subset, memo=memo)
+        node.data = dcpy(self.data, memo=memo)
+        node.wcr = dcpy(self.wcr, memo=memo)
+        node._veclen = self._veclen
+        node.debuginfo = dcpy(self.debuginfo, memo=memo)
+        node._wcr_nonatomic = self._wcr_nonatomic
+        node._allow_oob = self._allow_oob
+
+        # Nullify graph references
+        node._sdfg = None
+        node._state = None
+        node._edge = None
+        node._is_data_src = None
+
+        return node
 
     def is_empty(self) -> bool:
         """ 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -154,7 +154,8 @@ class Memlet(object):
             attrs['dst_subset'] = None
 
         # Fill in legacy (DEPRECATED) values for backwards compatibility
-        attrs['num_accesses'] = self.volume if not self.dynamic else -1
+        attrs['num_accesses'] = \
+            self.volume.to_json() if not self.dynamic else -1
 
         return {"type": "Memlet", "attributes": attrs}
 

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -189,7 +189,8 @@ class Memlet(object):
                other_subset_str=None,
                wcr_conflict=True,
                num_accesses=None,
-               debuginfo=None):
+               debuginfo=None,
+               dynamic=False):
         """ DEPRECATED: Constructs a Memlet from string-based expressions.
             :param data: The data object or name to access. 
             :type data: Either a string of the data descriptor name or an
@@ -217,7 +218,8 @@ class Memlet(object):
                                  unknown at compile time.
             :param debuginfo: Source-code information (e.g., line, file)
                               used for debugging.
-
+            :param dynamic: If True, the number of elements moved in this memlet
+                            is defined dynamically at runtime.
         """
         # warnings.warn(
         #     'This function is deprecated, please use the Memlet '
@@ -229,6 +231,8 @@ class Memlet(object):
             result.subset = subset_str
         else:
             result.subset = SubsetProperty.from_string(subset_str)
+
+        result.dynamic = dynamic
 
         if num_accesses is not None:
             if num_accesses == -1:

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -153,6 +153,9 @@ class Memlet(object):
         else:
             attrs['dst_subset'] = None
 
+        # Fill in legacy (DEPRECATED) values for backwards compatibility
+        attrs['num_accesses'] = self.volume if not self.dynamic else -1
+
         return {"type": "Memlet", "attributes": attrs}
 
     @staticmethod
@@ -162,7 +165,7 @@ class Memlet(object):
             ret,
             json_obj,
             context=context,
-            ignore_properties={'src_subset', 'dst_subset'})
+            ignore_properties={'src_subset', 'dst_subset', 'num_accesses'})
         if context:
             ret._sdfg = context['sdfg']
             ret._state = context['sdfg_state']

--- a/dace/runtime/include/dace/types.h
+++ b/dace/runtime/include/dace/types.h
@@ -73,7 +73,6 @@ namespace dace
 
     enum NumAccesses
     {
-        NA_DYNAMIC = -1, // Dynamic number of accesses
         NA_RUNTIME = 0, // Given at runtime
     };
 

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -40,7 +40,7 @@ class Edge(object):
         yield self._data
 
     def to_json(self, parent_graph):
-        memlet_ret = self.data.to_json(parent_graph)
+        memlet_ret = self.data.to_json()
         ret = {
             'type': type(self).__name__,
             'attributes': {
@@ -105,8 +105,7 @@ class MultiConnectorEdge(MultiEdge):
         sdfg = context['sdfg_state']
         if sdfg is None:
             raise Exception("parent_graph must be defined for this method")
-        data = dace.serialize.from_json(json_obj['attributes']['data'],
-                                        context)
+        data = dace.serialize.from_json(json_obj['attributes']['data'], context)
         src_nid = json_obj['src']
         dst_nid = json_obj['dst']
 
@@ -324,8 +323,7 @@ class Graph(object):
                     e = next(children)
                     if e.dst not in visited:
                         visited.add(e.dst)
-                        if condition is None or condition(
-                                e.src, e.dst, e.data):
+                        if condition is None or condition(e.src, e.dst, e.data):
                             yield e
                             stack.append(
                                 (e.dst, self.out_edges(e.dst).__iter__()))
@@ -579,11 +577,9 @@ class MultiDiConnectorGraph(MultiDiGraph):
     @staticmethod
     def _from_nx(edge):
         return MultiConnectorEdge(edge[0], edge[3]["src_conn"], edge[1],
-                                  edge[3]["dst_conn"], edge[3]["data"],
-                                  edge[2])
+                                  edge[3]["dst_conn"], edge[3]["data"], edge[2])
 
-    def add_edge(self, source, src_connector, destination, dst_connector,
-                 data):
+    def add_edge(self, source, src_connector, destination, dst_connector, data):
         key = self._nx.add_edge(source,
                                 destination,
                                 data=data,

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -221,9 +221,9 @@ class AccessNode(Node):
         node._access = self._access
         node._data = self._data
         node._setzero = self._setzero
-        node._in_connectors = self._in_connectors
-        node._out_connectors = self._out_connectors
-        node.debuginfo = dcpy(self.debuginfo)
+        node._in_connectors = dcpy(self._in_connectors, memo=memo)
+        node._out_connectors = dcpy(self._out_connectors, memo=memo)
+        node.debuginfo = dcpy(self.debuginfo, memo=memo)
         return node
 
     @property

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -8,7 +8,7 @@ import sympy
 import warnings
 
 from dace import registry, subsets, symbolic, dtypes
-from dace.memlet import EmptyMemlet, Memlet
+from dace.memlet import Memlet
 from dace.sdfg import nodes
 
 
@@ -64,8 +64,7 @@ class SeparableMemlet(MemletPattern):
                          expr[dim][1].approx if isinstance(
                              expr[dim][1], symbolic.SymExpr) else expr[dim][1],
                          expr[dim][2].approx if isinstance(
-                             expr[dim][2],
-                             symbolic.SymExpr) else expr[dim][2]))
+                             expr[dim][2], symbolic.SymExpr) else expr[dim][2]))
                 else:
                     dexprs.append(expr[dim])
 
@@ -266,8 +265,8 @@ class AffineSMemlet(SeparableMemletPattern):
             result_tile = 1
         else:
             if rt == 1:
-                result_skip = (result_end - result_begin - re +
-                               rb) / (node_re - node_rb)
+                result_skip = (result_end - result_begin - re + rb) / (node_re -
+                                                                       node_rb)
                 try:
                     if result_skip < 1:
                         result_skip = 1
@@ -624,8 +623,8 @@ def _propagate_node(dfg_state, node):
         ]
 
     for edge in external_edges:
-        if isinstance(edge.data, EmptyMemlet):
-            new_memlet = EmptyMemlet()
+        if edge.data.is_empty():
+            new_memlet = Memlet()
         else:
             internal_edge = next(e for e in internal_edges
                                  if e.data.data == edge.data.data)
@@ -658,8 +657,8 @@ def propagate_memlet(dfg_state,
         neighboring_edges = dfg_state.in_edges(scope_node)
     else:
         raise TypeError('Trying to propagate through a non-scope node')
-    if isinstance(memlet, EmptyMemlet):
-        return EmptyMemlet()
+    if memlet.is_empty():
+        return Memlet()
 
     sdfg = dfg_state.parent
     scope_node_symbols = set(conn for conn in entry_node.in_connectors
@@ -748,11 +747,11 @@ def propagate_memlet(dfg_state,
     new_memlet.num_accesses = (
         sum(m.num_accesses for m in aggdata) *
         functools.reduce(lambda a, b: a * b, scope_node.map.range.size(), 1))
-    if any(m.num_accesses == -1 for m in aggdata):
-        new_memlet.num_accesses = -1
+    if any(m.dynamic for m in aggdata):
+        new_memlet.dynamic = True
     elif symbolic.issymbolic(new_memlet.num_accesses) and any(
             s not in defined_vars
             for s in new_memlet.num_accesses.free_symbols):
-        new_memlet.num_accesses = -1
+        new_memlet.dynamic = True
 
     return new_memlet

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -743,7 +743,7 @@ def propagate_memlet(dfg_state,
     new_memlet.other_subset = None
 
     # Number of accesses in the propagated memlet is the sum of the internal
-    # number of accesses times the size of the map range set
+    # number of accesses times the size of the map range set (unbounded dynamic)
     new_memlet.num_accesses = (
         sum(m.num_accesses for m in aggdata) *
         functools.reduce(lambda a, b: a * b, scope_node.map.range.size(), 1))
@@ -753,5 +753,6 @@ def propagate_memlet(dfg_state,
             s not in defined_vars
             for s in new_memlet.num_accesses.free_symbols):
         new_memlet.dynamic = True
+        new_memlet.num_accesses = 0
 
     return new_memlet

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1873,7 +1873,7 @@ def _get_optimizer_class(class_override):
     if class_override is None:
         clazz = Config.get("optimizer", "interface")
 
-    if clazz == "" or clazz is False:
+    if clazz == "" or clazz is False or str(clazz).strip() == "":
         return None
 
     result = locate(clazz)

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -608,6 +608,10 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
         """ Returns the parent SDFG of this state. """
         return self._parent
 
+    @parent.setter
+    def parent(self, value):
+        self._parent = value
+
     def __str__(self):
         return self._label
 

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -159,9 +159,8 @@ class Range(Subset):
         return Range(tuples)
 
     @staticmethod
-    def from_array(array):
-        """ Constructs a range that covers the full array given as input.
-            @type array: dace.data.Data """
+    def from_array(array: 'dace.data.Data'):
+        """ Constructs a range that covers the full array given as input. """
         return Range([(0, s - 1, 1) for s in array.shape])
 
     def __hash__(self):
@@ -577,8 +576,8 @@ class Range(Subset):
         return Range.ndslice_to_string_list(self.ranges, self.tile_sizes)
 
     def replace(self, repl_dict):
-        for i, ((rb, re, rs),
-                ts) in enumerate(zip(self.ranges, self.tile_sizes)):
+        for i, ((rb, re, rs), ts) in enumerate(zip(self.ranges,
+                                                   self.tile_sizes)):
             self.ranges[i] = (
                 rb.subs(repl_dict) if symbolic.issymbolic(rb) else rb,
                 re.subs(repl_dict) if symbolic.issymbolic(re) else re,

--- a/dace/transformation/dataflow/map_fission.py
+++ b/dace/transformation/dataflow/map_fission.py
@@ -317,10 +317,16 @@ class MapFission(pattern_matching.Transformation):
                     sbs.offset([r[0] for r in outer_map.range], True)
                     state.add_edge(
                         edge.src, edge.src_conn, anode, None,
-                        mm.Memlet(name, outer_map.range.num_elements(), sbs, 1))
+                        mm.Memlet.simple(
+                            name,
+                            sbs,
+                            num_accesses=outer_map.range.num_elements()))
                     state.add_edge(
                         anode, None, edge.dst, edge.dst_conn,
-                        mm.Memlet(name, outer_map.range.num_elements(), sbs, 1))
+                        mm.Memlet.simple(
+                            name,
+                            sbs,
+                            num_accesses=outer_map.range.num_elements()))
                     state.remove_edge(edge)
 
             # Add extra maps around components
@@ -354,8 +360,7 @@ class MapFission(pattern_matching.Transformation):
                     state.remove_edge(e)
                 # Empty memlet edge in nested SDFGs
                 if state.in_degree(component_in) == 0:
-                    state.add_edge(me, None, component_in, None,
-                                   mm.EmptyMemlet())
+                    state.add_edge(me, None, component_in, None, mm.Memlet())
 
                 for e in state.out_edges(component_out):
                     state.add_edge(e.src, e.src_conn, mx, None, dcpy(e.data))
@@ -370,8 +375,7 @@ class MapFission(pattern_matching.Transformation):
                     state.remove_edge(e)
                 # Empty memlet edge in nested SDFGs
                 if state.out_degree(component_out) == 0:
-                    state.add_edge(component_out, None, mx, None,
-                                   mm.EmptyMemlet())
+                    state.add_edge(component_out, None, mx, None, mm.Memlet())
             # Connect other sources/sinks not in components (access nodes)
             # directly to external nodes
             if self.expr_index == 0:

--- a/dace/transformation/dataflow/mapreduce.py
+++ b/dace/transformation/dataflow/mapreduce.py
@@ -23,11 +23,10 @@ class MapReduceFusion(pm.Transformation):
         between the map and the reduction is not used anywhere else.
     """
 
-    no_init = Property(
-        dtype=bool,
-        default=False,
-        desc='If enabled, does not create initialization states '
-        'for reduce nodes with identity')
+    no_init = Property(dtype=bool,
+                       default=False,
+                       desc='If enabled, does not create initialization states '
+                       'for reduce nodes with identity')
 
     _tasklet = nodes.Tasklet('_')
     _tmap_exit = nodes.MapExit(nodes.Map("", [], []))
@@ -137,16 +136,16 @@ class MapReduceFusion(pm.Transformation):
         # Modify edge from tasklet to map exit
         memlet_edge.data.data = out_array.data
         memlet_edge.data.wcr = reduce_node.wcr
-        memlet_edge.data.subset = type(
-            memlet_edge.data.subset)(filtered_subset)
+        memlet_edge.data.subset = type(memlet_edge.data.subset)(filtered_subset)
 
         # Add edge from map exit to output array
         graph.add_edge(
             memlet_edge.dst, 'OUT_' + memlet_edge.dst_conn[3:], array_edge.dst,
             array_edge.dst_conn,
-            Memlet(array_edge.data.data, array_edge.data.num_accesses,
-                   array_edge.data.subset, array_edge.data.veclen,
-                   reduce_node.wcr))
+            Memlet.simple(array_edge.data.data,
+                          array_edge.data.subset,
+                          num_accesses=array_edge.data.num_accesses,
+                          wcr_str=reduce_node.wcr))
 
         # Add initialization state as necessary
         if reduce_node.identity is not None:

--- a/dace/transformation/dataflow/merge_arrays.py
+++ b/dace/transformation/dataflow/merge_arrays.py
@@ -25,9 +25,9 @@ class MergeArrays(pattern_matching.Transformation):
         g.add_node(MergeArrays._array2)
         g.add_node(MergeArrays._map_entry)
         g.add_edge(MergeArrays._array1, None, MergeArrays._map_entry, None,
-                   memlet.EmptyMemlet())
+                   memlet.Memlet())
         g.add_edge(MergeArrays._array2, None, MergeArrays._map_entry, None,
-                   memlet.EmptyMemlet())
+                   memlet.Memlet())
         return [g]
 
     @staticmethod

--- a/dace/transformation/dataflow/strip_mining.py
+++ b/dace/transformation/dataflow/strip_mining.py
@@ -327,7 +327,7 @@ class StripMining(pattern_matching.Transformation):
                     entry_out_conn.add('OUT_' + conn)
                     new_memlet = dcpy(memlet)
                     new_memlet.subset = new_subset
-                    if memlet.num_accesses == -1:
+                    if memlet.dynamic:
                         new_memlet.num_accesses = memlet.num_accesses
                     else:
                         new_memlet.num_accesses = new_memlet.num_elements()
@@ -374,7 +374,7 @@ class StripMining(pattern_matching.Transformation):
                     exit_out_conn.add('OUT_' + conn)
                     new_memlet = dcpy(memlet)
                     new_memlet.subset = new_subset
-                    if memlet.num_accesses == -1:
+                    if memlet.dynamic:
                         new_memlet.num_accesses = memlet.num_accesses
                     else:
                         new_memlet.num_accesses = new_memlet.num_elements()

--- a/dace/transformation/dataflow/vectorization.py
+++ b/dace/transformation/dataflow/vectorization.py
@@ -103,8 +103,7 @@ class Vectorization(pattern_matching.Transformation):
         tasklet = candidate[Vectorization._tasklet]
         map_exit = candidate[Vectorization._map_exit]
 
-        return ' -> '.join(
-            str(node) for node in [map_entry, tasklet, map_exit])
+        return ' -> '.join(str(node) for node in [map_entry, tasklet, map_exit])
 
     def apply(self, sdfg):
         graph = sdfg.nodes()[self.state_id]
@@ -121,8 +120,7 @@ class Vectorization(pattern_matching.Transformation):
         if self.strided_map:
             map_entry.map.range[-1] = (dim_from, dim_to, vector_size)
         else:
-            map_entry.map.range[-1] = (dim_from,
-                                       (dim_to + 1) / vector_size - 1,
+            map_entry.map.range[-1] = (dim_from, (dim_to + 1) / vector_size - 1,
                                        dim_step)
 
         # TODO: Postamble and/or preamble non-vectorized map

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from dace.sdfg import nodes
 from dace.sdfg.graph import SubgraphView, MultiConnectorEdge
 from dace.sdfg import SDFG, SDFGState
-from dace.memlet import EmptyMemlet, Memlet
+from dace.memlet import Memlet
 
 
 def nest_state_subgraph(sdfg: SDFG,
@@ -212,13 +212,13 @@ def nest_state_subgraph(sdfg: SDFG,
     for name in input_arrays:
         node = state.add_read(name)
         if entry is not None:
-            state.add_nedge(entry, node, EmptyMemlet())
+            state.add_nedge(entry, node, Memlet())
         state.add_edge(node, None, nested_sdfg, name,
                        Memlet.from_array(name, sdfg.arrays[name]))
     for name in output_arrays:
         node = state.add_write(name)
         if exit is not None:
-            state.add_nedge(node, exit, EmptyMemlet())
+            state.add_nedge(node, exit, Memlet())
         state.add_edge(nested_sdfg, name, node, None,
                        Memlet.from_array(name, sdfg.arrays[name]))
 

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -232,7 +232,7 @@ class FPGATransformState(pattern_matching.Transformation):
                 post_node = post_state.add_write(node.data)
                 post_fpga_node = post_state.add_read('fpga_' + node.data)
                 full_range = subsets.Range([(0, s - 1, 1) for s in desc.shape])
-                mem = memlet.Memlet, simple('fpga_' + node.data, full_range)
+                mem = memlet.Memlet.simple('fpga_' + node.data, full_range)
                 post_state.add_edge(post_fpga_node, None, post_node, None, mem)
 
                 fpga_node = state.add_write('fpga_' + node.data)

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -97,8 +97,7 @@ class FPGATransformState(pattern_matching.Transformation):
             # Map schedules that are disallowed to transform to FPGAs
             if (candidate_map.schedule == dtypes.ScheduleType.MPI
                     or candidate_map.schedule == dtypes.ScheduleType.GPU_Device
-                    or
-                    candidate_map.schedule == dtypes.ScheduleType.FPGA_Device
+                    or candidate_map.schedule == dtypes.ScheduleType.FPGA_Device
                     or candidate_map.schedule ==
                     dtypes.ScheduleType.GPU_ThreadBlock):
                 return False
@@ -189,8 +188,7 @@ class FPGATransformState(pattern_matching.Transformation):
                 pre_node = pre_state.add_read(node.data)
                 pre_fpga_node = pre_state.add_write('fpga_' + node.data)
                 full_range = subsets.Range([(0, s - 1, 1) for s in desc.shape])
-                mem = memlet.Memlet(node.data, full_range.num_elements(),
-                                    full_range, 1)
+                mem = memlet.Memlet.simple(node.data, full_range)
                 pre_state.add_edge(pre_node, None, pre_fpga_node, None, mem)
 
                 if node not in wcr_input_nodes:
@@ -234,8 +232,7 @@ class FPGATransformState(pattern_matching.Transformation):
                 post_node = post_state.add_write(node.data)
                 post_fpga_node = post_state.add_read('fpga_' + node.data)
                 full_range = subsets.Range([(0, s - 1, 1) for s in desc.shape])
-                mem = memlet.Memlet('fpga_' + node.data,
-                                    full_range.num_elements(), full_range, 1)
+                mem = memlet.Memlet, simple('fpga_' + node.data, full_range)
                 post_state.add_edge(post_fpga_node, None, post_node, None, mem)
 
                 fpga_node = state.add_write('fpga_' + node.data)

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -296,7 +296,7 @@ class GPUTransformSDFG(pattern_matching.Transformation):
 
                 # Map without inputs
                 if len(in_edges) == 0:
-                    state.add_nedge(me, gcode, memlet.EmptyMemlet())
+                    state.add_nedge(me, gcode, memlet.Memlet())
         #######################################################
         # Step 6: Change all top-level maps and library nodes to GPU schedule
 

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -6,7 +6,7 @@ import networkx as nx
 from typing import Dict, List, Set, Optional
 import warnings
 
-from dace import memlet, registry, sdfg as sd, Memlet, EmptyMemlet
+from dace import memlet, registry, sdfg as sd, Memlet
 from dace.sdfg import nodes
 from dace.sdfg.graph import MultiConnectorEdge, SubgraphView
 from dace.sdfg import SDFG, SDFGState
@@ -326,10 +326,10 @@ class InlineSDFG(pattern_matching.Transformation):
             for node in subgraph.nodes():
                 if state.in_degree(node) == 0:
                     state.add_edge(nsdfg_scope_entry, None, node, None,
-                                   EmptyMemlet())
+                                   Memlet())
                 if state.out_degree(node) == 0:
                     state.add_edge(node, None, nsdfg_scope_exit, None,
-                                   EmptyMemlet())
+                                   Memlet())
 
         # Replace nested SDFG parents with new SDFG
         for node in nstate.nodes():

--- a/diode/webclient/renderer_elements.js
+++ b/diode/webclient/renderer_elements.js
@@ -242,12 +242,19 @@ class Edge extends SDFGElement {
             if (attr.wcr)
                 contents += '<br /><b>CR: ' + sdfg_property_to_string(attr.wcr, dsettings) + '</b>';
 
-            let num_accesses = sdfg_property_to_string(attr.volume, dsettings);
+            let num_accesses = null;
+            if (attr.volume)
+                num_accesses = sdfg_property_to_string(attr.volume, dsettings);
+            else
+                num_accesses = sdfg_property_to_string(attr.num_accesses, dsettings);
+
             if (attr.dynamic) {
                 if (num_accesses == 0 || num_accesses == -1)
                     num_accesses = "<b>Dynamic (unbounded)</b>";
                 else
-                    num_accesses = "Dynamic (up to " + num_accesses + ")";
+                    num_accesses = "<b>Dynamic</b> (up to " + num_accesses + ")";
+            } else if (num_accesses == -1) {
+                num_accesses = "<b>Dynamic (unbounded)</b>";
             }
 
             contents += '<br /><font style="font-size: 14px">Volume: ' + num_accesses + '</font>';

--- a/diode/webclient/renderer_elements.js
+++ b/diode/webclient/renderer_elements.js
@@ -17,7 +17,7 @@ class SDFGElement {
         this.height = this.data.layout.height;
     }
 
-    draw(renderer, ctx, mousepos) {}
+    draw(renderer, ctx, mousepos) { }
 
     attributes() {
         return this.data.attributes;
@@ -40,7 +40,7 @@ class SDFGElement {
     }
 
     topleft() {
-        return {x: this.x - this.width / 2, y: this.y - this.height / 2};
+        return { x: this.x - this.width / 2, y: this.y - this.height / 2 };
     }
 
     strokeStyle() {
@@ -53,14 +53,14 @@ class SDFGElement {
     intersect(x, y, w = 0, h = 0) {
         if (w == 0 || h == 0) {  // Point-element intersection
             return (x >= this.x - this.width / 2.0) &&
-                   (x <= this.x + this.width / 2.0) &&
-                   (y >= this.y - this.height / 2.0) &&
-                   (y <= this.y + this.height / 2.0);
+                (x <= this.x + this.width / 2.0) &&
+                (y >= this.y - this.height / 2.0) &&
+                (y <= this.y + this.height / 2.0);
         } else {                 // Box-element intersection
             return (x <= this.x + this.width / 2.0) &&
-                    (x + w >= this.x - this.width / 2.0) &&
-                    (y <= this.y + this.height / 2.0) &&
-                    (y + h >= this.y - this.height / 2.0);
+                (x + w >= this.x - this.width / 2.0) &&
+                (y <= this.y + this.height / 2.0) &&
+                (y + h >= this.y - this.height / 2.0);
         }
     }
 }
@@ -147,7 +147,7 @@ class Node extends SDFGElement {
         ctx.strokeRect(topleft.x, topleft.y, this.width, this.height);
         ctx.fillStyle = "black";
         let textw = ctx.measureText(this.label()).width;
-        ctx.fillText(this.label(), this.x - textw/2, this.y + LINEHEIGHT/4);
+        ctx.fillText(this.label(), this.x - textw / 2, this.y + LINEHEIGHT / 4);
     }
 
     simple_draw(renderer, ctx, mousepos) {
@@ -194,7 +194,7 @@ class Edge extends SDFGElement {
                 ctx.quadraticCurveTo(edge.points[i].x, edge.points[i].y, xm, ym);
             }
             ctx.quadraticCurveTo(edge.points[i].x, edge.points[i].y,
-                                 edge.points[i+1].x, edge.points[i+1].y);
+                edge.points[i + 1].x, edge.points[i + 1].y);
         }
 
         let style = this.strokeStyle();
@@ -210,7 +210,7 @@ class Edge extends SDFGElement {
             ctx.setLineDash([2, 2]);
         else
             ctx.setLineDash([1, 0]);
-        
+
 
         ctx.stroke();
 
@@ -235,16 +235,20 @@ class Edge extends SDFGElement {
             }
             let contents = attr.data;
             contents += sdfg_property_to_string(attr.subset, dsettings);
-            
+
             if (attr.other_subset)
                 contents += ' -> ' + sdfg_property_to_string(attr.other_subset, dsettings);
 
             if (attr.wcr)
-                contents += '<br /><b>CR: ' + sdfg_property_to_string(attr.wcr, dsettings) +'</b>';
+                contents += '<br /><b>CR: ' + sdfg_property_to_string(attr.wcr, dsettings) + '</b>';
 
-            let num_accesses = sdfg_property_to_string(attr.num_accesses, dsettings);
-            if (num_accesses == -1)
-                num_accesses = "<b>Dynamic</b>";
+            let num_accesses = sdfg_property_to_string(attr.volume, dsettings);
+            if (attr.dynamic) {
+                if (num_accesses == 0 || num_accesses == -1)
+                    num_accesses = "<b>Dynamic (unbounded)</b>";
+                else
+                    num_accesses = "Dynamic (up to " + num_accesses + ")";
+            }
 
             contents += '<br /><font style="font-size: 14px">Volume: ' + num_accesses + '</font>';
             container.innerHTML = contents;
@@ -262,13 +266,13 @@ class Edge extends SDFGElement {
 
     intersect(x, y, w = 0, h = 0) {
         // First, check bounding box
-        if(!super.intersect(x, y, w, h))
+        if (!super.intersect(x, y, w, h))
             return false;
 
         // Then (if point), check distance from line
         if (w == 0 || h == 0) {
             for (let i = 0; i < this.points.length - 1; i++) {
-                let dist = ptLineDistance({x: x, y: y}, this.points[i], this.points[i + 1]);
+                let dist = ptLineDistance({ x: x, y: y }, this.points[i], this.points[i + 1]);
                 if (dist <= 5.0)
                     return true;
             }
@@ -381,9 +385,9 @@ class ScopeNode extends Node {
 
         let far_label = this.far_label();
         drawAdaptiveText(ctx, renderer, far_label,
-                         this.close_label(renderer), this.x, this.y, 
-                         this.width, this.height, 
-                         SCOPE_LOD);
+            this.close_label(renderer), this.x, this.y,
+            this.width, this.height,
+            SCOPE_LOD);
     }
 
     far_label() {
@@ -424,7 +428,7 @@ class ScopeNode extends Node {
                 result += attrs.params[i] + '=';
                 result += sdfg_range_elem_to_string(attrs.range.ranges[i], renderer.view_settings()) + ', ';
             }
-            result = result.substring(0, result.length-2); // Remove trailing comma
+            result = result.substring(0, result.length - 2); // Remove trailing comma
         }
         return result + ']';
     }
@@ -439,11 +443,11 @@ class ExitNode extends ScopeNode {
 }
 
 class MapEntry extends EntryNode { stroketype(ctx) { ctx.setLineDash([1, 0]); } }
-class MapExit extends ExitNode {  stroketype(ctx) { ctx.setLineDash([1, 0]); } }
-class ConsumeEntry extends EntryNode {  stroketype(ctx) { ctx.setLineDash([5, 3]); } }
-class ConsumeExit extends ExitNode {  stroketype(ctx) { ctx.setLineDash([5, 3]); } }
-class PipelineEntry extends EntryNode {  stroketype(ctx) { ctx.setLineDash([10, 3]); } }
-class PipelineExit extends ExitNode {  stroketype(ctx) { ctx.setLineDash([10, 3]); } }
+class MapExit extends ExitNode { stroketype(ctx) { ctx.setLineDash([1, 0]); } }
+class ConsumeEntry extends EntryNode { stroketype(ctx) { ctx.setLineDash([5, 3]); } }
+class ConsumeExit extends ExitNode { stroketype(ctx) { ctx.setLineDash([5, 3]); } }
+class PipelineEntry extends EntryNode { stroketype(ctx) { ctx.setLineDash([10, 3]); } }
+class PipelineExit extends ExitNode { stroketype(ctx) { ctx.setLineDash([10, 3]); } }
 
 class EmptyTasklet extends Node {
     draw(renderer, ctx, mousepos) {
@@ -480,20 +484,20 @@ class Tasklet extends Node {
             let textmetrics = ctx.measureText(lines[maxline]);
 
             // Fit font size to 80% height and width of tasklet
-            let height = lines.length * LINEHEIGHT*1.05;
+            let height = lines.length * LINEHEIGHT * 1.05;
             let width = textmetrics.width;
             let TASKLET_WRATIO = 0.9, TASKLET_HRATIO = 0.5;
             let hr = height / (this.height * TASKLET_HRATIO);
             let wr = width / (this.width * TASKLET_WRATIO);
             let FONTSIZE = Math.min(10 / hr, 10 / wr);
-            let text_yoffset = FONTSIZE/4;
+            let text_yoffset = FONTSIZE / 4;
 
             ctx.font = FONTSIZE + "px courier new";
             // Set the start offset such that the middle row of the text is in this.y
-            let y = this.y + text_yoffset - ((lines.length-1)/2) * FONTSIZE*1.05;
+            let y = this.y + text_yoffset - ((lines.length - 1) / 2) * FONTSIZE * 1.05;
             for (let i = 0; i < lines.length; i++)
-                ctx.fillText(lines[i], this.x - (this.width*TASKLET_WRATIO) / 2.0,
-                             y + i*FONTSIZE*1.05);
+                ctx.fillText(lines[i], this.x - (this.width * TASKLET_WRATIO) / 2.0,
+                    y + i * FONTSIZE * 1.05);
 
             ctx.font = oldfont;
             return;
@@ -526,9 +530,9 @@ class Reduce extends Node {
 
         let far_label = this.label().substring(4, this.label().indexOf(','));
         drawAdaptiveText(ctx, renderer, far_label,
-                         this.label(), this.x, this.y - this.height*0.2,
-                         this.width, this.height,
-                         SCOPE_LOD);
+            this.label(), this.x, this.y - this.height * 0.2,
+            this.width, this.height,
+            SCOPE_LOD);
     }
 }
 
@@ -539,12 +543,12 @@ class NestedSDFG extends Node {
             drawOctagon(ctx, topleft, this.width, this.height);
             ctx.strokeStyle = this.strokeStyle();
             ctx.stroke();
-            drawOctagon(ctx, {x: topleft.x + 2.5, y: topleft.y + 2.5}, this.width - 5, this.height - 5);
+            drawOctagon(ctx, { x: topleft.x + 2.5, y: topleft.y + 2.5 }, this.width - 5, this.height - 5);
             ctx.strokeStyle = this.strokeStyle();
             ctx.stroke();
             ctx.fillStyle = 'white';
             if (ctx.pdf) // PDFs do not support stroke and fill on the same object
-                drawOctagon(ctx, {x: topleft.x + 2.5, y: topleft.y + 2.5}, this.width - 5, this.height - 5);
+                drawOctagon(ctx, { x: topleft.x + 2.5, y: topleft.y + 2.5 }, this.width - 5, this.height - 5);
             ctx.fill();
             ctx.fillStyle = 'black';
             let label = this.data.node.attributes.label;
@@ -560,14 +564,14 @@ class NestedSDFG extends Node {
         draw_sdfg(renderer, ctx, this.data.graph, mousepos);
     }
 
-    set_layout() { 
+    set_layout() {
         if (this.data.node.attributes.is_collapsed) {
             let labelsize = this.data.node.attributes.label.length * LINEHEIGHT * 0.8;
             let inconnsize = 2 * LINEHEIGHT * this.data.node.attributes.in_connectors.length - LINEHEIGHT;
             let outconnsize = 2 * LINEHEIGHT * this.data.node.attributes.out_connectors.length - LINEHEIGHT;
             let maxwidth = Math.max(labelsize, inconnsize, outconnsize);
-            let maxheight = 2*LINEHEIGHT;
-            maxheight += 4*LINEHEIGHT;
+            let maxheight = 2 * LINEHEIGHT;
+            maxheight += 4 * LINEHEIGHT;
 
             let size = { width: maxwidth, height: maxheight };
             size.width += 2.0 * (size.height / 3.0);
@@ -618,7 +622,7 @@ class LibraryNode extends Node {
         ctx.stroke();
         ctx.fillStyle = "black";
         let textw = ctx.measureText(this.label()).width;
-        ctx.fillText(this.label(), this.x - textw/2, this.y + LINEHEIGHT/4);
+        ctx.fillText(this.label(), this.x - textw / 2, this.y + LINEHEIGHT / 4);
     }
 }
 
@@ -631,13 +635,13 @@ function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos) {
     // Render state machine
     let g = sdfg_dagre;
     if (!ctx.lod || ppp < EDGE_LOD)
-        g.edges().forEach( e => { g.edge(e).draw(renderer, ctx, mousepos); });
+        g.edges().forEach(e => { g.edge(e).draw(renderer, ctx, mousepos); });
 
 
     visible_rect = renderer.visible_rect;
 
     // Render each visible state's contents
-    g.nodes().forEach( v => {
+    g.nodes().forEach(v => {
         let node = g.node(v);
 
         if (ctx.lod && (ppp >= STATE_LOD || node.width / ppp < STATE_LOD)) {
@@ -652,8 +656,7 @@ function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos) {
 
         let ng = node.data.graph;
 
-        if (!node.data.state.attributes.is_collapsed && ng)
-        {
+        if (!node.data.state.attributes.is_collapsed && ng) {
             ng.nodes().forEach(v => {
                 let n = ng.node(v);
 
@@ -703,7 +706,7 @@ function offset_sdfg(sdfg, sdfg_graph, offset) {
 // Translate nodes, edges, and connectors in a given SDFG state by an offset
 function offset_state(state, state_graph, offset) {
     let drawn_nodes = new Set();
-    
+
     state.nodes.forEach((n, nid) => {
         let node = state_graph.data.graph.node(nid);
         if (!node) return;
@@ -741,8 +744,8 @@ function offset_state(state, state_graph, offset) {
 ///////////////////////////////////////////////////////
 
 function drawAdaptiveText(ctx, renderer, far_text, close_text,
-                          x, y, w, h, ppp_thres, max_font_size=50,
-                          font_multiplier=16) {
+    x, y, w, h, ppp_thres, max_font_size = 50,
+    font_multiplier = 16) {
     let ppp = renderer.canvas_manager.points_per_pixel();
     let label = close_text;
     let FONTSIZE = Math.min(ppp * font_multiplier, max_font_size);
@@ -770,7 +773,7 @@ function drawAdaptiveText(ctx, renderer, far_text, close_text,
 }
 
 function drawHexagon(ctx, x, y, w, h, offset) {
-    let topleft = {x: x - w / 2.0, y: y - h / 2.0};
+    let topleft = { x: x - w / 2.0, y: y - h / 2.0 };
     let hexseg = h / 3.0;
     ctx.beginPath();
     ctx.moveTo(topleft.x, y);
@@ -801,12 +804,12 @@ function drawOctagon(ctx, topleft, width, height) {
 // Adapted from https://stackoverflow.com/a/2173084/6489142
 function drawEllipse(ctx, x, y, w, h) {
     var kappa = .5522848,
-    ox = (w / 2) * kappa, // control point offset horizontal
-    oy = (h / 2) * kappa, // control point offset vertical
-    xe = x + w,           // x-end
-    ye = y + h,           // y-end
-    xm = x + w / 2,       // x-middle
-    ym = y + h / 2;       // y-middle
+        ox = (w / 2) * kappa, // control point offset horizontal
+        oy = (h / 2) * kappa, // control point offset vertical
+        xe = x + w,           // x-end
+        ye = y + h,           // y-end
+        xm = x + w / 2,       // x-middle
+        ym = y + h / 2;       // y-middle
 
     ctx.moveTo(x, ym);
     ctx.bezierCurveTo(x, ym - oy, xm - ox, y, xm, y);
@@ -833,7 +836,7 @@ function drawArrow(ctx, p1, p2, size, offset) {
     ctx.restore();
 }
 
-function drawTrapezoid(ctx, topleft, node, inverted=false) {
+function drawTrapezoid(ctx, topleft, node, inverted = false) {
     ctx.beginPath();
     if (inverted) {
         ctx.moveTo(topleft.x, topleft.y);
@@ -857,15 +860,17 @@ function ptLineDistance(p, line1, line2) {
     let dy = (line2.y - line1.y);
     let res = dy * p.x - dx * p.y + line2.x * line1.y - line2.y * line1.x;
 
-    return Math.abs(res) / Math.sqrt(dy*dy + dx*dx);
+    return Math.abs(res) / Math.sqrt(dy * dy + dx * dx);
 }
 
-var SDFGElements = {SDFGElement: SDFGElement, State: State, Node: Node,Edge: Edge, Connector: Connector, AccessNode: AccessNode,
-                    ScopeNode: ScopeNode, EntryNode: EntryNode, ExitNode: ExitNode, MapEntry: MapEntry, MapExit: MapExit,
-                    ConsumeEntry: ConsumeEntry, ConsumeExit: ConsumeExit, EmptyTasklet: EmptyTasklet, Tasklet: Tasklet, Reduce: Reduce,
-                    PipelineEntry: PipelineEntry, PipelineExit: PipelineExit, NestedSDFG: NestedSDFG, LibraryNode: LibraryNode};
-                    
+var SDFGElements = {
+    SDFGElement: SDFGElement, State: State, Node: Node, Edge: Edge, Connector: Connector, AccessNode: AccessNode,
+    ScopeNode: ScopeNode, EntryNode: EntryNode, ExitNode: ExitNode, MapEntry: MapEntry, MapExit: MapExit,
+    ConsumeEntry: ConsumeEntry, ConsumeExit: ConsumeExit, EmptyTasklet: EmptyTasklet, Tasklet: Tasklet, Reduce: Reduce,
+    PipelineEntry: PipelineEntry, PipelineExit: PipelineExit, NestedSDFG: NestedSDFG, LibraryNode: LibraryNode
+};
+
 // Save as globals
-Object.keys(SDFGElements).forEach(function(elem) {
+Object.keys(SDFGElements).forEach(function (elem) {
     window[elem] = SDFGElements[elem];
 });

--- a/samples/fpga/filter_fpga.py
+++ b/samples/fpga/filter_fpga.py
@@ -159,15 +159,14 @@ def make_loop_body(sdfg):
                    dace.memlet.Memlet.simple(ratio, "0"))
     state.add_edge(
         tasklet, "b", B, None,
-        dace.memlet.Memlet(B, dace.symbolic.pystr_to_symbolic("-1"),
-                           dace.subsets.Range.from_array(B.desc(sdfg)), 1))
+        dace.memlet.Memlet.simple(B,
+                                  dace.subsets.Range.from_array(B.desc(sdfg)),
+                                  num_accesses=-1))
     state.add_edge(outsize_buffer_in, None, tasklet, "write_index",
                    dace.memlet.Memlet.simple(outsize_buffer_in, "0"))
     state.add_edge(
         tasklet, "size_out", outsize_buffer_out, None,
-        dace.memlet.Memlet(outsize_buffer_out,
-                           dace.symbolic.pystr_to_symbolic("-1"),
-                           dace.properties.SubsetProperty.from_string("0"), 1))
+        dace.memlet.Memlet.simple(outsize_buffer_out, "0", num_accesses=-1))
 
     return state
 
@@ -205,8 +204,7 @@ def make_sdfg(specialize):
 
     sdfg.add_edge(copy_to_device_state, compute_state,
                   dace.sdfg.InterstateEdge())
-    sdfg.add_edge(compute_state, copy_to_host_state,
-                  dace.sdfg.InterstateEdge())
+    sdfg.add_edge(compute_state, copy_to_host_state, dace.sdfg.InterstateEdge())
 
     return sdfg
 
@@ -255,8 +253,8 @@ if __name__ == "__main__":
 
     if len(filtered) != outsize[0]:
         print(
-            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)"
-            % (outsize[0], len(filtered)))
+            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)" %
+            (outsize[0], len(filtered)))
         totalitems = min(outsize[0], N.get())
         print('DaCe:', B[:totalitems].view(type=np.ndarray))
         print('Regression:', filtered.view(type=np.ndarray))

--- a/samples/fpga/filter_fpga_vectorized.py
+++ b/samples/fpga/filter_fpga_vectorized.py
@@ -288,11 +288,10 @@ def make_read_sdfg():
 
     state.add_memlet_path(A,
                           A_pipe,
-                          memlet=Memlet(A_pipe,
-                                        1,
-                                        Indices(["0"]),
-                                        W.get(),
-                                        other_subset=Indices(["i"])))
+                          memlet=Memlet.simple(A_pipe,
+                                               '0',
+                                               other_subset_str='i',
+                                               veclen=W.get()))
 
     return sdfg
 
@@ -449,14 +448,13 @@ def make_main_state(sdfg):
                                          {"_A_pipe"})
 
     compute_sdfg = make_compute_sdfg()
-    compute_tasklet = state.add_nested_sdfg(
-        compute_sdfg, sdfg, {"_A_pipe", "ratio_nested"},
-        {"_B_pipe", "_valid_pipe", "count"})
+    compute_tasklet = state.add_nested_sdfg(compute_sdfg, sdfg,
+                                            {"_A_pipe", "ratio_nested"},
+                                            {"_B_pipe", "_valid_pipe", "count"})
 
     write_sdfg = make_write_sdfg()
     write_tasklet = state.add_nested_sdfg(write_sdfg, sdfg,
-                                          {"_B_pipe", "_valid_pipe"},
-                                          {"B_mem"})
+                                          {"_B_pipe", "_valid_pipe"}, {"B_mem"})
 
     state.add_memlet_path(A,
                           read_tasklet,
@@ -540,8 +538,7 @@ def make_sdfg(specialize):
 
     sdfg.add_edge(copy_to_device_state, compute_state,
                   dace.sdfg.InterstateEdge())
-    sdfg.add_edge(compute_state, copy_to_host_state,
-                  dace.sdfg.InterstateEdge())
+    sdfg.add_edge(compute_state, copy_to_host_state, dace.sdfg.InterstateEdge())
 
     return sdfg
 
@@ -602,8 +599,8 @@ if __name__ == "__main__":
 
     if len(filtered) != outsize[0]:
         print(
-            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)"
-            % (outsize[0], len(filtered)))
+            "Difference in number of filtered items: %d (DaCe) vs. %d (numpy)" %
+            (outsize[0], len(filtered)))
         totalitems = min(outsize[0], N.get())
         print('DaCe:', B[:totalitems].view(type=np.ndarray))
         print('Regression:', filtered.view(type=np.ndarray))

--- a/samples/fpga/filter_fpga_vectorized.py
+++ b/samples/fpga/filter_fpga_vectorized.py
@@ -247,12 +247,14 @@ count_out = std::min<unsigned>(W * count + elements_in_output, N);"""
                           memlet=Memlet.simple(B_pipe,
                                                "0",
                                                num_accesses="N",
+                                               dynamic=True,
                                                veclen=W.get()))
     state.add_memlet_path(tasklet,
                           valid_pipe,
                           src_conn="valid_pipe_out",
                           memlet=Memlet.simple(valid_pipe,
                                                "0",
+                                               dynamic=True,
                                                num_accesses="N"))
     state.add_memlet_path(tasklet,
                           count,
@@ -468,6 +470,7 @@ def make_main_state(sdfg):
                           src_conn="_A_pipe",
                           memlet=Memlet.simple(A_pipe_out,
                                                "0",
+                                               dynamic=True,
                                                num_accesses="N",
                                                veclen=W.get()))
 
@@ -488,12 +491,14 @@ def make_main_state(sdfg):
                           memlet=Memlet.simple(B_pipe_out,
                                                "0",
                                                num_accesses="N",
+                                               dynamic=True,
                                                veclen=W.get()))
     state.add_memlet_path(compute_tasklet,
                           valid_pipe_out,
                           src_conn="_valid_pipe",
                           memlet=Memlet.simple(valid_pipe_out,
                                                "0",
+                                               dynamic=True,
                                                num_accesses="N"))
     state.add_memlet_path(compute_tasklet,
                           outsize,

--- a/samples/fpga/gemm_fpga_pipelined.py
+++ b/samples/fpga/gemm_fpga_pipelined.py
@@ -79,7 +79,7 @@ def make_sdfg(specialized):
     m_entry, m_exit = state.add_map(
         "Map_M", {"m": "0:M"}, schedule=dace.dtypes.ScheduleType.FPGA_Device)
 
-    state.add_nedge(n_entry, C_buffer_in, dace.memlet.EmptyMemlet())
+    state.add_nedge(n_entry, C_buffer_in, dace.memlet.Memlet())
 
     ###########################################################################
     # Nested SDFG

--- a/samples/fpga/gemm_fpga_systolic.py
+++ b/samples/fpga/gemm_fpga_systolic.py
@@ -841,7 +841,7 @@ def make_fpga_state(sdfg):
     state.add_memlet_path(write_C_sdfg_node,
                           C,
                           src_conn="mem",
-                          memlet=dace.memlet.Memlet.simple(C, "N * M"))
+                          memlet=dace.memlet.Memlet.simple(C, "0:N, 0:M"))
 
     return state
 

--- a/samples/fpga/gemm_fpga_systolic.py
+++ b/samples/fpga/gemm_fpga_systolic.py
@@ -136,16 +136,10 @@ def make_read_A_sdfg():
                                 dace.float32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        mem,
-        pipe,
-        memlet=dace.memlet.Memlet(
-            pipe,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string(
-                "n0 * P + n1, k")))
+    loop_body.add_memlet_path(mem,
+                              pipe,
+                              memlet=dace.memlet.Memlet.simple(
+                                  pipe, "0", other_subset_str="n0 * P + n1, k"))
 
     return sdfg
 
@@ -222,15 +216,10 @@ def make_read_B_sdfg():
                                 dace.float32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        mem,
-        pipe,
-        memlet=dace.memlet.Memlet(
-            pipe,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("k, m")))
+    loop_body.add_memlet_path(mem,
+                              pipe,
+                              memlet=dace.memlet.Memlet.simple(
+                                  pipe, "0", other_subset_str="k, m"))
 
     return sdfg
 
@@ -289,15 +278,10 @@ def make_write_C_sdfg():
                                 dace.float32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        pipe,
-        mem,
-        memlet=dace.memlet.Memlet(
-            mem,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("n, m"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("0")))
+    loop_body.add_memlet_path(pipe,
+                              mem,
+                              memlet=dace.memlet.Memlet.simple(
+                                  mem, "n, m", other_subset_str="0"))
 
     return sdfg
 
@@ -448,9 +432,7 @@ def make_compute_sdfg():
 
     # Scalar buffer for A
     A_pipe_in = buffer_a_state.add_stream(
-        "A_stream_in",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        "A_stream_in", dace.float32, storage=dace.dtypes.StorageType.FPGA_Local)
     A_pipe_out = buffer_a_state.add_stream(
         "A_stream_out",
         dace.float32,
@@ -468,27 +450,21 @@ def make_compute_sdfg():
         "\nelse:"
         "\n\tif p < P - 1:"
         "\n\t\ta_out = a_input")
-    buffer_a_state.add_memlet_path(
-        A_pipe_in,
-        buffer_a_tasklet,
-        memlet=dace.memlet.Memlet(
-            A_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        dst_conn="a_in")
-    buffer_a_state.add_memlet_path(
-        buffer_a_tasklet,
-        A_reg_out,
-        memlet=dace.memlet.Memlet(
-            A_reg_out, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="a_reg")
-    buffer_a_state.add_memlet_path(
-        buffer_a_tasklet,
-        A_pipe_out,
-        memlet=dace.memlet.Memlet(
-            A_pipe_out, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="a_out")
+    buffer_a_state.add_memlet_path(A_pipe_in,
+                                   buffer_a_tasklet,
+                                   memlet=dace.memlet.Memlet.simple(
+                                       A_pipe_in, "0", num_accesses=-1),
+                                   dst_conn="a_in")
+    buffer_a_state.add_memlet_path(buffer_a_tasklet,
+                                   A_reg_out,
+                                   memlet=dace.memlet.Memlet.simple(
+                                       A_reg_out, "0", num_accesses=-1),
+                                   src_conn="a_reg")
+    buffer_a_state.add_memlet_path(buffer_a_tasklet,
+                                   A_pipe_out,
+                                   memlet=dace.memlet.Memlet.simple(
+                                       A_pipe_out, "0", num_accesses=-1),
+                                   src_conn="a_out")
 
     ###########################################################################
     # Nested SDFG
@@ -577,13 +553,11 @@ def make_compute_sdfg():
                                   compute_tasklet,
                                   memlet=dace.memlet.Memlet.simple(B_in, "0"),
                                   dst_conn="b_in")
-    compute_state.add_memlet_path(
-        compute_tasklet,
-        B_out,
-        memlet=dace.memlet.Memlet(
-            B_out, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="b_out")
+    compute_state.add_memlet_path(compute_tasklet,
+                                  B_out,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      B_out, "0", num_accesses=-1),
+                                  src_conn="b_out")
     compute_state.add_memlet_path(C_val_in,
                                   compute_tasklet,
                                   memlet=dace.memlet.Memlet.simple(
@@ -617,26 +591,21 @@ def make_compute_sdfg():
 
     state.add_memlet_path(B_pipe_in,
                           tasklet,
-                          memlet=dace.memlet.Memlet(
-                              B_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(B_pipe_in,
+                                                           "0",
+                                                           num_accesses=-1),
                           dst_conn="B_in")
     state.add_memlet_path(tasklet,
                           B_pipe_out,
-                          memlet=dace.memlet.Memlet(
-                              B_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(B_pipe_out,
+                                                           "0",
+                                                           num_accesses=-1),
                           src_conn="B_out")
     state.add_memlet_path(C_buffer_in,
                           tasklet,
-                          memlet=dace.memlet.Memlet(
-                              C_buffer_in,
-                              dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("m"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(C_buffer_in,
+                                                           "m",
+                                                           num_accesses=-1),
                           dst_conn="C_in")
     state.add_memlet_path(tasklet,
                           C_buffer_out,
@@ -644,19 +613,16 @@ def make_compute_sdfg():
                           src_conn="C_out")
     state.add_memlet_path(A_reg_in,
                           tasklet,
-                          memlet=dace.memlet.Memlet(
-                              A_reg_in, dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(A_reg_in,
+                                                           "0",
+                                                           num_accesses=-1),
                           dst_conn="A_val_in")
 
     ###########################################################################
     # Write back state
 
     C_pipe_in = write_c_state.add_stream(
-        "C_stream_in",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        "C_stream_in", dace.float32, storage=dace.dtypes.StorageType.FPGA_Local)
     C_pipe_out = write_c_state.add_stream(
         "C_stream_out",
         dace.float32,
@@ -672,27 +638,21 @@ def make_compute_sdfg():
         "\nelse:"
         "\n\tif p > 0:"
         "\n\t\tc_out = forward_in")
-    write_c_state.add_memlet_path(
-        C_buffer_write,
-        write_c_tasklet,
-        memlet=dace.memlet.Memlet(
-            C_buffer_in, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("m"), 1),
-        dst_conn="buffer_in")
-    write_c_state.add_memlet_path(
-        C_pipe_in,
-        write_c_tasklet,
-        memlet=dace.memlet.Memlet(
-            C_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        dst_conn="forward_in")
-    write_c_state.add_memlet_path(
-        write_c_tasklet,
-        C_pipe_out,
-        memlet=dace.memlet.Memlet(
-            C_pipe_out, dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"), 1),
-        src_conn="c_out")
+    write_c_state.add_memlet_path(C_buffer_write,
+                                  write_c_tasklet,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      C_buffer_in, "m", num_accesses=-1),
+                                  dst_conn="buffer_in")
+    write_c_state.add_memlet_path(C_pipe_in,
+                                  write_c_tasklet,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      C_pipe_in, "0", num_accesses=-1),
+                                  dst_conn="forward_in")
+    write_c_state.add_memlet_path(write_c_tasklet,
+                                  C_pipe_out,
+                                  memlet=dace.memlet.Memlet.simple(
+                                      C_pipe_out, "0"),
+                                  src_conn="c_out")
 
     return sdfg
 
@@ -783,121 +743,105 @@ def make_fpga_state(sdfg):
         unroll=True)
 
     # Bring data nodes into scope
-    state.add_memlet_path(compute_entry,
-                          A_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(compute_entry,
-                          B_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(compute_entry,
-                          C_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(A_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(B_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(C_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+    state.add_memlet_path(compute_entry, A_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(compute_entry, B_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(compute_entry, C_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(A_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(B_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(C_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
 
     # Connect data nodes
-    state.add_memlet_path(
-        A_pipe_in,
-        compute_sdfg_node,
-        dst_conn="A_stream_in",
-        memlet=dace.memlet.Memlet(
-            A_pipe_in,
-            dace.symbolic.pystr_to_symbolic("(N / P) * K * (P - p)"),
-            dace.properties.SubsetProperty.from_string("p"), 1))
-    state.add_memlet_path(B_pipe_in,
+    state.add_memlet_path(A_pipe_in,
                           compute_sdfg_node,
-                          dst_conn="B_stream_in",
-                          memlet=dace.memlet.Memlet(
-                              B_pipe_in,
-                              dace.symbolic.pystr_to_symbolic("N * K * M / P"),
-                              dace.properties.SubsetProperty.from_string("p"),
-                              1))
+                          dst_conn="A_stream_in",
+                          memlet=dace.memlet.Memlet.simple(
+                              A_pipe_in,
+                              'p',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(N / P) * K * (P - p)")))
+    state.add_memlet_path(
+        B_pipe_in,
+        compute_sdfg_node,
+        dst_conn="B_stream_in",
+        memlet=dace.memlet.Memlet.simple(
+            B_pipe_in,
+            'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N * K * M / P")))
     state.add_memlet_path(
         C_pipe_in,
         compute_sdfg_node,
         dst_conn="C_stream_in",
-        memlet=dace.memlet.Memlet(
-            C_pipe_in, dace.symbolic.pystr_to_symbolic("(N / P) * M * p"),
-            dace.properties.SubsetProperty.from_string("p"), 1))
-    state.add_memlet_path(
-        compute_sdfg_node,
-        A_pipe_out,
-        src_conn="A_stream_out",
-        memlet=dace.memlet.Memlet(
-            A_pipe_out,
-            dace.symbolic.pystr_to_symbolic("(N / P) * K * (P - p - 1)"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
-    state.add_memlet_path(
-        compute_sdfg_node,
-        B_pipe_out,
-        src_conn="B_stream_out",
-        memlet=dace.memlet.Memlet(
-            B_pipe_out,
-            dace.symbolic.pystr_to_symbolic(
-                "(p // (P - 1)) * (N / P) * K * M"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
-    state.add_memlet_path(
-        compute_sdfg_node,
-        C_pipe_out,
-        src_conn="C_stream_out",
-        memlet=dace.memlet.Memlet(
-            C_pipe_out,
-            dace.symbolic.pystr_to_symbolic("(N / P) * M * (p + 1)"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
-
-    state.add_memlet_path(
-        A,
-        read_A_sdfg_node,
-        dst_conn="mem",
-        memlet=dace.memlet.Memlet(
-            A, dace.symbolic.pystr_to_symbolic("N * K"),
-            dace.properties.SubsetProperty.from_string("0:N, 0:K"), 1))
-    state.add_memlet_path(read_A_sdfg_node,
-                          A_pipe_read,
-                          src_conn="pipe",
-                          memlet=dace.memlet.Memlet(
+        memlet=dace.memlet.Memlet.simple(
+            C_pipe_in,
+            'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * M * p")))
+    state.add_memlet_path(compute_sdfg_node,
+                          A_pipe_out,
+                          src_conn="A_stream_out",
+                          memlet=dace.memlet.Memlet.simple(
                               A_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("N * K"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1))
+                              'p + 1',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(N / P) * K * (P - p - 1)")))
+    state.add_memlet_path(compute_sdfg_node,
+                          B_pipe_out,
+                          src_conn="B_stream_out",
+                          memlet=dace.memlet.Memlet.simple(
+                              B_pipe_out,
+                              'p + 1',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(p // (P - 1)) * (N / P) * K * M")))
+    state.add_memlet_path(compute_sdfg_node,
+                          C_pipe_out,
+                          src_conn="C_stream_out",
+                          memlet=dace.memlet.Memlet.simple(
+                              C_pipe_out,
+                              'p + 1',
+                              num_accesses=dace.symbolic.pystr_to_symbolic(
+                                  "(N / P) * M * (p + 1)")))
+
+    state.add_memlet_path(A,
+                          read_A_sdfg_node,
+                          dst_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(A, '0:N, 0:K'))
+    state.add_memlet_path(
+        read_A_sdfg_node,
+        A_pipe_read,
+        src_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_out,
+            '0',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N * K")))
 
     state.add_memlet_path(
         B,
         read_B_sdfg_node,
         dst_conn="mem",
-        memlet=dace.memlet.Memlet(
-            B, dace.symbolic.pystr_to_symbolic("(N / P) * K * M"),
-            dace.properties.SubsetProperty.from_string("0:K, 0:M"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            B,
+            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * K * M"),
+            subset_str="0:K, 0:M"))
     state.add_memlet_path(
         read_B_sdfg_node,
         B_pipe_read,
         src_conn="pipe",
-        memlet=dace.memlet.Memlet(
-            B_pipe_out, dace.symbolic.pystr_to_symbolic("(N / P) * K * M"),
-            dace.properties.SubsetProperty.from_string("0"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            B_pipe_out,
+            '0',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * K * M")))
 
-    state.add_memlet_path(C_pipe_write,
-                          write_C_sdfg_node,
-                          dst_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              C_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("N * M"),
-                              dace.properties.SubsetProperty.from_string("P"),
-                              1))
     state.add_memlet_path(
+        C_pipe_write,
         write_C_sdfg_node,
-        C,
-        src_conn="mem",
-        memlet=dace.memlet.Memlet(
-            C, dace.symbolic.pystr_to_symbolic("N * M"),
-            dace.properties.SubsetProperty.from_string("0:N, 0:M"), 1))
+        dst_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            C_pipe_out,
+            'P',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N * M")))
+    state.add_memlet_path(write_C_sdfg_node,
+                          C,
+                          src_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(C, "N * M"))
 
     return state
 

--- a/samples/fpga/histogram_fpga.py
+++ b/samples/fpga/histogram_fpga.py
@@ -101,7 +101,7 @@ def make_init_buffer_state(sdfg):
 
     entry, exit = state.add_map("init_map", {"i": "0:num_bins"})
     tasklet = state.add_tasklet("zero", {}, {"out"}, "out = 0")
-    state.add_nedge(entry, tasklet, dace.memlet.EmptyMemlet())
+    state.add_nedge(entry, tasklet, dace.memlet.Memlet())
     state.add_memlet_path(tasklet,
                           exit,
                           hist_buffer,

--- a/samples/fpga/jacobi_fpga_systolic.py
+++ b/samples/fpga/jacobi_fpga_systolic.py
@@ -29,15 +29,13 @@ def make_init_state(sdfg):
     tmp0 = add_tmp(state)
     state.add_memlet_path(a0,
                           tmp0,
-                          memlet=dace.memlet.Memlet.simple(
-                              tmp0, "0, 0:H, 0:W"))
+                          memlet=dace.memlet.Memlet.simple(tmp0, "0, 0:H, 0:W"))
 
     a1 = state.add_array("A", (H, W), dtype)
     tmp1 = add_tmp(state)
     state.add_memlet_path(a1,
                           tmp1,
-                          memlet=dace.memlet.Memlet.simple(
-                              tmp1, "1, 0:H, 0:W"))
+                          memlet=dace.memlet.Memlet.simple(tmp1, "1, 0:H, 0:W"))
 
     return state
 
@@ -189,29 +187,25 @@ if (y >= 3 and x >= 3 and y < H - 1 and x < W - 1) or (y >= 2 and x >= 2):
                                   window_compute_in, "0:3, 0:3"))
 
     # Output result (conditional write)
-    out_memlet = dace.memlet.Memlet(
-        stream_out, dace.symbolic.pystr_to_symbolic("-1"),
-        dace.properties.SubsetProperty.from_string("0"), 1)
+    out_memlet = dace.memlet.Memlet.simple(stream_out, "0", num_accesses=-1)
     loop_body.add_memlet_path(tasklet,
                               stream_out,
                               src_conn="result",
                               memlet=out_memlet)
 
     # Read row buffer
-    read_row_memlet = dace.memlet.Memlet(
-        rows_in,
-        dace.symbolic.pystr_to_symbolic("2"),
-        dace.properties.SubsetProperty.from_string("0:2, x"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0:2, 2"))
+    read_row_memlet = dace.memlet.Memlet.simple(rows_in,
+                                                "0:2, x",
+                                                num_accesses=2,
+                                                other_subset_str="0:2, 2")
     pre_shift.add_memlet_path(rows_in,
                               window_buffer_out,
                               memlet=read_row_memlet)
 
     # Read from memory
-    read_memory_memlet = dace.memlet.Memlet(
-        stream_in, dace.symbolic.pystr_to_symbolic("-1"),
-        dace.properties.SubsetProperty.from_string("0"), 1)
+    read_memory_memlet = dace.memlet.Memlet.simple(stream_in,
+                                                   "0",
+                                                   num_accesses=-1)
     read_memory_tasklet = pre_shift.add_tasklet(
         "skip_last", {"read"}, {"window_buffer"},
         "if y < H - 1 and x < W - 1:\n\twindow_buffer = read")
@@ -226,23 +220,17 @@ if (y >= 3 and x >= 3 and y < H - 1 and x < W - 1) or (y >= 2 and x >= 2):
                               src_conn="window_buffer")
 
     # Shift window
-    shift_window_memlet = dace.memlet.Memlet(
-        window_shift_in,
-        dace.symbolic.pystr_to_symbolic("6"),
-        dace.properties.SubsetProperty.from_string("0:3, 1:3"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0:3, 0:2"))
+    shift_window_memlet = dace.memlet.Memlet.simple(window_shift_in,
+                                                    '0:3, 1:3',
+                                                    other_subset_str='0:3, 0:2')
     post_shift.add_memlet_path(window_shift_in,
                                window_shift_out,
                                memlet=shift_window_memlet)
 
     # To row buffer
-    write_row_memlet = dace.memlet.Memlet(
-        window_buffer_in,
-        dace.symbolic.pystr_to_symbolic("2"),
-        dace.properties.SubsetProperty.from_string("1:3, 2"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0:2, x"))
+    write_row_memlet = dace.memlet.Memlet.simple(window_buffer_in,
+                                                 '1:3, 2',
+                                                 other_subset_str='0:2, x')
     post_shift.add_memlet_path(window_buffer_in,
                                rows_out,
                                memlet=write_row_memlet)
@@ -322,12 +310,9 @@ def make_read_sdfg():
                                 storage=dace.dtypes.StorageType.FPGA_Global)
 
     # Read from memory
-    read_memory_memlet = dace.memlet.Memlet(
-        mem_read,
-        dace.symbolic.pystr_to_symbolic("1"),
-        dace.properties.SubsetProperty.from_string("t%2, y, x"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string("0"))
+    read_memory_memlet = dace.memlet.Memlet.simple(mem_read,
+                                                   "t%2, y, x",
+                                                   other_subset_str="0")
     loop_body.add_memlet_path(mem_read, pipe, memlet=read_memory_memlet)
 
     return sdfg
@@ -400,19 +385,13 @@ def make_write_sdfg():
                                 dtype,
                                 1,
                                 storage=dace.dtypes.StorageType.FPGA_Global)
-    mem_write = loop_body.add_array(
-        "mem_write", (2, H, W),
-        dtype,
-        storage=dace.dtypes.StorageType.FPGA_Global)
+    mem_write = loop_body.add_array("mem_write", (2, H, W),
+                                    dtype,
+                                    storage=dace.dtypes.StorageType.FPGA_Global)
 
     # Read from memory
-    write_memory_memlet = dace.memlet.Memlet(
-        pipe,
-        dace.symbolic.pystr_to_symbolic("1"),
-        dace.properties.SubsetProperty.from_string("0"),
-        1,
-        other_subset=dace.properties.SubsetProperty.from_string(
-            "1 - t%2, y, x"))
+    write_memory_memlet = dace.memlet.Memlet.simple(
+        pipe, '0', other_subset_str="1 - t%2, y, x")
     loop_body.add_memlet_path(pipe, mem_write, memlet=write_memory_memlet)
 
     return sdfg
@@ -453,8 +432,8 @@ def make_outer_compute_state(sdfg):
     read_sdfg_node = state.add_nested_sdfg(read_sdfg, sdfg, {"mem_read"},
                                            {"pipe"})
     compute_sdfg = make_compute_sdfg()
-    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg,
-                                              {"stream_in"}, {"stream_out"})
+    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg, {"stream_in"},
+                                              {"stream_out"})
     write_sdfg = make_write_sdfg()
     write_sdfg_node = state.add_nested_sdfg(write_sdfg, sdfg, {"pipe"},
                                             {"mem_write"})
@@ -466,14 +445,14 @@ def make_outer_compute_state(sdfg):
                           dst_conn="mem_read",
                           memlet=dace.memlet.Memlet.simple(
                               tmp_in, "0:2, 0:H, 0:W"))
-    state.add_memlet_path(read_sdfg_node,
-                          pipes_memory_write,
-                          src_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              pipes_memory_write,
-                              dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1))
+    state.add_memlet_path(
+        read_sdfg_node,
+        pipes_memory_write,
+        src_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            pipes_memory_write,
+            '0',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
 
     compute_entry, compute_exit = state.add_map(
         "unroll_compute", {"p": "0:P"},
@@ -481,34 +460,35 @@ def make_outer_compute_state(sdfg):
         unroll=True)
     state.add_memlet_path(compute_entry,
                           pipes_read,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(pipes_read,
-                          compute_sdfg_node,
-                          dst_conn="stream_in",
-                          memlet=dace.memlet.Memlet(
-                              pipes_read,
-                              dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-                              dace.properties.SubsetProperty.from_string("p"),
-                              1))
+                          memlet=dace.memlet.Memlet())
+    state.add_memlet_path(
+        pipes_read,
+        compute_sdfg_node,
+        dst_conn="stream_in",
+        memlet=dace.memlet.Memlet.simple(
+            pipes_read,
+            'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
     state.add_memlet_path(
         compute_sdfg_node,
         pipes_write,
         src_conn="stream_out",
-        memlet=dace.memlet.Memlet(
-            pipes_write, dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            pipes_write,
+            'p + 1',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
     state.add_memlet_path(pipes_write,
                           compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+                          memlet=dace.memlet.Memlet())
 
-    state.add_memlet_path(pipes_memory_read,
-                          write_sdfg_node,
-                          dst_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              pipes_memory_read,
-                              dace.symbolic.pystr_to_symbolic("(T/P)*H*W"),
-                              dace.properties.SubsetProperty.from_string("P"),
-                              1))
+    state.add_memlet_path(
+        pipes_memory_read,
+        write_sdfg_node,
+        dst_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            pipes_memory_read,
+            'P',
+            num_accesses=dace.symbolic.pystr_to_symbolic("(T/P)*H*W")))
     state.add_memlet_path(write_sdfg_node,
                           tmp_out,
                           src_conn="mem_write",
@@ -627,8 +607,7 @@ if __name__ == "__main__":
                                                    H.get() * W.get()))
         print("Highest difference: {}".format(highest_diff))
         print("** Result:\n", A[:min(6, H.get()), :min(6, W.get())])
-        print("** Reference:\n",
-              regression[:min(4, H.get()), :min(4, W.get())])
+        print("** Reference:\n", regression[:min(4, H.get()), :min(4, W.get())])
         print("Type \"debug\" to enter debugger, "
               "or any other string to quit (timeout in 10 seconds)")
         read, _, _ = select.select([sys.stdin], [], [], 10)

--- a/samples/fpga/spmv_fpga.py
+++ b/samples/fpga/spmv_fpga.py
@@ -250,31 +250,21 @@ def make_main_state(sdfg):
         {"row_begin", "row_end", "A_val_read", "A_col_read", "x_read"},
         {"b_write"})
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowptr,
-        memlet=dace.memlet.Memlet(
-            rowptr,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowptr,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowptr, "0", other_subset_str="i"))
     state.add_memlet_path(rowptr,
                           nested_sdfg_tasklet,
                           dst_conn="row_begin",
                           memlet=dace.memlet.Memlet.simple(rowptr, "0"))
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowend,
-        memlet=dace.memlet.Memlet(
-            rowend,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i + 1")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowend,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowend, "0", other_subset_str="i + 1"))
     state.add_memlet_path(rowend,
                           nested_sdfg_tasklet,
                           dst_conn="row_end",

--- a/samples/fpga/spmv_fpga_stream.py
+++ b/samples/fpga/spmv_fpga_stream.py
@@ -279,8 +279,7 @@ def make_compute_nested_sdfg():
                                        dtype,
                                        storage=StorageType.FPGA_Registers)
     else_tasklet = else_state.add_tasklet("b_wcr", {"_b_in", "b_prev"},
-                                          {"_b_out"},
-                                          "_b_out = b_prev + _b_in")
+                                          {"_b_out"}, "_b_out = b_prev + _b_in")
     else_state.add_memlet_path(b_tmp_else_in,
                                else_tasklet,
                                dst_conn="_b_in",
@@ -333,8 +332,10 @@ def make_compute_sdfg():
                          src_conn="b_out",
                          memlet=Memlet.simple(b_buffer_out, "0"))
 
-    b_buffer_post_in = post_state.add_scalar(
-        "b_buffer", dtype, transient=True, storage=StorageType.FPGA_Registers)
+    b_buffer_post_in = post_state.add_scalar("b_buffer",
+                                             dtype,
+                                             transient=True,
+                                             storage=StorageType.FPGA_Registers)
     b_pipe = post_state.add_stream("b_pipe",
                                    dtype,
                                    storage=StorageType.FPGA_Local)
@@ -767,31 +768,21 @@ def make_nested_compute_state(sdfg):
         {"row_begin", "row_end", "A_val_read", "A_col_read", "x_read"},
         {"b_write"})
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowptr,
-        memlet=dace.memlet.Memlet(
-            rowptr,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowptr,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowptr, "0", other_subset_str="i"))
     state.add_memlet_path(rowptr,
                           nested_sdfg_tasklet,
                           dst_conn="row_begin",
                           memlet=dace.memlet.Memlet.simple(rowptr, "0"))
 
-    state.add_memlet_path(
-        a_row,
-        row_entry,
-        rowend,
-        memlet=dace.memlet.Memlet(
-            rowend,
-            1,
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("i + 1")))
+    state.add_memlet_path(a_row,
+                          row_entry,
+                          rowend,
+                          memlet=dace.memlet.Memlet.simple(
+                              rowend, '0', other_subset_str='i + 1'))
     state.add_memlet_path(rowend,
                           nested_sdfg_tasklet,
                           dst_conn="row_end",

--- a/samples/graph/bfs_bsp.py
+++ b/samples/graph/bfs_bsp.py
@@ -64,8 +64,7 @@ def create_reset_state(state, frontier_index):
                               'ofsz = 0')
     state.add_edge(
         rtask, 'ofsz', frontiersize, None,
-        dp.Memlet.from_array('fsz%d' % frontier_index,
-                             frontiersize.desc(sdfg)))
+        dp.Memlet.from_array('fsz%d' % frontier_index, frontiersize.desc(sdfg)))
 
 
 create_reset_state(rst0, 0)
@@ -75,8 +74,7 @@ create_reset_state(rst1, 1)
 # Computation state
 
 
-def create_computation_state(dstate, in_frontier, out_frontier,
-                             frontier_index):
+def create_computation_state(dstate, in_frontier, out_frontier, frontier_index):
     frontiersize = dstate.add_scalar('fsz%d' % frontier_index,
                                      dtype=dp.uint32,
                                      storage=storage,
@@ -106,8 +104,7 @@ def create_computation_state(dstate, in_frontier, out_frontier,
     # Map inputs
     dstate.add_edge(
         frontiersize, None, me, 'fsz%d' % frontier_index,
-        dp.Memlet.from_array('fsz%d' % frontier_index,
-                             frontiersize.desc(sdfg)))
+        dp.Memlet.from_array('fsz%d' % frontier_index, frontiersize.desc(sdfg)))
     dstate.add_edge(
         in_frontier, None, me, 'IN_F',
         dp.Memlet.from_array(in_frontier.data, in_frontier.desc(sdfg)))
@@ -134,8 +131,9 @@ def create_computation_state(dstate, in_frontier, out_frontier,
                     dp.Memlet.simple(in_frontier, 'f'))
     dstate.add_edge(
         me, 'OUT_R', indirection, 'in_row',
-        dp.Memlet('G_row', 2, dp.subsets.Range.from_array(G_row.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('G_row',
+                         dp.subsets.Range.from_array(G_row.desc(sdfg)),
+                         num_accesses=2))
     dstate.add_edge(
         indirection, 'ob', rowb, None,
         dp.Memlet.from_array('rowb%d' % frontier_index, rowb.desc(sdfg)))
@@ -182,42 +180,46 @@ if d < dep:
     # Internal inputs
     dstate.add_edge(
         nme, 'OUT_C', ctask, 'in_col',
-        dp.Memlet('G_col', -1, dp.subsets.Range.from_array(G_col.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('G_col',
+                         dp.subsets.Range.from_array(G_col.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         nme, 'OUT_D', ctask, 'in_depth',
-        dp.Memlet('depth', -1, dp.subsets.Range.from_array(depth.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('depth',
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
 
     # Internal outputs
     dstate.add_edge(
         ctask, 'out_depth', nmx, 'IN_D',
-        dp.Memlet('depth', -1, dp.subsets.Range.from_array(depth.desc(sdfg)),
-                  1))
+        dp.Memlet.simple('depth',
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         ctask, 'out_fsz', nmx, 'IN_FSZ',
-        dp.Memlet(out_frontiersize,
-                  -1,
-                  dp.subsets.Indices([0]),
-                  1,
-                  wcr='lambda a,b: a+b'))
+        dp.Memlet.simple(out_frontiersize,
+                         dp.subsets.Indices([0]),
+                         num_accesses=-1,
+                         wcr_str='lambda a,b: a+b'))
     dstate.add_edge(
         ctask, 'out_frontier', nmx, 'IN_F',
-        dp.Memlet(out_frontier_stream, -1,
-                  dp.subsets.Range.from_array(out_frontier_stream.desc(sdfg)),
-                  1))
+        dp.Memlet.simple(out_frontier_stream,
+                         dp.subsets.Range.from_array(
+                             out_frontier_stream.desc(sdfg)),
+                         num_accesses=-1))
 
     # Internal neighbor map outputs
     dstate.add_edge(
         nmx, 'OUT_D', mx, 'IN_D',
-        dp.Memlet(depth, -1, dp.subsets.Range.from_array(depth.desc(sdfg)), 1))
+        dp.Memlet.simple(depth,
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         nmx, 'OUT_FSZ', mx, 'IN_FSZ',
-        dp.Memlet(out_frontiersize,
-                  -1,
-                  dp.subsets.Indices([0]),
-                  1,
-                  wcr='lambda a,b: a+b'))
+        dp.Memlet.simple(out_frontiersize,
+                         dp.subsets.Indices([0]),
+                         num_accesses=-1,
+                         wcr_str='lambda a,b: a+b'))
     dstate.add_edge(
         nmx, 'OUT_F', mx, 'IN_F',
         dp.Memlet.from_array(out_frontier_stream.data,
@@ -226,14 +228,15 @@ if d < dep:
     # Map outputs
     dstate.add_edge(
         mx, 'OUT_D', out_depth, None,
-        dp.Memlet(depth, -1, dp.subsets.Range.from_array(depth.desc(sdfg)), 1))
+        dp.Memlet.simple(depth,
+                         dp.subsets.Range.from_array(depth.desc(sdfg)),
+                         num_accesses=-1))
     dstate.add_edge(
         mx, 'OUT_FSZ', out_frontiersize, None,
-        dp.Memlet(out_frontiersize,
-                  -1,
-                  dp.subsets.Indices([0]),
-                  1,
-                  wcr='lambda a,b: a+b'))
+        dp.Memlet.simple(out_frontiersize,
+                         dp.subsets.Indices([0]),
+                         num_accesses=-1,
+                         wcr_str='lambda a,b: a+b'))
     dstate.add_edge(
         mx, 'OUT_F', out_frontier_stream, None,
         dp.Memlet.from_array(out_frontier_stream.data,
@@ -246,15 +249,11 @@ if d < dep:
 
 
 frontier = dstate.add_transient('frontier', [V], dtype=vtype, storage=storage)
-frontier2 = dstate.add_transient('frontier2', [V],
-                                 dtype=vtype,
-                                 storage=storage)
+frontier2 = dstate.add_transient('frontier2', [V], dtype=vtype, storage=storage)
 create_computation_state(dstate, frontier, frontier2, 0)
 
 frontier = estate.add_transient('frontier', [V], dtype=vtype, storage=storage)
-frontier2 = estate.add_transient('frontier2', [V],
-                                 dtype=vtype,
-                                 storage=storage)
+frontier2 = estate.add_transient('frontier2', [V], dtype=vtype, storage=storage)
 create_computation_state(estate, frontier2, frontier, 1)
 
 if __name__ == "__main__":

--- a/tests/blockreduce_cudatest.py
+++ b/tests/blockreduce_cudatest.py
@@ -28,7 +28,7 @@ state.add_edge(tA, None, red, None, Memlet.simple(tA, '0:2'))
 state.add_edge(red, None, tB, None, Memlet.simple(tB, '0'))
 state.add_edge(tB, None, write_tasklet, 'inp', Memlet.simple(tB, '0'))
 state.add_edge(write_tasklet, 'out', mxi, None,
-               Memlet('B', -1, dace.subsets.Indices(['bi']), 1))
+               Memlet.simple('B', 'bi', num_accesses=-1))
 state.add_edge(mxi, None, mx, None, Memlet.simple(B, 'bi'))
 state.add_edge(mx, None, B, None, Memlet.simple(B, '0:2'))
 sdfg.fill_scope_connectors()

--- a/tests/intel_fpga/simple_systolic_array.py
+++ b/tests/intel_fpga/simple_systolic_array.py
@@ -83,15 +83,10 @@ def make_read_A_sdfg():
                                 dace.int32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        mem,
-        pipe,
-        memlet=dace.memlet.Memlet(
-            pipe,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("0"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("n")))
+    loop_body.add_memlet_path(mem,
+                              pipe,
+                              memlet=dace.memlet.Memlet.simple(
+                                  pipe, '0', other_subset_str='n'))
 
     return sdfg
 
@@ -132,15 +127,10 @@ def make_write_A_sdfg():
                                 dace.int32,
                                 storage=dace.dtypes.StorageType.FPGA_Local)
 
-    loop_body.add_memlet_path(
-        pipe,
-        mem,
-        memlet=dace.memlet.Memlet(
-            mem,
-            dace.symbolic.pystr_to_symbolic("1"),
-            dace.properties.SubsetProperty.from_string("n"),
-            1,
-            other_subset=dace.properties.SubsetProperty.from_string("0")))
+    loop_body.add_memlet_path(pipe,
+                              mem,
+                              memlet=dace.memlet.Memlet.simple(
+                                  mem, 'n', other_subset_str='0'))
 
     return sdfg
 
@@ -188,18 +178,15 @@ def make_compute_sdfg():
 
     state.add_memlet_path(A_pipe_in,
                           compute_tasklet,
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_in, dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(A_pipe_in,
+                                                           '0',
+                                                           num_accesses=-1),
                           dst_conn="a_in")
     state.add_memlet_path(compute_tasklet,
                           A_pipe_out,
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_out,
-                              dace.symbolic.pystr_to_symbolic("-1"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1),
+                          memlet=dace.memlet.Memlet.simple(A_pipe_out,
+                                                           '0',
+                                                           num_accesses=-1),
                           src_conn="a_out")
 
     return sdfg
@@ -215,8 +202,7 @@ def make_fpga_state(sdfg):
 
     compute_sdfg = make_compute_sdfg()
     compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg,
-                                              {"A_stream_in"},
-                                              {"A_stream_out"})
+                                              {"A_stream_in"}, {"A_stream_out"})
 
     write_A_sdfg = make_write_A_sdfg()
     write_A_sdfg_node = state.add_nested_sdfg(write_A_sdfg, sdfg, {"pipe"},
@@ -257,59 +243,47 @@ def make_fpga_state(sdfg):
         unroll=True)
 
     # Bring data nodes into scope
-    state.add_memlet_path(compute_entry,
-                          A_pipe_in,
-                          memlet=dace.memlet.EmptyMemlet())
-    state.add_memlet_path(A_pipe_out,
-                          compute_exit,
-                          memlet=dace.memlet.EmptyMemlet())
+    state.add_memlet_path(compute_entry, A_pipe_in, memlet=dace.memlet.Memlet())
+    state.add_memlet_path(A_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
 
     # Connect data nodes
-    state.add_memlet_path(A_pipe_in,
-                          compute_sdfg_node,
-                          dst_conn="A_stream_in",
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_in,
-                              dace.symbolic.pystr_to_symbolic("N/P"),
-                              dace.properties.SubsetProperty.from_string("p"),
-                              1))
+    state.add_memlet_path(
+        A_pipe_in,
+        compute_sdfg_node,
+        dst_conn="A_stream_in",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_in, 'p',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N/P")))
     state.add_memlet_path(
         compute_sdfg_node,
         A_pipe_out,
         src_conn="A_stream_out",
-        memlet=dace.memlet.Memlet(
-            A_pipe_out, dace.symbolic.pystr_to_symbolic("N/P"),
-            dace.properties.SubsetProperty.from_string("p + 1"), 1))
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_out,
+            'p + 1',
+            num_accesses=dace.symbolic.pystr_to_symbolic("N/P")))
 
+    state.add_memlet_path(A_IN,
+                          read_A_sdfg_node,
+                          dst_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(A_IN, "0:N"))
     state.add_memlet_path(
-        A_IN,
         read_A_sdfg_node,
-        dst_conn="mem",
-        memlet=dace.memlet.Memlet(
-            A_IN, dace.symbolic.pystr_to_symbolic("N"),
-            dace.properties.SubsetProperty.from_string("0:N"), 1))
-    state.add_memlet_path(read_A_sdfg_node,
-                          A_pipe_read,
-                          src_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_in, dace.symbolic.pystr_to_symbolic("N"),
-                              dace.properties.SubsetProperty.from_string("0"),
-                              1))
+        A_pipe_read,
+        src_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_in, '0', num_accesses=dace.symbolic.pystr_to_symbolic("N")))
 
-    state.add_memlet_path(A_pipe_write,
-                          write_A_sdfg_node,
-                          dst_conn="pipe",
-                          memlet=dace.memlet.Memlet(
-                              A_pipe_out, dace.symbolic.pystr_to_symbolic("N"),
-                              dace.properties.SubsetProperty.from_string("P"),
-                              1))
     state.add_memlet_path(
+        A_pipe_write,
         write_A_sdfg_node,
-        A_OUT,
-        src_conn="mem",
-        memlet=dace.memlet.Memlet(
-            A_OUT, dace.symbolic.pystr_to_symbolic("N"),
-            dace.properties.SubsetProperty.from_string("0:N"), 1))
+        dst_conn="pipe",
+        memlet=dace.memlet.Memlet.simple(
+            A_pipe_out, 'P', num_accesses=dace.symbolic.pystr_to_symbolic("N")))
+    state.add_memlet_path(write_A_sdfg_node,
+                          A_OUT,
+                          src_conn="mem",
+                          memlet=dace.memlet.Memlet.simple(A_OUT, "0:N"))
 
     return state
 

--- a/tests/mapfission_test.py
+++ b/tests/mapfission_test.py
@@ -33,7 +33,7 @@ def mapfission_sdfg():
     wnode = state.add_write('B')
 
     # Edges
-    state.add_nedge(ome, scalar, dace.EmptyMemlet())
+    state.add_nedge(ome, scalar, dace.Memlet())
     state.add_memlet_path(rnode,
                           ome,
                           t1,
@@ -240,7 +240,7 @@ class MapFissionTest(unittest.TestCase):
         nstate.add_edge(t, 'out', a, None, dace.Memlet.simple('a', '0'))
         nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'a'})
 
-        state.add_edge(me, None, nsdfg_node, None, dace.EmptyMemlet())
+        state.add_edge(me, None, nsdfg_node, None, dace.Memlet())
         anode = state.add_write('A')
         state.add_memlet_path(nsdfg_node,
                               mx,

--- a/tests/properties_test.py
+++ b/tests/properties_test.py
@@ -67,14 +67,7 @@ class PropertyTests(unittest.TestCase):
         sdfg.add_array("arr2", (16, 16), dace.dtypes.float32)
         state1.add_node(dace.sdfg.nodes.AccessNode('arr2'))
 
-        memlet = dace.memlet.Memlet('arr2', 1, "0:N", 1)
-
-        with self.assertRaises(TypeError):
-            # Must pass SDFG as second argument
-            memlet = dace.memlet.Memlet(
-                dace.memlet.Memlet.__properties__["data"].from_string("arr0"),
-                None, 1, "i", 1)
-
+        memlet = dace.memlet.Memlet.simple('arr2', '0:N', num_accesses=1)
         memlet.data = 'arr0'
 
         self.assertEqual(sdfg.arrays[memlet.data], arr0)

--- a/tests/sdfg/free_symbols_test.py
+++ b/tests/sdfg/free_symbols_test.py
@@ -42,8 +42,8 @@ def test_state_subgraph():
     nsdfg = state.add_nested_sdfg(nsdfg,
                                   None, {}, {},
                                   symbol_mapping=dict(l=L / 2, i='i'))
-    state.add_nedge(me, nsdfg, dace.EmptyMemlet())
-    state.add_nedge(nsdfg, mx, dace.EmptyMemlet())
+    state.add_nedge(me, nsdfg, dace.Memlet())
+    state.add_nedge(nsdfg, mx, dace.Memlet())
 
     # Entire graph
     assert state.free_symbols == {'L', 'N'}

--- a/tests/sdfg_validate_scopes_test.py
+++ b/tests/sdfg_validate_scopes_test.py
@@ -17,7 +17,7 @@ class ScopeValidationTests(unittest.TestCase):
             state.add_edge(A, None, me, 'IN_a',
                            dace.Memlet.from_array(A.data, A.desc(sdfg)))
             state.add_edge(me, 'OUT_b', T, 'a', dace.Memlet.simple(A, '0'))
-            state.add_edge(T, None, mx, None, dace.EmptyMemlet())
+            state.add_edge(T, None, mx, None, dace.Memlet())
 
             sdfg.validate()
             self.fail('Failed to detect invalid SDFG')

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -32,7 +32,7 @@ state.add_memlet_path(matr,
                       tasklet,
                       dst_conn='mat_in',
                       memlet=dace.Memlet.simple('sparsemats_in', 'i'))
-# state.add_nedge(tasklet, omx, dace.EmptyMemlet())
+# state.add_nedge(tasklet, omx, dace.Memlet())
 state.add_memlet_path(tasklet,
                       omx,
                       matw,

--- a/tests/threadlocal_stream_test.py
+++ b/tests/threadlocal_stream_test.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import dace as dp
 from dace.sdfg import SDFG
-from dace.memlet import Memlet, EmptyMemlet
+from dace.memlet import Memlet
 
 N = dp.symbol('N')
 sdfg = SDFG('tlstream')
@@ -18,7 +18,7 @@ globalarr = state.add_array('ga', [N], dp.float32)
 me, mx = state.add_map('par', dict(i='0:N'))
 tasklet = state.add_tasklet('arange', set(), {'a'}, 'a = i')
 
-state.add_nedge(me, tasklet, EmptyMemlet())
+state.add_nedge(me, tasklet, Memlet())
 state.add_edge(tasklet, 'a', localstream, None,
                Memlet.from_array(localstream.data, localstream.desc(sdfg)))
 state.add_nedge(localstream, localarr,


### PR DESCRIPTION
- [x] Memlet API revamp
    * EmptyMemlet is removed in favor of Memlet() and `memlet.is_empty()`
    * Use legacy `Memlet.simple` API in all cases (Memlet API may be subject to further changes)
    * `num_accesses` is now two properties: `volume` and `dynamic` (for bounded but dynamic volume)
    * `wcr_conflict` is now `wcr_nonatomic` for clarity
    * New ease-of-use API for memlet construction from string (`Memlet('A[i:i+5]')`)
    * Memlet constructor accepts both strings and native types (AST, Subset) for supported fields
    * New `src_subset` and `dst_subset` properties
    * Remove unused `DYNAMIC` and `NA_DYNAMIC`
