### PR TITLE
SDFGCC: added -o support

### DIFF
--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -5,6 +5,7 @@ import dace
 import os
 import sys
 import argparse
+import shutil
 
 
 def main():
@@ -12,23 +13,30 @@ def main():
     parser = argparse.ArgumentParser(description='Simple SDFG command-line compiler.')
 
     # Required argument for SDGF file path
-    parser.add_argument('SDFGfile', help='<PATH TO SDFG FILE>', type=str)
+    parser.add_argument('SDFGfilepath', help='<PATH TO SDFG FILE>', type=str)
 
     # Optional argument for output location
-    parser.add_argument('-o','--out', type=str, help='If provided, save output to path or filename.\nDirectories in path already need to exist.')
+    parser.add_argument('-o','--out', type=str, help='If provided, saves lib and header file to path. Directories in path need to exist beforehand.')
 
     args = parser.parse_args()
 
-    filename = args.SDFGfile
-    if not os.path.isfile(filename):
-        print('SDFG file', filename, 'not found')
+    filepath = args.SDFGfilepath
+    if not os.path.isfile(filepath):
+        print('SDFG file', filepath, 'not found')
         exit(1)
 
     # Load SDFG
-    sdfg = dace.SDFG.from_file(filename)
+    sdfg = dace.SDFG.from_file(filepath)
 
     # Compile SDFG
     sdfg.compile(args.out)
+
+    # Copying header file to optional path
+    if args.out:
+        source = os.path.join(sdfg.build_folder, 'src/cpu', sdfg.name+'.h')
+        destination = os.path.join(args.out,sdfg.name+'.h')
+        shutil.copyfile(source, destination)
+
 
 if __name__ == '__main__':
     main()

--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -10,31 +10,40 @@ import shutil
 
 def main():
     # Command line options parser
-    parser = argparse.ArgumentParser(description='Simple SDFG command-line compiler.')
+    parser = argparse.ArgumentParser(
+        description='Simple SDFG command-line compiler.')
 
     # Required argument for SDFG file path
-    parser.add_argument('SDFGfilepath', help='<PATH TO SDFG FILE>', type=str)
+    parser.add_argument('filepath', help='<PATH TO SDFG FILE>', type=str)
 
     # Optional argument for output location
-    parser.add_argument('-o','--out', type=str, help='If provided, saves lib and header file to path. Directories in path need to exist beforehand.')
+    parser.add_argument(
+        '-o',
+        '--out',
+        type=str,
+        help=
+        'If provided, saves lib and header file to path. Directories in path need to exist beforehand.'
+    )
 
     args = parser.parse_args()
 
-    filepath = args.SDFGfilepath
+    filepath = args.filepath
     if not os.path.isfile(filepath):
         print('SDFG file', filepath, 'not found')
         exit(1)
+
+    outpath = args.out
 
     # Load SDFG
     sdfg = dace.SDFG.from_file(filepath)
 
     # Compile SDFG
-    sdfg.compile(args.out)
+    sdfg.compile(outpath)
 
     # Copying header file to optional path
     if args.out:
-        source = os.path.join(sdfg.build_folder, 'src', 'cpu', sdfg.name+'.h')
-        destination = os.path.join(args.out,sdfg.name+'.h')
+        source = os.path.join(sdfg.build_folder, 'src', 'cpu', sdfg.name + '.h')
+        destination = os.path.join(os.path.dirname(outpath), sdfg.name + '.h')
         shutil.copyfile(source, destination)
 
 

--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -12,7 +12,7 @@ def main():
     # Command line options parser
     parser = argparse.ArgumentParser(description='Simple SDFG command-line compiler.')
 
-    # Required argument for SDGF file path
+    # Required argument for SDFG file path
     parser.add_argument('SDFGfilepath', help='<PATH TO SDFG FILE>', type=str)
 
     # Optional argument for output location
@@ -33,7 +33,7 @@ def main():
 
     # Copying header file to optional path
     if args.out:
-        source = os.path.join(sdfg.build_folder, 'src/cpu', sdfg.name+'.h')
+        source = os.path.join(sdfg.build_folder, 'src', 'cpu', sdfg.name+'.h')
         destination = os.path.join(args.out,sdfg.name+'.h')
         shutil.copyfile(source, destination)
 

--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -22,7 +22,8 @@ def main():
         '--out',
         type=str,
         help=
-        'If provided, saves lib and header file to path. Directories in path need to exist beforehand.'
+        'If provided, saves library as the given file or in the specified path, '
+        'together with a header file.'
     )
 
     args = parser.parse_args()

--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -15,7 +15,7 @@ def main():
     parser.add_argument('SDFGfile', help='<PATH TO SDFG FILE>', type=str)
 
     # Optional argument for output location
-    parser.add_argument('-o','--out', type=str, help='If provided, save output to path or filename')
+    parser.add_argument('-o','--out', type=str, help='If provided, save output to path or filename.\nDirectories in path already need to exist.')
 
     args = parser.parse_args()
 

--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -23,8 +23,7 @@ def main():
         type=str,
         help=
         'If provided, saves library as the given file or in the specified path, '
-        'together with a header file.'
-    )
+        'together with a header file.')
 
     args = parser.parse_args()
 
@@ -42,10 +41,13 @@ def main():
     sdfg.compile(outpath)
 
     # Copying header file to optional path
-    if args.out:
+    if outpath is not None:
         source = os.path.join(sdfg.build_folder, 'src', 'cpu', sdfg.name + '.h')
-        destination = os.path.join(os.path.dirname(outpath), sdfg.name + '.h')
-        shutil.copyfile(source, destination)
+        if os.path.isdir(outpath):
+            outpath = os.path.join(outpath, sdfg.name + '.h')
+        else:
+            outpath = os.path.join(os.path.dirname(outpath), sdfg.name + '.h')
+        shutil.copyfile(source, outpath)
 
 
 if __name__ == '__main__':

--- a/dace/codegen/sdfgcc.py
+++ b/dace/codegen/sdfgcc.py
@@ -4,24 +4,31 @@
 import dace
 import os
 import sys
+import argparse
 
 
 def main():
-    if len(sys.argv) != 2:
-        print('USAGE: sdfgcc <PATH TO SDFG FILE>')
-        exit(1)
+    # Command line options parser
+    parser = argparse.ArgumentParser(description='Simple SDFG command-line compiler.')
 
-    filename = sys.argv[1]
+    # Required argument for SDGF file path
+    parser.add_argument('SDFGfile', help='<PATH TO SDFG FILE>', type=str)
+
+    # Optional argument for output location
+    parser.add_argument('-o','--out', type=str, help='If provided, save output to path or filename')
+
+    args = parser.parse_args()
+
+    filename = args.SDFGfile
     if not os.path.isfile(filename):
         print('SDFG file', filename, 'not found')
-        exit(2)
+        exit(1)
 
     # Load SDFG
     sdfg = dace.SDFG.from_file(filename)
 
     # Compile SDFG
-    sdfg.compile()
-
+    sdfg.compile(args.out)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Should close issue #256.
I added -o support via sdfg.compile(path/filename).
I rewrote the parsing of the command line arguments with argparse.

new usage:
sdfgcc <PATH TO SDFG FILE> [-o <OUTPUTPATH>]

Directories in OUTPUTPATH need to exist beforehand.