### PR TITLE
Add support for tqdm status bar to dace profiler

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -548,7 +548,7 @@ required:
         title: Profiling
         description: Enable profiling support.
 
-    profiling-status:
+    profiling_status:
         type: bool
         default: true
         title: Status bar for profiling

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -554,7 +554,7 @@ required:
         title: Status bar for profiling
         description: >
             Enable tqdm status bar while profiling. If tqdm is not installed 
-            a warning will appear. To diable this feature (and the warning) set 
+            a warning will appear. To disable this feature (and the warning) set 
             this option to false.
 
     treps:

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -548,6 +548,15 @@ required:
         title: Profiling
         description: Enable profiling support.
 
+    profiling-status:
+        type: bool
+        default: true
+        title: Status bar for profiling
+        description: >
+            Enable tqdm status bar while profiling. If tqdm is not installed 
+            a warning will appear. To diable this feature (and the warning) set 
+            this option to false.
+
     treps:
         type: int
         default: 100

--- a/dace/frontend/operations.py
+++ b/dace/frontend/operations.py
@@ -30,7 +30,16 @@ def timethis(program, title, flop_count, f, *args, **kwargs):
     REPS = int(Config.get('treps'))
     times = [start] * (REPS + 1)
     ret = None
-    for i in range(REPS):
+    print('\nProfiling...')
+    iterator = range(REPS)
+    try:
+        from tqdm import tqdm
+        iterator = tqdm(iterator)
+    except ImportError:
+        print('WARNING: Cannot show profiling progress, missing optional '
+              'dependency tqdm...\n\tTo see a live progress bar please install '
+              'tqdm (`pip install tqdm`)')
+    for i in iterator:
         # Call function
         ret = f(*args, **kwargs)
         times[i + 1] = timer()

--- a/dace/frontend/operations.py
+++ b/dace/frontend/operations.py
@@ -34,7 +34,7 @@ def timethis(program, title, flop_count, f, *args, **kwargs):
     iterator = range(REPS)
     try:
         from tqdm import tqdm
-        iterator = tqdm(iterator)
+        iterator = tqdm(iterator, desc="Profiling")
     except ImportError:
         print('WARNING: Cannot show profiling progress, missing optional '
               'dependency tqdm...\n\tTo see a live progress bar please install '

--- a/dace/frontend/operations.py
+++ b/dace/frontend/operations.py
@@ -32,13 +32,16 @@ def timethis(program, title, flop_count, f, *args, **kwargs):
     ret = None
     print('\nProfiling...')
     iterator = range(REPS)
-    try:
-        from tqdm import tqdm
-        iterator = tqdm(iterator, desc="Profiling")
-    except ImportError:
-        print('WARNING: Cannot show profiling progress, missing optional '
-              'dependency tqdm...\n\tTo see a live progress bar please install '
-              'tqdm (`pip install tqdm`)')
+    if Config.get_bool('profiling-status'):
+        try:
+            from tqdm import tqdm
+            iterator = tqdm(iterator, desc="Profiling")
+        except ImportError:
+                print('WARNING: Cannot show profiling progress, missing optional '
+                    'dependency tqdm...\n\tTo see a live progress bar please install '
+                    'tqdm (`pip install tqdm`)\n\tTo disable this feature (and '
+                    'this warning) set `profiling-status` to false in the dace '
+                    'config (~/.dace.conf).')
     for i in iterator:
         # Call function
         ret = f(*args, **kwargs)

--- a/dace/frontend/operations.py
+++ b/dace/frontend/operations.py
@@ -32,7 +32,7 @@ def timethis(program, title, flop_count, f, *args, **kwargs):
     ret = None
     print('\nProfiling...')
     iterator = range(REPS)
-    if Config.get_bool('profiling-status'):
+    if Config.get_bool('profiling_status'):
         try:
             from tqdm import tqdm
             iterator = tqdm(iterator, desc="Profiling")

--- a/dace/frontend/operations.py
+++ b/dace/frontend/operations.py
@@ -40,7 +40,7 @@ def timethis(program, title, flop_count, f, *args, **kwargs):
                 print('WARNING: Cannot show profiling progress, missing optional '
                     'dependency tqdm...\n\tTo see a live progress bar please install '
                     'tqdm (`pip install tqdm`)\n\tTo disable this feature (and '
-                    'this warning) set `profiling-status` to false in the dace '
+                    'this warning) set `profiling_status` to false in the dace '
                     'config (~/.dace.conf).')
     for i in iterator:
         # Call function


### PR DESCRIPTION
If you install [`tqdm`](https://github.com/tqdm/tqdm) in you dace python environment you will be able to see a live status bar during profiling.

![image](https://user-images.githubusercontent.com/16564943/85668955-9f8c4400-b6bf-11ea-9596-25c1d36088ef.png)
