### PR TITLE
Added allocation code for SDFG arrays in framecode

### DIFF
--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -714,9 +714,20 @@ DACE_EXPORTED void __dace_exit_%s(%s)
             if instr is not None:
                 instr.on_sdfg_begin(sdfg, callsite_stream, global_stream)
 
+        # Allocate arrays
+        arrays = sdfg.arrays.keys()
+        allocated = set()
+        for state in sdfg.nodes():
+            for node in state.data_nodes():
+                if (node.data in arrays
+                        and node.data not in allocated):
+                    self._dispatcher.dispatch_allocate(sdfg, state, None, node,
+                                                       global_stream,
+                                                       callsite_stream)
+                    allocated.add(node.data)
+
         # Allocate outer-level transients
         shared_transients = sdfg.shared_transients()
-        allocated = set()
         for state in sdfg.nodes():
             for node in state.data_nodes():
                 if (node.data in shared_transients


### PR DESCRIPTION
This is useful for the MPI code generation, where the SDFG arrays may be distributed and therefore have to be "allocated" by initializing RMA windows for them.