### PR TITLE
Better support for pi, constexpr, and other constants in modules

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -512,9 +512,7 @@ def add_indirection_subgraph(sdfg: SDFG,
     #                         indirectRange, num_accesses=memlet.num_accesses)
     # graph.add_edge(tasklet, 'lookup', dataNode, None, indirectMemlet)
 
-    valueMemlet = Memlet.simple(tmp_name,
-                                indirectRange,
-                                num_accesses=1)
+    valueMemlet = Memlet.simple(tmp_name, indirectRange, num_accesses=1)
     if output:
         path = [src] + inp_base_path
         if isinstance(src, nodes.AccessNode):
@@ -910,10 +908,6 @@ class TaskletTransformer(ExtNodeTransformer):
         self.lang = dtypes.Language.CPP
 
         return node
-
-
-# TODO: Take care of recursive SDFG generation w.r.t. temporary transient creation (maybe there
-#  is no need if the temporary transients from the parent SDFG are added to the current SDFG arrays)
 
 
 class ProgramVisitor(ExtNodeVisitor):
@@ -2060,7 +2054,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         target: Union[str, Tuple[str, subsets.Range]],
                         operand: Union[str, Tuple[str, subsets.Range]],
                         op: str = None):
-
+        op_is_scalar = False
         if isinstance(target, tuple):
             target_name, target_subset = target
         else:
@@ -2069,6 +2063,8 @@ class ProgramVisitor(ExtNodeVisitor):
             target_subset = subsets.Range.from_array(target_array)
         if isinstance(operand, tuple):
             op_name, op_subset = operand
+        elif isinstance(operand, (int, float, complex)):
+            op_is_scalar = True
         else:
             op_name = operand
             op_array = self.sdfg.arrays[op_name]
@@ -2078,7 +2074,7 @@ class ProgramVisitor(ExtNodeVisitor):
                                                         c=node.col_offset))
 
         if target_subset.num_elements() != 1:
-            if op_subset.num_elements() != 1:
+            if not op_is_scalar and op_subset.num_elements() != 1:
                 op1 = state.add_read(op_name, debuginfo=self.current_lineinfo)
                 op2 = state.add_write(target_name,
                                       debuginfo=self.current_lineinfo)
@@ -2092,30 +2088,49 @@ class ProgramVisitor(ExtNodeVisitor):
                 if op:
                     memlet.wcr = LambdaProperty.from_string(
                         'lambda x, y: x {} y'.format(op))
-                state.add_mapped_tasklet(
-                    state.label, {
+                if op_is_scalar:
+                    state.add_mapped_tasklet(state.label, {
                         '__i%d' % i: '%s:%s+1:%s' % (start, end, step)
                         for i, (start, end, step) in enumerate(target_subset)
+                    }, {},
+                                             '__out = %s' % operand,
+                                             {'__out': memlet},
+                                             external_edges=True,
+                                             debuginfo=self.current_lineinfo)
+                else:
+                    state.add_mapped_tasklet(state.label, {
+                        '__i%d' % i: '%s:%s+1:%s' % (start, end, step)
+                        for i, (start, end, step) in enumerate(target_subset)
+                    }, {
+                        '__inp':
+                        Memlet.simple(op_name, '%s' % op_subset[0][0])
                     },
-                    {'__inp': Memlet.simple(op_name, '%s' % op_subset[0][0])},
-                    '__out = __inp', {'__out': memlet},
-                    external_edges=True,
-                    debuginfo=self.current_lineinfo)
+                                             '__out = __inp', {'__out': memlet},
+                                             external_edges=True,
+                                             debuginfo=self.current_lineinfo)
         else:
-            if op_subset.num_elements() != 1:
+            if not op_is_scalar and op_subset.num_elements() != 1:
                 raise DaceSyntaxError(
                     self, node, "Incompatible subsets %s and %s" %
                     (target_subset, op_subset))
-            op1 = state.add_read(op_name, debuginfo=self.current_lineinfo)
+            if op_is_scalar:
+                tasklet = state.add_tasklet(name=state.label,
+                                            inputs={},
+                                            outputs={'__out'},
+                                            code='__out = %s' % operand,
+                                            debuginfo=self.current_lineinfo)
+            else:
+                op1 = state.add_read(op_name, debuginfo=self.current_lineinfo)
+                tasklet = state.add_tasklet(name=state.label,
+                                            inputs={'__inp'},
+                                            outputs={'__out'},
+                                            code='__out = __inp',
+                                            debuginfo=self.current_lineinfo)
+                inp_memlet = Memlet.simple(op_name, '%s' % op_subset[0][0])
+                state.add_edge(op1, None, tasklet, '__inp', inp_memlet)
+
             op2 = state.add_write(target_name, debuginfo=self.current_lineinfo)
-            tasklet = state.add_tasklet(name=state.label,
-                                        inputs={'__inp'},
-                                        outputs={'__out'},
-                                        code='__out = __inp',
-                                        debuginfo=self.current_lineinfo)
-            inp_memlet = Memlet.simple(op_name, '%s' % op_subset[0][0])
             out_memlet = Memlet.simple(target_name, '%s' % target_subset[0][0])
-            state.add_edge(op1, None, tasklet, '__inp', inp_memlet)
             state.add_edge(tasklet, '__out', op2, None, out_memlet)
 
     def _add_aug_assignment(self, node: Union[ast.Assign, ast.AugAssign],

--- a/dace/runtime/include/dace/types.h
+++ b/dace/runtime/include/dace/types.h
@@ -19,7 +19,7 @@
 #endif
 
 // Visual Studio (<=2017) + CUDA support
-#if defined(_MSC_VER) && (_MSC_VER <= 1999 || defined(__CUDACC__)) || defined(DACE_XILINX)
+#if defined(_MSC_VER) && _MSC_VER <= 1999
 #define DACE_CONSTEXPR
 #else
 #define DACE_CONSTEXPR constexpr

--- a/dace/runtime/include/dace/xilinx/math.h
+++ b/dace/runtime/include/dace/xilinx/math.h
@@ -6,7 +6,7 @@
 
 // fabs support for xilinx
 template <typename T, int vector_length>
-DACE_CONSTEXPR DACE_HDFI hlslib::DataPack<T, vector_length> fabs(const hlslib::DataPack<T, vector_length>& a) {
+DACE_HDFI hlslib::DataPack<T, vector_length> fabs(const hlslib::DataPack<T, vector_length>& a) {
     hlslib::DataPack<T, vector_length> res;
     for (int i = 0; i < vector_length; ++i) {
         #pragma HLS UNROLL

--- a/tests/numpy/pi_test.py
+++ b/tests/numpy/pi_test.py
@@ -1,0 +1,41 @@
+import dace
+import numpy as np
+import math
+
+
+def test_pi_tasklet():
+    @dace.program
+    def returnpi(result: dace.float64[1]):
+        with dace.tasklet:
+            r = math.pi
+            r >> result[0]
+
+    a = np.random.rand(1)
+    returnpi(a)
+    assert np.allclose(a, np.array(math.pi))
+
+
+def test_pi_numpy():
+    @dace.program
+    def returnpi(result: dace.float64[1]):
+        result[0] = math.pi
+
+    a = np.random.rand(1)
+    returnpi(a)
+    assert np.allclose(a, np.array(math.pi))
+
+
+def test_piarray_numpy():
+    @dace.program
+    def returnpi(result: dace.float64[20]):
+        result[:] = math.pi
+
+    a = np.random.rand(20)
+    returnpi(a)
+    assert np.allclose(a, np.array([math.pi] * 20))
+
+
+if __name__ == '__main__':
+    test_pi_tasklet()
+    test_pi_numpy()
+    test_piarray_numpy()


### PR DESCRIPTION
This fixes an issue where the Python frontend is used with constants in modules, such as `math.pi`, and eliminates warnings from GPU and FPGA compilation.