### PR TITLE
Fix bug in numpy broadcasting

### DIFF
--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -579,14 +579,14 @@ def _broadcast_together(arr1_shape, arr2_shape):
 
             all_idx_dict[get_idx(i)] = dim1
 
-        elif dim1 == 1:
+        elif dim1 == 1 and dim2 is not None:
             a1_idx.append("0")
             # dim2 != 1 must hold here
             a2_idx.append(get_idx(i))
 
             all_idx_dict[get_idx(i)] = dim2
 
-        elif dim2 == 1:
+        elif dim2 == 1 and dim1 is not None:
             # dim1 != 1 must hold here
             a1_idx.append(get_idx(i))
             a2_idx.append("0")

--- a/tests/numpy/binop_broadcasting_test.py
+++ b/tests/numpy/binop_broadcasting_test.py
@@ -1,7 +1,5 @@
 # Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
-import numpy as np
-import pytest
 from common import compare_numpy_output
 
 ### Left, match first pos ######################################################
@@ -223,6 +221,10 @@ def test_bitorr4(A: dace.int64[4, 1], B: dace.int64[3, 5]):
 #def test_noteqr4(A: dace.int64[3, 3, 2], B: dace.int64[3, 5]):
 #    return A != B
 
+@compare_numpy_output()
+def test_regression_result_none(A: dace.int32[1, 3], B: dace.int32[3]):
+    return A + B
+
 if __name__ == '__main__':
     # generate this with
     # cat binop_broadcasting_test.py | grep -oP '(?<=f ).*(?=\()' | awk '{print $0 "()"}'
@@ -261,3 +263,4 @@ if __name__ == '__main__':
     test_ltl4()
     test_multr4()
     test_bitorr4()
+    test_regression_result_none()


### PR DESCRIPTION
Broadcasting with dim 1 matching dim None previously resulted in the output shape having `None` inside of it. This PR fixes that.