### PR TITLE
Fixing relaxation of checks in state fusion

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2384,8 +2384,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 true_array = defined_arrays[true_name]
 
             if (isinstance(target, ast.Name) and true_name and not op
-                    and not isinstance(true_array, data.Scalar)
-                    and not (true_array.shape == (1, ))):
+                    and not isinstance(true_array, data.Scalar)):
                 raise DaceSyntaxError(
                     self, target,
                     'Cannot reassign value to variable "{}"'.format(name))

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2384,7 +2384,8 @@ class ProgramVisitor(ExtNodeVisitor):
                 true_array = defined_arrays[true_name]
 
             if (isinstance(target, ast.Name) and true_name and not op
-                    and not isinstance(true_array, data.Scalar)):
+                    and not isinstance(true_array, data.Scalar)
+                    and not (true_array.shape == (1, ))):
                 raise DaceSyntaxError(
                     self, target,
                     'Cannot reassign value to variable "{}"'.format(name))

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -226,26 +226,26 @@ class StateFusion(pattern_matching.Transformation):
             first_state.add_edge(src, src_conn, dst, dst_conn, data)
 
         # Merge common (data) nodes
-        for node in first_input:
-            try:
-                old_node = next(x for x in second_input
-                                if x.label == node.label)
-            except StopIteration:
-                continue
-            sdutil.change_edge_src(first_state, old_node, node)
-            first_state.remove_node(old_node)
-            second_input.remove(old_node)
-            node.access = dtypes.AccessType.ReadWrite
-        for node in first_output:
-            try:
-                new_node = next(x for x in second_input
-                                if x.label == node.label)
-            except StopIteration:
-                continue
-            sdutil.change_edge_dest(first_state, node, new_node)
-            first_state.remove_node(node)
-            second_input.remove(new_node)
-            new_node.access = dtypes.AccessType.ReadWrite
+        # for node in first_input:
+        #     try:
+        #         old_node = next(x for x in second_input
+        #                         if x.label == node.label)
+        #     except StopIteration:
+        #         continue
+        #     sdutil.change_edge_src(first_state, old_node, node)
+        #     first_state.remove_node(old_node)
+        #     second_input.remove(old_node)
+        #     node.access = dtypes.AccessType.ReadWrite
+        # for node in first_output:
+        #     try:
+        #         new_node = next(x for x in second_input
+        #                         if x.label == node.label)
+        #     except StopIteration:
+        #         continue
+        #     sdutil.change_edge_dest(first_state, node, new_node)
+        #     first_state.remove_node(node)
+        #     second_input.remove(new_node)
+        #     new_node.access = dtypes.AccessType.ReadWrite
         # Check if any input nodes of the second state have to be merged with
         # non-input/output nodes of the first state.
         for node in second_input:

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -136,7 +136,7 @@ class StateFusion(pattern_matching.Transformation):
 
                 # Otherwise, check if any of the second state's connected
                 # components for matching input
-                for node in cc_output:
+                for node in out_nodes:
                     if (next((x for x in second_input if x.label == node.label),
                              None) is not None):
                         check_strict -= 1

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -226,28 +226,6 @@ class StateFusion(pattern_matching.Transformation):
             first_state.add_edge(src, src_conn, dst, dst_conn, data)
 
         # Merge common (data) nodes
-        # for node in first_input:
-        #     try:
-        #         old_node = next(x for x in second_input
-        #                         if x.label == node.label)
-        #     except StopIteration:
-        #         continue
-        #     sdutil.change_edge_src(first_state, old_node, node)
-        #     first_state.remove_node(old_node)
-        #     second_input.remove(old_node)
-        #     node.access = dtypes.AccessType.ReadWrite
-        # for node in first_output:
-        #     try:
-        #         new_node = next(x for x in second_input
-        #                         if x.label == node.label)
-        #     except StopIteration:
-        #         continue
-        #     sdutil.change_edge_dest(first_state, node, new_node)
-        #     first_state.remove_node(node)
-        #     second_input.remove(new_node)
-        #     new_node.access = dtypes.AccessType.ReadWrite
-        # Check if any input nodes of the second state have to be merged with
-        # non-input/output nodes of the first state.
         for node in second_input:
             if first_state.in_degree(node) == 0:
                 n = next((x for x in order if x.label == node.label), None)

--- a/tests/transformations/state_fusion_node_merge_test.py
+++ b/tests/transformations/state_fusion_node_merge_test.py
@@ -1,0 +1,62 @@
+import dace
+import numpy as np
+
+N = dace.symbol('N')
+
+@dace.program
+def test1(A: dace.float64[N], B:dace.float64[N]):
+    for i in dace.map[0:N]:
+        with dace.tasklet:
+            input << A[i]
+            out >> A[i]
+            out = input + 42
+    B[:] = A[:]
+    for i in dace.map[0:N]:
+        with dace.tasklet:
+            input << A[i]
+            out >> A[i]
+            out = input + 43
+
+@dace.program
+def test2(C: dace.float32[1], E: dace.float32[1], F:dace.float32[1]):
+    with dace.tasklet:
+        ci << C[0]
+        co >> C[0]
+        co = ci + 1
+        
+    with dace.tasklet:
+        c << C[0]       
+        e >> E[0]
+        e = c 
+
+    with dace.tasklet:
+        c << C[0]
+        f >> F[0]
+        f = c
+
+
+def relative_error(val, ref):
+    return np.linalg.norm(val - ref) / np.linalg.norm(ref)
+
+if __name__ == '__main__':
+
+    N.set(42)
+    A = np.random.rand(N.get()).astype(np.float64)
+    B = np.random.rand(N.get()).astype(np.float64)
+    A_ref = A + 42 + 43
+    B_ref = A + 42
+
+    test1(A, B)
+    assert(relative_error(A, A_ref) < 1e-12)
+    assert(relative_error(B, B_ref) < 1e-12)
+
+    C = np.random.rand(1).astype(np.float32)
+    E = np.random.rand(1).astype(np.float32)
+    F = np.random.rand(1).astype(np.float32)
+    C_ref = np.random.rand(1).astype(np.float32)
+    C_ref[:] = C[:] + 1
+
+    test2(C, E, F)
+    assert(C[0] == C_ref[0])
+    assert(E[0] == C_ref[0])
+    assert(F[0] == C_ref[0])


### PR DESCRIPTION
State fusion has the following code for relaxing checking RW/WW dependencies:
```python
            # Apply transformation in case all paths to the second state's
            # nodes go through the same access node, which implies sequential
            # behavior in SDFG semantics.
            check_strict = len(first_cc)
            for cc_output in first_cc_output:
                out_nodes = [
                    n for n in first_state.sink_nodes() if n in cc_output
                ]
                # Branching exists, multiple paths may involve same access node
                # potentially causing data races
                if len(out_nodes) > 1:
                    continue

                # Otherwise, check if any of the second state's connected
                # components for matching input
                for node in cc_output:
                    if (next((x for x in second_input if x.label == node.label),
                             None) is not None):
                        check_strict -= 1
                        break
```
The relaxation is supposed to be applied when there is a single sink node in the first state, i.e. out_nodes has length of 1. However, it is possible (see #274) that cc_output has two access nodes, one connected to the other (A -> B). In this case, the existence of a single sink node will be correctly detected (B), but then the other node (A) will trigger relaxing the checks if an access node of the same data exists in the input of the second state.  The correct formula is that (1) the must be a single sink node, and (2) that same sink node does not appear in the input of the second state, i.e. the check must be:
```python
                # Otherwise, check if any of the second state's connected
                # components for matching input
                for node in out_nodes:
                    if (next((x for x in second_input if x.label == node.label),
                             None) is not None):
                        check_strict -= 1
                        break
```

EDIT

Looking at #193, I realized that the code merging the common nodes does not make sense. We first merge the source nodes of the first state with source nodes of the second state. Then we merge the sink nodes of the first state with source nodes of the second state. Finally, we merge other access nodes of the first state with the source nodes of the second state. This order is not correct. We should first merge with sink nodes when possible, then with intermediate nodes, and last with source nodes. The code already in place for intermediate nodes seems to already cover everything since it uses the inverse topological order. I commented out the code for the source and sink nodes to check what happens. Issue #193 is fixed by this change.