### PR TITLE
propagate_memlet extension

### DIFF
--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -662,11 +662,26 @@ def propagate_memlet(dfg_state,
 
     # Find other adjacent edges within the connected to the scope node
     # and union their subsets
+       # Find other adjacent edges within the connected to the scope node
+    # and union their subsets
     if union_inner_edges:
-        aggdata = [
-            e.data for e in neighboring_edges
-            if e.data.data == memlet.data and e.data != memlet
-        ]
+        if isinstance(scope_node, nodes.EntryNode):
+            target_conn = next(e.src_conn for e in neighboring_edges if e.data == memlet)
+            aggdata = [
+                e.data for e in neighboring_edges
+                if e.data.data == memlet.data and e.data != memlet
+                and e.src_conn == target_conn
+
+            ]
+        if isinstance(scope_node, nodes.ExitNode):
+            # multiple incoming edges into an exit node in_conn are technically not allowed... 
+            target_conn = next(e.dst_conn for e in neighboring_edges if e.data == memlet)
+            aggdata = [
+                e.data for e in neighboring_edges
+                if e.data.data == memlet.data and e.data != memlet
+                and e.dst_conn == target_conn
+
+            ]
     else:
         aggdata = []
 


### PR DESCRIPTION
In the API propagate_memlet, if union_inner_edges = True, only add edges to the neighboring_edges set iff they have the same connector as the memlet to propagate. Else this could lead to wrong volumes if the same data flows through more than one connector. 
To see this in action, again launch jacobi2d.py in polybench samples.