### PR TITLE
Fixes to PruneConnectors and LoopToMap

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1752,13 +1752,10 @@ class SDFG(OrderedDiGraph):
         # These are imported in order to update the transformation registry
         from dace.transformation import dataflow, interstate
         # This is imported here to avoid an import loop
-        from dace.transformation.transformation import Transformation
+        from dace.transformation.transformation import (Transformation,
+                                                        strict_transformations)
 
-        strict_transformations = [
-            k for k, v in Transformation.extensions().items()
-            if v.get('strict', False)
-        ]
-        self.apply_transformations_repeated(strict_transformations,
+        self.apply_transformations_repeated(strict_transformations(),
                                             validate=validate,
                                             strict=True,
                                             validate_all=validate_all)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -12,7 +12,8 @@ import random
 import re
 import shutil
 import sys
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
+from typing import (Any, AnyStr, Dict, Iterator, List, Optional, Set, Tuple,
+                    Type, Union)
 import warnings
 import numpy as np
 import sympy as sp
@@ -530,7 +531,8 @@ class SDFG(OrderedDiGraph):
         """
         if location not in self.exit_code:
             self.exit_code[location] = CodeBlock('', dtypes.Language.CPP)
-        self.exit_code[location].code = cpp_code + self.exit_code[location].code
+        self.exit_code[
+            location].code = cpp_code + self.exit_code[location].code
 
     def append_transformation(self, transformation):
         """
@@ -887,6 +889,23 @@ class SDFG(OrderedDiGraph):
 
         # Subtract symbols defined in inter-state edges and constants
         return free_syms - defined_syms
+
+    def read_and_write_sets(self) -> Tuple[Set[AnyStr], Set[AnyStr]]:
+        """
+        Determines what data containers are read and written in this SDFG.
+        Writes with conflict resolution are included as both reads and writes.
+        :return: A two-tuple of sets of things denoting
+                 ({data read}, {data written}).
+        """
+        read_set = set()
+        write_set = set()
+        for state in self.states():
+            rs, ws = state.read_and_write_sets()
+            read_set |= rs
+            write_set |= ws
+        for edge in self.edges():
+            read_set |= edge.data.free_symbols & self.arrays.keys()
+        return read_set, write_set
 
     def arglist(self) -> Dict[str, dt.Data]:
         """
@@ -1379,8 +1398,9 @@ class SDFG(OrderedDiGraph):
             if find_new_name:
                 name = self._find_new_name(name)
             else:
-                raise NameError('Array or Stream with name "%s" already exists '
-                                "in SDFG" % name)
+                raise NameError(
+                    'Array or Stream with name "%s" already exists '
+                    "in SDFG" % name)
         self._arrays[name] = datadesc
 
         # Add free symbols to the SDFG global symbol storage
@@ -1458,7 +1478,8 @@ class SDFG(OrderedDiGraph):
         else:
             cond_ast = CodeBlock('True').code
         self.add_edge(guard, loop_state, InterstateEdge(cond_ast))
-        self.add_edge(guard, after_state, InterstateEdge(negate_expr(cond_ast)))
+        self.add_edge(guard, after_state,
+                      InterstateEdge(negate_expr(cond_ast)))
 
         # Loop incrementation
         incr = None if increment_expr is None else {loop_var: increment_expr}
@@ -1506,8 +1527,8 @@ class SDFG(OrderedDiGraph):
             self.add_constant(str(k), v)
 
     def optimize(self, optimizer=None) -> 'SDFG':
-        """ 
-        Optimize an SDFG using the CLI or external hooks. 
+        """
+        Optimize an SDFG using the CLI or external hooks.
         :param optimizer: If defines a valid class name, it will be called
                           during compilation to transform the SDFG as
                           necessary. If None, uses configuration setting.
@@ -1569,8 +1590,8 @@ class SDFG(OrderedDiGraph):
             sdfg, program_objects, sdfg.build_folder)
 
         # Compile the code and get the shared library path
-        shared_library = compiler.configure_and_compile(program_folder,
-                                                        sdfg.name)
+        shared_library = compiler.configure_and_compile(
+            program_folder, sdfg.name)
 
         # If provided, save output to path or filename
         if output_file is not None:
@@ -1927,8 +1948,8 @@ class SDFG(OrderedDiGraph):
                     node.sdfg.expand_library_nodes()  # Call recursively
                 elif isinstance(node, nd.LibraryNode):
                     node.expand(self, state)
-                    print("Automatically expanded library node \"" + str(node) +
-                          "\".")
+                    print("Automatically expanded library node \"" +
+                          str(node) + "\".")
                     # We made a copy of the original list of nodes, so we keep
                     # iterating even though this list has now changed
                     if recursive:

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -415,6 +415,12 @@ class SDFG(OrderedDiGraph):
             stype = dtypes.DTYPE_TO_TYPECLASS[stype]
         self.symbols[name] = stype
 
+    def remove_symbol(self, name):
+        """ Removes a symbol from the SDFG.
+            :param name: Symbol name.
+        """
+        del self.symbols[name]
+
     @property
     def start_state(self):
         """ Returns the starting state of this SDFG. """

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -29,7 +29,8 @@ def _getdebuginfo(old_dinfo=None) -> dtypes.DebugInfo:
         return old_dinfo
 
     caller = getframeinfo(stack()[2][0])
-    return dtypes.DebugInfo(caller.lineno, 0, caller.lineno, 0, caller.filename)
+    return dtypes.DebugInfo(caller.lineno, 0, caller.lineno, 0,
+                            caller.filename)
 
 
 class StateGraphView(object):
@@ -77,7 +78,8 @@ class StateGraphView(object):
     ###################################################################
     # Memlet-tracking methods
 
-    def memlet_path(self, edge: MultiConnectorEdge) -> List[MultiConnectorEdge]:
+    def memlet_path(self,
+                    edge: MultiConnectorEdge) -> List[MultiConnectorEdge]:
         """ Given one edge, returns a list of edges representing a path
             between its source and sink nodes. Used for memlet tracking.
 
@@ -123,7 +125,8 @@ class StateGraphView(object):
                 if not curedge.dst_conn.startswith("IN_"):  # Map variable
                     break
                 next_edge = next(e for e in state.out_edges(curedge.dst)
-                                 if e.src_conn == "OUT_" + curedge.dst_conn[3:])
+                                 if e.src_conn == "OUT_" +
+                                 curedge.dst_conn[3:])
                 result.append(next_edge)
                 curedge = next_edge
 
@@ -144,7 +147,8 @@ class StateGraphView(object):
             (isinstance(edge.dst, nd.EntryNode) and edge.dst_conn is not None
              and edge.dst_conn.startswith('IN_'))):
             propagate_forward = True
-        if ((isinstance(edge.src, nd.ExitNode) and edge.src_conn is not None) or
+        if ((isinstance(edge.src, nd.ExitNode) and edge.src_conn is not None)
+                or
             (isinstance(edge.dst, nd.ExitNode) and edge.dst_conn is not None)):
             propagate_backward = True
 
@@ -448,6 +452,27 @@ class StateGraphView(object):
 
         return defined_syms
 
+    def read_and_write_sets(self) -> Tuple[Set[AnyStr], Set[AnyStr]]:
+        """
+        Determines what data is read and written in this subgraph. Writes
+        with conflict resolution are included as both reads and writes.
+        :return: A two-tuple of sets of things denoting
+                 ({data read}, {data written}).
+        """
+        read_set = set()
+        write_set = set()
+        for n in self.data_nodes():
+            in_edges = self.in_edges(n)
+            if len(in_edges) > 0:
+                write_set.add(n.data)
+            for e in in_edges:
+                if e.data.wcr is not None:
+                    read_set.add(n.data)
+                    break
+            if len(self.out_edges(n)) > 0:
+                read_set.add(n.data)
+        return read_set, write_set
+
     def arglist(self) -> Dict[str, dt.Data]:
         """
         Returns an ordered dictionary of arguments (names and types) required
@@ -593,7 +618,10 @@ class StateGraphView(object):
             for k, v in self.arglist().items()
         ]
 
-    def scope_subgraph(self, entry_node, include_entry=True, include_exit=True):
+    def scope_subgraph(self,
+                       entry_node,
+                       include_entry=True,
+                       include_exit=True):
         from dace.sdfg.scope import _scope_subgraph
         return _scope_subgraph(self, entry_node, include_entry, include_exit)
 
@@ -637,9 +665,10 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
                       default=False,
                       desc="Do not synchronize at the end of the state")
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = Property(
+        choices=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation)
 
     location = DictProperty(
         key_type=str,
@@ -744,8 +773,8 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
                             str(type(memlet)))
 
         self._clear_scopedict_cache()
-        result = super(SDFGState, self).add_edge(u, u_connector, v, v_connector,
-                                                 memlet)
+        result = super(SDFGState, self).add_edge(u, u_connector, v,
+                                                 v_connector, memlet)
         memlet.try_initialize(self.parent, self, result)
         return result
 
@@ -886,7 +915,8 @@ class SDFGState(OrderedMultiDiConnectorGraph, StateGraphView):
         # Add symbols from inter-state edges along the path to the state
         try:
             start_state = sdfg.start_state
-            for path in sdfg.all_simple_paths(start_state, self, as_edges=True):
+            for path in sdfg.all_simple_paths(start_state, self,
+                                              as_edges=True):
                 for e in path:
                     symbols.update(e.data.new_symbols(symbols))
         except ValueError:

--- a/dace/transformation/__init__.py
+++ b/dace/transformation/__init__.py
@@ -1,0 +1,1 @@
+from .transformation import strict_transformations

--- a/dace/transformation/dataflow/prune_connectors.py
+++ b/dace/transformation/dataflow/prune_connectors.py
@@ -70,8 +70,15 @@ class PruneConnectors(pm.Transformation):
             for n in s.data_nodes():
                 all_data_used.add(n.data)
 
-        for conn in itertools.chain(prune_in, prune_out):
-            for e in state.edges_by_connector(nsdfg, conn):
+        for conn in prune_in:
+            for e in state.in_edges_by_connector(nsdfg, conn):
+                state.remove_memlet_path(e, remove_orphans=True)
+                if conn in nsdfg.sdfg.arrays and conn not in all_data_used:
+                    # If the data is now unused, we can purge it from the SDFG
+                    nsdfg.sdfg.remove_data(conn)
+
+        for conn in prune_out:
+            for e in state.out_edges_by_connector(nsdfg, conn):
                 state.remove_memlet_path(e, remove_orphans=True)
                 if conn in nsdfg.sdfg.arrays and conn not in all_data_used:
                     # If the data is now unused, we can purge it from the SDFG

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -3,7 +3,7 @@
 import copy
 
 from dace.subsets import Range, Subset, union
-from typing import AnyStr, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from dace.sdfg import nodes, utils
 from dace.sdfg.graph import SubgraphView, MultiConnectorEdge
@@ -59,7 +59,8 @@ def nest_state_subgraph(sdfg: SDFG,
         scope_node = scope_dict[node]
         if scope_node not in subgraph.nodes():
             if top_scopenode != -1 and top_scopenode != scope_node:
-                raise ValueError('Subgraph is contained in more than one scope')
+                raise ValueError(
+                    'Subgraph is contained in more than one scope')
             top_scopenode = scope_node
 
     scope = scope_tree[top_scopenode]
@@ -200,16 +201,16 @@ def nest_state_subgraph(sdfg: SDFG,
         node = nstate.add_read(name)
         new_edge = copy.deepcopy(edge.data)
         new_edge.data = name
-        edges_to_offset.append(
-            (edge, nstate.add_edge(node, None, edge.dst, edge.dst_conn,
-                                   new_edge)))
+        edges_to_offset.append((edge,
+                                nstate.add_edge(node, None, edge.dst,
+                                                edge.dst_conn, new_edge)))
     for name, edge in zip(output_names, outputs):
         node = nstate.add_write(name)
         new_edge = copy.deepcopy(edge.data)
         new_edge.data = name
-        edges_to_offset.append(
-            (edge, nstate.add_edge(edge.src, edge.src_conn, node, None,
-                                   new_edge)))
+        edges_to_offset.append((edge,
+                                nstate.add_edge(edge.src, edge.src_conn, node,
+                                                None, new_edge)))
 
     # Offset memlet paths inside nested SDFG according to subsets
     for original_edge, new_edge in edges_to_offset:
@@ -338,7 +339,8 @@ def unsqueeze_memlet(internal_memlet: Memlet, external_memlet: Memlet):
         # Special case: If internal memlet is one element and the top
         # memlet uses all its dimensions, ignore the internal element
         # TODO: There must be a better solution
-        if (len(internal_memlet.subset) == 1 and ones == list(range(len(shape)))
+        if (len(internal_memlet.subset) == 1
+                and ones == list(range(len(shape)))
                 and (internal_memlet.subset[0] == (0, 0, 1)
                      or internal_memlet.subset[0] == 0)):
             to_unsqueeze = ones[1:]
@@ -350,10 +352,10 @@ def unsqueeze_memlet(internal_memlet: Memlet, external_memlet: Memlet):
         # Try to squeeze internal memlet
         result.subset.squeeze()
         if len(result.subset) != len(external_memlet.subset):
-            raise ValueError('Unexpected extra dimensions in internal memlet '
-                             'while un-squeezing memlet.\nExternal memlet: %s\n'
-                             'Internal memlet: %s' %
-                             (external_memlet, internal_memlet))
+            raise ValueError(
+                'Unexpected extra dimensions in internal memlet '
+                'while un-squeezing memlet.\nExternal memlet: %s\n'
+                'Internal memlet: %s' % (external_memlet, internal_memlet))
 
     result.subset.offset(external_memlet.subset, False)
 
@@ -408,30 +410,6 @@ def replicate_scope(sdfg: SDFG, state: SDFGState,
     new_exit.map = new_entry.map
 
     return ScopeSubgraphView(state, new_nodes, new_entry)
-
-
-def read_and_write_sets(state: SDFGState) -> Tuple[Set[AnyStr], Set[AnyStr]]:
-    """
-    Determines which data containers are read and which are written in the
-    given SDFG state. Containers that are written with write conflict
-    resolution are also included in the read set.
-    :param state: An SDFG state.
-    :return: A tuple of strings denoting (container read, containers written).
-    """
-    data_nodes = state.data_nodes()
-    read_set = set()
-    write_set = set()
-    for n in data_nodes:
-        in_edges = state.in_edges(n)
-        if len(in_edges) > 0:
-            write_set.add(n.data)
-        for e in in_edges:
-            if e.data.wcr is not None:
-                read_set.add(n.data)
-                break
-        if len(state.out_edges(n)) > 0:
-            read_set.add(n.data)
-    return read_set, write_set
 
 
 def split_interstate_edges(sdfg: SDFG) -> None:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -108,6 +108,15 @@ class LoopToMap(DetectLoop):
         body.add_node(entry)
         body.add_node(exit)
 
+        # If the map uses symbols from data containers, instantiate reads
+        containers_to_read = entry.free_symbols & sdfg.arrays.keys()
+        for rd in containers_to_read:
+            access_node = body.add_read(rd)
+            body.add_memlet_path(access_node,
+                                 entry,
+                                 dst_conn=rd,
+                                 memlet=memlet.Memlet(rd))
+
         # Reroute all memlets through the entry and exit nodes
         for n in source_nodes:
             if isinstance(n, nodes.AccessNode):

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -24,7 +24,6 @@ class LoopToMap(DetectLoop):
        the body of the loop, and where the loop body only consists of a single
        state.
     """
-
     @staticmethod
     def can_be_applied(graph, candidate, expr_index, sdfg, strict=False):
         # Is this even a loop
@@ -58,12 +57,13 @@ class LoopToMap(DetectLoop):
 
         # Currently only detect the trivial case where the set of containers
         # that are read are completely disjoint from those that are written
-        read_set, write_set = helpers.read_and_write_sets(begin)
+        read_set, write_set = begin.read_and_write_sets()
         if len(read_set & write_set) != 0:
             return False
 
         # Check that the iteration variable is not used on other edges
-        loop_edges = set(itertools.chain(graph.out_edges(guard), graph.out_edges(begin)))
+        loop_edges = set(
+            itertools.chain(graph.out_edges(guard), graph.out_edges(begin)))
         if any(itervar in e.data.free_symbols for e in sdfg.edges()
                if e not in loop_edges):
             return False
@@ -131,7 +131,6 @@ class LoopToMap(DetectLoop):
                                        internal_connector=e.src_conn)
             else:
                 body.add_nedge(n, exit, memlet.Memlet())
-
 
         # Get rid of the loop exit condition edge
         sdfg.remove_edge(sdfg.edges_between(guard, after)[0])

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -149,3 +149,7 @@ class LoopToMap(DetectLoop):
 
         # Route body directly to after state
         sdfg.add_edge(body, after, sd.InterstateEdge())
+
+        # Remove symbol from SDFG
+        if itervar in sdfg.symbols:
+            sdfg.remove_symbol(itervar)

--- a/dace/transformation/interstate/loop_unroll.py
+++ b/dace/transformation/interstate/loop_unroll.py
@@ -86,14 +86,15 @@ class LoopUnroll(DetectLoop):
         loop_subgraph = gr.SubgraphView(sdfg, loop_states)
 
         # Evaluate the real values of the loop
-        start, end, stride = (symbolic.evaluate(r, sdfg.constants) for r in rng)
+        start, end, stride = (symbolic.evaluate(r, sdfg.constants)
+                              for r in rng)
 
         # Create states for loop subgraph
         unrolled_states = []
         for i in range(start, end + 1, stride):
             # Instantiate loop states with iterate value
-            new_states = self.instantiate_loop(sdfg, loop_states, loop_subgraph,
-                                               itervar, i)
+            new_states = self.instantiate_loop(sdfg, loop_states,
+                                               loop_subgraph, itervar, i)
 
             # Connect iterations with unconditional edges
             if len(unrolled_states) > 0:

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
-""" 
-Contains classes that represent data-centric transformations. 
+"""
+Contains classes that represent data-centric transformations.
 
 There are three general types of transformations:
   * Pattern-matching Transformations (extending Transformation): Transformations
@@ -26,11 +26,11 @@ from typing import Any, Dict, List, Optional, Set, Type, Union
 class Transformation(object):
     """ Base class for transformations, as well as a static registry of
         transformations, where new transformations can be added in a
-        decentralized manner. 
+        decentralized manner.
         An instance of a Transformation represents a match of the transformation
         on an SDFG, complete with a subgraph candidate and properties.
 
-        New transformations that extend this class must contain static 
+        New transformations that extend this class must contain static
         `PatternNode` fields that represent the nodes in the pattern graph, and
         use them to implement at least three methods:
           * `expressions`: A static method that returns a list of graph
@@ -45,11 +45,11 @@ class Transformation(object):
         For more information and optimization opportunities, see the respective
         methods' documentation.
 
-        In order to be included in lists and apply through the 
+        In order to be included in lists and apply through the
         `sdfg.apply_transformations` API, each transformation shouls be
         registered with ``Transformation.register`` (or, more commonly,
-        the ``@dace.registry.autoregister_params`` class decorator) with two 
-        optional boolean keyword arguments: ``singlestate`` (default: False) 
+        the ``@dace.registry.autoregister_params`` class decorator) with two
+        optional boolean keyword arguments: ``singlestate`` (default: False)
         and ``strict`` (default: False).
         If ``singlestate`` is True, the transformation is matched on subgraphs
         inside an SDFGState; otherwise, subgraphs of the SDFG state machine are
@@ -175,7 +175,7 @@ class Transformation(object):
         return self._subgraph_user
 
     def apply_pattern(self, sdfg: SDFG) -> Union[Any, None]:
-        """ 
+        """
         Applies this transformation on the given SDFG, using the transformation
         instance to find the right SDFG object (based on SDFG ID), and applying
         memlet propagation as necessary.
@@ -192,7 +192,7 @@ class Transformation(object):
         return retval
 
     def __lt__(self, other: 'Transformation') -> bool:
-        """ 
+        """
         Comparing two transformations by their class name and node IDs
         in match. Used for ordering transformations consistently.
         """
@@ -231,7 +231,7 @@ class Transformation(object):
 
     @classmethod
     def _get_pattern_nodes(cls) -> Dict[str, 'PatternNode']:
-        """ 
+        """
         Returns a dictionary of pattern-matching node in this transformation
         subclass. Used internally for pattern-matching.
         :return: A dictionary mapping between pattern-node name and its type.
@@ -265,7 +265,7 @@ class Transformation(object):
         ```
 
         :param sdfg: The SDFG to apply the transformation to.
-        :param options: A set of parameters to use for applying the 
+        :param options: A set of parameters to use for applying the
                         transformation.
         :param expr_index: The pattern expression index to try to match with.
         :param verify: Check that `can_be_applied` returns True before applying.
@@ -379,9 +379,9 @@ class Transformation(object):
 
 
 class PatternNode(object):
-    """ 
+    """
     Static field wrapper of a node or an SDFG state that designates it as part
-    of a subgraph pattern. These objects are used in subclasses of 
+    of a subgraph pattern. These objects are used in subclasses of
     `Transformation` to represent the subgraph patterns.
 
     Example use:
@@ -435,7 +435,7 @@ class ExpandTransformation(Transformation):
     subgraph, and thus needs only simple matching and replacement
     functionality. Subclasses only need to implement the method
     "expansion".
-    
+
     This is an internal interface used to track the expansion of library nodes.
     """
     @classmethod
@@ -512,10 +512,10 @@ class ExpandTransformation(Transformation):
 @make_properties
 class SubgraphTransformation(object):
     """
-    Base class for transformations that apply on arbitrary subgraphs, rather 
-    than matching a specific pattern. 
-    
-    Subclasses need to implement the `can_be_applied` and `apply` operations, 
+    Base class for transformations that apply on arbitrary subgraphs, rather
+    than matching a specific pattern.
+
+    Subclasses need to implement the `can_be_applied` and `apply` operations,
     as well as registered with the subclass registry. See the `Transformation`
     class docstring for more information.
     """
@@ -574,7 +574,7 @@ class SubgraphTransformation(object):
         Tries to match the transformation on a given subgraph, returning
         True if this transformation can be applied.
         :param sdfg: The SDFG that includes the subgraph.
-        :param subgraph: The SDFG or state subgraph to try to apply the 
+        :param subgraph: The SDFG or state subgraph to try to apply the
                          transformation on.
         :return: True if the subgraph can be transformed, or False otherwise.
         """
@@ -598,10 +598,10 @@ class SubgraphTransformation(object):
         nodes. Raises an error if arguments are invalid or transformation is
         not applicable.
 
-        To apply the transformation on a specific subgraph, the `where` 
+        To apply the transformation on a specific subgraph, the `where`
         parameter can be used either on a subgraph object (`SubgraphView`), or
         on directly on a list of subgraph nodes, given as `Node` or `SDFGState`
-        objects. Transformation properties can then be given as keyword 
+        objects. Transformation properties can then be given as keyword
         arguments. For example, applying `SubgraphFusion` on a subgraph of three
         nodes can be called in one of two ways:
         ```
@@ -616,7 +616,7 @@ class SubgraphTransformation(object):
         :param sdfg: The SDFG to apply the transformation to.
         :param where: A set of nodes in the SDFG/state, or a subgraph thereof.
         :param verify: Check that `can_be_applied` returns True before applying.
-        :param options: A set of parameters to use for applying the 
+        :param options: A set of parameters to use for applying the
                         transformation.
         """
         subgraph = None
@@ -690,3 +690,12 @@ class SubgraphTransformation(object):
             context=context,
             ignore_properties={'transformation', 'type'})
         return ret
+
+
+def strict_transformations() -> List[Transformation]:
+    """ :return: List of all registered strict transformations.
+    """
+    return [
+        k for k, v in Transformation.extensions().items()
+        if v.get('strict', False)
+    ]

--- a/tests/python_frontend/transients_test.py
+++ b/tests/python_frontend/transients_test.py
@@ -2,28 +2,32 @@
 import dace
 import numpy as np
 
+n = 1024
+
 
 @dace.program
-def transients(A: dace.float32[10]):
-    ostream = dace.define_stream(dace.float32, 10)
+def transients(A: dace.float32[n]):
+    ostream = dace.define_stream(dace.float32, n)
     oscalar = dace.define_local_scalar(dace.int32)
-    oarray = dace.define_local([10], dace.float32)
+    oarray = dace.define_local([n], dace.float32)
     oarray[:] = 0
     oscalar = 0
-    for i in dace.map[0:10]:
+    for i in dace.map[0:n]:
         if A[i] >= 0.5:
             A[i] >> ostream(-1)
-            oscalar += 1
+            with dace.tasklet:
+                out >> oscalar(1, lambda a, b: a + b)
+                out = 1
     ostream >> oarray
     return oscalar, oarray
 
 
 def test_transients():
-    A = np.random.rand(10).astype(np.float32)
+    A = np.random.rand(n).astype(np.float32)
     scal, arr = transients(A)
     if scal[0] > 0:
-        assert((arr[0:scal[0]] >= 0.5).all())
-    assert((arr[scal[0]:] == 0).all())
+        assert (arr[0:scal[0]] >= 0.5).all()
+    assert (arr[scal[0]:] == 0).all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix issues found in both transformations by applying it to Polybench and LULESH SDFGs.

Move `read_and_write_sets` into `SDFG` and `SubgraphView`. Add symmetric `remove_symbol` function to `SDFG`.