### PR TITLE
Fix reductions when reducing along all axes and allow local SDFGs to be called

### DIFF
--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -825,6 +825,7 @@ class callback(typeclass):
 
 # Helper function to determine whether a global variable is a constant
 _CONSTANT_TYPES = [
+    type(None),
     int,
     float,
     complex,

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -239,7 +239,6 @@ class DaceProgram:
         self._name = f.__name__
         self.argnames = _get_argnames(f)
 
-        # NOTE: Important to call this outside list/dict comprehensions
         global_vars = _get_locals_and_globals(f)
 
         self.global_vars = {
@@ -346,7 +345,7 @@ class DaceProgram:
         # NOTE: These are the globals AT THE TIME OF INVOCATION, NOT DEFINITION
         other_sdfgs = {
             k: v
-            for k, v in dace_func.__globals__.items()
+            for k, v in _get_locals_and_globals(dace_func).items()
             if isinstance(v, (SDFG, DaceProgram))
         }
 

--- a/tests/numpy/nested_call_subarray_test.py
+++ b/tests/numpy/nested_call_subarray_test.py
@@ -18,7 +18,27 @@ def nested_call_subarray(a: dace.float32[2], b: dace.float32[2]):
     dace_softmax(a[:], b[:])
 
 
+def test_local_program():
+    @dace.program
+    def dace_softmax2(X_in: dace.float32[N], X_out: dace.float32[N]):
+        tmp_max = dace.reduce(lambda a, b: a + b, X_in, identity=0)
+        X_out[:] = exp(X_in - tmp_max)
+        tmp_sum = dace.reduce(lambda a, b: max(a, b), X_in)
+        X_out[:] /= tmp_sum
+
+    A = np.array([1, 2], dtype=np.float32)
+    B = np.array([1, 2], dtype=np.float32)
+
+    @dace.program
+    def nested_call_subarray2(a: dace.float32[2], b: dace.float32[2]):
+        dace_softmax2(a[:], b[:])
+
+    nested_call_subarray2(A, B, N=2)
+
+
 if __name__ == '__main__':
     A = np.array([1, 2], dtype=np.float32)
     B = np.array([1, 2], dtype=np.float32)
     nested_call_subarray(A, B, N=2)
+
+    test_local_program()

--- a/tests/numpy/reductions_test.py
+++ b/tests/numpy/reductions_test.py
@@ -169,6 +169,20 @@ def test_mean_reduce_symbolic_shape():
     assert np.allclose(dace_result, numpy_result)
 
 
+@compare_numpy_output()
+def test_reduce_all_axes(A: dace.float64[10, 5, 3]):
+    return np.mean(A, axis=(0, -2, 2))
+
+
+# test accessing a global variable
+my_none = None
+
+
+@compare_numpy_output()
+def test_reduce_global_None(A: dace.float64[10, 5, 3]):
+    return np.mean(A, axis=my_none)
+
+
 if __name__ == '__main__':
 
     # generated with cat tests/numpy/reductions_test.py | grep -oP '(?<=^def ).*(?=\()' | awk '{print $0 "()"}'


### PR DESCRIPTION
Reductions rely on `Subset.pop`, but this doesn't work correctly when reducing along all axes. It instead reduces along the last axes.

This PR bypasses that issue.