### PR TITLE
Allows loop detection to correctly handle for loops with > 1 init edge

### DIFF
--- a/dace/transformation/interstate/loop_annotation.py
+++ b/dace/transformation/interstate/loop_annotation.py
@@ -8,6 +8,7 @@ from dace.registry import autoregister
 from dace.sdfg import graph as gr, utils as sdutil
 from dace.subsets import Range
 
+
 @autoregister
 class AnnotateLoop(DetectLoop):
     """
@@ -19,7 +20,6 @@ class AnnotateLoop(DetectLoop):
     of the loop's iteration variable, and the attribute `condition_edge`, which
     points to the edge holding the condition leading in to the loop.
     """
-
     @staticmethod
     def annotates_memlets():
         # DO NOT REAPPLY MEMLET PROPAGATION!
@@ -27,7 +27,8 @@ class AnnotateLoop(DetectLoop):
 
     @staticmethod
     def can_be_applied(graph, candidate, expr_index, sdfg, strict):
-        if not DetectLoop.can_be_applied(graph, candidate, expr_index, sdfg, strict):
+        if not DetectLoop.can_be_applied(graph, candidate, expr_index, sdfg,
+                                         strict):
             return False
 
         # Ensure range was not yet given.
@@ -55,11 +56,10 @@ class AnnotateLoop(DetectLoop):
             rng = (stop, start, -stride)
 
         # Get loop states
-        loop_states = list(sdutil.dfs_conditional(
-            sdfg,
-            sources=[begin],
-            condition=lambda _, child: child != guard
-        ))
+        loop_states = list(
+            sdutil.dfs_conditional(sdfg,
+                                   sources=[begin],
+                                   condition=lambda _, child: child != guard))
         loop_subgraph = gr.SubgraphView(sdfg, loop_states)
         for v in loop_subgraph.nodes():
             v.ranges[itervar] = Range([rng])

--- a/dace/transformation/interstate/loop_detection.py
+++ b/dace/transformation/interstate/loop_detection.py
@@ -4,7 +4,7 @@
 import sympy as sp
 import networkx as nx
 import typing
-from typing import AnyStr, Optional, Tuple
+from typing import AnyStr, Optional, Tuple, List
 
 from dace import sdfg as sd, symbolic
 from dace.sdfg import utils as sdutil
@@ -54,20 +54,24 @@ class DetectLoop(transformation.Transformation):
 
         # A for-loop guard only has two incoming edges (init and increment)
         guard_inedges = graph.in_edges(guard)
-        if len(guard_inedges) != 2:
+        if len(guard_inedges) < 2:
             return False
         # A for-loop guard only has two outgoing edges (loop and exit-loop)
         guard_outedges = graph.out_edges(guard)
         if len(guard_outedges) != 2:
             return False
 
-        # Both incoming edges to guard must set exactly one variable and
-        # the same one
-        if (len(guard_inedges[0].data.assignments) != 1
-                or len(guard_inedges[1].data.assignments) != 1):
-            return False
-        itervar = list(guard_inedges[0].data.assignments.keys())[0]
-        if itervar not in guard_inedges[1].data.assignments:
+        # All incoming edges to the guard must set exactly one variable and
+        # it must be the same one.
+        itvar = None
+        for iedge in guard_inedges:
+            if len(iedge.data.assignments) != 1:
+                return False
+            if itvar is None:
+                itvar = list(iedge.data.assignments.keys())[0]
+            elif itvar not in iedge.data.assignments:
+                return False
+        if itvar is None:
             return False
 
         # Outgoing edges must be a negation of each other
@@ -118,13 +122,15 @@ class DetectLoop(transformation.Transformation):
 def find_for_loop(
     sdfg: sd.SDFG, guard: sd.SDFGState, entry: sd.SDFGState
 ) -> Optional[Tuple[AnyStr, Tuple[symbolic.SymbolicType, symbolic.SymbolicType,
-                                  symbolic.SymbolicType]]]:
+                                  symbolic.SymbolicType], Tuple[
+                                      List[sd.SDFGState], sd.SDFGState]]]:
     """
     Finds loop range from state machine.
     :param guard: State from which the outgoing edges detect whether to exit
                   the loop or not.
     :param entry: First state in the loop "body".
-    :return: (iteration variable, (start, end, stride)), or None if proper
+    :return: (iteration variable, (start, end, stride),
+              (start_states[], last_loop_state)), or None if proper
              for-loop was not detected. ``end`` is inclusive.
     """
 
@@ -134,26 +140,49 @@ def find_for_loop(
     itervar = list(guard_inedges[0].data.assignments.keys())[0]
     condition = condition_edge.data.condition_sympy()
 
-    # Find starting expression and stride
+    # Find the stride edge. All in-edges to the guard except for the stride edge
+    # should have exactly the same assignment, since a valid for loop can only
+    # have one assignment.
+    init_edges = []
+    init_assignment = None
+    step_edge = None
     itersym = symbolic.symbol(itervar)
-    if (itersym in symbolic.pystr_to_symbolic(
-            guard_inedges[0].data.assignments[itervar]).free_symbols
-            and itersym not in symbolic.pystr_to_symbolic(
-                guard_inedges[1].data.assignments[itervar]).free_symbols):
-        stride = (symbolic.pystr_to_symbolic(
-            guard_inedges[0].data.assignments[itervar]) - itersym)
-        start = symbolic.pystr_to_symbolic(
-            guard_inedges[1].data.assignments[itervar])
-    elif (itersym in symbolic.pystr_to_symbolic(
-            guard_inedges[1].data.assignments[itervar]).free_symbols
-          and itersym not in symbolic.pystr_to_symbolic(
-              guard_inedges[0].data.assignments[itervar]).free_symbols):
-        stride = (symbolic.pystr_to_symbolic(
-            guard_inedges[1].data.assignments[itervar]) - itersym)
-        start = symbolic.pystr_to_symbolic(
-            guard_inedges[0].data.assignments[itervar])
-    else:
+    for iedge in guard_inedges:
+        assignment = iedge.data.assignments[itervar]
+        if itersym in symbolic.pystr_to_symbolic(assignment).free_symbols:
+            if step_edge is None:
+                step_edge = iedge
+            else:
+                # More than one edge with the iteration variable as a free
+                # symbol, which is not legal. Invalid for loop.
+                return None
+        else:
+            if init_assignment is None:
+                init_assignment = assignment
+                init_edges.append(iedge)
+            elif init_assignment != assignment:
+                # More than one init assignment variations mean that this for
+                # loop is not valid.
+                return None
+            else:
+                init_edges.append(iedge)
+    if step_edge is None or len(init_edges) == 0 or init_assignment is None:
+        # Less than two assignment variations, can't be a valid for loop.
         return None
+
+    # Get the init expression and the stride.
+    start = symbolic.pystr_to_symbolic(init_assignment)
+    stride = (symbolic.pystr_to_symbolic(step_edge.data.assignments[itervar]) -
+              itersym)
+
+    # Get a list of the last states before the loop and a reference to the last
+    # loop state.
+    start_states = []
+    for init_edge in init_edges:
+        start_state = init_edge.src
+        if start_state not in start_states:
+            start_states.append(start_state)
+    last_loop_state = step_edge.src
 
     # Find condition by matching expressions
     end: Optional[symbolic.SymbolicType] = None
@@ -177,4 +206,4 @@ def find_for_loop(
     if end is None:  # No match found
         return None
 
-    return itervar, (start, end, stride)
+    return itervar, (start, end, stride), (start_states, last_loop_state)

--- a/dace/transformation/interstate/loop_peeling.py
+++ b/dace/transformation/interstate/loop_peeling.py
@@ -111,7 +111,7 @@ class LoopPeeling(LoopUnroll):
             for before_state in before_states:
                 init_edge = sdfg.edges_between(before_state, guard)[0]
                 init_edge.data.assignments[itervar] = str(rng[0] +
-                                                        self.count * rng[2])
+                                                          self.count * rng[2])
                 init_edges.append(init_edge)
             append_states = before_states
 
@@ -134,7 +134,7 @@ class LoopPeeling(LoopUnroll):
                 # Connect states to before the loop with unconditional edges
                 for append_state in append_states:
                     sdfg.add_edge(append_state, new_states[first_id],
-                                sd.InterstateEdge())
+                                  sd.InterstateEdge())
                 append_states = [new_states[last_id]]
 
             # Reconnect edge to guard state from last peeled iteration

--- a/dace/transformation/interstate/loop_peeling.py
+++ b/dace/transformation/interstate/loop_peeling.py
@@ -86,22 +86,9 @@ class LoopPeeling(LoopUnroll):
             self.subgraph[DetectLoop._exit_state])
 
         # Obtain iteration variable, range, and stride
-        guard_inedges = sdfg.in_edges(guard)
         condition_edge = sdfg.edges_between(guard, begin)[0]
         not_condition_edge = sdfg.edges_between(guard, after_state)[0]
-        condition = condition_edge.data.condition_sympy()
-        itervar, rng = find_for_loop(sdfg, guard, begin)
-
-        # Find the state prior to the loop
-        if rng[0] == symbolic.pystr_to_symbolic(
-                guard_inedges[0].data.assignments[itervar]):
-            init_edge: sd.InterstateEdge = guard_inedges[0]
-            before_state: sd.SDFGState = guard_inedges[0].src
-            last_state: sd.SDFGState = guard_inedges[1].src
-        else:
-            init_edge: sd.InterstateEdge = guard_inedges[1]
-            before_state: sd.SDFGState = guard_inedges[1].src
-            last_state: sd.SDFGState = guard_inedges[0].src
+        itervar, rng, loop_struct = find_for_loop(sdfg, guard, begin)
 
         # Get loop states
         loop_states = list(
@@ -109,6 +96,7 @@ class LoopPeeling(LoopUnroll):
                                    sources=[begin],
                                    condition=lambda _, child: child != guard))
         first_id = loop_states.index(begin)
+        last_state = loop_struct[1]
         last_id = loop_states.index(last_state)
         loop_subgraph = gr.SubgraphView(sdfg, loop_states)
 
@@ -118,9 +106,14 @@ class LoopPeeling(LoopUnroll):
         if self.begin:
             # If begin, change initialization assignment and prepend states before
             # guard
-            init_edge.data.assignments[itervar] = str(rng[0] +
-                                                      self.count * rng[2])
-            append_state = before_state
+            init_edges = []
+            before_states = loop_struct[0]
+            for before_state in before_states:
+                init_edge = sdfg.edges_between(before_state, guard)[0]
+                init_edge.data.assignments[itervar] = str(rng[0] +
+                                                        self.count * rng[2])
+                init_edges.append(init_edge)
+            append_states = before_states
 
             # Add `count` states, each with instantiated iteration variable
             for i in range(self.count):
@@ -139,14 +132,17 @@ class LoopPeeling(LoopUnroll):
                 )
 
                 # Connect states to before the loop with unconditional edges
-                sdfg.add_edge(append_state, new_states[first_id],
-                              sd.InterstateEdge())
-                append_state = new_states[last_id]
+                for append_state in append_states:
+                    sdfg.add_edge(append_state, new_states[first_id],
+                                sd.InterstateEdge())
+                append_states = [new_states[last_id]]
 
             # Reconnect edge to guard state from last peeled iteration
-            if append_state != before_state:
-                sdfg.remove_edge(init_edge)
-                sdfg.add_edge(append_state, guard, init_edge.data)
+            for append_state in append_states:
+                if append_state not in before_states:
+                    for init_edge in init_edges:
+                        sdfg.remove_edge(init_edge)
+                    sdfg.add_edge(append_state, guard, init_edges[0].data)
         else:
             # If begin, change initialization assignment and prepend states before
             # guard

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -48,7 +48,7 @@ class LoopToMap(DetectLoop):
         if not found:
             return False
 
-        itervar, (start, end, step) = found
+        itervar, (start, end, step), _ = found
 
         # We cannot handle symbols read from data containers unless they are
         # scalar
@@ -112,7 +112,7 @@ class LoopToMap(DetectLoop):
         after: sd.SDFGState = sdfg.node(self.subgraph[DetectLoop._exit_state])
 
         # Obtain iteration variable, range, and stride
-        itervar, (start, end, step) = find_for_loop(sdfg, guard, body)
+        itervar, (start, end, step), _ = find_for_loop(sdfg, guard, body)
 
         if (step < 0) == True:
             # If step is negative, we have to flip start and end to produce a

--- a/dace/transformation/interstate/loop_unroll.py
+++ b/dace/transformation/interstate/loop_unroll.py
@@ -41,7 +41,7 @@ class LoopUnroll(DetectLoop):
         # If loop cannot be detected, fail
         if not found:
             return False
-        _, rng = found
+        _, rng, _ = found
 
         # If loop is not specialized or constant-sized, fail
         if any(symbolic.issymbolic(r, sdfg.constants) for r in rng):
@@ -56,8 +56,9 @@ class LoopUnroll(DetectLoop):
         after_state: sd.SDFGState = sdfg.node(
             self.subgraph[DetectLoop._exit_state])
 
-        # Obtain iteration variable, range, and stride
-        itervar, rng = find_for_loop(sdfg, guard, begin)
+        # Obtain iteration variable, range, and stride, together with the last
+        # state(s) before the loop and the last loop state.
+        itervar, rng, loop_struct = find_for_loop(sdfg, guard, begin)
 
         # Loop must be unrollable
         if self.count == 0 and any(
@@ -66,15 +67,6 @@ class LoopUnroll(DetectLoop):
         if self.count != 0:
             raise NotImplementedError  # TODO(later)
 
-        # Find the state prior to the loop
-        guard_inedges = sdfg.in_edges(guard)
-        if rng[0] == symbolic.pystr_to_symbolic(
-                guard_inedges[0].data.assignments[itervar]):
-            before_state: sd.SDFGState = guard_inedges[0].src
-            last_state: sd.SDFGState = guard_inedges[1].src
-        else:
-            before_state: sd.SDFGState = guard_inedges[1].src
-            last_state: sd.SDFGState = guard_inedges[0].src
 
         # Get loop states
         loop_states = list(
@@ -82,6 +74,7 @@ class LoopUnroll(DetectLoop):
                                    sources=[begin],
                                    condition=lambda _, child: child != guard))
         first_id = loop_states.index(begin)
+        last_state = loop_struct[1]
         last_id = loop_states.index(last_state)
         loop_subgraph = gr.SubgraphView(sdfg, loop_states)
 
@@ -109,8 +102,10 @@ class LoopUnroll(DetectLoop):
 
         # Connect new states to before and after states without conditions
         if unrolled_states:
-            sdfg.add_edge(before_state, unrolled_states[0][0],
-                          sd.InterstateEdge())
+            before_states = loop_struct[0]
+            for before_state in before_states:
+                sdfg.add_edge(before_state, unrolled_states[0][0],
+                            sd.InterstateEdge())
             sdfg.add_edge(unrolled_states[-1][1], after_state,
                           sd.InterstateEdge(assignments=after_assignments))
 

--- a/dace/transformation/interstate/loop_unroll.py
+++ b/dace/transformation/interstate/loop_unroll.py
@@ -67,7 +67,6 @@ class LoopUnroll(DetectLoop):
         if self.count != 0:
             raise NotImplementedError  # TODO(later)
 
-
         # Get loop states
         loop_states = list(
             sdutil.dfs_conditional(sdfg,
@@ -79,15 +78,14 @@ class LoopUnroll(DetectLoop):
         loop_subgraph = gr.SubgraphView(sdfg, loop_states)
 
         # Evaluate the real values of the loop
-        start, end, stride = (symbolic.evaluate(r, sdfg.constants)
-                              for r in rng)
+        start, end, stride = (symbolic.evaluate(r, sdfg.constants) for r in rng)
 
         # Create states for loop subgraph
         unrolled_states = []
         for i in range(start, end + 1, stride):
             # Instantiate loop states with iterate value
-            new_states = self.instantiate_loop(sdfg, loop_states,
-                                               loop_subgraph, itervar, i)
+            new_states = self.instantiate_loop(sdfg, loop_states, loop_subgraph,
+                                               itervar, i)
 
             # Connect iterations with unconditional edges
             if len(unrolled_states) > 0:
@@ -105,7 +103,7 @@ class LoopUnroll(DetectLoop):
             before_states = loop_struct[0]
             for before_state in before_states:
                 sdfg.add_edge(before_state, unrolled_states[0][0],
-                            sd.InterstateEdge())
+                              sd.InterstateEdge())
             sdfg.add_edge(unrolled_states[-1][1], after_state,
                           sd.InterstateEdge(assignments=after_assignments))
 


### PR DESCRIPTION
- Enable detection of for loop constructs with more than 1 init edge going in to the guard.
- Let `find_for_loop` return all states immidiately before the loop, as well as the last loop state, to generalize this functionality and move it out of the transformations using it (loop peeling, unroll).