### PR TITLE
Convert all keys (including symbols) to strings for proper conversion…

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -279,9 +279,11 @@ class SDFG(OrderedDiGraph):
         """
         tmp = super().to_json()
 
+        # Convert all keys to strings
+        constants_prop = {str(k): tmp['attributes']['constants_prop'][k] for k in tmp['attributes']['constants_prop']}
+
         # Ensure properties are serialized correctly
-        tmp['attributes']['constants_prop'] = json.loads(
-            dace.serialize.dumps(tmp['attributes']['constants_prop']))
+        tmp['attributes']['constants_prop'] = json.loads(dace.serialize.dumps(constants_prop))
 
         # Location in the SDFG list
         self.reset_sdfg_list()

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -279,11 +279,9 @@ class SDFG(OrderedDiGraph):
         """
         tmp = super().to_json()
 
-        # Convert all keys to strings
-        constants_prop = {str(k): tmp['attributes']['constants_prop'][k] for k in tmp['attributes']['constants_prop']}
-
         # Ensure properties are serialized correctly
-        tmp['attributes']['constants_prop'] = json.loads(dace.serialize.dumps(constants_prop))
+        tmp['attributes']['constants_prop'] = json.loads(
+            dace.serialize.dumps(tmp['attributes']['constants_prop']))
 
         # Location in the SDFG list
         self.reset_sdfg_list()
@@ -1481,7 +1479,7 @@ class SDFG(OrderedDiGraph):
 
         # Update constants
         for k, v in syms.items():
-            self.add_constant(k, v)
+            self.add_constant(str(k), v)
 
     def optimize(self, optimizer=None) -> 'SDFG':
         """ 


### PR DESCRIPTION
While using `N = dace.symbol('N')` within the RTL codegen, i came accross the following json exception:

```
  File "/home/andreas/anaconda3/lib/python3.7/json/encoder.py", line 376, in _iterencode_dict
    raise TypeError(f'keys must be str, int, float, bool or None, '
TypeError: keys must be str, int, float, bool or None, not symbol
```
Since this happens within the json library, we have to ensure that the keys in the dictionary are already in a supported format. My suggestion is to convert all of them to strings before passing them to the `json.dumps()` method.
