### PR TITLE
VC-INTERFACE: Added docstrings to the transformation listings

### DIFF
--- a/dace/transformation/interface/vscode/__main__.py
+++ b/dace/transformation/interface/vscode/__main__.py
@@ -30,11 +30,14 @@ def get_transformations(sdfg):
     matches = optimizer.get_pattern_matches()
 
     transformations = []
+    docstrings = {}
     for transformation in matches:
         transformations.append(transformation.to_json())
+        docstrings[type(transformation).__name__] = transformation.__doc__
 
     return {
         'transformations': transformations,
+        'docstrings': docstrings,
     }
 
 def run_daemon():


### PR DESCRIPTION
This adds docstrings to the JSON being sent out by the module. VSCode uses these docstrings to formulate the tooltips when hovering over a specific transformation.