### PR TITLE
Removes element 'begin' from 'all_nodes_between(..)'.

### DIFF
--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -947,12 +947,14 @@ DACE_EXPORTED void __dace_exit_%s(%s)
                 if left_nodes is None:
                     # Not all paths lead to the next dominator
                     continue
+                left_nodes |= left # left also belong to scope
+
                 right_nodes = sdfg.all_nodes_between(right, dominator)
                 if right_nodes is None:
                     # Not all paths lead to the next dominator
                     continue
-                all_nodes = left_nodes | right_nodes
-
+                right_nodes |= right # right also belong to scope
+                
                 # Make sure there is no overlap between left and right nodes
                 if len(left_nodes & right_nodes) > 0:
                     continue

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -402,7 +402,7 @@ class Graph(object):
                 continue  # We've reached the end node
             if n in seen:
                 continue  # We've already visited this node
-			if n != begin:
+            if n != begin:
                 seen.add(n)
             # Keep chasing all paths to reach the end node
             node_out_edges = self.out_edges(n)

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -402,7 +402,8 @@ class Graph(object):
                 continue  # We've reached the end node
             if n in seen:
                 continue  # We've already visited this node
-            seen.add(n)
+			if n != begin:
+                seen.add(n)
             # Keep chasing all paths to reach the end node
             node_out_edges = self.out_edges(n)
             if len(node_out_edges) == 0:


### PR DESCRIPTION
This change won't break any existing code because 'all_nodes_between(..)' is only ever used in framecode.py. The code there assumed it returns 'None' if there is any path starting at 'begin' that does not reach 'end', which still holds true. And the now missing 'begin' is artificially added after the function call.