### PR TITLE
Propagate strict argument of to_sdfg when nested dace programs are parsed

### DIFF
--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -106,7 +106,7 @@ def parse_from_function(function, *compilation_args, strict=None):
             'Function must be of type dace.frontend.python.DaceProgram')
 
     # Obtain DaCe program as SDFG
-    sdfg = function.generate_pdp(*compilation_args)
+    sdfg = function.generate_pdp(*compilation_args, strict=strict)
 
     # Apply strict transformations automatically
     if (strict == True or
@@ -265,9 +265,10 @@ class DaceProgram:
 
         return binaryobj(**kwargs)
 
-    def generate_pdp(self, *compilation_args):
+    def generate_pdp(self, *compilation_args, strict=None):
         """ Generates the parsed AST representation of a DaCe program.
             :param compilation_args: Various compilation arguments e.g., dtypes.
+            :param strict: Whether to apply strict transforms when parsing nested dace programs.
             :return: A 2-tuple of (program, modules), where `program` is a
                      `dace.astnodes._ProgramNode` representing the parsed DaCe 
                      program, and `modules` is a dictionary mapping imported 
@@ -332,4 +333,4 @@ class DaceProgram:
 
         # Parse AST to create the SDFG
         return newast.parse_dace_program(dace_func, argtypes, global_vars,
-                                         modules, other_sdfgs, self.kwargs)
+                                         modules, other_sdfgs, self.kwargs, strict=strict)

--- a/tests/python_frontend/test_propagate_strict.py
+++ b/tests/python_frontend/test_propagate_strict.py
@@ -1,0 +1,42 @@
+""" Test that the strict argument to to_sdfg is propagated when parsing calls to other dace programs """
+
+import dace
+
+
+@dace
+def nested_prog1(X: dace.int32[2, 2]):
+    return X + 1
+
+
+@dace
+def nested_prog2(X: dace.int32[2, 2]):
+    return nested_prog1(X + 1)
+
+
+@dace
+def prog(X: dace.int32[2, 2]):
+    return nested_prog2(X + 1)
+
+
+def test_propagate_strict():
+    strict_sdfg = prog.to_sdfg(strict=True)
+
+    strict_sdfgs = {
+        parent
+        for _, parent in strict_sdfg.all_nodes_recursive()
+        if isinstance(parent, dace.SDFG)
+    }
+    assert len(strict_sdfgs) == 1
+
+    non_strict_sdfg = prog.to_sdfg(strict=False)
+
+    non_strict_sdfgs = {
+        parent
+        for _, parent in non_strict_sdfg.all_nodes_recursive()
+        if isinstance(parent, dace.SDFG)
+    }
+    assert len(non_strict_sdfgs) > 1
+
+
+if __name__ == "__main__":
+    test_propagate_strict()

--- a/tests/python_frontend/test_propagate_strict.py
+++ b/tests/python_frontend/test_propagate_strict.py
@@ -20,22 +20,10 @@ def prog(X: dace.int32[2, 2]):
 
 def test_propagate_strict():
     strict_sdfg = prog.to_sdfg(strict=True)
-
-    strict_sdfgs = {
-        parent
-        for _, parent in strict_sdfg.all_nodes_recursive()
-        if isinstance(parent, dace.SDFG)
-    }
-    assert len(strict_sdfgs) == 1
+    assert len(list(strict_sdfg.all_sdfgs_recursive())) == 1
 
     non_strict_sdfg = prog.to_sdfg(strict=False)
-
-    non_strict_sdfgs = {
-        parent
-        for _, parent in non_strict_sdfg.all_nodes_recursive()
-        if isinstance(parent, dace.SDFG)
-    }
-    assert len(non_strict_sdfgs) > 1
+    assert len(list(non_strict_sdfg.all_sdfgs_recursive())) > 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I would like this for a test in daceml.