### PR TITLE
VSCode interface API module

### DIFF
--- a/dace/properties.py
+++ b/dace/properties.py
@@ -878,21 +878,6 @@ class LambdaProperty(Property):
         super(LambdaProperty, self).__set__(obj, val)
 
 
-class SubgraphProperty(Property):
-    """ Property class that provides read-only (loading from json value is disabled)
-        access to a dict value. Intended for Transformation.subgraph.
-    """
-    def __set__(self, obj, val):
-        if val is not None:
-            super(SubgraphProperty, self).__set__(obj, val)
-
-    def to_json(self, obj):
-        return str(obj)
-
-    def from_json(self, s, sdfg=None):
-        return None
-
-
 class CodeBlock(object):
     """ Helper class that represents code blocks with language. 
         Used in `CodeProperty`, implemented as a list of AST statements if 

--- a/dace/transformation/interface/vscode/__init__.py
+++ b/dace/transformation/interface/vscode/__init__.py
@@ -1,0 +1,2 @@
+""" This module initializes the interface to VSCode. """
+

--- a/dace/transformation/interface/vscode/__main__.py
+++ b/dace/transformation/interface/vscode/__main__.py
@@ -1,0 +1,11 @@
+from flask import Flask
+
+deamon = Flask('dace.transformation.interface.vscode')
+deamon.config['DEBUG'] = True
+
+@deamon.route('/', methods=['GET'])
+def root():
+    return 'success!'
+
+if __name__ == '__main__':
+    deamon.run()

--- a/dace/transformation/interface/vscode/__main__.py
+++ b/dace/transformation/interface/vscode/__main__.py
@@ -4,20 +4,14 @@ from argparse import ArgumentParser
 def apply_transformation(sdfg, transformation):
     # We lazy import DaCe, not to break cyclic imports, but to avoid any large
     # delays when booting in daemon mode.
-    from dace.transformation.optimizer import SDFGOptimizer
     from dace.transformation.pattern_matching import Transformation
     from dace.sdfg import SDFG
 
     sdfg_json = json.loads(sdfg)
     sdfg_object = SDFG.from_json(sdfg_json)
-    optimizer = SDFGOptimizer(sdfg_object)
 
-    transformation_obj = next(t for t in Transformation.extensions().keys()
-                              if t.__name__ == transformation['label'])
-    matching = optimizer.get_pattern_matches(patterns=[transformation_obj])
-
-    for pattern in matching:
-        pattern.apply_pattern(sdfg_object)
+    revived_transformation = Transformation.from_json(transformation)
+    revived_transformation.apply_pattern(sdfg_object)
 
     new_sdfg = sdfg_object.to_json()
     return {
@@ -37,24 +31,7 @@ def get_transformations(sdfg):
 
     transformations = []
     for transformation in matches:
-        parameters = []
-        node_ids = []
-        if transformation is not None:
-            sdfg_id = transformation.sdfg_id
-            state_id = transformation.state_id
-            nodes = list(transformation.subgraph.values())
-            for node in nodes:
-                node_ids.append([sdfg_id, state_id, node])
-            #print(transformation.to_json())
-
-        transformations.append({
-            'label': transformation.__str__(),
-            'parameters': parameters,
-            'affected_nodes': node_ids,
-            'children': [],
-        })
-        # if set(transformation.subgraph.values()) & viewed_nodes:
-        #     pass
+        transformations.append(transformation.to_json())
 
     return {
         'transformations': transformations,

--- a/dace/transformation/interface/vscode/__main__.py
+++ b/dace/transformation/interface/vscode/__main__.py
@@ -1,11 +1,38 @@
-from flask import Flask
+from argparse import ArgumentParser
 
-deamon = Flask('dace.transformation.interface.vscode')
-deamon.config['DEBUG'] = True
+def get_transformations(sdfg):
+    print("ok")
 
-@deamon.route('/', methods=['GET'])
-def root():
-    return 'success!'
+def run_daemon():
+    from flask import Flask
+
+    deamon = Flask('dace.transformation.interface.vscode')
+    deamon.config['DEBUG'] = False
+
+    @deamon.route('/', methods=['GET'])
+    def root():
+        return 'success!'
+
+    deamon.run()
 
 if __name__ == '__main__':
-    deamon.run()
+    parser = ArgumentParser()
+
+    '''
+    parser.add_argument('-d',
+                        '--daemon',
+                        action='store_true',
+                        help='Run as a daemon')
+                        '''
+
+    parser.add_argument('-t',
+                        '--transformations',
+                        action='store_true',
+                        help='Get applicable transformations for an SDFG')
+
+    args = parser.parse_args()
+
+    if (args.transformations):
+        get_transformations(None)
+    else:
+        run_daemon()

--- a/dace/transformation/interface/vscode/__main__.py
+++ b/dace/transformation/interface/vscode/__main__.py
@@ -1,6 +1,29 @@
 import json
 from argparse import ArgumentParser
 
+def apply_transformation(sdfg, transformation):
+    # We lazy import DaCe, not to break cyclic imports, but to avoid any large
+    # delays when booting in daemon mode.
+    from dace.transformation.optimizer import SDFGOptimizer
+    from dace.transformation.pattern_matching import Transformation
+    from dace.sdfg import SDFG
+
+    sdfg_json = json.loads(sdfg)
+    sdfg_object = SDFG.from_json(sdfg_json)
+    optimizer = SDFGOptimizer(sdfg_object)
+
+    transformation_obj = next(t for t in Transformation.extensions().keys()
+                              if t.__name__ == transformation['label'])
+    matching = optimizer.get_pattern_matches(patterns=[transformation_obj])
+
+    for pattern in matching:
+        pattern.apply_pattern(sdfg_object)
+
+    new_sdfg = sdfg_object.to_json()
+    return {
+        'sdfg': new_sdfg
+    }
+
 def get_transformations(sdfg):
     # We lazy import DaCe, not to break cyclic imports, but to avoid any large
     # delays when booting in daemon mode.
@@ -22,6 +45,7 @@ def get_transformations(sdfg):
             nodes = list(transformation.subgraph.values())
             for node in nodes:
                 node_ids.append([sdfg_id, state_id, node])
+            #print(transformation.to_json())
 
         transformations.append({
             'label': transformation.__str__(),
@@ -43,14 +67,18 @@ def run_daemon():
     daemon.config['DEBUG'] = False
 
     @daemon.route('/', methods=['GET'])
-    def root():
+    def _root():
         return 'success!'
 
     @daemon.route('/transformations', methods=['POST'])
-    def transformations():
-        sdfg = request.get_json()
-        transformation_json = get_transformations(sdfg)
-        return transformation_json
+    def _get_transformations():
+        return get_transformations(request.get_json())
+
+    @daemon.route('/apply_transformation', methods=['POST'])
+    def _apply_transformation():
+        request_json = request.get_json()
+        return apply_transformation(request_json['sdfg'],
+                                    request_json['transformation'])
 
     daemon.run()
 

--- a/dace/transformation/interface/vscode/__main__.py
+++ b/dace/transformation/interface/vscode/__main__.py
@@ -1,19 +1,58 @@
+import json
 from argparse import ArgumentParser
 
 def get_transformations(sdfg):
-    print("ok")
+    # We lazy import DaCe, not to break cyclic imports, but to avoid any large
+    # delays when booting in daemon mode.
+    from dace.transformation.optimizer import SDFGOptimizer
+    from dace.sdfg import SDFG
+
+    sdfg_json = json.loads(sdfg)
+    sdfg_object = SDFG.from_json(sdfg_json)
+    optimizer = SDFGOptimizer(sdfg_object)
+    matches = optimizer.get_pattern_matches()
+
+    transformations = []
+    for transformation in matches:
+        parameters = []
+        node_ids = []
+        if transformation is not None:
+            sdfg_id = transformation.sdfg_id
+            state_id = transformation.state_id
+            nodes = list(transformation.subgraph.values())
+            for node in nodes:
+                node_ids.append([sdfg_id, state_id, node])
+
+        transformations.append({
+            'label': transformation.__str__(),
+            'parameters': parameters,
+            'affected_nodes': node_ids,
+            'children': [],
+        })
+        # if set(transformation.subgraph.values()) & viewed_nodes:
+        #     pass
+
+    return {
+        'transformations': transformations,
+    }
 
 def run_daemon():
-    from flask import Flask
+    from flask import Flask, request
 
-    deamon = Flask('dace.transformation.interface.vscode')
-    deamon.config['DEBUG'] = False
+    daemon = Flask('dace.transformation.interface.vscode')
+    daemon.config['DEBUG'] = False
 
-    @deamon.route('/', methods=['GET'])
+    @daemon.route('/', methods=['GET'])
     def root():
         return 'success!'
 
-    deamon.run()
+    @daemon.route('/transformations', methods=['POST'])
+    def transformations():
+        sdfg = request.get_json()
+        transformation_json = get_transformations(sdfg)
+        return transformation_json
+
+    daemon.run()
 
 if __name__ == '__main__':
     parser = ArgumentParser()
@@ -23,6 +62,14 @@ if __name__ == '__main__':
                         '--daemon',
                         action='store_true',
                         help='Run as a daemon')
+                        '''
+
+    '''
+    parser.add_argument('-p',
+                        '--port',
+                        action='store',
+                        type='int',
+                        help='The port to listen on')
                         '''
 
     parser.add_argument('-t',

--- a/dace/transformation/optimizer.py
+++ b/dace/transformation/optimizer.py
@@ -13,7 +13,7 @@ from dace.sdfg.graph import SubgraphView
 from dace.transformation import pattern_matching
 
 # This import is necessary since it registers all the patterns
-from dace.transformation import dataflow, interstate
+from dace.transformation import dataflow, interstate, subgraph
 
 
 class Optimizer(object):

--- a/dace/transformation/pattern_matching.py
+++ b/dace/transformation/pattern_matching.py
@@ -200,7 +200,7 @@ class Transformation(object):
 
         # Recreate subgraph
         expr = xform.expressions()[json_obj['expr_index']]
-        subgraph = {expr.node(int(k)): v for k, v in json_obj['_subgraph'].items()}
+        subgraph = {expr.node(int(k)): int(v) for k, v in json_obj['_subgraph'].items()}
 
         # Reconstruct transformation
         ret = xform(json_obj['sdfg_id'], json_obj['state_id'], subgraph,

--- a/dace/transformation/pattern_matching.py
+++ b/dace/transformation/pattern_matching.py
@@ -9,7 +9,7 @@ from typing import Dict
 from dace.sdfg import SDFG, SDFGState
 from dace.sdfg import utils as sdutil, propagation
 from dace.sdfg.graph import SubgraphView
-from dace.properties import make_properties, Property, SubgraphProperty
+from dace.properties import make_properties, Property, DictProperty
 from dace.registry import make_registry
 from dace.sdfg import graph as gr, nodes as nd
 from dace.dtypes import ScheduleType
@@ -39,7 +39,7 @@ class Transformation(object):
     # Properties
     sdfg_id = Property(dtype=int, category="(Debug)")
     state_id = Property(dtype=int, category="(Debug)")
-    subgraph = SubgraphProperty(dtype=dict, category="(Debug)")
+    _subgraph = DictProperty(key_type=int, value_type=int, category="(Debug)")
     expr_index = Property(dtype=int, category="(Debug)")
 
     @staticmethod
@@ -111,8 +111,15 @@ class Transformation(object):
                                 'subgraph'
                                 ' dictionary must be '
                                 'instances of int.')
-        self.subgraph = subgraph
+        # Serializable subgraph with node IDs as keys
+        expr = self.expressions()[expr_index]
+        self._subgraph = {expr.node_id(k): v for k, v in subgraph.items()}
+        self._subgraph_user = subgraph
         self.expr_index = expr_index
+
+    @property
+    def subgraph(self):
+        return self._subgraph_user
 
     def __lt__(self, other):
         """ Comparing two transformations by their class name and node IDs
@@ -178,6 +185,35 @@ class Transformation(object):
         string += type(self).match_to_str(graph, self.subgraph)
         return string
 
+    def to_json(self, parent=None):
+        props = dace.serialize.all_properties_to_json(self)
+        return {
+            'type': 'Transformation',
+            'transformation': type(self).__name__,
+            **props
+        }
+
+    @staticmethod
+    def from_json(json_obj, context=None):
+        xform = next(ext for ext in Transformation.extensions().keys()
+                     if ext.__name__ == json_obj['transformation'])
+
+        # Recreate subgraph
+        expr = xform.expressions()[json_obj['expr_index']]
+        subgraph = {expr.node(int(k)): v for k, v in json_obj['_subgraph'].items()}
+
+        # Reconstruct transformation
+        ret = xform(json_obj['sdfg_id'], json_obj['state_id'], subgraph,
+                    json_obj['expr_index'])
+        context = context or {}
+        context['transformation'] = ret
+        dace.serialize.set_properties_from_json(
+            ret,
+            json_obj,
+            context=context,
+            ignore_properties={'transformation', 'type'})
+        return ret
+
 
 class ExpandTransformation(Transformation):
     """Base class for transformations that simply expand a node into a
@@ -242,6 +278,7 @@ class ExpandTransformation(Transformation):
         state.remove_node(node)
         type(self).postprocessing(sdfg, state, expansion)
 
+
 @make_registry
 class SubgraphTransformation(object):
     """
@@ -260,7 +297,7 @@ class SubgraphTransformation(object):
         :return: True if the subgraph can be transformed, or False otherwise.
         """
         pass
-    
+
     def apply(self, sdfg: SDFG, subgraph: SubgraphView):
         """
         Applies the transformation on the given subgraph.
@@ -269,8 +306,6 @@ class SubgraphTransformation(object):
                          transformation on.
         """
         pass
-
-
 
 
 # Module functions ############################################################

--- a/dace/transformation/subgraph/gpu_persistent_fusion.py
+++ b/dace/transformation/subgraph/gpu_persistent_fusion.py
@@ -1,6 +1,6 @@
 import copy
 import dace
-from dace import dtypes, nodes, Memlet
+from dace import dtypes, nodes, registry, Memlet
 from dace.sdfg import SDFG, SDFGState, InterstateEdge
 from dace.dtypes import StorageType, ScheduleType
 from dace.properties import Property, make_properties
@@ -8,7 +8,7 @@ from dace.sdfg.utils import find_sink_nodes, concurrent_subgraphs
 from dace.sdfg.graph import SubgraphView
 from dace.transformation.pattern_matching import SubgraphTransformation
 
-
+@registry.autoregister
 @make_properties
 class GPUPersistentKernel(SubgraphTransformation):
     """


### PR DESCRIPTION
This adds a new module that serves as an interface between DaCe and its VSCode extension.

The interface is by default started as a deamon from within the VSCode extension and then serves HTTP requests to facilitate interaction between the two components.

As part of this, (de)serialization to and from JSON has been added to the Transformation class.