### PR TITLE
Apply correct conversion from python types to cpp types (i.e. from 'T…

### DIFF
--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -58,7 +58,7 @@ class DaCeCodeGenerator(object):
             else:
                 callsite_stream.write(
                     "constexpr %s %s = %s;\n" %
-                    (csttype.dtype.ctype, cstname, str(cstval)), sdfg)
+                    (csttype.dtype.ctype, cstname, sym2cpp(cstval)), sdfg)
 
     def generate_fileheader(self,
                             sdfg: SDFG,


### PR DESCRIPTION
`sdfg.add_constant("DACE_VERILATOR_ENALBE_DEBUG", True)` translates in the cpp code header to `constexpr bool DACE_VERILATOR_ENALBE_DEBUG = False;` for boolean values, which is not correct cpp syntax (i.e. True should be lowercase 'true' or '1'). I mitigated this by calling sym2cpp() over the python value.