### PR TITLE
Fix invalid subsets propagated out of nested SDFGs if symbols not defined outside NSDFG

### DIFF
--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -441,11 +441,31 @@ class Memlet(object):
             return self.subset if self._is_data_src else self.other_subset
         return self.subset
 
+    @src_subset.setter
+    def src_subset(self, new_src_subset):
+        if self._is_data_src is not None:
+            if self._is_data_src:
+                self.subset = new_src_subset
+            else:
+                self.other_subset = new_src_subset
+        else:
+            self.subset = new_src_subset
+
     @property
     def dst_subset(self):
         if self._is_data_src is not None:
             return self.other_subset if self._is_data_src else self.subset
         return self.other_subset
+
+    @dst_subset.setter
+    def dst_subset(self, new_dst_subset):
+        if self._is_data_src is not None:
+            if self._is_data_src:
+                self.other_subset = new_dst_subset
+            else:
+                self.subset = new_dst_subset
+        else:
+            self.other_subset = new_dst_subset
 
     def validate(self, sdfg, state):
         if self.data is not None and self.data not in sdfg.arrays:

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -895,8 +895,9 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
                     use_dst = False
                     if direction == 'out':
                         use_dst = True
+                    array = sdfg.arrays[node.label]
                     subset = propagate_subset(memlets,
-                                              sdfg.arrays[node.label],
+                                              array,
                                               params,
                                               subsets.Range(ranges),
                                               use_dst=use_dst).subset
@@ -909,6 +910,8 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
                                              'of unequal dimension!')
                         else:
                             memlet.subset = subsets.union(memlet.subset, subset)
+                            if memlet.subset is None:
+                                memlet.subset = subsets.Range.from_array(array)
                     else:
                         memlet.subset = subset
 
@@ -919,6 +922,20 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
             border_memlet = border_memlets[direction][connector]
             if border_memlet is not None:
                 border_memlet.replace(nsdfg_node.symbol_mapping)
+
+                # Also make sure that there's no symbol in the border memlet's
+                # range that only exists inside the nested SDFG. If that's the
+                # case, use the entire range.
+                if border_memlet.src_subset is not None and any(
+                        s not in parent_sdfg.symbols
+                        for s in border_memlet.src_subset.free_symbols):
+                    border_memlet.src_subset = subsets.Range.from_array(
+                        sdfg.arrays[border_memlet.data])
+                if border_memlet.dst_subset is not None and any(
+                        s not in parent_sdfg.symbols
+                        for s in border_memlet.dst_subset.free_symbols):
+                    border_memlet.dst_subset = subsets.Range.from_array(
+                        sdfg.arrays[border_memlet.data])
 
     # Propagate the inside 'border' memlets outside the SDFG by
     # offsetting, and unsqueezing if necessary.

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1936,9 +1936,13 @@ class SDFG(OrderedDiGraph):
             try:
                 self.validate()
             except InvalidSDFGError as err:
-                raise InvalidSDFGError(
-                    "Validation failed after applying {}.".format(
-                        match.print_match(sdfg)), sdfg, match.state_id) from err
+                if applied:
+                    raise InvalidSDFGError(
+                        "Validation failed after applying {}.".format(
+                            match.print_match(sdfg)), sdfg,
+                        match.state_id) from err
+                else:
+                    raise err
 
         if (len(applied_transformations) > 0
                 and (print_report or


### PR DESCRIPTION
Also provides a short fix for a potential reference to an undefined variable when failing a validation in SDFG's `apply_transformations_repeated`.