### PR TITLE
Allowing reassignment of arrays of shape (1, )

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2384,7 +2384,8 @@ class ProgramVisitor(ExtNodeVisitor):
                 true_array = defined_arrays[true_name]
 
             if (isinstance(target, ast.Name) and true_name and not op
-                    and not isinstance(true_array, data.Scalar)):
+                    and not isinstance(true_array, data.Scalar)
+                    and not (true_array.shape == (1, ))):
                 raise DaceSyntaxError(
                     self, target,
                     'Cannot reassign value to variable "{}"'.format(name))

--- a/tests/numpy/variable_reassignment_test.py
+++ b/tests/numpy/variable_reassignment_test.py
@@ -1,0 +1,13 @@
+import dace
+import numpy as np
+
+@dace.program
+def reassign(a: dace.float64[1]):
+    s = 0.0
+    s = 1.0
+    a = s
+
+if __name__ == '__main__':
+    a = np.random.rand(1).astype(np.float64)
+    reassign(a)
+    assert(a == 1.0)


### PR DESCRIPTION
The purpose is to allow code like the following to work:
```python
@dace.program
def reassign(a: dace.float64[1]):
    s = 0.0
    s = 1.0
```
The solution is to interpret the second statement `s = 1.0` as `s[0] = 1.0` or `s[:] = 1.0`.
However, redefinition of arrays is still now allowed, i.e., this only works with arrays of shape (1, ).