### PR TITLE
Make scalar promotion match numpy behavior when scalars are known

### DIFF
--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -477,12 +477,12 @@ def _min(sdfg: SDFG, state: SDFGState, a: str, axis=None):
 
 
 @oprepo.replaces('numpy.argmax')
-def _argmax(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int32):
+def _argmax(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int64):
     return _argminmax(sdfg, state, a, axis, func="max", result_type=result_type)
 
 
 @oprepo.replaces('numpy.argmin')
-def _argmin(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int32):
+def _argmin(sdfg: SDFG, state: SDFGState, a: str, axis, result_type=dace.int64):
     return _argminmax(sdfg, state, a, axis, func="min", result_type=result_type)
 
 
@@ -491,7 +491,7 @@ def _argminmax(sdfg: SDFG,
                a: str,
                axis,
                func,
-               result_type=dace.int32,
+               result_type=dace.int64,
                return_both=False):
     nest = NestedCall(sdfg, state)
 

--- a/tests/numpy/binop_broadcasting_test.py
+++ b/tests/numpy/binop_broadcasting_test.py
@@ -15,22 +15,22 @@ def test_multl1(A: dace.int64[5, 3], B: dace.int64[3]):
     return A * B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorl1(A: dace.int64[5, 3], B: dace.int64[3]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorl1(A: dace.int64[5, 3], B: dace.int64[3]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteql1(A: dace.int64[5, 3], B: dace.int64[3]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltl1(A: dace.int64[5, 3], B: dace.int64[3]):
     return A < B
 
@@ -48,22 +48,22 @@ def test_multr1(A: dace.int64[5], B: dace.int64[3, 5]):
     return A * B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorr1(A: dace.int64[5], B: dace.int64[3, 5]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorr1(A: dace.int64[5], B: dace.int64[3, 5]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteqr1(A: dace.int64[5], B: dace.int64[3, 5]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltr1(A: dace.int64[5], B: dace.int64[3, 5]):
     return A < B
 
@@ -81,22 +81,22 @@ def test_multl2(A: dace.int64[5, 3], B: dace.int64[5, 1]):
     return A * B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorl2(A: dace.int64[5, 3], B: dace.int64[5, 1]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorl2(A: dace.int64[5, 3], B: dace.int64[5, 1]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteql2(A: dace.int64[5, 3], B: dace.int64[5, 1]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltl2(A: dace.int64[5, 3], B: dace.int64[5, 1]):
     return A < B
 
@@ -114,22 +114,22 @@ def test_multr2(A: dace.int64[3, 1], B: dace.int64[3, 5]):
     return A * B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorr2(A: dace.int64[3, 1], B: dace.int64[3, 5]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorr2(A: dace.int64[3, 1], B: dace.int64[3, 5]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteqr2(A: dace.int64[3, 1], B: dace.int64[3, 5]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltr2(A: dace.int64[3, 1], B: dace.int64[3, 5]):
     return A < B
 
@@ -142,12 +142,12 @@ def test_subl3(A: dace.float64[5, 3], B: dace.float64[2, 5, 1]):
     return A - B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorl3(A: dace.int64[5, 3], B: dace.int64[2, 5, 1]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltl3(A: dace.int64[5, 3], B: dace.int64[2, 5, 1]):
     return A < B
 
@@ -160,12 +160,12 @@ def test_multr3(A: dace.int64[4, 3, 1], B: dace.int64[3, 5]):
     return A * B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorr3(A: dace.int64[4, 3, 1], B: dace.int64[3, 5]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteqr3(A: dace.int64[4, 3, 1], B: dace.int64[3, 5]):
     return A != B
 
@@ -178,12 +178,12 @@ def test_subl4(A: dace.float64[5, 3], B: dace.float64[2]):
     return A - B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorl4(A: dace.int64[5, 3], B: dace.int64[2, 3]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltl4(A: dace.int64[5, 3], B: dace.int64[3, 2, 3]):
     return A < B
 
@@ -196,7 +196,7 @@ def test_multr4(A: dace.int64[4], B: dace.int64[3, 5]):
     return A * B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorr4(A: dace.int64[4, 1], B: dace.int64[3, 5]):
     return A | B
 

--- a/tests/numpy/binop_test.py
+++ b/tests/numpy/binop_test.py
@@ -26,7 +26,7 @@ def test_div(A: dace.float64[5, 5], B: dace.float64[5, 5]):
 
 
 # A // B is not implemented correctly in dace for negative numbers
-@compare_numpy_output(non_zero=True, positive=True)
+@compare_numpy_output(non_zero=True, positive=True, check_result_type=False)
 def test_floordiv(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A // B
 
@@ -38,7 +38,7 @@ def test_mod(A: dace.int64[5, 5], B: dace.int64[5, 5]):
 
 
 # numpy throws an error for negative B, dace doesn't
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_pow(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A**B
 
@@ -49,57 +49,57 @@ def test_matmult(A: dace.int64[5, 5], B: dace.int64[5, 5]):
 
 
 # dace has weird behavior here too
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_lshift(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A << B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_rshift(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A >> B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitor(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxor(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bit(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A & B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_eq(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A == B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteq(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_lt(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A < B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_lte(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A <= B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gt(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A > B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gte(A: dace.int64[5, 5], B: dace.int64[5, 5]):
     return A >= B
 

--- a/tests/numpy/binop_with_pseudoscalars_test.py
+++ b/tests/numpy/binop_with_pseudoscalars_test.py
@@ -27,7 +27,7 @@ def test_divl(A: dace.float64[5, 5], B: dace.float64[1]):
 
 
 # A // B is not implemented correctly in dace for negative numbers
-@compare_numpy_output(non_zero=True, positive=True)
+@compare_numpy_output(non_zero=True, positive=True, check_result_type=False)
 def test_floordivl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A // B
 
@@ -39,63 +39,63 @@ def test_modl(A: dace.int64[5, 5], B: dace.int64[1]):
 
 
 # numpy throws an error for negative B, dace doesn't
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_powl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A**B
 
 
 # dace has weird behavior here too
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_lshiftl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A << B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_rshiftl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A >> B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitandl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A & B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_eql(A: dace.int64[5, 5], B: dace.int64[1]):
     return A == B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteql(A: dace.int64[5, 5], B: dace.int64[1]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A < B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltel(A: dace.int64[5, 5], B: dace.int64[1]):
     return A <= B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gtl(A: dace.int64[5, 5], B: dace.int64[1]):
     return A > B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gtel(A: dace.int64[5, 5], B: dace.int64[1]):
     return A >= B
 
@@ -123,7 +123,7 @@ def test_divr(A: dace.float64[1], B: dace.float64[5, 5]):
     return A / B
 
 
-@compare_numpy_output(non_zero=True, positive=True)
+@compare_numpy_output(non_zero=True, positive=True, check_result_type=False)
 def test_floordivr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A // B
 
@@ -133,62 +133,62 @@ def test_modr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A % B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_powr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A**B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_lshiftr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A << B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_rshiftr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A >> B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitandr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A & B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_eqr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A == B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteqr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A < B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_lter(A: dace.int64[1], B: dace.int64[5, 5]):
     return A <= B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gtr(A: dace.int64[1], B: dace.int64[5, 5]):
     return A > B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gter(A: dace.int64[1], B: dace.int64[5, 5]):
     return A >= B
 

--- a/tests/numpy/binop_with_scalars_test.py
+++ b/tests/numpy/binop_with_scalars_test.py
@@ -27,8 +27,9 @@ def test_divl(A: dace.float64[5, 5], B: dace.float64):
     return A / B
 
 
-# A // B is not implemented correctly in dace for negative numbers
-@compare_numpy_output(non_zero=True, positive=True)
+# A // B is not implemented correctly in dace for negative numbers.
+# result type explicitly deviates from the numpy result
+@compare_numpy_output(non_zero=True, positive=True, check_result_type=False)
 def test_floordivl(A: dace.int64[5, 5], B: dace.int64):
     return A // B
 
@@ -40,63 +41,63 @@ def test_modl(A: dace.int64[5, 5], B: dace.int64):
 
 
 # numpy throws an error for negative B, dace doesn't
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_powl(A: dace.int64[5, 5], B: dace.int64):
     return A**B
 
 
 # dace has weird behavior here too
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_lshiftl(A: dace.int64[5, 5], B: dace.int64):
     return A << B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_rshiftl(A: dace.int64[5, 5], B: dace.int64):
     return A >> B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorl(A: dace.int64[5, 5], B: dace.int64):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorl(A: dace.int64[5, 5], B: dace.int64):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitandl(A: dace.int64[5, 5], B: dace.int64):
     return A & B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_eql(A: dace.int64[5, 5], B: dace.int64):
     return A == B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteql(A: dace.int64[5, 5], B: dace.int64):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltl(A: dace.int64[5, 5], B: dace.int64):
     return A < B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltel(A: dace.int64[5, 5], B: dace.int64):
     return A <= B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gtl(A: dace.int64[5, 5], B: dace.int64):
     return A > B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gtel(A: dace.int64[5, 5], B: dace.int64):
     return A >= B
 
@@ -124,7 +125,7 @@ def test_divr(A: dace.float64, B: dace.float64[5, 5]):
     return A / B
 
 
-@compare_numpy_output(non_zero=True, positive=True)
+@compare_numpy_output(non_zero=True, positive=True, check_result_type=False)
 def test_floordivr(A: dace.int64, B: dace.int64[5, 5]):
     return A // B
 
@@ -134,62 +135,62 @@ def test_modr(A: dace.int64, B: dace.int64[5, 5]):
     return A % B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_powr(A: dace.int64, B: dace.int64[5, 5]):
     return A**B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_lshiftr(A: dace.int64, B: dace.int64[5, 5]):
     return A << B
 
 
-@compare_numpy_output(positive=True)
+@compare_numpy_output(positive=True, check_result_type=False)
 def test_rshiftr(A: dace.int64, B: dace.int64[5, 5]):
     return A >> B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitorr(A: dace.int64, B: dace.int64[5, 5]):
     return A | B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitxorr(A: dace.int64, B: dace.int64[5, 5]):
     return A ^ B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_bitandr(A: dace.int64, B: dace.int64[5, 5]):
     return A & B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_eqr(A: dace.int64, B: dace.int64[5, 5]):
     return A == B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_noteqr(A: dace.int64, B: dace.int64[5, 5]):
     return A != B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_ltr(A: dace.int64, B: dace.int64[5, 5]):
     return A < B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_lter(A: dace.int64, B: dace.int64[5, 5]):
     return A <= B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gtr(A: dace.int64, B: dace.int64[5, 5]):
     return A > B
 
 
-@compare_numpy_output()
+@compare_numpy_output(check_result_type=False)
 def test_gter(A: dace.int64, B: dace.int64[5, 5]):
     return A >= B
 

--- a/tests/numpy/common.py
+++ b/tests/numpy/common.py
@@ -7,7 +7,7 @@ import dace
 import numpy as np
 
 
-def compare_numpy_output(non_zero=False, positive=False):
+def compare_numpy_output(non_zero=False, positive=False, check_result_type=True):
     """Check that the `dace.program` func works identically to the python version (including errors).
 
        `func` will be run once as a dace program, and once using python. The inputs to the function
@@ -83,6 +83,8 @@ def compare_numpy_output(non_zero=False, positive=False):
                     type(dace_thrown), dace_thrown, type(numpy_thrown),
                     numpy_thrown)
             else:
+                if check_result_type:
+                    assert reference_result.dtype == dace_result.dtype, "expected {}, got {}".format(reference_result.dtype, dace_result.dtype)
                 assert np.allclose(reference_result, dace_result)
 
         return test

--- a/tests/numpy/reductions_test.py
+++ b/tests/numpy/reductions_test.py
@@ -116,17 +116,17 @@ def test_return_both():
 def test_argmin_result_type():
     @dace.program
     def test_argmin_result(A: dace.float64[10, 5, 3]):
-        return np.argmin(A, axis=1, result_type=dace.int64)
+        return np.argmin(A, axis=1, result_type=dace.int32)
 
     res = test_argmin_result(np.random.rand(10, 5, 3))
-    assert res.dtype == np.int64
+    assert res.dtype == np.int32
 
     @dace.program
     def test_argmin_result(A: dace.float64[10, 5, 3]):
         return np.argmin(A, axis=1)
 
     res = test_argmin_result(np.random.rand(10, 5, 3))
-    assert res.dtype == np.int32
+    assert res.dtype == np.int64
 
 
 @compare_numpy_output()

--- a/tests/numpy/scalar_type_promotion.py
+++ b/tests/numpy/scalar_type_promotion.py
@@ -1,0 +1,33 @@
+"""
+See https://github.com/numpy/numpy/issues/13591 for some wacky examples
+"""
+import dace
+
+from common import compare_numpy_output
+
+
+@compare_numpy_output()
+def int32_plus_one_test(A: dace.int32[5, 5]):
+    return A + 1
+
+
+@compare_numpy_output()
+def one_plus_int32_test(A: dace.int32[5, 5]):
+    return 1 + A
+
+
+@compare_numpy_output()
+def float_plus_int32_test(A: dace.int32[5, 5]):
+    return 1.0 + A
+
+
+@compare_numpy_output()
+def float_plus_int8_test(A: dace.int8[5, 5]):
+    return 0.0 + A
+
+
+if __name__ == "__main__":
+    int32_plus_one_test()
+    one_plus_int32_test()
+    float_plus_int32_test()
+    float_plus_int8_test()


### PR DESCRIPTION
Closes #454
Current exceptions are:
bitwise ops, pow, div, floordiv and boolean ops.