### PR TITLE
Fixed wrong arguments to Python 3.6 version of subprocess.run()

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -5,7 +5,6 @@ import os
 import re
 import shutil
 import subprocess
-from subprocess import PIPE
 from typing import Any, Dict, List
 import warnings
 
@@ -98,7 +97,8 @@ class ReloadableDLL(object):
             reason = ''
             if os.name == 'posix':
                 result = subprocess.run(['ld', self._library_filename],
-                                        stdout=PIPE, stderr=PIPE)
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
                 stderr = result.stderr.decode('utf-8')
                 reason = 'Reason:\n' + '\n'.join(
                     [l for l in stderr.split('\n') if '_start' not in l])

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess
+from subprocess import PIPE
 from typing import Any, Dict, List
 import warnings
 
@@ -97,7 +98,7 @@ class ReloadableDLL(object):
             reason = ''
             if os.name == 'posix':
                 result = subprocess.run(['ld', self._library_filename],
-                                        capture_output=True)
+                                        stdout=PIPE, stderr=PIPE)
                 stderr = result.stderr.decode('utf-8')
                 reason = 'Reason:\n' + '\n'.join(
                     [l for l in stderr.split('\n') if '_start' not in l])


### PR DESCRIPTION
The `capture_output` argument to `subprocess.run()` wasn't added until Python 3.7 [https://docs.python.org/3.7/library/subprocess.html#subprocess.run](url)

This patch reverts the call to be functional in Python 3.6