### PR TITLE
Fix for missing inner indices

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1891,14 +1891,15 @@ class ProgramVisitor(ExtNodeVisitor):
                         self.accesses[(name, scope_memlet.subset,
                                        'r')] = (vname, orng)
                         orig_shape = orng.size()
-                        shape = [d for d in orig_shape if d != 1]
+                        shape = [d for i, d in enumerate(orig_shape)
+                                 if d != 1 or i in inner_indices]
                         strides = [
                             i for j, i in enumerate(arr.strides)
                             if j not in outer_indices
                         ]
-                        strides = [
-                            s for d, s in zip(orig_shape, strides) if d != 1
-                        ]
+                        strides = [s for i, (d, s) in enumerate(zip(orig_shape,
+                                                                    strides))
+                                   if d != 1 or i in inner_indices]
                         if not shape:
                             shape = [1]
                             strides = [1]
@@ -2005,13 +2006,15 @@ class ProgramVisitor(ExtNodeVisitor):
                                        'w')] = (vname, orng)
                         orig_shape = orng.size()
                         shape = [d for d in orig_shape if d != 1]
+                        shape = [d for i, d in enumerate(orig_shape)
+                                 if d != 1 or i in inner_indices]
                         strides = [
                             i for j, i in enumerate(arr.strides)
                             if j not in outer_indices
                         ]
-                        strides = [
-                            s for d, s in zip(orig_shape, strides) if d != 1
-                        ]
+                        strides = [s for i, (d, s) in enumerate(zip(orig_shape,
+                                                                    strides))
+                                   if d != 1 or i in inner_indices]
                         if not shape:
                             shape = [1]
                             strides = [1]


### PR DESCRIPTION
When adding inner scope dependencies that are scope variables (i.e., the SDFG is neither top-level nor "leaf"), an appropriately "squeezed" connector must be generated. However, dimensions of size 1 must not be squeezed if they belong to the set of "inner dimensions." This is a corner case that occurs when the dependency comes out of a map where one of the dimensions has a range of length 1, e.g., as in issue #352. This PR fixes this bug.