### PR TITLE
Modernize FPGA GEMM streaming example

### DIFF
--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -1141,8 +1141,8 @@ class OpenCLDaceKeywordRemover(cpp.DaCeKeywordRemover):
         defined_type, _ = self.defined_vars.get(node.id)
         updated = node
 
-        if (defined_type == DefinedType.Stream or defined_type == DefinedType.StreamArray) \
-                and memlet.num_accesses != 1:
+        if ((defined_type == DefinedType.Stream
+             or defined_type == DefinedType.StreamArray) and memlet.dynamic):
             # Input memlet, we read from channel
             updated = ast.Name(id="read_channel_intel({})".format(node.id))
             self.used_streams.append(node.id)

--- a/samples/fpga/gemm_fpga_stream.py
+++ b/samples/fpga/gemm_fpga_stream.py
@@ -65,9 +65,6 @@ def make_copy_to_host_state(sdfg):
     return state
 
 
-def make_compute_sdfg():
-
-    sdfg = dace.SDFG("gemm_compute")
 
 
 def make_fpga_state(sdfg):

--- a/samples/fpga/gemm_fpga_stream.py
+++ b/samples/fpga/gemm_fpga_stream.py
@@ -25,22 +25,19 @@ def make_copy_to_fpga_state(sdfg):
     A_device = state.add_array("A_device", [N, K],
                                dtype=dace.float32,
                                transient=True,
-                               storage=dace.dtypes.StorageType.FPGA_Global)
+                               storage=dace.StorageType.FPGA_Global)
     B_device = state.add_array("B_device", [K, M],
                                dtype=dace.float32,
                                transient=True,
-                               storage=dace.dtypes.StorageType.FPGA_Global)
+                               storage=dace.StorageType.FPGA_Global)
     C_device = state.add_array("C_device", [N, M],
                                dtype=dace.float32,
                                transient=True,
-                               storage=dace.dtypes.StorageType.FPGA_Global)
+                               storage=dace.StorageType.FPGA_Global)
 
-    state.add_edge(A_host, None, A_device, None,
-                   dace.memlet.Memlet.simple(A_device, "0:N, 0:K"))
-    state.add_edge(B_host, None, B_device, None,
-                   dace.memlet.Memlet.simple(B_device, "0:K, 0:M"))
-    state.add_edge(C_host, None, C_device, None,
-                   dace.memlet.Memlet.simple(C_device, "0:N, 0:M"))
+    state.add_edge(A_host, None, A_device, None, dace.memlet.Memlet("A_device"))
+    state.add_edge(B_host, None, B_device, None, dace.memlet.Memlet("B_device"))
+    state.add_edge(C_host, None, C_device, None, dace.memlet.Memlet("C_device"))
 
     return state
 
@@ -55,75 +52,12 @@ def make_copy_to_host_state(sdfg):
     C_device = state.add_array("C_device", [N, M],
                                dtype=dace.float32,
                                transient=True,
-                               storage=dace.dtypes.StorageType.FPGA_Global)
+                               storage=dace.StorageType.FPGA_Global)
     C_host = state.add_array("C", [N, M], dtype=dace.float32)
 
-    state.add_edge(C_device, None, C_host, None,
-                   dace.memlet.Memlet.simple(C_host, "0:N, 0:M"))
+    state.add_edge(C_device, None, C_host, None, dace.memlet.Memlet("C"))
 
     return state
-
-
-def make_read_A_sdfg():
-
-    sdfg = dace.SDFG("gemm_read_A")
-
-    n_begin = sdfg.add_state("n_begin")
-    n_entry = sdfg.add_state("n_entry")
-    n_end = sdfg.add_state("n_end")
-
-    k_begin = sdfg.add_state("k_begin")
-    k_entry = sdfg.add_state("k_entry")
-    k_end = sdfg.add_state("k_end")
-
-    loop_body = sdfg.add_state("read_memory")
-
-    sdfg.add_edge(n_begin, n_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n": 0}))
-    sdfg.add_edge(k_begin, k_entry,
-                  dace.sdfg.InterstateEdge(assignments={"k": 0}))
-
-    sdfg.add_edge(
-        n_entry, k_begin,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n < N", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        k_entry, loop_body,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "k < K", language=dace.dtypes.Language.Python)))
-
-    sdfg.add_edge(k_end, n_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n": "n + 1"}))
-    sdfg.add_edge(loop_body, k_entry,
-                  dace.sdfg.InterstateEdge(assignments={"k": "k + 1"}))
-
-    sdfg.add_edge(
-        n_entry, n_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n >= N", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        k_entry, k_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "k >= K", language=dace.dtypes.Language.Python)))
-
-    mem = loop_body.add_array("mem", [N, K],
-                              dtype=dace.float32,
-                              storage=dace.dtypes.StorageType.FPGA_Global)
-
-    pipe = loop_body.add_stream("pipe",
-                                dace.float32,
-                                storage=dace.dtypes.StorageType.FPGA_Local)
-
-    loop_body.add_memlet_path(mem,
-                              pipe,
-                              memlet=dace.memlet.Memlet.simple(
-                                  pipe, '0', other_subset_str="n, k"))
-
-    return sdfg
 
 
 def make_read_B_sdfg():
@@ -192,11 +126,11 @@ def make_read_B_sdfg():
 
     mem = loop_body.add_array("mem", [K, M],
                               dtype=dace.float32,
-                              storage=dace.dtypes.StorageType.FPGA_Global)
+                              storage=dace.StorageType.FPGA_Global)
 
     pipe = loop_body.add_stream("pipe",
                                 dace.float32,
-                                storage=dace.dtypes.StorageType.FPGA_Local)
+                                storage=dace.StorageType.FPGA_Local)
 
     loop_body.add_memlet_path(mem,
                               pipe,
@@ -254,11 +188,11 @@ def make_write_C_sdfg():
 
     mem = loop_body.add_array("mem", [N, M],
                               dtype=dace.float32,
-                              storage=dace.dtypes.StorageType.FPGA_Global)
+                              storage=dace.StorageType.FPGA_Global)
 
     pipe = loop_body.add_stream("pipe",
                                 dace.float32,
-                                storage=dace.dtypes.StorageType.FPGA_Local)
+                                storage=dace.StorageType.FPGA_Local)
 
     loop_body.add_memlet_path(pipe,
                               mem,
@@ -295,14 +229,13 @@ def make_compute_sdfg():
     # Data nodes
     A_pipe = state.add_stream("A_stream_in",
                               dace.float32,
-                              storage=dace.dtypes.StorageType.FPGA_Local)
+                              storage=dace.StorageType.FPGA_Local)
     B_pipe = state.add_stream("B_stream_in",
                               dace.float32,
-                              storage=dace.dtypes.StorageType.FPGA_Local)
-    C_pipe = write_c_state.add_stream(
-        "C_stream_out",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+                              storage=dace.StorageType.FPGA_Local)
+    C_pipe = write_c_state.add_stream("C_stream_out",
+                                      dace.float32,
+                                      storage=dace.StorageType.FPGA_Local)
 
     # N-loop
     sdfg.add_edge(n_begin, n_entry,
@@ -380,16 +313,16 @@ def make_compute_sdfg():
     C_buffer_in = state.add_array("C_buffer", [M],
                                   dtype=dace.float32,
                                   transient=True,
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
+                                  storage=dace.StorageType.FPGA_Local)
     C_buffer_out = state.add_array("C_buffer", [M],
                                    dtype=dace.float32,
                                    transient=True,
-                                   storage=dace.dtypes.StorageType.FPGA_Local)
+                                   storage=dace.StorageType.FPGA_Local)
     C_buffer_write = write_c_state.add_array(
         "C_buffer", [M],
         dtype=dace.float32,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        storage=dace.StorageType.FPGA_Local)
 
     ###########################################################################
     # Nested SDFG
@@ -443,7 +376,7 @@ def make_compute_sdfg():
         "C_val",
         dtype=dace.float32,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        storage=dace.StorageType.FPGA_Local)
     then_state_c.add_memlet_path(zero_tasklet,
                                  C_val_out_then,
                                  src_conn="c_out",
@@ -453,49 +386,43 @@ def make_compute_sdfg():
     # Else state C
     C_in = else_state_c.add_scalar("C_in",
                                    dtype=dace.float32,
-                                   storage=dace.dtypes.StorageType.FPGA_Local)
+                                   storage=dace.StorageType.FPGA_Local)
     C_val_out_else = else_state_c.add_scalar(
         "C_val",
         dtype=dace.float32,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Local)
+        storage=dace.StorageType.FPGA_Local)
     else_state_c.add_memlet_path(C_in,
                                  C_val_out_else,
                                  memlet=dace.memlet.Memlet.simple(
                                      C_val_out_else, "0"))
 
     # Then state A
-    A_in = then_state_a.add_scalar(
-        "A_in",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    A_val_out = then_state_a.add_scalar(
-        "A_val_out",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
+    A_in = then_state_a.add_scalar("A_in",
+                                   dtype=dace.float32,
+                                   storage=dace.StorageType.FPGA_Registers)
+    A_val_out = then_state_a.add_scalar("A_val_out",
+                                        dtype=dace.float32,
+                                        storage=dace.StorageType.FPGA_Registers)
     then_state_a.add_memlet_path(A_in,
                                  A_val_out,
                                  memlet=dace.memlet.Memlet.simple(
                                      A_val_out, "0", num_accesses=-1))
 
     # Compute state
-    A_val_in = compute_state.add_scalar(
-        "A_val_in",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    B_in = compute_state.add_scalar(
-        "B_in",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    C_val_in = compute_state.add_scalar(
-        "C_val",
-        dtype=dace.float32,
-        transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    C_out = compute_state.add_scalar(
-        "C_out",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
+    A_val_in = compute_state.add_scalar("A_val_in",
+                                        dtype=dace.float32,
+                                        storage=dace.StorageType.FPGA_Registers)
+    B_in = compute_state.add_scalar("B_in",
+                                    dtype=dace.float32,
+                                    storage=dace.StorageType.FPGA_Registers)
+    C_val_in = compute_state.add_scalar("C_val",
+                                        dtype=dace.float32,
+                                        transient=True,
+                                        storage=dace.StorageType.FPGA_Registers)
+    C_out = compute_state.add_scalar("C_out",
+                                     dtype=dace.float32,
+                                     storage=dace.StorageType.FPGA_Registers)
     compute_state.add_memlet_path(A_val_in,
                                   compute_tasklet,
                                   memlet=dace.memlet.Memlet.simple(
@@ -527,12 +454,12 @@ def make_compute_sdfg():
                                 dtype=dace.float32,
                                 transient=True,
                                 lifetime=dace.dtypes.AllocationLifetime.SDFG,
-                                storage=dace.dtypes.StorageType.FPGA_Registers)
+                                storage=dace.StorageType.FPGA_Registers)
     A_reg_out = state.add_scalar("A_reg",
                                  dtype=dace.float32,
                                  transient=True,
                                  lifetime=dace.dtypes.AllocationLifetime.SDFG,
-                                 storage=dace.dtypes.StorageType.FPGA_Registers)
+                                 storage=dace.StorageType.FPGA_Registers)
 
     state.add_memlet_path(A_pipe,
                           tasklet,
@@ -580,10 +507,6 @@ def make_fpga_state(sdfg):
 
     state = sdfg.add_state("gemm")
 
-    read_A_sdfg = make_read_A_sdfg()
-    read_A_sdfg_node = state.add_nested_sdfg(read_A_sdfg, sdfg, {"mem"},
-                                             {"pipe"})
-
     read_B_sdfg = make_read_B_sdfg()
     read_B_sdfg_node = state.add_nested_sdfg(read_B_sdfg, sdfg, {"mem"},
                                              {"pipe"})
@@ -600,53 +523,43 @@ def make_fpga_state(sdfg):
     A = state.add_array("A_device", [N, K],
                         dtype=dace.float32,
                         transient=True,
-                        storage=dace.dtypes.StorageType.FPGA_Global)
+                        storage=dace.StorageType.FPGA_Global)
     B = state.add_array("B_device", [K, M],
                         dtype=dace.float32,
                         transient=True,
-                        storage=dace.dtypes.StorageType.FPGA_Global)
+                        storage=dace.StorageType.FPGA_Global)
     C = state.add_array("C_device", [N, M],
                         dtype=dace.float32,
                         transient=True,
-                        storage=dace.dtypes.StorageType.FPGA_Global)
+                        storage=dace.StorageType.FPGA_Global)
 
     A_pipe_in = state.add_stream("A_pipe",
                                  dace.float32,
                                  transient=True,
-                                 storage=dace.dtypes.StorageType.FPGA_Local)
+                                 storage=dace.StorageType.FPGA_Local)
     B_pipe_in = state.add_stream("B_pipe",
                                  dace.float32,
                                  transient=True,
-                                 storage=dace.dtypes.StorageType.FPGA_Local)
+                                 storage=dace.StorageType.FPGA_Local)
     C_pipe_in = state.add_stream("C_pipe",
                                  dace.float32,
                                  transient=True,
-                                 storage=dace.dtypes.StorageType.FPGA_Local)
+                                 storage=dace.StorageType.FPGA_Local)
     A_pipe_out = state.add_stream("A_pipe",
                                   dace.float32,
                                   transient=True,
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
+                                  storage=dace.StorageType.FPGA_Local)
     B_pipe_out = state.add_stream("B_pipe",
                                   dace.float32,
                                   transient=True,
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
+                                  storage=dace.StorageType.FPGA_Local)
     C_pipe_out = state.add_stream("C_pipe",
                                   dace.float32,
                                   transient=True,
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
+                                  storage=dace.StorageType.FPGA_Local)
 
-    state.add_memlet_path(A,
-                          read_A_sdfg_node,
-                          dst_conn="mem",
-                          memlet=dace.memlet.Memlet.simple(A, "0:N, 0:K"))
-    state.add_memlet_path(
-        read_A_sdfg_node,
-        A_pipe_out,
-        src_conn="pipe",
-        memlet=dace.memlet.Memlet.simple(
-            A_pipe_out,
-            '0',
-            num_accesses=dace.symbolic.pystr_to_symbolic("N * K")))
+    state.add_memlet_path(A, A_pipe_out, memlet=dace.memlet.Memlet("A_device"))
+
     state.add_memlet_path(
         A_pipe_in,
         compute_sdfg_node,


### PR DESCRIPTION
Some FPGA samples still use ancient ways of creating SDFGs. Update the `gemm_fpga_stream.py` sample to a more modern version.

Along the way, fix a bug in the Intel FPGA codegen :-)