### PR TITLE
Fixes nested loop tracking and branch annotation in state propagation

### DIFF
--- a/dace/transformation/interstate/branch_annotation.py
+++ b/dace/transformation/interstate/branch_annotation.py
@@ -70,6 +70,12 @@ class AnnotateBranch(DetectBranch):
         if len(common_frontier) == 1:
             frontier_state = list(common_frontier)[0]
             guard.full_merge_state = frontier_state
+        elif self.expr_index == 1 and sdfg.out_degree(guard) == 2:
+            # If we matched the second case of branch detection, and have
+            # exactly two branches, we know that the second branch's state is a
+            # full merge state.
+            guard.full_merge_state = sdfg.node(
+                self.subgraph[DetectBranch._second_branch])
 
         # Mark this conditional branch construct as annotated, so it doesn't
         # get processed again when applied repeatedly.

--- a/dace/transformation/interstate/branch_detection.py
+++ b/dace/transformation/interstate/branch_detection.py
@@ -31,7 +31,32 @@ class DetectBranch(transformation.Transformation):
             DetectBranch._second_branch,
             sd.InterstateEdge()
         )
-        return [sdfg]
+
+        # Second case, at least two children but with them connected among
+        # themselves. This happens if one branch contains one state, and the
+        # other contains none, and then having them merge right away.
+        second_sdfg = sd.SDFG('_')
+        second_sdfg.add_nodes_from([
+            DetectBranch._branch_guard,
+            DetectBranch._first_branch,
+            DetectBranch._second_branch,
+        ])
+        second_sdfg.add_edge(
+            DetectBranch._branch_guard,
+            DetectBranch._first_branch,
+            sd.InterstateEdge()
+        )
+        second_sdfg.add_edge(
+            DetectBranch._branch_guard,
+            DetectBranch._second_branch,
+            sd.InterstateEdge()
+        )
+        second_sdfg.add_edge(
+            DetectBranch._first_branch,
+            DetectBranch._second_branch,
+            sd.InterstateEdge()
+        )
+        return [sdfg, second_sdfg]
 
     @staticmethod
     def can_be_applied(graph, candidate, expr_index, sdfg, strict=False):


### PR DESCRIPTION
- Corrects wrongful removal of iteration variables from the iteration variable stack by moving the iteration variable stack to the traversal's own state instead of keeping it global.
- Make branch detection correctly detect full merges in cases where there are two branches with one of the branch's only state itself being the branch construct's full merge state.