### PR TITLE
Scalar-to-Symbol Promotion

### DIFF
--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -734,6 +734,11 @@ DACE_EXPORTED void __dace_exit_%s(%s)
         interstate_symbols = {}
         for e in sdfg.edges():
             symbols = e.data.new_symbols(global_symbols)
+            # Inferred symbols only take precedence if not None
+            symbols = {
+                k: v if v is not None else global_symbols[k]
+                for k, v in symbols.items()
+            }
             interstate_symbols.update(symbols)
             global_symbols.update(symbols)
 

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -862,6 +862,13 @@ DACE_EXPORTED void __dace_exit_%s(%s)
                 if any([len(set(c) - internal_nodes) > 1 for c in cycles]):
                     continue
 
+                # Filter out loops with conditions and assignments that would
+                # generate code within the loop
+                if (entry_edge.data.assignments or exit_edge.data.assignments
+                        or not back_edge.data.is_unconditional()
+                        or not previous_edge.data.is_unconditional()):
+                    continue
+
                 # This is a loop! Generate the necessary annotation objects.
                 loop_scope = cflow.LoopScope(internal_nodes)
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -79,8 +79,9 @@ class AddTransientMethods(object):
 
 
 @dtypes.paramdec
-def specifies_datatype(func: Callable[[Any, data.Data, Any],
-                       Tuple[str, data.Data]], datatype=None):
+def specifies_datatype(func: Callable[[Any, data.Data, Any], Tuple[str,
+                                                                   data.Data]],
+                       datatype=None):
     AddTransientMethods._methods[datatype] = func
     return func
 
@@ -109,7 +110,9 @@ def _method(sdfg: SDFG, sample_data: data.Stream, dtype):
     return name, new_data
 
 
-def _add_transient_data(sdfg: SDFG, sample_data: data.Data, dtype: dtypes.typeclass = None):
+def _add_transient_data(sdfg: SDFG,
+                        sample_data: data.Data,
+                        dtype: dtypes.typeclass = None):
     """ Adds to the sdfg transient data of the same dtype, shape and other
         parameters as sample_data. """
     func = AddTransientMethods.get(type(sample_data))
@@ -121,8 +124,13 @@ def _add_transient_data(sdfg: SDFG, sample_data: data.Data, dtype: dtypes.typecl
         return func(sdfg, sample_data, dtype)
 
 
-def parse_dace_program(f, argtypes, global_vars, modules, other_sdfgs,
-                       constants, strict=None):
+def parse_dace_program(f,
+                       argtypes,
+                       global_vars,
+                       modules,
+                       other_sdfgs,
+                       constants,
+                       strict=None):
     """ Parses a `@dace.program` function into a _ProgramNode object.
         :param f: A Python function to parse.
         :param argtypes: An dictionary of (name, type) for the given
@@ -397,12 +405,12 @@ def add_indirection_subgraph(sdfg: SDFG,
                 arr_rng = dace.subsets.Range([(a, a, 1) for a in access])
                 if output:
                     arrname, rng = pvisitor._add_write_access(arr_name,
-                                                            arr_rng,
-                                                            target=None)
+                                                              arr_rng,
+                                                              target=None)
                 else:
                     arrname, rng = pvisitor._add_read_access(arr_name,
-                                                           arr_rng,
-                                                           target=None)
+                                                             arr_rng,
+                                                             target=None)
                 conn = 'index_%s_%d' % (arr_name, i)
                 arr = sdfg.arrays[arrname]
                 subset = subsets.Range.from_array(arr)
@@ -736,8 +744,8 @@ class TaskletTransformer(ExtNodeTransformer):
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)
                 for s, r in self.symbols.items():
-                    tmp_memlet = propagate_subset(
-                        [tmp_memlet], parent_array, [s], r)
+                    tmp_memlet = propagate_subset([tmp_memlet], parent_array,
+                                                  [s], r)
 
             squeezed_rng = copy.deepcopy(rng)
             non_squeezed = squeezed_rng.squeeze(ignore_indices)
@@ -750,10 +758,9 @@ class TaskletTransformer(ExtNodeTransformer):
                 shape[sqz_idx] = ts * sympy.ceiling(
                     ((iMax.approx
                       if isinstance(iMax, symbolic.SymExpr) else iMax) + 1 -
-                     (iMin.approx
-                      if isinstance(iMin, symbolic.SymExpr) else iMin)) / 
-                    (step.approx
-                     if isinstance(step, symbolic.SymExpr) else step))
+                     (iMin.approx if isinstance(iMin, symbolic.SymExpr) else
+                      iMin)) / (step.approx if isinstance(
+                          step, symbolic.SymExpr) else step))
             # squeezed_rng = copy.deepcopy(rng)
             # non_squeezed = squeezed_rng.squeeze()
             # shape = squeezed_rng.size()
@@ -917,10 +924,10 @@ class TaskletTransformer(ExtNodeTransformer):
                     if squeezed_rng is not None:
                         # TODO: Fix for `contains_sympy_functions`
                         # not liking ints
-                        memlet.subset = subsets.Range([(
-                            symbolic.pystr_to_symbolic(b),
-                            symbolic.pystr_to_symbolic(e),
-                            symbolic.pystr_to_symbolic(s))
+                        memlet.subset = subsets.Range([
+                            (symbolic.pystr_to_symbolic(b),
+                             symbolic.pystr_to_symbolic(e),
+                             symbolic.pystr_to_symbolic(s))
                             for b, e, s in squeezed_rng.ranges
                         ])
                     if self.nested and _subset_has_indirection(rng):
@@ -953,10 +960,10 @@ class TaskletTransformer(ExtNodeTransformer):
                     if squeezed_rng is not None:
                         # TODO: Fix for `contains_sympy_functions`
                         # not liking ints
-                        memlet.subset = subsets.Range([(
-                            symbolic.pystr_to_symbolic(b),
-                            symbolic.pystr_to_symbolic(e),
-                            symbolic.pystr_to_symbolic(s))
+                        memlet.subset = subsets.Range([
+                            (symbolic.pystr_to_symbolic(b),
+                             symbolic.pystr_to_symbolic(e),
+                             symbolic.pystr_to_symbolic(s))
                             for b, e, s in squeezed_rng.ranges
                         ])
                     if self.nested and _subset_has_indirection(rng):
@@ -1741,8 +1748,8 @@ class ProgramVisitor(ExtNodeVisitor):
             for conn, memlet in map_inputs.items():
                 if self.nested:
                     # TODO: Make this work nested for-loops
-                    new_name, _ = self._add_read_access(memlet.data, memlet.subset,
-                                                        None)
+                    new_name, _ = self._add_read_access(memlet.data,
+                                                        memlet.subset, None)
                     memlet = Memlet.from_array(new_name,
                                                self.sdfg.arrays[new_name])
                 else:
@@ -2076,7 +2083,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     infer_expr_type(ranges[0][0], self.sdfg.symbols),
                     infer_expr_type(ranges[0][1], self.sdfg.symbols),
                     infer_expr_type(ranges[0][2], self.sdfg.symbols)))
-            
+
             # TODO: What if two consecutive loops use the same symbol?
             if sym_name in self.symbols.keys():
                 warnings.warn("Two for-loops using the same symbol ({}) in the "
@@ -2084,8 +2091,8 @@ class ProgramVisitor(ExtNodeVisitor):
                               "supported (yet).".format(sym_name))
 
             extra_syms = {sym_name: sym_obj}
-            self.symbols[sym_name] = subsets.Range(
-                [(b, "({}) - 1".format(e), s) for b, e, s in ranges])
+            self.symbols[sym_name] = subsets.Range([(b, "({}) - 1".format(e), s)
+                                                    for b, e, s in ranges])
 
             # Add range symbols as necessary
             for rng in ranges[0]:
@@ -2180,7 +2187,7 @@ class ProgramVisitor(ExtNodeVisitor):
                               " of loops of outer scopes)")
             raise DaceSyntaxError(self, node, error_msg)
         self.break_states[self.loop_idx].append(self.last_state)
-    
+
     def visit_Continue(self, node: ast.Continue):
         if self.loop_idx < 0:
             error_msg = ("'continue' is only supported inside for and while "
@@ -2195,8 +2202,8 @@ class ProgramVisitor(ExtNodeVisitor):
     def visit_If(self, node: ast.If):
         # Add a guard state
         self._add_state('if_guard')
-        if (isinstance(node.test, ast.Compare) and
-                isinstance(node.test.left, ast.Subscript)):
+        if (isinstance(node.test, ast.Compare)
+                and isinstance(node.test.left, ast.Subscript)):
             cond = self.visit(node.test)
             if cond in self.sdfg.arrays:
                 cond_dt = self.sdfg.arrays[cond]
@@ -2309,20 +2316,21 @@ class ProgramVisitor(ExtNodeVisitor):
                     memlet.wcr = LambdaProperty.from_string(
                         'lambda x, y: x {} y'.format(op))
                 if op_name:
-                    inp_memlet = {'__inp': Memlet.simple(
-                        op_name, '%s' % op_subset)}
+                    inp_memlet = {
+                        '__inp': Memlet.simple(op_name, '%s' % op_subset)
+                    }
                     tasklet_code = '__out = __inp'
                 else:
                     inp_memlet = dict()
                     tasklet_code = '__out = {}'.format(operand)
-                state.add_mapped_tasklet(
-                    state.label, {
-                        '__i%d' % i: '%s:%s+1:%s' % (start, end, step)
-                        for i, (start, end, step) in enumerate(target_subset)
-                    },
-                    inp_memlet, tasklet_code, {'__out': memlet},
-                    external_edges=True,
-                    debuginfo=self.current_lineinfo)
+                state.add_mapped_tasklet(state.label, {
+                    '__i%d' % i: '%s:%s+1:%s' % (start, end, step)
+                    for i, (start, end, step) in enumerate(target_subset)
+                },
+                                         inp_memlet,
+                                         tasklet_code, {'__out': memlet},
+                                         external_edges=True,
+                                         debuginfo=self.current_lineinfo)
         else:
             if op_subset.num_elements() != 1:
                 raise DaceSyntaxError(
@@ -2457,13 +2465,14 @@ class ProgramVisitor(ExtNodeVisitor):
                 out_memlet = Memlet.simple(
                     wtarget_name,
                     ','.join(['__i%d' % i for i in range(len(wtarget_subset))]))
-                state.add_mapped_tasklet(
-                    state.label, {
-                        '__i%d' % i: '%s:%s+1:%s' % (start, end, step)
-                        for i, (start, end, step) in enumerate(wtarget_subset)
-                    }, inp_memlets, tasklet_code, {'__out': out_memlet},
-                    external_edges=True,
-                    debuginfo=self.current_lineinfo)
+                state.add_mapped_tasklet(state.label, {
+                    '__i%d' % i: '%s:%s+1:%s' % (start, end, step)
+                    for i, (start, end, step) in enumerate(wtarget_subset)
+                },
+                                         inp_memlets,
+                                         tasklet_code, {'__out': out_memlet},
+                                         external_edges=True,
+                                         debuginfo=self.current_lineinfo)
         else:
             if op_subset.num_elements() != 1:
                 raise DaceSyntaxError(
@@ -2483,12 +2492,11 @@ class ProgramVisitor(ExtNodeVisitor):
                                                                    n=operand)
                 op3 = state.add_write(wtarget_name,
                                       debuginfo=self.current_lineinfo)
-                tasklet = state.add_tasklet(
-                    name=state.label,
-                    inputs=inp_conns,
-                    outputs={'__out'},
-                    code=tasklet_code,
-                    debuginfo=self.current_lineinfo)
+                tasklet = state.add_tasklet(name=state.label,
+                                            inputs=inp_conns,
+                                            outputs={'__out'},
+                                            code=tasklet_code,
+                                            debuginfo=self.current_lineinfo)
                 in1_memlet = Memlet.simple(rtarget_name, '%s' % rtarget_subset)
                 if op_name:
                     in2_memlet = Memlet.simple(op_name, '%s' % op_subset)
@@ -2538,8 +2546,8 @@ class ProgramVisitor(ExtNodeVisitor):
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)
                 for s, r in self.symbols.items():
-                    tmp_memlet = propagate_subset(
-                        [tmp_memlet], parent_array, [s], r)
+                    tmp_memlet = propagate_subset([tmp_memlet], parent_array,
+                                                  [s], r)
 
             squeezed_rng = copy.deepcopy(rng)
             non_squeezed = squeezed_rng.squeeze(ignore_indices)
@@ -2551,10 +2559,10 @@ class ProgramVisitor(ExtNodeVisitor):
                 sqz_idx = squeezed_rng.ranges.index(rng.ranges[i])
                 shape[sqz_idx] = ts * sympy.ceiling(
                     ((iMax.approx
-                    if isinstance(iMax, symbolic.SymExpr) else iMax) + 1 -
-                    (iMin.approx
-                    if isinstance(iMin, symbolic.SymExpr) else iMin)) / 
-                    (step.approx if isinstance(step, symbolic.SymExpr) else step))
+                      if isinstance(iMax, symbolic.SymExpr) else iMax) + 1 -
+                     (iMin.approx if isinstance(iMin, symbolic.SymExpr) else
+                      iMin)) / (step.approx if isinstance(
+                          step, symbolic.SymExpr) else step))
         dtype = parent_array.dtype
 
         if arr_type is None:
@@ -2582,15 +2590,15 @@ class ProgramVisitor(ExtNodeVisitor):
                 self.inputs[var_name] = (dace.Memlet.from_array(
                     parent_name, parent_array), inner_indices)
             else:
-                self.inputs[var_name] = (dace.Memlet.simple(
-                    parent_name, rng), inner_indices)
+                self.inputs[var_name] = (dace.Memlet.simple(parent_name,
+                                                            rng), inner_indices)
         else:
             if _subset_has_indirection(rng, self):
                 self.outputs[var_name] = (dace.Memlet.from_array(
                     parent_name, parent_array), inner_indices)
             else:
-                self.outputs[var_name] = (dace.Memlet.simple(
-                    parent_name, rng), inner_indices)
+                self.outputs[var_name] = (dace.Memlet.simple(parent_name, rng),
+                                          inner_indices)
 
         return (var_name, squeezed_rng)
 
@@ -2637,13 +2645,13 @@ class ProgramVisitor(ExtNodeVisitor):
             return self._add_access(name, rng, 'w', target, new_name, arr_type)
         else:
             raise NotImplementedError
-    
+
     def visit_NamedExpr(self, node):  # node : ast.NamedExpr
         self._visit_assign(node, node.target, None)
 
     def visit_Assign(self, node: ast.Assign):
         self._visit_assign(node, node.targets[0], None)
-    
+
     def visit_AnnAssign(self, node: ast.AnnAssign):
         type_name = rname(node.annotation)
         try:
@@ -2701,13 +2709,12 @@ class ProgramVisitor(ExtNodeVisitor):
 
             new_data = None
             dtype_keys = tuple(dtypes.DTYPE_TO_TYPECLASS.keys())
-            if not (symbolic.issymbolic(result)
-                    or isinstance(result, dtype_keys)
-                    or result in self.sdfg.arrays):
+            if not (symbolic.issymbolic(result) or isinstance(
+                    result, dtype_keys) or result in self.sdfg.arrays):
                 raise DaceSyntaxError(
                     self, result, "In assignments, the rhs may only be "
-                                  "data, numerical/boolean constants "
-                                  "and symbols")
+                    "data, numerical/boolean constants "
+                    "and symbols")
             if not true_name:
                 if (symbolic.issymbolic(result)
                         or isinstance(result, dtype_keys)):
@@ -2724,8 +2731,9 @@ class ProgramVisitor(ExtNodeVisitor):
                             ttype = dtype
                         else:
                             ttype = rtype
-                        _, new_data = self.sdfg.add_scalar(
-                            true_name, ttype, transient=True)
+                        _, new_data = self.sdfg.add_scalar(true_name,
+                                                           ttype,
+                                                           transient=True)
                     self.variables[name] = true_name
                     defined_vars[name] = true_name
                 elif result in self.sdfg.arrays:
@@ -2781,19 +2789,18 @@ class ProgramVisitor(ExtNodeVisitor):
             # Handle augassign output indirection
             if op:
                 if _subset_has_indirection(rng, self):
-                    self._add_state('rslice_%s_%d' %
-                                    (new_name, node.lineno))
+                    self._add_state('rslice_%s_%d' % (new_name, node.lineno))
                     rnode = self.last_state.add_read(
                         new_name, debuginfo=self.current_lineinfo)
                     memlet = Memlet.simple(new_name, str(rng))
                     tmp = self.sdfg.temp_data_name()
-                    ind_name = add_indirection_subgraph(
-                        self.sdfg, self.last_state, rnode, None, memlet,
-                        tmp, self)
+                    ind_name = add_indirection_subgraph(self.sdfg,
+                                                        self.last_state, rnode,
+                                                        None, memlet, tmp, self)
                     rtarget = ind_name
                 else:
                     rtarget = (new_name, new_rng)
-            
+
             # Generate subgraph for assignment
             if op:
                 self._add_aug_assignment(node, rtarget, wtarget, result, op)
@@ -2803,7 +2810,7 @@ class ProgramVisitor(ExtNodeVisitor):
             # Connect states properly when there is output indirection
             if output_indirection:
                 self.sdfg.add_edge(self.last_state, output_indirection,
-                                    dace.sdfg.InterstateEdge())
+                                   dace.sdfg.InterstateEdge())
                 self.last_state = output_indirection
 
     def visit_AugAssign(self, node: ast.AugAssign):
@@ -3309,15 +3316,17 @@ class ProgramVisitor(ExtNodeVisitor):
             if isinstance(self.sdfg.arrays[dst_name], data.Stream):
                 dst_rng = dst_rng or subsets.Range.from_array(
                     self.sdfg.arrays[dst_name])
-                mem = Memlet.simple(
-                    dst_name, dst_rng,
-                    num_accesses=dst_expr.accesses, wcr_str = dst_expr.wcr)
+                mem = Memlet.simple(dst_name,
+                                    dst_rng,
+                                    num_accesses=dst_expr.accesses,
+                                    wcr_str=dst_expr.wcr)
             else:
                 src_rng = src_rng or subsets.Range.from_array(
                     self.sdfg.arrays[src_name])
-                mem = Memlet.simple(
-                    src_name, src_rng,
-                    num_accesses=src_expr.accesses, wcr_str = dst_expr.wcr)
+                mem = Memlet.simple(src_name,
+                                    src_rng,
+                                    num_accesses=src_expr.accesses,
+                                    wcr_str=dst_expr.wcr)
             state.add_nedge(rnode, wnode, mem)
             return
 
@@ -3329,7 +3338,7 @@ class ProgramVisitor(ExtNodeVisitor):
             return
 
         elif (sys.version_info.major == 3 and sys.version_info.minor >= 8
-                and isinstance(node.value, ast.NamedExpr)):
+              and isinstance(node.value, ast.NamedExpr)):
             self.visit_NamedExpr(node.value)
             return
 
@@ -3424,7 +3433,7 @@ class ProgramVisitor(ExtNodeVisitor):
     def visit_Name(self, node: ast.Name):
         # If visiting a name, check if it is a defined variable or a global
         return self._visitname(node.id, node)
-    
+
     def visit_NameConstant(self, node: ast.NameConstant):
         return self.visit_Constant(node)
 
@@ -3636,7 +3645,7 @@ class ProgramVisitor(ExtNodeVisitor):
                               wcr_str=expr.wcr,
                               other_subset_str=other_subset))
             return tmp
-    
+
     def make_slice(self, arrname: str, rng: subsets.Range):
 
         array = arrname
@@ -3652,18 +3661,19 @@ class ProgramVisitor(ExtNodeVisitor):
             memlet = Memlet.simple(array, rng)
             tmp = self.sdfg.temp_data_name()
             tmp = add_indirection_subgraph(self.sdfg, self.last_state, rnode,
-                                            None, memlet, tmp, self)
+                                           None, memlet, tmp, self)
         else:
             tmp, tmparr = self.sdfg.add_temp_transient(other_subset.size(),
-                                                        arrobj.dtype,
-                                                        arrobj.storage)
+                                                       arrobj.dtype,
+                                                       arrobj.storage)
             wnode = self.last_state.add_write(tmp,
-                                                debuginfo=self.current_lineinfo)
+                                              debuginfo=self.current_lineinfo)
             self.last_state.add_nedge(
                 rnode, wnode,
-                Memlet.simple(array, rng,
-                                num_accesses=rng.num_elements(),
-                                other_subset_str=other_subset))
+                Memlet.simple(array,
+                              rng,
+                              num_accesses=rng.num_elements(),
+                              other_subset_str=other_subset))
         return tmp, other_subset
 
     ##################################

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -103,6 +103,7 @@ def parse_from_function(function, *compilation_args, strict=None):
     """
     # Avoid import loop
     from dace.sdfg.analysis import scalar_to_symbol as scal2sym
+    from dace.transformation import helpers as xfh
 
     if not isinstance(function, DaceProgram):
         raise TypeError(
@@ -123,6 +124,10 @@ def parse_from_function(function, *compilation_args, strict=None):
                   ', '.join(p for p in sorted(promoted)))
 
         sdfg.apply_strict_transformations()
+
+        # Split back edges with assignments and conditions to allow richer
+        # control flow detection in code generation
+        xfh.split_interstate_edges(sdfg)
 
     # Save the SDFG (again)
     sdfg.save(os.path.join('_dacegraphs', 'program.sdfg'))

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -959,7 +959,7 @@ class CodeBlock(object):
         return set()
 
     @property
-    def as_string(self):
+    def as_string(self) -> str:
         if isinstance(self.code, str) or self.code is None:
             return self.code
         return unparse(self.code)

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -522,7 +522,8 @@ def promote_scalars_to_symbols(sdfg: sd.SDFG) -> Set[str]:
                 # Replace tasklet inputs with incoming edges
                 for e in new_state.in_edges(input):
                     memlet_str: str = e.data.data
-                    if e.data.subset is not None:
+                    if (e.data.subset is not None and not isinstance(
+                            sdfg.arrays[memlet_str], dt.Scalar)):
                         memlet_str += '[%s]' % e.data.subset
                     newcode = re.sub(r'\b%s\b' % re.escape(e.dst_conn),
                                      memlet_str, newcode)
@@ -530,7 +531,8 @@ def promote_scalars_to_symbols(sdfg: sd.SDFG) -> Set[str]:
                 new_isedge.data.assignments[node.data] = newcode
             elif isinstance(input, nodes.AccessNode):
                 memlet: mm.Memlet = in_edge.data
-                if memlet.src_subset:
+                if (memlet.src_subset and
+                        not isinstance(sdfg.arrays[memlet.data], dt.Scalar)):
                     new_isedge.data.assignments[
                         node.data] = '%s[%s]' % (input.data, memlet.src_subset)
                 else:

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -85,10 +85,10 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
                     continue
                 # If inputs to tasklets are not arrays, skip
                 for tinput in state.in_edges(edge.src):
-                    if not isinstance(tinput, nodes.AccessNode):
+                    if not isinstance(tinput.src, nodes.AccessNode):
                         candidates.remove(candidate)
                         break
-                    if isinstance(sdfg.arrays[tinput.data], dt.Stream):
+                    if isinstance(sdfg.arrays[tinput.src.data], dt.Stream):
                         candidates.remove(candidate)
                         break
                 else:

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -456,7 +456,7 @@ def remove_scalar_reads(sdfg: sd.SDFG, array_names: Dict[str, str]):
             [n for n in scalar_nodes if len(state.all_edges(n)) == 0])
 
 
-def promote_scalars_to_symbols(sdfg: sd.SDFG):
+def promote_scalars_to_symbols(sdfg: sd.SDFG) -> Set[str]:
     """
     Promotes all matching transient scalars to SDFG symbols, changing all
     tasklets to inter-state assignments. This enables the transformed symbols
@@ -465,6 +465,7 @@ def promote_scalars_to_symbols(sdfg: sd.SDFG):
     optimization.
 
     :param sdfg: The SDFG to run the pass on.
+    :return: Set of promoted scalars.
     :note: Operates in-place.
     """
     # Process:
@@ -483,7 +484,7 @@ def promote_scalars_to_symbols(sdfg: sd.SDFG):
 
     to_promote = find_promotable_scalars(sdfg)
     if len(to_promote) == 0:
-        return
+        return to_promote
 
     for state in sdfg.nodes():
         scalar_nodes = [
@@ -576,3 +577,5 @@ def promote_scalars_to_symbols(sdfg: sd.SDFG):
 
     # Step 7: Indirection
     remove_symbol_indirection(sdfg)
+
+    return to_promote

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -1,0 +1,129 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
+""" Scalar to symbol promotion functionality. """
+
+import ast
+from dace import dtypes, nodes, sdfg as sd, data as dt, properties as props
+import re
+from typing import Dict, Set
+
+
+def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
+    """
+    Finds scalars that can be promoted to symbols in the given SDFG.
+    Conditions for matching a scalar for symbol-promotion are as follows:
+        * Size of data must be 1, it must not be a stream and must be transient.
+        * Only inputs to candidate scalars must be either arrays or tasklets.
+        * All tasklets that lead to it must have one statement, one output, 
+          and may have zero or more **array** inputs and not be in a scope.
+        * Scalar must not be accessed with a write-conflict resolution.
+        * Scalar must not be written to more than once in a state.
+
+    These conditions must apply on all occurences of the scalar in order for
+    it to be promotable.
+
+    :param sdfg: The SDFG to query.
+    :return: A set of promotable scalar names.
+    """
+    # Keep set of active candidates
+    candidates: Set[str] = set()
+
+    # General array checks
+    for aname, desc in sdfg.arrays.items():
+        if not desc.transient or isinstance(desc, dt.Stream):
+            continue
+        if desc.total_size != 1:
+            continue
+        candidates.add(aname)
+
+    # Check all occurrences of candidates in SDFG and filter out
+    for state in sdfg.nodes():
+        candidates_in_state: Set[str] = set()
+
+        for node in state.nodes():
+            if not isinstance(node, nodes.AccessNode):
+                continue
+            candidate = node.data
+            if candidate not in candidates:
+                continue
+
+            # If candidate is read-only, continue normally
+            if state.in_degree(node) == 0:
+                continue
+
+            # Candidate may only be accessed in a top-level scope
+            if state.entry_node(node) is not None:
+                candidates.remove(candidate)
+                continue
+
+            # Candidate may only be written to once within a state
+            if candidate in candidates_in_state:
+                if state.in_degree(node) == 1:
+                    candidates.remove(candidate)
+                    continue
+            candidates_in_state.add(candidate)
+
+            # If input is not a single array nor tasklet, skip
+            if state.in_degree(node) > 1:
+                candidates.remove(candidate)
+                continue
+            edge = state.in_edges(node)[0]
+
+            # Edge must not be WCR
+            if edge.data.wcr is not None:
+                candidates.remove(candidate)
+                continue
+
+            # Check inputs
+            if isinstance(edge.src, nodes.AccessNode):
+                # If input is array, ensure it is not a stream
+                if isinstance(sdfg.arrays[edge.src.data], dt.Stream):
+                    candidates.remove(candidate)
+            elif isinstance(edge.src, nodes.Tasklet):
+                # If input tasklet has more than one output, skip
+                if state.out_degree(edge.src) > 1:
+                    candidates.remove(candidate)
+                    continue
+                # If inputs to tasklets are not arrays, skip
+                for tinput in state.in_edges(edge.src):
+                    if not isinstance(tinput, nodes.AccessNode):
+                        candidates.remove(candidate)
+                        break
+                    if isinstance(sdfg.arrays[tinput.data], dt.Stream):
+                        candidates.remove(candidate)
+                        break
+                else:
+                    # Check that tasklets have only one statement
+                    cb: props.CodeBlock = edge.src.code
+                    if cb.language is dtypes.Language.Python:
+                        if (len(cb.code) > 1
+                                or not isinstance(cb.code[0], ast.Assign)):
+                            candidates.remove(candidate)
+                            break
+                    elif cb.language is dtypes.Language.CPP:
+                        # Try to match a single C assignment
+                        cstr = cb.as_string.strip()
+                        if re.match(r'^[a-zA-Z_][a-zA-Z_0-9]* = .*;$',
+                                    cstr) is None:
+                            candidates.remove(candidate)
+                            break
+                    else:  # Other languages are currently unsupported
+                        candidates.remove(candidate)
+                        break
+            else:  # If input is not an acceptable node type, skip
+                candidates.remove(candidate)
+
+    return candidates
+
+
+def promote_scalars_to_symbols(sdfg: sd.SDFG):
+    """
+    Promotes all matching transient scalars to SDFG symbols, changing all
+    tasklets to inter-state assignments. This enables the transformed symbols
+    to be used within states as part of memlets, and allows further
+    transformations (such as loop detection) to use the information for
+    optimization.
+
+    :param sdfg: The SDFG to run the pass on.
+    :note: Operates in-place.
+    """
+    to_promote = find_promotable_scalars(sdfg)

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -2,9 +2,15 @@
 """ Scalar to symbol promotion functionality. """
 
 import ast
-from dace import dtypes, nodes, sdfg as sd, data as dt, properties as props
+from dace.sdfg.sdfg import InterstateEdge
+from dace.frontend.python.astutils import ASTFindReplace
+from dace import (dtypes, nodes, sdfg as sd, data as dt, properties as props,
+                  memlet as mm)
+from dace.sdfg import graph as gr
+from dace.frontend.python import astutils
+from dace.transformation import helpers as xfh
 import re
-from typing import Dict, Set
+from typing import Any, Dict, Set
 
 
 def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
@@ -79,6 +85,11 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
                 # If input is array, ensure it is not a stream
                 if isinstance(sdfg.arrays[edge.src.data], dt.Stream):
                     candidates.remove(candidate)
+                    continue
+                # Ensure no inputs exist to the array
+                if state.in_degree(edge.src) > 0:
+                    candidates.remove(candidate)
+                    continue
             elif isinstance(edge.src, nodes.Tasklet):
                 # If input tasklet has more than one output, skip
                 if state.out_degree(edge.src) > 1:
@@ -99,17 +110,24 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
                         if (len(cb.code) > 1
                                 or not isinstance(cb.code[0], ast.Assign)):
                             candidates.remove(candidate)
-                            break
+                            continue
+                        # Ensure the candidate is assigned to
+                        if (len(cb.code[0].targets) != 1 or astutils.rname(
+                                cb.code[0].targets[0]) != edge.src_conn):
+                            candidates.remove(candidate)
+                            continue
                     elif cb.language is dtypes.Language.CPP:
                         # Try to match a single C assignment
                         cstr = cb.as_string.strip()
-                        if re.match(r'^[a-zA-Z_][a-zA-Z_0-9]* = .*;$',
+                        # Since we cannot remove subscripts from C++ tasklets,
+                        # if the type of the data is an array we will also skip
+                        if re.match(r'^[a-zA-Z_][a-zA-Z_0-9]*\s*=.*;$',
                                     cstr) is None:
                             candidates.remove(candidate)
-                            break
+                            continue
                     else:  # Other languages are currently unsupported
                         candidates.remove(candidate)
-                        break
+                        continue
             else:  # If input is not an acceptable node type, skip
                 candidates.remove(candidate)
         candidates_seen |= candidates_in_state
@@ -118,6 +136,36 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
     candidates &= candidates_seen
 
     return candidates
+
+
+class TaskletPromoter(ast.NodeTransformer):
+    """
+    Promotes scalars to symbols in Tasklets.
+    If connector name is used in tasklet as subscript, modifies to symbol name.
+    If connector is used as a standard name, modify tasklet code to use symbol.
+    """
+    def __init__(self, connector: str, symbol: str) -> None:
+        """
+        Initializes AST transformer.
+        :param connector: Connector name (replacement source).
+        :param symbol: Symbol name (replacement target).
+        """
+        self.conn = connector
+        self.symbol = symbol
+
+    def visit_Name(self, node: ast.Name) -> Any:
+        # Convert connector to symbol
+        if node.id == self.conn:
+            node.id = self.symbol
+        return self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> Any:
+        # Convert subscript to symbol name
+        node_name = astutils.rname(node)
+        if node_name == self.conn:
+            return ast.copy_location(ast.Name(id=self.symbol, ctx=ast.Load()),
+                                     node)
+        return self.generic_visit(node)
 
 
 def promote_scalars_to_symbols(sdfg: sd.SDFG):
@@ -131,4 +179,141 @@ def promote_scalars_to_symbols(sdfg: sd.SDFG):
     :param sdfg: The SDFG to run the pass on.
     :note: Operates in-place.
     """
+    # Process:
+    # 1. Find scalars to promote
+    # 2. For every assignment tasklet/access:
+    #    2.1. Fission state to isolate assignment
+    #    2.2. Replace assignment with inter-state edge assignment
+    # 3. For every read of the scalar:
+    #    3.1. If destination is tasklet, remove node, edges, and connectors
+    #    3.2. If used in tasklet as subscript or connector, modify tasklet code
+    #    3.3. If destination is array, change to tasklet that copies symbol data
+    # 4. Remove newly-isolated access nodes
+    # 5. Remove data descriptors and add symbols to SDFG
+    # 6. Replace subscripts in all interstate conditions and assignments
+    # 7. Make indirections with symbols a single memlet
+
     to_promote = find_promotable_scalars(sdfg)
+
+    for state in sdfg.nodes():
+        scalar_nodes = [
+            n for n in state.nodes()
+            if isinstance(n, nodes.AccessNode) and n.data in to_promote
+        ]
+        # Step 2: Assignment tasklets
+        for node in scalar_nodes:
+            # There is only zero or one incoming edges by definition
+            if state.in_degree(node) == 0:
+                continue
+            in_edge = state.in_edges(node)[0]
+            input = in_edge.src
+            tasklet_inputs = [e.src for e in state.in_edges(input)]
+            # Step 2.1
+            new_state = xfh.state_fission(
+                sdfg, gr.SubgraphView(state, [input, node] + tasklet_inputs))
+            new_isedge: sd.InterstateEdge = sdfg.out_edges(new_state)[0]
+            # Step 2.2
+            node: nodes.AccessNode = new_state.sink_nodes()[0]
+            input = new_state.in_edges(node)[0].src
+            if isinstance(input, nodes.Tasklet):
+                # Convert tasklet to interstate edge
+                newcode: str = ''
+                if input.language is dtypes.Language.Python:
+                    newcode = astutils.unparse(input.code.code[0].value)
+                elif input.language is dtypes.Language.CPP:
+                    newcode = re.findall(r'.*=\s*(.*);',
+                                         input.code.as_string.strip())[0]
+                # Replace tasklet inputs with incoming edges
+                for e in new_state.in_edges(input):
+                    memlet_str: str = e.data.data
+                    if e.data.subset is not None:
+                        memlet_str += '[%s]' % e.data.subset
+                    newcode = re.sub(r'\b%s\b' % re.escape(e.dst_conn),
+                                     memlet_str, newcode)
+                # Add interstate edge assignment
+                new_isedge.data.assignments[node.data] = newcode
+            elif isinstance(input, nodes.AccessNode):
+                memlet: mm.Memlet = in_edge.data
+                if memlet.src_subset:
+                    new_isedge.data.assignments[
+                        node.data] = '%s[%s]' % (input.data, memlet.src_subset)
+                else:
+                    new_isedge.data.assignments[node.data] = input.data
+
+            # Clean up all nodes after assignment was transferred
+            new_state.remove_nodes_from(new_state.nodes())
+
+        scalar_nodes = [
+            n for n in state.nodes()
+            if isinstance(n, nodes.AccessNode) and n.data in to_promote
+        ]
+
+        # Step 3: Scalar reads
+        for node in scalar_nodes:
+            for out_edge in state.out_edges(node):
+                for e in state.memlet_tree(out_edge):
+                    # Step 3.1
+                    dst = e.dst
+                    state.remove_edge_and_connectors(e)
+                    if isinstance(dst, nodes.Tasklet):
+                        # Step 3.2
+                        if dst.language is dtypes.Language.Python:
+                            promo = TaskletPromoter(e.dst_conn, node.data)
+                            for stmt in dst.code.code:
+                                promo.visit(stmt)
+                        elif dst.language is dtypes.Language.CPP:
+                            # Replace whole-word matches (identifiers) in code
+                            dst.code = re.sub(r'\b%s\b' % re.escape(e.dst_conn),
+                                              node.data, dst.code.as_string)
+                    elif isinstance(dst, nodes.AccessNode):
+                        # Step 3.3
+                        t = state.add_tasklet('symassign', {}, {'__out'},
+                                              '__out = %s' % node.data)
+                        state.add_edge(
+                            t, '__out', dst, e.dst_conn,
+                            mm.Memlet(data=dst.data,
+                                      subset=e.data.dst_subset,
+                                      volume=1))
+                        # Reassign destination for check below
+                        dst = t
+
+                    # If nodes were disconnected, reconnect with empty memlet
+                    if (isinstance(e.src, nodes.EntryNode)
+                            and len(state.edges_between(e.src, dst)) == 0):
+                        state.add_nedge(e.src, dst, mm.Memlet())
+
+    # Step 4: Isolated nodes
+    for state in sdfg.nodes():
+        scalar_nodes = [
+            n for n in state.nodes()
+            if isinstance(n, nodes.AccessNode) and n.data in to_promote
+        ]
+        state.remove_nodes_from(
+            [n for n in scalar_nodes if len(state.all_edges(n)) == 0])
+
+    # Step 5: Data descriptor management
+    for scalar in to_promote:
+        desc = sdfg.arrays[scalar]
+        sdfg.remove_data(scalar, validate=False)
+        sdfg.add_symbol(scalar, desc.dtype)
+
+    # Step 6: Inter-state edge cleanup
+    for edge in sdfg.edges():
+        ise: InterstateEdge = edge.data
+        for scalar in to_promote:
+            # Condition
+            if ise.condition.language is dtypes.Language.Python:
+                promo = TaskletPromoter(scalar, scalar)
+                for stmt in ise.condition.code:
+                    promo.visit(stmt)
+            elif ise.condition.language is dtypes.Language.CPP:
+                ise.condition = re.sub(r'\b%s\[.*\]' % re.escape(scalar),
+                                       scalar, ise.condition.as_string)
+            # Assignments
+            for aname, assignment in ise.assignments.items():
+                ise.assignments[aname] = re.sub(
+                    r'\b%s\[.*\]' % re.escape(scalar), scalar,
+                    assignment.strip())
+
+    # Step 7: Indirection
+    # TODO

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -119,6 +119,11 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
                     if isinstance(sdfg.arrays[tinput.src.data], dt.Stream):
                         candidates.remove(candidate)
                         break
+                    # If input is not a single-element memlet, skip
+                    if (tinput.data.dynamic
+                            or tinput.data.subset.num_elements() != 1):
+                        candidates.remove(candidate)
+                        break
                 else:
                     # Check that tasklets have only one statement
                     cb: props.CodeBlock = edge.src.code

--- a/dace/sdfg/analysis/scalar_to_symbol.py
+++ b/dace/sdfg/analysis/scalar_to_symbol.py
@@ -36,6 +36,7 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
         candidates.add(aname)
 
     # Check all occurrences of candidates in SDFG and filter out
+    candidates_seen: Set[str] = set()
     for state in sdfg.nodes():
         candidates_in_state: Set[str] = set()
 
@@ -111,6 +112,10 @@ def find_promotable_scalars(sdfg: sd.SDFG) -> Set[str]:
                         break
             else:  # If input is not an acceptable node type, skip
                 candidates.remove(candidate)
+        candidates_seen |= candidates_in_state
+
+    # Only keep candidates that were found in SDFG
+    candidates &= candidates_seen
 
     return candidates
 

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -201,9 +201,10 @@ class AffineSMemlet(SeparableMemletPattern):
                     return False  # Step must be independent of parameter
 
             node_rb, node_re, node_rs = node_range[self.paramind]
+            result_begin = subexpr.subs(self.param, node_rb).expand()
             if node_rs != 1:
                 # Special case: i:i+stride for a begin:end:stride range
-                if bre + 1 == node_rs and step == 1:
+                if node_rb == result_begin and bre + 1 == node_rs and step == 1:
                     pass
                 else:
                     # Map ranges where the last index is not known

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -146,7 +146,7 @@ class AffineSMemlet(SeparableMemletPattern):
             subexprs = None
             step = None
             if isinstance(dexpr, sympy.Basic):  # Affine index
-                subexprs = [dexpr]
+                subexprs = [dexpr, dexpr]
 
             elif isinstance(dexpr, tuple) and len(dexpr) == 3:  # Affine range
                 subexprs = [dexpr[0], dexpr[1]]
@@ -201,7 +201,7 @@ class AffineSMemlet(SeparableMemletPattern):
                     return False  # Step must be independent of parameter
 
             node_rb, node_re, node_rs = node_range[self.paramind]
-            result_begin = subexpr.subs(self.param, node_rb).expand()
+            result_begin = subexprs[0].subs(self.param, node_rb).expand()
             if node_rs != 1:
                 # Special case: i:i+stride for a begin:end:stride range
                 if node_rb == result_begin and bre + 1 == node_rs and step == 1:

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -124,9 +124,8 @@ class InterstateEdge(object):
         result = set(
             map(str, dace.symbolic.symbols_in_ast(self.condition.code[0])))
         for assign in self.assignments.values():
-            result |= set(
-                map(str,
-                    symbolic.pystr_to_symbolic(assign).free_symbols))
+            result |= symbolic.free_symbols_and_functions(
+                symbolic.pystr_to_symbolic(assign))
 
         return result - set(self.assignments.keys())
 

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -564,9 +564,9 @@ class Range(Subset):
                         new_subset.append(rb + rs * other[idx])
 
         else:
-            raise ValueError("Dimension mismatch in composition:"
-                             "Subset composed must be either completely"
-                             "stripped of all non-data dimensions"
+            raise ValueError("Dimension mismatch in composition: "
+                             "Subset composed must be either completely "
+                             "stripped of all non-data dimensions "
                              "or be not stripped of latter at all.")
 
         if isinstance(other, Range):

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -2,14 +2,13 @@
 """ Transformation helper API. """
 import copy
 
-from numpy.core.numeric import full
 from dace.subsets import Range, Subset, union
 from typing import Dict, List, Optional, Tuple
 
 from dace.sdfg import nodes, utils
 from dace.sdfg.graph import SubgraphView, MultiConnectorEdge
 from dace.sdfg.scope import ScopeSubgraphView
-from dace.sdfg import SDFG, SDFGState
+from dace.sdfg import SDFG, SDFGState, InterstateEdge
 from dace.sdfg import graph
 from dace.memlet import Memlet
 
@@ -409,3 +408,20 @@ def replicate_scope(sdfg: SDFG, state: SDFGState,
     new_exit.map = new_entry.map
 
     return ScopeSubgraphView(state, new_nodes, new_entry)
+
+
+def split_interstate_edges(sdfg: SDFG) -> None:
+    """
+    Splits all inter-state edges into edges with conditions and edges with
+    assignments. This procedure helps in nested loop detection.
+    :param sdfg: The SDFG to split 
+    :note: Operates in-place on the SDFG.
+    """
+    for e in sdfg.edges():
+        if e.data.assignments and not e.data.is_unconditional():
+            tmpstate = sdfg.add_state()
+            sdfg.add_edge(e.src, tmpstate,
+                          InterstateEdge(condition=e.data.condition))
+            sdfg.add_edge(tmpstate, e.dst,
+                          InterstateEdge(assignments=e.data.assignments))
+            sdfg.remove_edge(e)

--- a/tests/codegen/control_flow_detection_test.py
+++ b/tests/codegen/control_flow_detection_test.py
@@ -59,7 +59,7 @@ def test_edge_split_loop_detection():
             i += 2
         return A
 
-    sdfg: dace.SDFG = looptest.to_sdfg()
+    sdfg: dace.SDFG = looptest.to_sdfg(strict=True)
     assert 'for (' in sdfg.generate_code()[0].code
 
     A = looptest()

--- a/tests/codegen/control_flow_detection_test.py
+++ b/tests/codegen/control_flow_detection_test.py
@@ -1,0 +1,73 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
+from math import exp
+import dace
+import numpy as np
+
+
+def test_for_loop_detection():
+    N = dace.symbol('N')
+
+    @dace.program
+    def looptest(A: dace.float64[N]):
+        for i in range(N):
+            A[i] += 5
+
+    sdfg: dace.SDFG = looptest.to_sdfg()
+    assert 'for (' in sdfg.generate_code()[0].code
+
+    A = np.random.rand(20)
+    expected = A + 5
+    sdfg(A=A, N=20)
+    assert np.allclose(A, expected)
+
+
+def test_invalid_for_loop_detection():
+    sdfg = dace.SDFG('looptest')
+    sdfg.add_array('A', [20], dace.float64)
+    init = sdfg.add_state()
+    guard = sdfg.add_state()
+    loop = sdfg.add_state()
+    end = sdfg.add_state()
+    sdfg.add_edge(init, guard, dace.InterstateEdge(assignments=dict(i='0')))
+    # Invalid: Edge between guard and loop state must not have assignments
+    sdfg.add_edge(
+        guard, loop,
+        dace.InterstateEdge(condition='i < 20', assignments=dict(j='i')))
+    sdfg.add_edge(guard, end, dace.InterstateEdge(condition='i >= 20'))
+    sdfg.add_edge(loop, guard, dace.InterstateEdge(assignments=dict(i='i + 1')))
+
+    r = loop.add_read('A')
+    t = loop.add_tasklet('add', {'a'}, {'out'}, 'out = a + 5')
+    w = loop.add_write('A')
+    loop.add_edge(r, None, t, 'a', dace.Memlet('A[j]'))
+    loop.add_edge(t, 'out', w, None, dace.Memlet('A[j]'))
+
+    assert 'for (' not in sdfg.generate_code()[0].code
+    A = np.random.rand(20)
+    expected = A + 5
+    sdfg(A=A)
+    assert np.allclose(A, expected)
+
+
+def test_edge_split_loop_detection():
+    @dace.program
+    def looptest():
+        A = dace.ndarray([10], dtype=dace.int32)
+        i = 0
+        while (i < 10):
+            A[i] = i
+            i += 2
+        return A
+
+    sdfg: dace.SDFG = looptest.to_sdfg()
+    assert 'for (' in sdfg.generate_code()[0].code
+
+    A = looptest()
+    A_ref = np.array([0, 0, 2, 0, 4, 0, 6, 0, 8, 0], dtype=np.int32)
+    assert (np.array_equal(A, A_ref))
+
+
+if __name__ == '__main__':
+    test_for_loop_detection()
+    test_invalid_for_loop_detection()
+    test_edge_split_loop_detection()

--- a/tests/python_frontend/arithmetic_conversions_test.py
+++ b/tests/python_frontend/arithmetic_conversions_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 

--- a/tests/python_frontend/assignment_statements_test.py
+++ b/tests/python_frontend/assignment_statements_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 
@@ -110,7 +111,7 @@ if __name__ == "__main__":
     test_single_target_parentheses()
     test_multiple_targets()
     test_multiple_targets_parentheses()
-    
+
     # test_starred_target()
     # test_attribute_reference()
 

--- a/tests/python_frontend/binop_replacements_test.py
+++ b/tests/python_frontend/binop_replacements_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 

--- a/tests/python_frontend/identifiers_and_keywords_test.py
+++ b/tests/python_frontend/identifiers_and_keywords_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 

--- a/tests/python_frontend/indirection_with_scalars_test.py
+++ b/tests/python_frontend/indirection_with_scalars_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace as dc
 import numpy as np
 

--- a/tests/python_frontend/line_structure_test.py
+++ b/tests/python_frontend/line_structure_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 
@@ -70,7 +71,7 @@ def blank_lines(A: dace.float32[N], B: dace.float32[N]):
 
     )
     tmp[:] = A[:]  # for i in 0 .. N-1; tmp[i] = A[i]
-                         
+
     B[:] = tmp[:]  # for i in 0 .. N-1; B[i] = tmp[i]
 
 # yapf: enable

--- a/tests/python_frontend/loops_test.py
+++ b/tests/python_frontend/loops_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 

--- a/tests/python_frontend/loops_test.py
+++ b/tests/python_frontend/loops_test.py
@@ -16,7 +16,7 @@ def for_loop():
 def test_for_loop():
     A = for_loop()
     A_ref = np.array([0, 0, 2, 0, 4, 0, 6, 0, 8, 0], dtype=np.int32)
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -35,7 +35,7 @@ def for_loop_with_break_continue():
 def test_for_loop_with_break_continue():
     A = for_loop_with_break_continue()
     A_ref = np.array([0, 0, 2, 0, 4, 0, 6, 0, 8, 0], dtype=np.int32)
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -61,7 +61,7 @@ def test_nested_for_loop():
     A_ref = np.zeros([10, 10], dtype=np.int32)
     for i in range(0, 10, 2):
         A_ref[i] = [0, 0, 2, 0, 4, 0, 6, 0, 8, 0]
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -78,7 +78,7 @@ def while_loop():
 def test_while_loop():
     A = while_loop()
     A_ref = np.array([0, 0, 2, 0, 4, 0, 6, 0, 8, 0], dtype=np.int32)
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -99,7 +99,7 @@ def while_loop_with_break_continue():
 def test_while_loop_with_break_continue():
     A = while_loop_with_break_continue()
     A_ref = np.array([0, 0, 2, 0, 4, 0, 6, 0, 8, 0], dtype=np.int32)
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -129,7 +129,7 @@ def test_nested_while_loop():
     A_ref = np.zeros([10, 10], dtype=np.int32)
     for i in range(0, 10, 2):
         A_ref[i] = [0, 0, 2, 0, 4, 0, 6, 0, 8, 0]
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -157,7 +157,7 @@ def test_nested_for_while_loop():
     A_ref = np.zeros([10, 10], dtype=np.int32)
     for i in range(0, 10, 2):
         A_ref[i] = [0, 0, 2, 0, 4, 0, 6, 0, 8, 0]
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -185,7 +185,7 @@ def test_nested_while_for_loop():
     A_ref = np.zeros([10, 10], dtype=np.int32)
     for i in range(0, 10, 2):
         A_ref[i] = [0, 0, 2, 0, 4, 0, 6, 0, 8, 0]
-    assert(np.array_equal(A, A_ref))
+    assert (np.array_equal(A, A_ref))
 
 
 @dace.program
@@ -207,7 +207,7 @@ def test_map_with_break_continue():
     except Exception as e:
         if isinstance(e, DaceSyntaxError):
             return 0
-    assert(False)
+    assert (False)
 
 
 @dace.program
@@ -225,7 +225,7 @@ def test_nested_map_for_loop():
         for j in range(10):
             ref[i, j] = i * 10 + j
     val = nested_map_for_loop()
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -245,7 +245,7 @@ def test_nested_map_for_for_loop():
             for k in range(10):
                 ref[i, j, k] = i * 100 + j * 10 + k
     val = nested_map_for_for_loop()
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -265,7 +265,7 @@ def test_nested_for_map_for_loop():
             for k in range(10):
                 ref[i, j, k] = i * 100 + j * 10 + k
     val = nested_for_map_for_loop()
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -273,10 +273,12 @@ def nested_map_for_loop_with_tasklet():
     A = np.ndarray([10, 10], dtype=np.int64)
     for i in dace.map[0:10]:
         for j in range(10):
+
             @dace.tasklet
             def comp():
                 out >> A[i, j]
                 out = i * 10 + j
+
     return A
 
 
@@ -286,7 +288,7 @@ def test_nested_map_for_loop_with_tasklet():
         for j in range(10):
             ref[i, j] = i * 10 + j
     val = nested_map_for_loop_with_tasklet()
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -295,10 +297,12 @@ def nested_map_for_for_loop_with_tasklet():
     for i in dace.map[0:10]:
         for j in range(10):
             for k in range(10):
+
                 @dace.tasklet
                 def comp():
                     out >> A[i, j, k]
                     out = i * 100 + j * 10 + k
+
     return A
 
 
@@ -309,7 +313,7 @@ def test_nested_map_for_for_loop_with_tasklet():
             for k in range(10):
                 ref[i, j, k] = i * 100 + j * 10 + k
     val = nested_map_for_for_loop_with_tasklet()
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -318,10 +322,12 @@ def nested_for_map_for_loop_with_tasklet():
     for i in range(10):
         for j in dace.map[0:10]:
             for k in range(10):
+
                 @dace.tasklet
                 def comp():
                     out >> A[i, j, k]
                     out = i * 100 + j * 10 + k
+
     return A
 
 
@@ -332,7 +338,7 @@ def test_nested_for_map_for_loop_with_tasklet():
             for k in range(10):
                 ref[i, j, k] = i * 100 + j * 10 + k
     val = nested_for_map_for_loop_with_tasklet()
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -351,7 +357,7 @@ def test_nested_map_for_loop_2():
         for j in range(10):
             ref[i, j] = 2 + i * 10 + j
     val = nested_map_for_loop_2(B)
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 @dace.program
@@ -359,11 +365,13 @@ def nested_map_for_loop_with_tasklet_2(B: dace.int64[10, 10]):
     A = np.ndarray([10, 10], dtype=np.int64)
     for i in dace.map[0:10]:
         for j in range(10):
+
             @dace.tasklet
             def comp():
                 inp << B[i, j]
                 out >> A[i, j]
                 out = 2 * inp + i * 10 + j
+
     return A
 
 
@@ -374,7 +382,7 @@ def test_nested_map_for_loop_with_tasklet_2():
         for j in range(10):
             ref[i, j] = 2 + i * 10 + j
     val = nested_map_for_loop_with_tasklet_2(B)
-    assert(np.array_equal(val, ref))
+    assert (np.array_equal(val, ref))
 
 
 if __name__ == "__main__":

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace as dc
 import numpy as np
 

--- a/tests/python_frontend/power_operator_test.py
+++ b/tests/python_frontend/power_operator_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 

--- a/tests/python_frontend/subscript_regression_test.py
+++ b/tests/python_frontend/subscript_regression_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import numpy as np
 import dace
 

--- a/tests/python_frontend/test_propagate_strict.py
+++ b/tests/python_frontend/test_propagate_strict.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 """ Test that the strict argument to to_sdfg is propagated when parsing calls to other dace programs """
 
 import dace

--- a/tests/python_frontend/transients_test.py
+++ b/tests/python_frontend/transients_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 

--- a/tests/sdfg/scalar_to_symbol_test.py
+++ b/tests/sdfg/scalar_to_symbol_test.py
@@ -7,13 +7,20 @@ from dace.sdfg.analysis import scalar_to_symbol
 def test_find_promotable():
     """ Find promotable and non-promotable symbols. """
     @dace.program
-    def testprog(A: dace.float32[20, 20]):
+    def testprog(A: dace.float32[20, 20], scal: dace.float32):
         tmp = dace.ndarray([20, 20], dtype=dace.float32)
+        m = dace.define_local_scalar(dace.float32)
+        j = dace.ndarray([1], dtype=dace.int64)
         i = 1
         i = 2
-        j = 0
-        while j < 5:
+        j[:] = 0
+        while j[0] < 5:
             tmp[:] = A + j
+            for k in dace.map[0:20]:
+                with dace.tasklet:
+                    inp << scal
+                    out >> m(1, lambda a, b: a + b)
+                    out = inp
             j += 1
             i += j
 
@@ -23,7 +30,7 @@ def test_find_promotable():
 
 
 def test_promote_simple():
-    """ Simple promotion. """
+    """ Simple promotion with Python tasklets. """
     pass
 
 

--- a/tests/sdfg/scalar_to_symbol_test.py
+++ b/tests/sdfg/scalar_to_symbol_test.py
@@ -2,6 +2,12 @@
 """ Tests the scalar to symbol promotion functionality. """
 import dace
 from dace.sdfg.analysis import scalar_to_symbol
+from dace.transformation import interstate as isxf
+from dace.transformation.interstate import loop_detection as ld
+from dace import registry
+from dace.transformation import helpers as xfh
+
+import numpy as np
 
 
 def test_find_promotable():
@@ -31,21 +37,314 @@ def test_find_promotable():
 
 def test_promote_simple():
     """ Simple promotion with Python tasklets. """
-    pass
+    @dace.program
+    def testprog(A: dace.float64[20, 20]):
+        j = 5
+        A[:] += j
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_transformations_repeated(isxf.StateFusion)
+
+    # There should be two states:
+    # [empty] --j=5--> [A->MapEntry->Tasklet->MapExit->A]
+    assert sdfg.number_of_nodes() == 2
+    assert sdfg.source_nodes()[0].number_of_nodes() == 0
+    assert sdfg.sink_nodes()[0].number_of_nodes() == 5
+    tasklet = next(n for n in sdfg.sink_nodes()[0]
+                   if isinstance(n, dace.nodes.Tasklet))
+    assert '+ j' in tasklet.code.as_string
+
+    # Program should produce correct result
+    A = np.random.rand(20, 20)
+    expected = A + 5
+    sdfg(A=A)
+    assert np.allclose(A, expected)
+
+
+def test_promote_simple_c():
+    """ Simple promotion with C++ tasklets. """
+    @dace.program
+    def testprog(A: dace.float32[20, 20]):
+        i = 0
+        j = 0
+        k = dace.ndarray([1], dtype=dace.int32)
+        with dace.tasklet(dace.Language.CPP):
+            jj << j
+            """
+            ii = jj + 1;
+            """
+            ii >> i
+        with dace.tasklet(dace.Language.CPP):
+            jin << j
+            """
+            int something = (int)jin;
+            jout = something + 1;
+            """
+            jout >> j
+        with dace.tasklet(dace.Language.CPP):
+            """
+            kout[0] = 0;
+            """
+            kout >> k
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    scalars = scalar_to_symbol.find_promotable_scalars(sdfg)
+    assert scalars == {'i'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_transformations_repeated(isxf.StateFusion)
+
+    # SDFG: [empty] --i=0--> [Tasklet->j] --i=j+1--> [j->Tasklet->j, Tasklet->k]
+    assert sdfg.number_of_nodes() == 3
+    src_state = sdfg.source_nodes()[0]
+    sink_state = sdfg.sink_nodes()[0]
+    middle_state = next(s for s in sdfg.nodes()
+                        if s not in [src_state, sink_state])
+    assert src_state.number_of_nodes() == 0
+    assert middle_state.number_of_nodes() == 2
+    assert sink_state.number_of_nodes() == 5
+
+
+def test_promote_disconnect():
+    """ Promotion that disconnects tasklet from map. """
+    @dace.program
+    def testprog(A: dace.float64[20, 20]):
+        j = 5
+        A[:] = j
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_transformations_repeated(isxf.StateFusion)
+
+    # There should be two states:
+    # [empty] --j=5--> [MapEntry->Tasklet->MapExit->A]
+    assert sdfg.number_of_nodes() == 2
+    assert sdfg.source_nodes()[0].number_of_nodes() == 0
+    assert sdfg.sink_nodes()[0].number_of_nodes() == 4
+
+    # Program should produce correct result
+    A = np.random.rand(20, 20)
+    expected = np.zeros_like(A)
+    expected[:] = 5
+    sdfg(A=A)
+    assert np.allclose(A, expected)
+
+
+def test_promote_copy():
+    """ Promotion that has a connection to an array and to another symbol. """
+    # Create SDFG
+    sdfg = dace.SDFG('testprog')
+    sdfg.add_array('A', [20, 20], dace.float64)
+    sdfg.add_transient('i', [1], dace.int32)
+    sdfg.add_transient('j', [1], dace.int32)
+    state = sdfg.add_state()
+    state.add_edge(state.add_tasklet('seti', {}, {'out'}, 'out = 0'), 'out',
+                   state.add_write('i'), None, dace.Memlet('i'))
+    state = sdfg.add_state_after(state)
+    state.add_edge(state.add_tasklet('setj', {}, {'out'}, 'out = 5'), 'out',
+                   state.add_write('j'), None, dace.Memlet('j'))
+    state = sdfg.add_state_after(state)
+    state.add_nedge(state.add_read('j'), state.add_write('i'), dace.Memlet('i'))
+    state = sdfg.add_state_after(state)
+    state.add_nedge(state.add_read('i'), state.add_write('A'),
+                    dace.Memlet('A[5, 5]'))
+
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i', 'j'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_transformations_repeated(isxf.StateFusion)
+
+    # There should be two states:
+    # [empty] --i=0,j=5--> [empty] --j=i--> [Tasklet->A]
+    assert sdfg.number_of_nodes() == 3
+    src_state = sdfg.source_nodes()[0]
+    sink_state = sdfg.sink_nodes()[0]
+    middle_state = next(s for s in sdfg.nodes()
+                        if s not in [src_state, sink_state])
+    assert src_state.number_of_nodes() == 0
+    assert middle_state.number_of_nodes() == 0
+    assert sink_state.number_of_nodes() == 2
+
+    # Program should produce correct result
+    A = np.random.rand(20, 20)
+    expected = np.copy(A)
+    expected[5, 5] = 5.0
+    sdfg(A=A)
+    assert np.allclose(A, expected)
+
+
+def test_promote_array_assignment():
+    """ Simple promotion with array assignment. """
+    @dace.program
+    def testprog(A: dace.float64[20, 20]):
+        j = A[1, 1]
+        A[:] += j
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_transformations_repeated(isxf.StateFusion)
+
+    # There should be two states:
+    # [empty] --j=A[1, 1]--> [A->MapEntry->Tasklet->MapExit->A]
+    assert sdfg.number_of_nodes() == 2
+    assert sdfg.source_nodes()[0].number_of_nodes() == 0
+    assert sdfg.sink_nodes()[0].number_of_nodes() == 5
+
+    # Program should produce correct result
+    A = np.random.rand(20, 20)
+    expected = A + A[1, 1]
+    sdfg(A=A)
+    assert np.allclose(A, expected)
+
+
+def test_promote_array_assignment_tasklet():
+    """ Simple promotion with array assignment. """
+    @dace.program
+    def testprog(A: dace.float64[20, 20]):
+        j = dace.define_local_scalar(dace.float64)
+        with dace.tasklet:
+            inp << A[1, 1]
+            out >> j
+            out = inp
+        A[:] += j
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_transformations_repeated(isxf.StateFusion)
+
+    # There should be two states:
+    # [empty] --j=A[1, 1]--> [A->MapEntry->Tasklet->MapExit->A]
+    assert sdfg.number_of_nodes() == 2
+    assert sdfg.source_nodes()[0].number_of_nodes() == 0
+    assert sdfg.sink_nodes()[0].number_of_nodes() == 5
+
+    # Program should produce correct result
+    A = np.random.rand(20, 20)
+    expected = A + A[1, 1]
+    sdfg(A=A)
+    assert np.allclose(A, expected)
+
+
+@registry.autoregister
+class LoopTester(ld.DetectLoop):
+    """ Tester method that sets loop index on a guard state. """
+    @staticmethod
+    def can_be_applied(graph, candidate, expr_index, sdfg, strict):
+        if not ld.DetectLoop.can_be_applied(graph, candidate, expr_index, sdfg,
+                                            strict):
+            return False
+        guard = graph.node(candidate[ld.DetectLoop._loop_guard])
+        if hasattr(guard, '_LOOPINDEX'):
+            return False
+        return True
+
+    def apply(self, sdfg: dace.SDFG):
+        guard = sdfg.node(self.subgraph[ld.DetectLoop._loop_guard])
+        edge = sdfg.in_edges(guard)[0]
+        loopindex = next(iter(edge.data.assignments.keys()))
+        guard._LOOPINDEX = loopindex
+
+
+def test_promote_loop():
+    """ Loop promotion. """
+    N = dace.symbol('N')
+
+    @dace.program
+    def testprog(A: dace.float32[20, 20]):
+        i = dace.ndarray([1], dtype=dace.int32)
+        i = 0
+        while i[0] < N:
+            A += i
+            i += 2
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_strict_transformations()
+    assert sdfg.apply_transformations_repeated(LoopTester) == 1
 
 
 def test_promote_loops():
     """ Nested loops. """
-    pass
+    N = dace.symbol('N')
+
+    @dace.program
+    def testprog(A: dace.float32[20, 20]):
+        i = 0
+        while i < N:
+            A += i
+            for j in range(5):
+                k = 0
+                while k < N / 2:
+                    A += k
+                    k += 1
+            i += 2
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i', 'k'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_strict_transformations()
+    xfh.split_interstate_edges(sdfg)
+    assert sdfg.apply_transformations_repeated(LoopTester) == 3
 
 
 def test_promote_indirection():
     """ Indirect access in promotion. """
-    pass
+    @dace.program
+    def testprog(A: dace.float64[2, 3, 4, 5], B: dace.float64[4]):
+        i = 2
+        j = 1
+        k = 0
+
+        # Complex numpy expression with double indirection
+        B[:] = A[:, i, :, j][k, :]
+
+        # Include tasklet with more than one statement (one with indirection
+        # and one without) and two outputs.
+        for m in dace.map[0:2]:
+            with dace.tasklet:
+                a << A(1)[:]
+                ii << i
+                b1in << B[m]
+                b2in << B[2 * m]
+
+                c = a[0, 0, 0, ii]
+                b1 = c + 1
+                b2 = b2in + 1
+
+                b1 >> B[m]
+                b2 >> B[2 * m]
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i', 'j', 'k'}
+    scalar_to_symbol.promote_scalars_to_symbols(sdfg)
+    sdfg.apply_strict_transformations()
+
+    # Assertions on SDFG
+
+    # Check result
+    A = np.random.rand(2, 3, 4, 5)
+    B = np.random.rand(4)
+    expected = A[0, 2, :, 1]
+    expected[0:2] += A[0, 0, 0, 2]
+    expected[2:4] += 1
+
+    sdfg(A=A, B=B)
+
+    assert np.allclose(B, expected)
 
 
 if __name__ == '__main__':
     test_find_promotable()
     test_promote_simple()
+    test_promote_simple_c()
+    test_promote_disconnect()
+    test_promote_copy()
+    test_promote_array_assignment()
+    test_promote_array_assignment_tasklet()
+    test_promote_loop()
     test_promote_loops()
-    test_promote_indirection()
+    # test_promote_indirection()

--- a/tests/sdfg/scalar_to_symbol_test.py
+++ b/tests/sdfg/scalar_to_symbol_test.py
@@ -1,0 +1,39 @@
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests the scalar to symbol promotion functionality. """
+import dace
+from dace.sdfg.analysis import scalar_to_symbol
+
+
+def test_find_promotable():
+    """ Find promotable and non-promotable symbols. """
+    @dace.program
+    def testprog():
+        i = 1
+        i = 2
+        # some_non_promotable_symbols
+
+    sdfg: dace.SDFG = testprog.to_sdfg()
+    scalars = scalar_to_symbol.find_promotable_scalars(sdfg)
+    assert scalars == set('i')
+
+
+def test_promote_simple():
+    """ Simple promotion. """
+    pass
+
+
+def test_promote_loops():
+    """ Nested loops. """
+    pass
+
+
+def test_promote_indirection():
+    """ Indirect access in promotion. """
+    pass
+
+
+if __name__ == '__main__':
+    test_find_promotable()
+    test_promote_simple()
+    test_promote_loops()
+    test_promote_indirection()

--- a/tests/sdfg/scalar_to_symbol_test.py
+++ b/tests/sdfg/scalar_to_symbol_test.py
@@ -181,7 +181,7 @@ def test_promote_array_assignment():
         j = A[1, 1]
         A[:] += j
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_transformations_repeated(isxf.StateFusion)
@@ -210,7 +210,7 @@ def test_promote_array_assignment_tasklet():
             out = inp
         A[:] += j
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_transformations_repeated(isxf.StateFusion)

--- a/tests/sdfg/scalar_to_symbol_test.py
+++ b/tests/sdfg/scalar_to_symbol_test.py
@@ -30,7 +30,7 @@ def test_find_promotable():
             j += 1
             i += j
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     scalars = scalar_to_symbol.find_promotable_scalars(sdfg)
     assert scalars == {'i', 'j'}
 
@@ -42,7 +42,7 @@ def test_promote_simple():
         j = 5
         A[:] += j
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_transformations_repeated(isxf.StateFusion)
@@ -89,7 +89,7 @@ def test_promote_simple_c():
             """
             kout >> k
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     scalars = scalar_to_symbol.find_promotable_scalars(sdfg)
     assert scalars == {'i'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
@@ -113,7 +113,7 @@ def test_promote_disconnect():
         j = 5
         A[:] = j
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'j'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_transformations_repeated(isxf.StateFusion)
@@ -260,7 +260,7 @@ def test_promote_loop():
             A += i
             i += 2
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_strict_transformations()
@@ -283,7 +283,7 @@ def test_promote_loops():
                     k += 1
             i += 2
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i', 'k'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_strict_transformations()
@@ -318,7 +318,7 @@ def test_promote_indirection():
                 b1 >> B[m]
                 b2 >> B[m + 2]
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i', 'j', 'k'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_strict_transformations()
@@ -348,7 +348,7 @@ def test_promote_output_indirection():
             a[ii] = ii
             a[ii + 1] = ii + 1
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_strict_transformations()
@@ -379,7 +379,7 @@ def test_promote_indirection_c():
             aout[ii + 1] = ii + 1;
             '''
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_strict_transformations()
@@ -408,7 +408,7 @@ def test_promote_indirection_impossible():
             out >> A(1)[:, :]
             out[i, s] = a[s, i]
 
-    sdfg: dace.SDFG = testprog.to_sdfg()
+    sdfg: dace.SDFG = testprog.to_sdfg(strict=False)
     assert scalar_to_symbol.find_promotable_scalars(sdfg) == {'i'}
     scalar_to_symbol.promote_scalars_to_symbols(sdfg)
     sdfg.apply_strict_transformations()

--- a/tests/sdfg/scalar_to_symbol_test.py
+++ b/tests/sdfg/scalar_to_symbol_test.py
@@ -7,14 +7,19 @@ from dace.sdfg.analysis import scalar_to_symbol
 def test_find_promotable():
     """ Find promotable and non-promotable symbols. """
     @dace.program
-    def testprog():
+    def testprog(A: dace.float32[20, 20]):
+        tmp = dace.ndarray([20, 20], dtype=dace.float32)
         i = 1
         i = 2
-        # some_non_promotable_symbols
+        j = 0
+        while j < 5:
+            tmp[:] = A + j
+            j += 1
+            i += j
 
     sdfg: dace.SDFG = testprog.to_sdfg()
     scalars = scalar_to_symbol.find_promotable_scalars(sdfg)
-    assert scalars == set('i')
+    assert scalars == {'i', 'j'}
 
 
 def test_promote_simple():


### PR DESCRIPTION
A global SDFG pass that converts SDFG scalars and arrays of size 1 to inter-state symbols.
- [x] Find candidate scalars to promote
- [x] Promotion pass
- [x] Symbol indirection to memlet conversion
- [x] Invoke in frontend