### PR TITLE
Style Cleanup #2: scope_dict

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -372,7 +372,7 @@ class CPUCodeGen(TargetCodeGenerator):
         if isinstance(src_node, nodes.Tasklet):
             src_storage = dtypes.StorageType.Register
             try:
-                src_parent = dfg.scope_dict()[src_node]
+                src_parent = dfg.entry_node(src_node)
             except KeyError:
                 src_parent = None
             dst_schedule = None if src_parent is None else src_parent.map.schedule
@@ -385,12 +385,12 @@ class CPUCodeGen(TargetCodeGenerator):
             dst_storage = dst_node.desc(sdfg).storage
 
         try:
-            dst_parent = dfg.scope_dict()[dst_node]
+            dst_parent = dfg.entry_node(dst_node)
         except KeyError:
             dst_parent = None
         dst_schedule = None if dst_parent is None else dst_parent.map.schedule
 
-        state_dfg = sdfg.nodes()[state_id]
+        state_dfg = sdfg.node(state_id)
 
         # Emit actual copy
         self._emit_copy(
@@ -1561,7 +1561,7 @@ class CPUCodeGen(TargetCodeGenerator):
         # Emit internal transient array allocation
         to_allocate = local_transients(sdfg, dfg, node)
         allocated = set()
-        for child in dfg.scope_dict(node_to_children=True)[node]:
+        for child in dfg.scope_children()[node]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in allocated:
@@ -1586,7 +1586,7 @@ class CPUCodeGen(TargetCodeGenerator):
         # Emit internal transient array deallocation
         to_allocate = local_transients(sdfg, dfg, map_node)
         deallocated = set()
-        for child in dfg.scope_dict(node_to_children=True)[map_node]:
+        for child in dfg.scope_children()[map_node]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in deallocated:
@@ -1737,7 +1737,7 @@ class CPUCodeGen(TargetCodeGenerator):
         # Emit internal transient array allocation
         to_allocate = local_transients(sdfg, dfg, node)
         allocated = set()
-        for child in dfg.scope_dict(node_to_children=True)[node]:
+        for child in dfg.scope_children()[node]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in allocated:
@@ -1785,7 +1785,7 @@ class CPUCodeGen(TargetCodeGenerator):
         # Emit internal transient array deallocation
         to_allocate = local_transients(sdfg, dfg, entry_node)
         deallocated = set()
-        for child in dfg.scope_dict(node_to_children=True)[entry_node]:
+        for child in dfg.scope_children()[entry_node]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in deallocated:

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -570,8 +570,8 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                     if (isinstance(e.src, nodes.EntryNode)
                             and e.src.schedule in dtypes.GPU_SCHEDULES):
                         e.src._cs_childpath = False
-                    elif state.scope_dict()[e.src] is not None:
-                        parent = state.scope_dict()[e.src]
+                    elif state.entry_node(e.src) is not None:
+                        parent = state.entry_node(e.src)
                         if parent.schedule in dtypes.GPU_SCHEDULES:
                             e.src._cs_childpath = False
                 else:
@@ -919,7 +919,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                     function_stream, callsite_stream):
         if isinstance(src_node, nodes.Tasklet):
             src_storage = dtypes.StorageType.Register
-            src_parent = dfg.scope_dict()[src_node]
+            src_parent = dfg.entry_node(src_node)
             dst_schedule = None if src_parent is None else src_parent.map.schedule
         else:
             src_storage = src_node.desc(sdfg).storage
@@ -929,7 +929,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
         else:
             dst_storage = dst_node.desc(sdfg).storage
 
-        dst_parent = dfg.scope_dict()[dst_node]
+        dst_parent = dfg.entry_node(dst_node)
         dst_schedule = None if dst_parent is None else dst_parent.map.schedule
 
         # Emit actual copy
@@ -1610,7 +1610,7 @@ void  *{kname}_args[] = {{ {kargs} }};
         scope_entry = dfg_scope.source_nodes()[0]
         to_allocate = dace.sdfg.local_transients(sdfg, dfg_scope, scope_entry)
         allocated = set()
-        for child in dfg_scope.scope_dict(node_to_children=True)[node]:
+        for child in dfg_scope.scope_children()[node]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in allocated:
@@ -1665,7 +1665,7 @@ void  *{kname}_args[] = {{ {kargs} }};
         self._grid_dims = None
 
     def get_next_scope_entries(self, dfg, scope_entry):
-        parent_scope_entry = dfg.scope_dict()[scope_entry]
+        parent_scope_entry = dfg.entry_node(scope_entry)
         # We're in a nested SDFG, use full graph
         if parent_scope_entry is None:
             parent_scope = dfg
@@ -1911,7 +1911,7 @@ void  *{kname}_args[] = {{ {kargs} }};
         # Emit internal array allocation (deallocation handled at MapExit)
         to_allocate = dace.sdfg.local_transients(sdfg, dfg_scope, scope_entry)
         allocated = set()
-        for child in dfg_scope.scope_dict(node_to_children=True)[scope_entry]:
+        for child in dfg_scope.scope_children()[scope_entry]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in allocated:

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -514,9 +514,9 @@ for (int u_{name} = 0; u_{name} < {size} - {veclen}; ++u_{name}) {{
 
         # Unrolling processing elements: if there first scope of the subgraph
         # is an unrolled map, generate a processing element for each iteration
-        scope_dict = subgraph.scope_dict(node_to_children=True)
+        scope_children = subgraph.scope_children()
         top_scopes = [
-            n for n in scope_dict[None]
+            n for n in scope_children[None]
             if isinstance(n, dace.sdfg.nodes.EntryNode)
         ]
         unrolled_loops = 0

--- a/dace/codegen/targets/mpi.py
+++ b/dace/codegen/targets/mpi.py
@@ -126,7 +126,7 @@ void __dace_exit_mpi({params}) {{
 
         to_allocate = dace.sdfg.local_transients(sdfg, dfg_scope, map_header)
         allocated = set()
-        for child in dfg_scope.scope_dict(node_to_children=True)[map_header]:
+        for child in dfg_scope.scope_children()[map_header]:
             if not isinstance(child, nodes.AccessNode):
                 continue
             if child.data not in to_allocate or child.data in allocated:

--- a/dace/codegen/targets/target.py
+++ b/dace/codegen/targets/target.py
@@ -565,9 +565,9 @@ class TargetDispatcher(object):
                 and not isinstance(dst_node, nodes.Tasklet)):
             # Special case: Copying from a tasklet to an array, schedule of
             # the copy is in the copying tasklet
-            dst_schedule_node = dfg.scope_dict()[src_node]
+            dst_schedule_node = dfg.entry_node(src_node)
         else:
-            dst_schedule_node = dfg.scope_dict()[dst_node]
+            dst_schedule_node = dfg.entry_node(dst_node)
 
         if dst_schedule_node is not None:
             dst_schedule = dst_schedule_node.map.schedule

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -547,9 +547,9 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
         module_function_name = "module_" + name
         # Unrolling processing elements: if there first scope of the subgraph
         # is an unrolled map, generate a processing element for each iteration
-        scope_dict = subgraph.scope_dict(node_to_children=True)
+        scope_children = subgraph.scope_children()
         top_scopes = [
-            n for n in scope_dict[None]
+            n for n in scope_children[None]
             if isinstance(n, dace.sdfg.nodes.EntryNode)
         ]
         unrolled_loops = 0

--- a/dace/sdfg/infer_types.py
+++ b/dace/sdfg/infer_types.py
@@ -168,7 +168,7 @@ def _set_default_schedule_in_scope(parent_node: nodes.Node,
 def _set_default_schedule_types(sdfg: SDFG,
                                 toplevel_schedule: dtypes.ScheduleType):
     for state in sdfg.nodes():
-        reverse_scope_dict = state.scope_dict(node_to_children=True)
+        reverse_scope_dict = state.scope_children()
 
         # Start with top-level nodes and call recursively
         _set_default_schedule_in_scope(None, toplevel_schedule,

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -678,7 +678,7 @@ def propagate_memlet(dfg_state,
         entry_node = scope_node
         neighboring_edges = dfg_state.out_edges(scope_node)
     elif isinstance(scope_node, nodes.ExitNode):
-        entry_node = dfg_state.scope_dict()[scope_node]
+        entry_node = dfg_state.entry_node(scope_node)
         neighboring_edges = dfg_state.in_edges(scope_node)
     else:
         raise TypeError('Trying to propagate through a non-scope node')

--- a/dace/sdfg/scope.py
+++ b/dace/sdfg/scope.py
@@ -38,10 +38,10 @@ class ScopeSubgraphView(StateSubgraphView):
 
     def top_level_transients(self):
         """ Iterate over top-level transients of this subgraph. """
-        sdict = self.scope_dict(node_to_children=True)
+        schildren = self.scope_children()
         sdfg = self.parent
         result = set()
-        for node in sdict[self.entry]:
+        for node in schildren[self.entry]:
             if isinstance(node, nd.AccessNode) and node.desc(sdfg).transient:
                 result.add(node.data)
         return result
@@ -51,7 +51,7 @@ def _scope_subgraph(graph, entry_node, include_entry, include_exit):
     if not isinstance(entry_node, nd.EntryNode):
         raise TypeError("Received {}: should be dace.nodes.EntryNode".format(
             type(entry_node).__name__))
-    node_to_children = graph.scope_dict(True)
+    node_to_children = graph.scope_children()
     if include_exit:
         children_nodes = set(node_to_children[entry_node])
     else:

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -747,7 +747,7 @@ def local_transients(sdfg, dfg, entry_node):
     """ Returns transients local to the scope defined by the specified entry
         node in the dataflow graph. """
     state: SDFGState = dfg._graph
-    scope_dict = state.scope_dict(node_to_children=True)
+    scope_children = state.scope_children()
     scope_tree = state.scope_tree()
     current_scope = scope_tree[entry_node]
 
@@ -755,13 +755,13 @@ def local_transients(sdfg, dfg, entry_node):
     defined_transients = set(sdfg.shared_transients())
 
     # Get access nodes in current scope
-    transients = _transients_in_scope(sdfg, current_scope, scope_dict)
+    transients = _transients_in_scope(sdfg, current_scope, scope_children)
 
     # Add transients defined in parent scopes
     while current_scope.parent is not None:
         current_scope = current_scope.parent
         defined_transients.update(
-            _transients_in_scope(sdfg, current_scope, scope_dict))
+            _transients_in_scope(sdfg, current_scope, scope_children))
 
     return sorted(list(transients - defined_transients))
 

--- a/dace/transformation/dataflow/gpu_transform_local_storage.py
+++ b/dace/transformation/dataflow/gpu_transform_local_storage.py
@@ -80,7 +80,7 @@ class GPUTransformLocalStorage(transformation.Transformation):
 
             # Disallow GPUTransform on nested maps in strict mode
             if strict:
-                if graph.scope_dict()[map_entry] is not None:
+                if graph.entry_node(map_entry) is not None:
                     return False
 
             # Map schedules that are disallowed to transform to GPUs
@@ -476,7 +476,7 @@ class GPUTransformLocalStorage(transformation.Transformation):
                     graph.add_edge(edge.src, edge.src_conn, node, None,
                                    newmemlet)
 
-                    end_node = graph.scope_dict()[edge.src]
+                    end_node = graph.entry_node(edge.src)
                     for e in graph.bfs_edges(edge.src, reverse=True):
                         parent, _, _child, _, memlet = e
                         if parent == end_node:

--- a/dace/transformation/dataflow/map_fission.py
+++ b/dace/transformation/dataflow/map_fission.py
@@ -60,9 +60,9 @@ class MapFission(transformation.Transformation):
         """
         graph = (subgraph
                  if isinstance(subgraph, sd.SDFGState) else subgraph.graph)
-        sdict = subgraph.scope_dict(node_to_children=True)
+        schildren = subgraph.scope_children()
         ns = [(n, graph.exit_node(n)) if isinstance(n, nodes.EntryNode) else
-              (n, n) for n in sdict[None]
+              (n, n) for n in schildren[None]
               if isinstance(n, (nodes.CodeNode, nodes.EntryNode))]
 
         return ns
@@ -72,8 +72,8 @@ class MapFission(transformation.Transformation):
         """ Returns a set of array names that are local to the fission
             subgraph. """
         nested = isinstance(parent, sd.SDFGState)
-        sdict = subgraph.scope_dict(node_to_children=True)
-        subset = gr.SubgraphView(parent, sdict[None])
+        schildren = subgraph.scope_children()
+        subset = gr.SubgraphView(parent, schildren[None])
         if nested:
             return set(node.data for node in subset.nodes()
                        if isinstance(node, nodes.AccessNode)

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -39,7 +39,7 @@ def nest_state_subgraph(sdfg: SDFG,
     # Find the top-level scope
     scope_tree = state.scope_tree()
     scope_dict = state.scope_dict()
-    scope_dict_children = state.scope_dict(True)
+    scope_dict_children = state.scope_children()
     top_scopenode = -1  # Initialized to -1 since "None" already means top-level
 
     for node in subgraph.nodes():

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -81,8 +81,8 @@ class GPUTransformSDFG(transformation.Transformation):
                 return False
 
         for state in sdfg.nodes():
-            sdict = state.scope_dict(node_to_children=True)
-            for node in sdict[None]:
+            schildren = state.scope_children()
+            for node in schildren[None]:
                 # If two top-level tasklets are connected with a code->code
                 # memlet, they will transform into an invalid SDFG
                 if (isinstance(node, nodes.CodeNode) and any(

--- a/dace/transformation/interstate/transient_reuse.py
+++ b/dace/transformation/interstate/transient_reuse.py
@@ -58,13 +58,13 @@ class TransientReuse(transformation.Transformation):
                     G.add_edge(e.src, e.dst)
 
             # Collapse all mappings and their scopes into one node
-            scope_dict = state.scope_dict(node_to_children=True)
-            for n in scope_dict[None]:
+            scope_children = state.scope_children()
+            for n in scope_children[None]:
                 if isinstance(n, nodes.EntryNode):
                     G.add_edges_from([
                         (n, x) for (y, x) in G.out_edges(state.exit_node(n))
                     ])
-                    G.remove_nodes_from(scope_dict[n])
+                    G.remove_nodes_from(scope_children[n])
 
             # Remove all nodes that are not AccessNodes or have incoming wcr edges
             # and connect their predecessors and successors

--- a/dace/transformation/subgraph/helpers.py
+++ b/dace/transformation/subgraph/helpers.py
@@ -12,10 +12,9 @@ from typing import List, Union, Dict, Tuple
 
 import dace.libraries.standard as stdlib
 
-
-
 # ****************
 # Helper functions
+
 
 def common_map_base_ranges(maps: List[nodes.Map]) -> List[subsets.Range]:
     """ Finds a maximal set of ranges that can be found
@@ -36,11 +35,11 @@ def common_map_base_ranges(maps: List[nodes.Map]) -> List[subsets.Range]:
 
         map_base = map_base_new
 
-
     return map_base
 
 
-def find_reassignment(maps: List[nodes.Map], map_base_ranges) -> Dict[nodes.Map, List]:
+def find_reassignment(maps: List[nodes.Map],
+                      map_base_ranges) -> Dict[nodes.Map, List]:
     """ Provided a list of maps and their common base ranges
         (found via common_map_base_ranges()),
         for each map greedily assign each loop to an index so that
@@ -77,11 +76,13 @@ def find_reassignment(maps: List[nodes.Map], map_base_ranges) -> Dict[nodes.Map,
 
     return result
 
+
 ########################################################################
 
-def toplevel_scope_subgraph(graph, subgraph, scope_dict = None):
+
+def toplevel_scope_subgraph(graph, subgraph, scope_dict=None):
     """
-    returns the toplevel scope of a subgraph
+    Returns the toplevel scope of a subgraph
     """
     if not scope_dict:
         scope_dict = graph.scope_dict()
@@ -97,12 +98,12 @@ def toplevel_scope_subgraph(graph, subgraph, scope_dict = None):
         if current_scope is None:
             return scope
 
-
     raise RuntimeError("Subgraph is not sound")
 
-def toplevel_scope_maps(graph, maps, scope_dict = None):
+
+def toplevel_scope_maps(graph, maps, scope_dict=None):
     """
-    returns the toplevel scope of a set of given maps
+    Returns the toplevel scope of a set of given maps
     """
     if not scope_dict:
         scope_dict = graph.scope_dict()
@@ -116,16 +117,17 @@ def toplevel_scope_maps(graph, maps, scope_dict = None):
         if current_scope is None:
             return scope
 
-    raise RuntimeError("Map structure is not sound (underlying subgraph must be connected)")
+    raise RuntimeError(
+        "Map structure is not sound (underlying subgraph must be connected)")
 
 
-def get_highest_scope_maps(sdfg, graph, subgraph = None):
+def get_highest_scope_maps(sdfg, graph, subgraph=None):
     """
-    returns the Map Entries of the highest scope maps
+    Returns the Map Entries of the highest scope maps
     that reside inside a given subgraph.
     If subgraph = None, the whole graph is taken
     """
-    subgraph = graph if not subgraph else subgraph
+    subgraph = graph if subgraph is None else subgraph
     scope_dict = graph.scope_dict()
 
     def is_lowest_scope(node):
@@ -136,7 +138,9 @@ def get_highest_scope_maps(sdfg, graph, subgraph = None):
 
         return True
 
-    maps = [node for node in subgraph.nodes() if isinstance(node, nodes.MapEntry)
-                                              and is_lowest_scope(node)]
+    maps = [
+        node for node in subgraph.nodes()
+        if isinstance(node, nodes.MapEntry) and is_lowest_scope(node)
+    ]
 
     return maps

--- a/dace/transformation/subgraph/reduce_expansion.py
+++ b/dace/transformation/subgraph/reduce_expansion.py
@@ -140,6 +140,7 @@ class ReduceExpansion(transformation.Transformation):
         nsdfg = self._expand_reduce(sdfg, graph, reduce_node)
 
         # find the new nodes in the nested sdfg created
+        # TODO SCOPE_DICT => SCOPE CHILDREN?
         nstate = nsdfg.sdfg.nodes()[0]
         for node, scope in nstate.scope_dict().items():
             if isinstance(node, nodes.MapEntry):
@@ -479,7 +480,7 @@ class ReduceExpansion(transformation.Transformation):
         node.add_out_connector('_out')
 
         if node.schedule != dtypes.ScheduleType.Default:
-            topnodes = nstate.scope_dict(node_to_children=True)[None]
+            topnodes = nstate.scope_children()[None]
             for topnode in topnodes:
                 if isinstance(topnode, (nodes.EntryNode, nodes.LibraryNode)):
                     topnode.schedule = node.schedule

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -337,7 +337,7 @@ class ExpandTransformation(Transformation):
             # Modify internal schedules according to node schedule
             if node.schedule != ScheduleType.Default:
                 for nstate in expansion.nodes():
-                    topnodes = nstate.scope_dict(node_to_children=True)[None]
+                    topnodes = nstate.scope_children()[None]
                     for topnode in topnodes:
                         if isinstance(topnode, (nd.EntryNode, nd.LibraryNode)):
                             topnode.schedule = node.schedule

--- a/tests/nest_subgraph_test.py
+++ b/tests/nest_subgraph_test.py
@@ -120,7 +120,7 @@ class NestStateSubgraph(unittest.TestCase):
 
         # Outer map scope
         sdfg, state = create_tiled_sdfg()
-        sdc = state.scope_dict(True)
+        sdc = state.scope_children()
         entry = next(n for n in sdc[None] if isinstance(n, MapEntry))
         nest_state_subgraph(sdfg, state, state.scope_subgraph(entry))
         sdfg.validate()

--- a/tests/persistent_map_cudatest.py
+++ b/tests/persistent_map_cudatest.py
@@ -35,10 +35,12 @@ def test_persistent_dynamic_map():
     sdfg.apply_gpu_transformations()
 
     for state in sdfg:
-        for scope in [n for n in state if isinstance(n, nodes.MapEntry)]:
-            if state.scope_dict()[scope] is None:
+        for scope in state.nodes():
+            if not isinstance(scope, nodes.EntryNode):
+                continue
+            if state.entry_node(scope) is None:
                 scope.map.schedule = ScheduleType.GPU_Persistent
-            elif state.scope_dict()[state.scope_dict()[scope]] is None:
+            elif state.entry_node(state.entry_node(scope)) is None:
                 scope.map.schedule = ScheduleType.GPU_Device
             else:
                 scope.map.schedule = ScheduleType.GPU_ThreadBlock_Dynamic
@@ -54,8 +56,10 @@ def test_persistent_default():
     sdfg.apply_gpu_transformations()
 
     for state in sdfg:
-        for scope in [n for n in state if isinstance(n, nodes.MapEntry)]:
-            if state.scope_dict()[scope] is None:
+        for scope in state.nodes():
+            if not isinstance(scope, nodes.EntryNode):
+                continue
+            if state.entry_node(scope) is None:
                 scope.map.schedule = ScheduleType.GPU_Persistent
             else:
                 scope.map.schedule = ScheduleType.Default

--- a/tests/persistent_tb_map_cudatest.py
+++ b/tests/persistent_tb_map_cudatest.py
@@ -27,8 +27,10 @@ def test_persistent_thread_block():
     sdfg.apply_transformations(StripMining, options={'tile_size': '256'})
 
     for state in sdfg:
-        for scope in [n for n in state if isinstance(n, nodes.MapEntry)]:
-            if state.scope_dict()[scope] is None:
+        for scope in state.nodes():
+            if not isinstance(scope, nodes.EntryNode):
+                continue
+            if state.entry_node(scope) is None:
                 scope.map.schedule = ScheduleType.GPU_Device
             else:
                 scope.map.schedule = ScheduleType.GPU_ThreadBlock


### PR DESCRIPTION
Replaces `scope_dict` (which had two functionalities) with `scope_dict` (parent scope node mapping) and `scope_children`.