### PR TITLE
Improve LoopToMap and StateAssignElimination and StateFusion

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -537,8 +537,7 @@ class SDFG(OrderedDiGraph):
         """
         if location not in self.exit_code:
             self.exit_code[location] = CodeBlock('', dtypes.Language.CPP)
-        self.exit_code[
-            location].code = cpp_code + self.exit_code[location].code
+        self.exit_code[location].code = cpp_code + self.exit_code[location].code
 
     def append_transformation(self, transformation):
         """
@@ -1404,9 +1403,8 @@ class SDFG(OrderedDiGraph):
             if find_new_name:
                 name = self._find_new_name(name)
             else:
-                raise NameError(
-                    'Array or Stream with name "%s" already exists '
-                    "in SDFG" % name)
+                raise NameError('Array or Stream with name "%s" already exists '
+                                "in SDFG" % name)
         self._arrays[name] = datadesc
 
         # Add free symbols to the SDFG global symbol storage
@@ -1484,8 +1482,7 @@ class SDFG(OrderedDiGraph):
         else:
             cond_ast = CodeBlock('True').code
         self.add_edge(guard, loop_state, InterstateEdge(cond_ast))
-        self.add_edge(guard, after_state,
-                      InterstateEdge(negate_expr(cond_ast)))
+        self.add_edge(guard, after_state, InterstateEdge(negate_expr(cond_ast)))
 
         # Loop incrementation
         incr = None if increment_expr is None else {loop_var: increment_expr}
@@ -1596,8 +1593,8 @@ class SDFG(OrderedDiGraph):
             sdfg, program_objects, sdfg.build_folder)
 
         # Compile the code and get the shared library path
-        shared_library = compiler.configure_and_compile(
-            program_folder, sdfg.name)
+        shared_library = compiler.configure_and_compile(program_folder,
+                                                        sdfg.name)
 
         # If provided, save output to path or filename
         if output_file is not None:
@@ -1899,12 +1896,23 @@ class SDFG(OrderedDiGraph):
                 match.apply(sdfg)
                 applied_transformations[type(match).__name__] += 1
                 if validate_all:
-                    self.validate()
+                    try:
+                        self.validate()
+                    except InvalidSDFGError as err:
+                        raise InvalidSDFGError(
+                            "Validation failed after applying {}.".format(
+                                match.print_match(sdfg)), sdfg,
+                            match.state_id) from err
                 applied = True
                 break
 
         if validate:
-            self.validate()
+            try:
+                self.validate()
+            except InvalidSDFGError as err:
+                raise InvalidSDFGError(
+                    "Validation failed after applying {}.".format(
+                        match.print_match(sdfg)), sdfg, match.state_id) from err
 
         if Config.get_bool('debugprint') and len(applied_transformations) > 0:
             print('Applied {}.'.format(', '.join([
@@ -1951,8 +1959,8 @@ class SDFG(OrderedDiGraph):
                     node.sdfg.expand_library_nodes()  # Call recursively
                 elif isinstance(node, nd.LibraryNode):
                     node.expand(self, state)
-                    print("Automatically expanded library node \"" +
-                          str(node) + "\".")
+                    print("Automatically expanded library node \"" + str(node) +
+                          "\".")
                     # We made a copy of the original list of nodes, so we keep
                     # iterating even though this list has now changed
                     if recursive:

--- a/dace/transformation/interstate/loop_detection.py
+++ b/dace/transformation/interstate/loop_detection.py
@@ -70,10 +70,7 @@ class DetectLoop(transformation.Transformation):
         if itervar not in guard_inedges[1].data.assignments:
             return False
 
-        # Outgoing edges must not have assignments and be a negation of each
-        # other
-        if any(len(e.data.assignments) > 0 for e in guard_outedges):
-            return False
+        # Outgoing edges must be a negation of each other
         if guard_outedges[0].data.condition_sympy() != (sp.Not(
                 guard_outedges[1].data.condition_sympy())):
             return False

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -165,7 +165,8 @@ class LoopToMap(DetectLoop):
                 body.add_nedge(n, exit, memlet.Memlet())
 
         # Get rid of the loop exit condition edge
-        sdfg.remove_edge(sdfg.edges_between(guard, after)[0])
+        after_edge = sdfg.edges_between(guard, after)[0]
+        sdfg.remove_edge(after_edge)
 
         # Remove the assignment on the edge to the guard
         for e in sdfg.in_edges(guard):
@@ -179,8 +180,11 @@ class LoopToMap(DetectLoop):
         # Get rid of backedge to guard
         sdfg.remove_edge(sdfg.edges_between(body, guard)[0])
 
-        # Route body directly to after state
-        sdfg.add_edge(body, after, sd.InterstateEdge())
+        # Route body directly to after state, maintaining any other assignments
+        # it might have had
+        sdfg.add_edge(
+            body, after,
+            sd.InterstateEdge(assignments=after_edge.data.assignments))
 
         # Remove symbol from SDFG
         if itervar in sdfg.symbols:

--- a/dace/transformation/interstate/loop_unroll.py
+++ b/dace/transformation/interstate/loop_unroll.py
@@ -103,12 +103,16 @@ class LoopUnroll(DetectLoop):
 
             unrolled_states.append((new_states[first_id], new_states[last_id]))
 
+        # Get any assignments that might be on the edge to the after state
+        after_assignments = (sdfg.edges_between(
+            guard, after_state)[0].data.assignments)
+
         # Connect new states to before and after states without conditions
         if unrolled_states:
             sdfg.add_edge(before_state, unrolled_states[0][0],
                           sd.InterstateEdge())
             sdfg.add_edge(unrolled_states[-1][1], after_state,
-                          sd.InterstateEdge())
+                          sd.InterstateEdge(assignments=after_assignments))
 
         # Remove old states from SDFG
         sdfg.remove_nodes_from([guard] + loop_states)

--- a/dace/transformation/interstate/state_elimination.py
+++ b/dace/transformation/interstate/state_elimination.py
@@ -148,7 +148,7 @@ class StateAssignElimination(transformation.Transformation):
             del edge.data.assignments[varname]
 
             for e in sdfg.edges():
-                if varname in edge.data.free_symbols:
+                if varname in e.data.free_symbols:
                     break
             else:
                 # If removed assignment does not appear in any other edge,

--- a/dace/transformation/interstate/state_elimination.py
+++ b/dace/transformation/interstate/state_elimination.py
@@ -61,16 +61,10 @@ class EndStateElimination(transformation.Transformation):
 def _assignments_to_consider(sdfg, edge):
     assignments_to_consider = {}
     for var, assign in edge.data.assignments.items():
-        # Assignments must not use a data container
         as_symbolic = symbolic.pystr_to_symbolic(assign)
-        for s in as_symbolic.free_symbols:
-            # They will appear either as symbols...
-            if str(s) in sdfg.arrays:
-                break
-        else:
-            # ...or as "functions" (when they are subscripted)
-            if not symbolic.contains_sympy_functions(as_symbolic):
-                assignments_to_consider[var] = assign
+        # Assignments cannot subscript a data container
+        if not symbolic.contains_sympy_functions(as_symbolic):
+            assignments_to_consider[var] = assign
     return assignments_to_consider
 
 

--- a/dace/transformation/interstate/state_elimination.py
+++ b/dace/transformation/interstate/state_elimination.py
@@ -13,7 +13,7 @@ from dace.config import Config
 
 @registry.autoregister_params(strict=True)
 class EndStateElimination(transformation.Transformation):
-    """ 
+    """
     End-state elimination removes a redundant state that has one incoming edge
     and no contents.
     """
@@ -60,7 +60,7 @@ class EndStateElimination(transformation.Transformation):
 
 @registry.autoregister_params(strict=True)
 class StateAssignElimination(transformation.Transformation):
-    """ 
+    """
     State assign elimination removes all assignments into the final state
     and subsumes the assigned value into its contents.
     """

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -25,9 +25,9 @@ class CCDesc:
 @registry.autoregister_params(strict=True)
 class StateFusion(transformation.Transformation):
     """ Implements the state-fusion transformation.
-        
+
         State-fusion takes two states that are connected through a single edge,
-        and fuses them into one state. If strict, only applies if no memory 
+        and fuses them into one state. If strict, only applies if no memory
         access hazards are created.
     """
 
@@ -80,9 +80,9 @@ class StateFusion(transformation.Transformation):
                           inputs_a: bool, graph_b: SDFGState,
                           group_b: List[nodes.AccessNode],
                           inputs_b: bool) -> bool:
-        """ 
+        """
         Performs an all-pairs check for subset intersection on two
-        groups of nodes. If group intersects or result is indeterminate, 
+        groups of nodes. If group intersects or result is indeterminate,
         returns True as a precaution.
         :param graph_a: The graph in which the first set of nodes reside.
         :param group_a: The first set of nodes to check.

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -153,6 +153,12 @@ class StateFusion(transformation.Transformation):
                                 if isinstance(n, nodes.AccessNode)
                                 and first_state.in_degree(n) > 0):
                 return False
+            # Fail if symbols assigned on the first edge are free symbols on the
+            # second edge
+            symbols_used = set(out_edges[0].data.free_symbols)
+            for e in in_edges:
+                if e.data.assignments.keys() & symbols_used:
+                    return False
 
         # There can be no state that have output edges pointing to both the
         # first and the second state. Such a case will produce a multi-graph.

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -161,6 +161,12 @@ class StateFusion(transformation.Transformation):
                 if dst == second_state:
                     return False
 
+        # No data containers written in the first state can be free symbols in
+        # the second
+        _, write_set = first_state.read_and_write_sets()
+        if len(write_set & second_state.free_symbols) > 0:
+            return False
+
         if strict:
             # If second state has other input edges, there might be issues
             # Exceptions are when none of the states contain dataflow, unless


### PR DESCRIPTION
Extend LoopToMap:
- Allow the iteration variable to be used later in the state machine if it is first reassigned to something else (so that we don't have to output the end value after executing the map).
- Allow overlap between read and write sets if the container is read and written at exactly the same index at exactly one memory location.

Fixes to StateAssignElimination:
- Fix a typo in `apply`

Fix to StateFusion:
- Don't allow fusion when a free symbol of the second state is written as a data container in the first.