### PR TITLE
Typos in codegen tutorial

### DIFF
--- a/tutorials/codegen.ipynb
+++ b/tutorials/codegen.ipynb
@@ -529,7 +529,7 @@
     "            # to convert symbolic expressions to proper C++\n",
     "            begin, end, stride = (sym2cpp(r) for r in rng)\n",
     "            \n",
-    "            # Every write is optionally (but recommended yo be) tagged with\n",
+    "            # Every write is optionally (but recommended to be) tagged with\n",
     "            # 1-3 extra arguments, serving as line information to match\n",
     "            # SDFG, state, and graph nodes/edges to written code.\n",
     "            callsite_stream.write(f'''// Loopy-loop {param}\n",
@@ -555,7 +555,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After the code generator has been register, all that's left is to change the map schedule and generate new code:"
+    "After the code generator has been registered, all that's left is to change the map schedule and generate new code:"
    ]
   },
   {


### PR DESCRIPTION
Found two typos in the codegen tutorial.