### PR TITLE
Issues with subsets.Range.pop

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1744,7 +1744,7 @@ class ProgramVisitor(ExtNodeVisitor):
                           symbols: Dict[str, 'dace.symbol'] = dict()):
 
         # Parse map inputs (for memory-based ranges)
-        if map_inputs is not None:
+        if map_inputs:
             for conn, memlet in map_inputs.items():
                 if self.nested:
                     # TODO: Make this work nested for-loops

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -615,8 +615,12 @@ class Range(Subset):
                 new_ranges.append(self.ranges[i])
                 new_tsizes.append(self.tile_sizes[i])
         if not new_ranges:
-            new_ranges = [self.ranges[-1]]
-            new_tsizes = [self.tile_sizes[-1]]
+            # new_ranges = [self.ranges[-1]]
+            # new_tsizes = [self.tile_sizes[-1]]
+            new_ranges = [(symbolic.pystr_to_symbolic(0),
+                           symbolic.pystr_to_symbolic(0),
+                           symbolic.pystr_to_symbolic(1))]
+            new_tsizes = [symbolic.pystr_to_symbolic(1)]
         self.ranges = new_ranges
         self.tile_sizes = new_tsizes
 

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -615,8 +615,6 @@ class Range(Subset):
                 new_ranges.append(self.ranges[i])
                 new_tsizes.append(self.tile_sizes[i])
         if not new_ranges:
-            # new_ranges = [self.ranges[-1]]
-            # new_tsizes = [self.tile_sizes[-1]]
             new_ranges = [(symbolic.pystr_to_symbolic(0),
                            symbolic.pystr_to_symbolic(0),
                            symbolic.pystr_to_symbolic(1))]


### PR DESCRIPTION
When a range ends up empty after executing `subsets.Range.pop`, it keeps its original last dimension. This may lead to erroneous computation of the inner and outer indices in `ProgramVisitor._add_dependencies`. To alleviate the problem, `subsets.Range.pop` must default to a unit range `[(0, 0, 1)]` when popping all dimensions. If such behavior is not appropriate for all cases where `subsets.Range.pop` is called, then `ProgramVisitor._add_dependencies` must be rewritten to compute the inner and outer indices in a different manner.