### PR TITLE
Modernize Systolic GEMM and fix issues along the way

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
-""" 
-Helper functions for C++ code generation. 
+"""
+Helper functions for C++ code generation.
 NOTE: The C++ code generator is currently located in cpu.py.
 """
 import ast
@@ -204,8 +204,8 @@ def memlet_copy_to_absolute_strides(dispatcher,
 def emit_memlet_reference(dispatcher, sdfg: SDFG, memlet: mmlt.Memlet,
                           pointer_name: str,
                           conntype: dtypes.typeclass) -> Tuple[str, str, str]:
-    """ 
-    Returns a tuple of three strings with a definition of a reference to an 
+    """
+    Returns a tuple of three strings with a definition of a reference to an
     existing memlet. Used in nested SDFG arguments.
     :return: A tuple of the form (type, name, value).
     """
@@ -459,7 +459,7 @@ def cpp_array_expr(sdfg,
 
 
 def make_ptr_vector_cast(sdfg, expr, memlet, conntype, is_scalar, defined_type):
-    """ 
+    """
     If there is a type mismatch, cast pointer type. Used mostly in vector types.
     """
     if conntype != sdfg.arrays[memlet.data].dtype:
@@ -750,9 +750,9 @@ def shape_to_strides(shape):
 
 
 class InterstateEdgeUnparser(cppunparse.CPPUnparser):
-    """ 
-    An extension of the Python->C++ unparser that allows including 
-    multidimensional array expressions from an existing SDFGs. Used in 
+    """
+    An extension of the Python->C++ unparser that allows including
+    multidimensional array expressions from an existing SDFGs. Used in
     inter-state edge code generation.
     """
     def __init__(self,
@@ -887,8 +887,10 @@ class DaCeKeywordRemover(ExtNodeTransformer):
         if not isinstance(node.targets[-1], ast.Subscript):
             # Dynamic accesses or streams -> every access counts
             try:
+                desc = (self.sdfg.arrays[memlet.data]
+                        if memlet and memlet.data else None)
                 if memlet and memlet.data and (memlet.dynamic or isinstance(
-                        self.sdfg.arrays[memlet.data], data.Stream)):
+                        desc, data.Stream)):
                     if wcr is not None:
                         newnode = ast.Name(
                             id=self.codegen.write_and_resolve_expr(
@@ -901,9 +903,14 @@ class DaCeKeywordRemover(ExtNodeTransformer):
                                 dtype=dtype))
                         node.value = ast.copy_location(newnode, node.value)
                         return node
-                    elif isinstance(self.sdfg.arrays[memlet.data], data.Stream):
+                    elif isinstance(desc, data.Stream):
+                        if desc.is_stream_array():
+                            index = cpp_offset_expr(desc, memlet.subset)
+                            target = f"{memlet.data}[{index}]"
+                        else:
+                            target = memlet.data
                         newnode = ast.Name(id="%s.push(%s);" % (
-                            memlet.data,
+                            target,
                             cppunparse.cppunparse(value, expr_semicolon=False),
                         ))
                     else:

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -467,7 +467,7 @@ def make_ptr_vector_cast(sdfg, expr, memlet, conntype, is_scalar, defined_type):
             expr = '*(%s *)(&%s)' % (conntype.ctype, expr)
         elif conntype.base_type != sdfg.arrays[memlet.data].dtype:
             expr = '(%s)(&%s)' % (conntype.ctype, expr)
-        elif defined_type in [DefinedType.Pointer, DefinedType.StreamArray]:
+        elif defined_type == DefinedType.Pointer:
             expr = '&' + expr
     elif not is_scalar:
         expr = '&' + expr

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -392,7 +392,7 @@ class FPGACodeGen(TargetCodeGenerator):
 
             # Language-specific implementation
             ctype, is_global = self.define_stream(nodedesc.dtype,
-                                                  nodedesc.buffer_size,
+                                                  buffer_size,
                                                   dataname, arrsize,
                                                   function_stream, result)
 

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -650,7 +650,6 @@ __kernel void \\
                 "#undef _DACE_FPGA_KERNEL_{}\n".format(module_function_name))
         self._dispatcher.defined_vars.exit_scope(subgraph)
 
-
     def generate_nsdfg_header(self, sdfg, state, state_id, node,
                               memlet_references, sdfg_label):
         # Intel FPGA needs to deal with streams
@@ -1007,8 +1006,7 @@ __kernel void \\
 
             if data_name is not None:
                 data_desc = sdfg.arrays[data_name]
-                if (isinstance(data_desc, dace.data.Stream)
-                        and memlet.num_accesses != 1):
+                if (isinstance(data_desc, dace.data.Stream) and memlet.dynamic):
                     callsite_stream.write("#undef {}".format(memlet_name), sdfg)
 
     def _generate_converter(self, is_unpack, ctype, veclen, sdfg,

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -257,8 +257,6 @@ DACE_EXPORTED void __dace_exit_intel_fpga({signature}) {{
         if defined_type == DefinedType.Stream:
             read_expr = "read_channel_intel({})".format(expr)
         elif defined_type == DefinedType.StreamArray:
-            # remove "[0]" index as this is not allowed if the subscripted value is not an array
-            expr = expr.replace("[0]", "")
             read_expr = "read_channel_intel({})".format(expr)
         elif defined_type == DefinedType.Pointer:
             read_expr = "*({}{})".format(expr, " + " + index if index else "")

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -989,8 +989,13 @@ __kernel void \\
                 data_desc = sdfg.arrays[data_name]
                 if (isinstance(data_desc, dace.data.Stream)
                         and memlet.volume == 1 and not memlet.dynamic):
+                    if data_desc.is_stream_array():
+                        offset = cpp.cpp_offset_expr(data_desc, memlet.subset)
+                        target = f"{data_name}[{offset}]"
+                    else:
+                        target = data_name
                     callsite_stream.write(
-                        f"write_channel_intel({data_name}, {connector});", sdfg)
+                        f"write_channel_intel({target}, {connector});", sdfg)
 
     def generate_undefines(self, sdfg, dfg, node, callsite_stream):
         for edge in itertools.chain(dfg.in_edges(node), dfg.out_edges(node)):

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -968,8 +968,7 @@ __kernel void \\
                                                       memlet.subset)
                 result += "#define {} {}[{}] ".format(connector, data_name,
                                                       channel_idx)
-                self._dispatcher.defined_vars.add(connector,
-                                                  DefinedType.StreamArray,
+                self._dispatcher.defined_vars.add(connector, DefinedType.Stream,
                                                   ctypedef)
         else:
             raise TypeError("Unknown variable type: {}".format(def_type))

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -328,12 +328,10 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
     @staticmethod
     def make_read(defined_type, dtype, var_name, expr, index, is_pack,
                   packing_factor):
-        if defined_type == DefinedType.Stream:
-            read_expr = "{}.pop()".format(expr)
-        elif defined_type == DefinedType.StreamArray:
+        if defined_type in [DefinedType.Stream, DefinedType.StreamArray]:
             if " " in expr:
                 expr = "(" + expr + ")"
-            read_expr = "{}[{}].pop()".format(expr, index)
+            read_expr = "{}.pop()".format(expr)
         elif defined_type == DefinedType.Scalar:
             read_expr = var_name
         else:
@@ -553,7 +551,7 @@ DACE_EXPORTED void __dace_exit_xilinx({signature}) {{
                         p.as_arg(with_types=False, name=pname))
                     kernel_args_module.append(
                         p.as_arg(with_types=True, name=pname))
-                    
+
         # create a unique module name to prevent name clashes
         module_function_name = "module_" + name + "_" + str(sdfg.sdfg_id)
 

--- a/samples/fpga/gemm_fpga_systolic.py
+++ b/samples/fpga/gemm_fpga_systolic.py
@@ -127,433 +127,141 @@ def make_write_C(state):
     pipe = state.add_read("C_pipe")
     mem = state.add_write("C_device")
 
-    state.add_memlet_path(pipe, mem, memlet=dace.Memlet("C_device[0:N, 0:M]", other_subset="P"))
+    state.add_memlet_path(pipe,
+                          mem,
+                          memlet=dace.Memlet("C_device[0:N, 0:M]",
+                                             other_subset="P"))
 
 
-def make_compute_sdfg():
-
-    sdfg = dace.SDFG("gemm_compute")
-
-    n_begin = sdfg.add_state("n0_begin")
-    n_entry = sdfg.add_state("n0_entry")
-    n_end = sdfg.add_state("n0_end")
-
-    k_begin = sdfg.add_state("k_begin")
-    k_entry = sdfg.add_state("k_entry")
-    k_end = sdfg.add_state("k_end")
-
-    a_begin = sdfg.add_state("a_begin")
-    a_entry = sdfg.add_state("a_entry")
-    a_end = sdfg.add_state("a_end")
-
-    buffer_a_state = sdfg.add_state("read_a")
-
-    m_begin = sdfg.add_state("m_begin")
-    m_entry = sdfg.add_state("m_entry")
-    m_end = sdfg.add_state("m_end")
-
-    state = sdfg.add_state("compute")
-
-    c_n1_begin = sdfg.add_state("c_n1_begin")
-    c_n1_entry = sdfg.add_state("c_n1_entry")
-    c_n1_end = sdfg.add_state("c_n1_end")
-
-    c_m_begin = sdfg.add_state("c_m_begin")
-    c_m_entry = sdfg.add_state("c_m_entry")
-    c_m_end = sdfg.add_state("c_m_end")
-
-    write_c_state = sdfg.add_state("write_c")
-
-    # Data nodes
-    B_pipe_in = state.add_stream("B_stream_in",
-                                 dace.float32,
-                                 storage=dace.dtypes.StorageType.FPGA_Local)
-    B_pipe_out = state.add_stream("B_stream_out",
-                                  dace.float32,
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
-
-    # N-loop
-    sdfg.add_edge(n_begin, n_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n0": 0}))
-    sdfg.add_edge(
-        n_entry, k_begin,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n0 < N / P", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        n_entry, n_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n0 >= N / P", language=dace.dtypes.Language.Python)))
-
-    # K-loop
-    sdfg.add_edge(k_begin, k_entry,
-                  dace.sdfg.InterstateEdge(assignments={"k": 0}))
-    sdfg.add_edge(
-        k_entry, a_begin,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "k < K", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        k_entry, k_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "k >= K", language=dace.dtypes.Language.Python)))
-
-    # Buffer A-loop
-    sdfg.add_edge(a_begin, a_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n1": 0}))
-    sdfg.add_edge(
-        a_entry, buffer_a_state,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n1 < P - p", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(buffer_a_state, a_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n1": "n1 + 1"}))
-    sdfg.add_edge(
-        a_entry, a_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n1 >= P - p", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(a_end, m_begin, dace.sdfg.InterstateEdge())
-
-    # Inner M-loop
-    sdfg.add_edge(m_begin, m_entry,
-                  dace.sdfg.InterstateEdge(assignments={"m": 0}))
-    sdfg.add_edge(
-        m_entry, state,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "m < M", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        m_entry, m_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "m >= M", language=dace.dtypes.Language.Python)))
-
-    # Backtrack two loops
-    sdfg.add_edge(state, m_entry,
-                  dace.sdfg.InterstateEdge(assignments={"m": "m + 1"}))
-    sdfg.add_edge(m_end, k_entry,
-                  dace.sdfg.InterstateEdge(assignments={"k": "k + 1"}))
-
-    # Continue to next sequential loop
-    sdfg.add_edge(k_end, c_n1_begin, dace.sdfg.InterstateEdge())
-
-    # Two C-loops
-    sdfg.add_edge(c_n1_begin, c_n1_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n1": 0}))
-    sdfg.add_edge(
-        c_n1_entry, c_m_begin,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n1 < p + 1", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        c_n1_entry, c_n1_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "n1 >= p + 1", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(c_m_begin, c_m_entry,
-                  dace.sdfg.InterstateEdge(assignments={"m": 0}))
-    sdfg.add_edge(
-        c_m_entry, write_c_state,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "m < M", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(
-        c_m_entry, c_m_end,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "m >= M", language=dace.dtypes.Language.Python)))
-    sdfg.add_edge(write_c_state, c_m_entry,
-                  dace.sdfg.InterstateEdge(assignments={"m": "m + 1"}))
-    sdfg.add_edge(c_m_end, c_n1_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n1": "n1 + 1"}))
-
-    # Backtrack
-    sdfg.add_edge(c_n1_end, n_entry,
-                  dace.sdfg.InterstateEdge(assignments={"n0": "n0 + 1"}))
-
-    # Scalar buffer for A
-    A_pipe_in = buffer_a_state.add_stream(
-        "A_stream_in", dace.float32, storage=dace.dtypes.StorageType.FPGA_Local)
-    A_pipe_out = buffer_a_state.add_stream(
-        "A_stream_out",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
-    A_reg_out = buffer_a_state.add_scalar(
-        "A_reg",
-        dtype=dace.float32,
-        transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    buffer_a_tasklet = buffer_a_state.add_tasklet(
-        "buffer_a", {"a_in"}, {"a_reg", "a_out"}, "a_input = float(0)"
-        "\nif n1 == P-p-1 or p < P - 1: a_input = a_in"
-        "\nif n1 == P - p - 1:"
-        "\n\ta_reg = a_input"
-        "\nelse:"
-        "\n\tif p < P - 1:"
-        "\n\t\ta_out = a_input")
-    buffer_a_state.add_memlet_path(A_pipe_in,
-                                   buffer_a_tasklet,
-                                   memlet=dace.memlet.Memlet.simple(
-                                       A_pipe_in, "0", num_accesses=-1),
-                                   dst_conn="a_in")
-    buffer_a_state.add_memlet_path(buffer_a_tasklet,
-                                   A_reg_out,
-                                   memlet=dace.memlet.Memlet.simple(
-                                       A_reg_out, "0", num_accesses=-1),
-                                   src_conn="a_reg")
-    buffer_a_state.add_memlet_path(buffer_a_tasklet,
-                                   A_pipe_out,
-                                   memlet=dace.memlet.Memlet.simple(
-                                       A_pipe_out, "0", num_accesses=-1),
-                                   src_conn="a_out")
-
-    ###########################################################################
-    # Nested SDFG
-
-    nested_sdfg = dace.SDFG("gemm_nested")
-
-    if_state_c = nested_sdfg.add_state("if_state_c")
-    then_state_c = nested_sdfg.add_state("then_state_c")
-    else_state_c = nested_sdfg.add_state("else_state_c")
-    compute_state = nested_sdfg.add_state("compute_state")
-    nested_sdfg.add_edge(
-        if_state_c, then_state_c,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "k == 0", language=dace.dtypes.Language.Python)))
-    nested_sdfg.add_edge(
-        if_state_c, else_state_c,
-        dace.sdfg.InterstateEdge(
-            condition=dace.properties.CodeProperty.from_string(
-                "k != 0", language=dace.dtypes.Language.Python)))
-    nested_sdfg.add_edge(then_state_c, compute_state,
-                         dace.sdfg.InterstateEdge())
-    nested_sdfg.add_edge(else_state_c, compute_state,
-                         dace.sdfg.InterstateEdge())
-
-    compute_tasklet = compute_state.add_tasklet(
-        "multiply_add", {"a_in", "b_in", "c_in"}, {"b_out", "c_out"},
-        "c_out = c_in + a_in * b_in\nif p < P - 1:\n\tb_out = b_in")
-
-    # Then state C
-    zero_tasklet = then_state_c.add_tasklet("zero_C_buffer", {}, {"c_out"},
-                                            "c_out = 0")
-    C_val_out_then = then_state_c.add_scalar(
-        "C_val",
-        dtype=dace.float32,
-        transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Local)
-    then_state_c.add_memlet_path(zero_tasklet,
-                                 C_val_out_then,
-                                 src_conn="c_out",
-                                 memlet=dace.memlet.Memlet.simple(
-                                     C_val_out_then, "0"))
-
-    # Else state C
-    C_in = else_state_c.add_scalar("C_in",
-                                   dtype=dace.float32,
-                                   storage=dace.dtypes.StorageType.FPGA_Local)
-    C_val_out_else = else_state_c.add_scalar(
-        "C_val",
-        dtype=dace.float32,
-        transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Local)
-    else_state_c.add_memlet_path(C_in,
-                                 C_val_out_else,
-                                 memlet=dace.memlet.Memlet.simple(
-                                     C_val_out_else, "0"))
-
-    # Compute state
-    A_val_in = compute_state.add_scalar(
-        "A_val_in",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    B_in = compute_state.add_stream(
-        "B_in",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    B_out = compute_state.add_stream(
-        "B_out",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    C_val_in = compute_state.add_scalar(
-        "C_val",
-        dtype=dace.float32,
-        transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    C_out = compute_state.add_scalar(
-        "C_out",
-        dtype=dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
-    compute_state.add_memlet_path(A_val_in,
-                                  compute_tasklet,
-                                  memlet=dace.memlet.Memlet.simple(
-                                      A_val_in, "0"),
-                                  dst_conn="a_in")
-    compute_state.add_memlet_path(B_in,
-                                  compute_tasklet,
-                                  memlet=dace.memlet.Memlet.simple(B_in, "0"),
-                                  dst_conn="b_in")
-    compute_state.add_memlet_path(compute_tasklet,
-                                  B_out,
-                                  memlet=dace.memlet.Memlet.simple(
-                                      B_out, "0", num_accesses=-1),
-                                  src_conn="b_out")
-    compute_state.add_memlet_path(C_val_in,
-                                  compute_tasklet,
-                                  memlet=dace.memlet.Memlet.simple(
-                                      C_val_in, "0"),
-                                  dst_conn="c_in")
-    compute_state.add_memlet_path(compute_tasklet,
-                                  C_out,
-                                  memlet=dace.memlet.Memlet.simple(C_out, "0"),
-                                  src_conn="c_out")
-
-    tasklet = state.add_nested_sdfg(nested_sdfg, sdfg,
-                                    {"A_val_in", "B_in", "C_in"},
-                                    {"B_out", "C_out"})
-
-    ###########################################################################
-    # Compute continued
-
-    A_reg_in = state.add_scalar("A_reg",
-                                dtype=dace.float32,
-                                transient=True,
-                                storage=dace.dtypes.StorageType.FPGA_Registers)
-
-    C_buffer_in = state.add_array("C_buffer", [M],
-                                  dtype=dace.float32,
-                                  transient=True,
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
-    C_buffer_out = state.add_array("C_buffer", [M],
-                                   dtype=dace.float32,
-                                   transient=True,
-                                   storage=dace.dtypes.StorageType.FPGA_Local)
-
-    state.add_memlet_path(B_pipe_in,
-                          tasklet,
-                          memlet=dace.memlet.Memlet.simple(B_pipe_in,
-                                                           "0",
-                                                           num_accesses=-1),
-                          dst_conn="B_in")
-    state.add_memlet_path(tasklet,
-                          B_pipe_out,
-                          memlet=dace.memlet.Memlet.simple(B_pipe_out,
-                                                           "0",
-                                                           num_accesses=-1),
-                          src_conn="B_out")
-    state.add_memlet_path(C_buffer_in,
-                          tasklet,
-                          memlet=dace.memlet.Memlet.simple(C_buffer_in,
-                                                           "m",
-                                                           num_accesses=-1),
-                          dst_conn="C_in")
-    state.add_memlet_path(tasklet,
-                          C_buffer_out,
-                          memlet=dace.memlet.Memlet.simple(C_buffer_out, "m"),
-                          src_conn="C_out")
-    state.add_memlet_path(A_reg_in,
-                          tasklet,
-                          memlet=dace.memlet.Memlet.simple(A_reg_in,
-                                                           "0",
-                                                           num_accesses=-1),
-                          dst_conn="A_val_in")
-
-    ###########################################################################
-    # Write back state
-
-    C_pipe_in = write_c_state.add_stream(
-        "C_stream_in", dace.float32, storage=dace.dtypes.StorageType.FPGA_Local)
-    C_pipe_out = write_c_state.add_stream(
-        "C_stream_out",
-        dace.float32,
-        storage=dace.dtypes.StorageType.FPGA_Local)
-    C_buffer_write = write_c_state.add_array(
-        "C_buffer", [M],
-        dtype=dace.float32,
-        transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Local)
-    write_c_tasklet = write_c_state.add_tasklet(
-        "write_c", {"buffer_in", "forward_in"}, {"c_out"}, "if n1 == p:"
-        "\n\tc_out = buffer_in"
-        "\nelse:"
-        "\n\tif p > 0:"
-        "\n\t\tc_out = forward_in")
-    write_c_state.add_memlet_path(C_buffer_write,
-                                  write_c_tasklet,
-                                  memlet=dace.memlet.Memlet.simple(
-                                      C_buffer_in, "m", num_accesses=-1),
-                                  dst_conn="buffer_in")
-    write_c_state.add_memlet_path(C_pipe_in,
-                                  write_c_tasklet,
-                                  memlet=dace.memlet.Memlet.simple(
-                                      C_pipe_in, "0", num_accesses=-1),
-                                  dst_conn="forward_in")
-    write_c_state.add_memlet_path(write_c_tasklet,
-                                  C_pipe_out,
-                                  memlet=dace.memlet.Memlet.simple(
-                                      C_pipe_out, "0"),
-                                  src_conn="c_out")
-
-    return sdfg
-
-
-def make_fpga_state(sdfg):
-
-    state = sdfg.add_state("gemm")
-
-    sdfg.add_stream("A_pipe",
-                    dace.float32,
-                    transient=True,
-                    shape=(P + 1, ),
-                    storage=dace.dtypes.StorageType.FPGA_Local)
-    sdfg.add_stream("B_pipe",
-                    dace.float32,
-                    transient=True,
-                    shape=(P + 1, ),
-                    storage=dace.dtypes.StorageType.FPGA_Local)
-    sdfg.add_stream("C_pipe",
-                    dace.float32,
-                    transient=True,
-                    shape=(P + 1, ),
-                    storage=dace.dtypes.StorageType.FPGA_Local)
-
-    make_read_A(state)
-    make_read_B(state)
-
-    compute_sdfg = make_compute_sdfg()
-    compute_sdfg_node = state.add_nested_sdfg(
-        compute_sdfg, sdfg, {"A_stream_in", "B_stream_in", "C_stream_in"},
-        {"A_stream_out", "B_stream_out", "C_stream_out"})
-
-    write_C_sdfg = make_write_C(state)
+def make_compute(sdfg, state):
 
     A_pipe_in = state.add_read("A_pipe")
+    A_pipe_out = state.add_write("A_pipe")
     B_pipe_in = state.add_read("B_pipe")
-    C_pipe_in = state.add_stream("C_pipe",
-                                 dace.float32,
-                                 transient=True,
-                                 shape=(P + 1, ),
-                                 storage=dace.dtypes.StorageType.FPGA_Local)
-    A_pipe_out = state.add_stream("A_pipe",
-                                  dace.float32,
-                                  transient=True,
-                                  shape=(P + 1, ),
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
-    B_pipe_out = state.add_stream("B_pipe",
-                                  dace.float32,
-                                  transient=True,
-                                  shape=(P + 1, ),
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
-    C_pipe_out = state.add_stream("C_pipe",
-                                  dace.float32,
-                                  transient=True,
-                                  shape=(P + 1, ),
-                                  storage=dace.dtypes.StorageType.FPGA_Local)
+    B_pipe_out = state.add_write("B_pipe")
+    C_pipe_in = state.add_read("C_pipe")
+    C_pipe_out = state.add_write("C_pipe")
 
+    entry_n0, exit_n0 = state.add_map("n0", {
+        "n0": "0:N/P",
+    },
+                                      schedule=dace.ScheduleType.FPGA_Device)
+    entry_k, exit_k = state.add_map("k", {"k": "0:K"},
+                                    schedule=dace.ScheduleType.FPGA_Device)
+    entry_a, exit_a = state.add_map("buffer_A", {"n1": "0:P"},
+                                    schedule=dace.ScheduleType.FPGA_Device)
+    entry_m, exit_m = state.add_map("m", {"m": "0:M"},
+                                    schedule=dace.ScheduleType.FPGA_Device)
+    entry_c, exit_c = state.add_map("write_C", {
+        "n1": "0:P",
+        "m": "0:M"
+    },
+                                    schedule=dace.ScheduleType.FPGA_Device)
+
+    # Instantiate buffers
+    sdfg.add_scalar("A_reg",
+                    dtype=dace.float32,
+                    transient=True,
+                    storage=dace.dtypes.StorageType.FPGA_Registers)
+    A_reg = state.add_write("A_reg")
+    sdfg.add_array("C_buffer", [M],
+                   dtype=dace.float32,
+                   transient=True,
+                   storage=dace.dtypes.StorageType.FPGA_Local)
+    C_buffer_in = state.add_read("C_buffer")
+    C_buffer_out = state.add_write("C_buffer")
+
+    buffer_a_tasklet = state.add_tasklet(
+        "buffer_a", {"a_in"}, {"a_reg", "a_out"}, """\
+if n1 == P - p - 1:
+    a_reg = a_in
+if p < P - 1:
+    a_out = a_in""")
+    state.add_memlet_path(A_pipe_in,
+                          entry_n0,
+                          entry_k,
+                          entry_a,
+                          buffer_a_tasklet,
+                          memlet=dace.Memlet("A_pipe[p]", dynamic=False),
+                          dst_conn="a_in")
+    state.add_memlet_path(buffer_a_tasklet,
+                          exit_a,
+                          A_reg,
+                          memlet=dace.Memlet("A_reg[0]", dynamic=True),
+                          src_conn="a_reg")
+    state.add_memlet_path(buffer_a_tasklet,
+                          exit_a,
+                          exit_k,
+                          exit_n0,
+                          A_pipe_out,
+                          memlet=dace.Memlet("A_pipe[p + 1]", dynamic=True),
+                          src_conn="a_out")
+
+    compute_tasklet = state.add_tasklet(
+        "multiply_add", {"a_in", "b_in", "c_in"}, {"b_out", "c_out"}, """\
+c_prev = 0 if k == 0 else c_in
+c_out = c_prev + a_in * b_in
+if p < P - 1:
+    b_out = b_in""")
+
+    state.add_memlet_path(A_reg,
+                          entry_m,
+                          compute_tasklet,
+                          dst_conn="a_in",
+                          memlet=dace.Memlet("A_reg[0]"))
+    state.add_memlet_path(B_pipe_in,
+                          entry_n0,
+                          entry_k,
+                          entry_m,
+                          compute_tasklet,
+                          memlet=dace.Memlet("B_pipe[p]", dynamic=False),
+                          dst_conn="b_in")
+    state.add_memlet_path(compute_tasklet,
+                          exit_m,
+                          exit_k,
+                          exit_n0,
+                          B_pipe_out,
+                          memlet=dace.Memlet("B_pipe[p + 1]", dynamic=True),
+                          src_conn="b_out")
+    state.add_memlet_path(C_buffer_in,
+                          entry_k,
+                          entry_m,
+                          compute_tasklet,
+                          dst_conn="c_in",
+                          memlet=dace.Memlet("C_buffer[m]"))
+    state.add_memlet_path(entry_n0, C_buffer_in, memlet=dace.Memlet())
+    state.add_memlet_path(compute_tasklet,
+                          exit_m,
+                          exit_k,
+                          C_buffer_out,
+                          memlet=dace.Memlet("C_buffer[m]"),
+                          src_conn="c_out")
+    state.add_memlet_path(C_buffer_out, exit_n0, memlet=dace.Memlet())
+
+    # Write back
+    write_c_tasklet = state.add_tasklet(
+        "write_c", {"buffer_in", "forward_in"}, {"c_out"}, """\
+if n1 <= p:
+    c_out = buffer_in if n1 == p else forward_in""")
+    state.add_memlet_path(C_buffer_out,
+                          entry_c,
+                          write_c_tasklet,
+                          memlet=dace.Memlet("C_buffer[m]", dynamic=True),
+                          dst_conn="buffer_in")
+    state.add_memlet_path(C_pipe_in,
+                          entry_n0,
+                          entry_c,
+                          write_c_tasklet,
+                          memlet=dace.Memlet("C_pipe[p]", dynamic=True),
+                          dst_conn="forward_in")
+    state.add_memlet_path(write_c_tasklet,
+                          exit_c,
+                          exit_n0,
+                          C_pipe_out,
+                          memlet=dace.Memlet("C_pipe[p+1]", dynamic=True),
+                          src_conn="c_out")
+
+    # Unroll processing elements
     compute_entry, compute_exit = state.add_map(
         "unroll_compute", {"p": "0:P"},
         schedule=dace.ScheduleType.FPGA_Device,
@@ -567,55 +275,32 @@ def make_fpga_state(sdfg):
     state.add_memlet_path(B_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
     state.add_memlet_path(C_pipe_out, compute_exit, memlet=dace.memlet.Memlet())
 
-    # Connect data nodes
-    state.add_memlet_path(A_pipe_in,
-                          compute_sdfg_node,
-                          dst_conn="A_stream_in",
-                          memlet=dace.memlet.Memlet.simple(
-                              A_pipe_in,
-                              'p',
-                              num_accesses=dace.symbolic.pystr_to_symbolic(
-                                  "(N / P) * K * (P - p)")))
-    state.add_memlet_path(
-        B_pipe_in,
-        compute_sdfg_node,
-        dst_conn="B_stream_in",
-        memlet=dace.memlet.Memlet.simple(
-            B_pipe_in,
-            'p',
-            num_accesses=dace.symbolic.pystr_to_symbolic("N * K * M / P")))
-    state.add_memlet_path(
-        C_pipe_in,
-        compute_sdfg_node,
-        dst_conn="C_stream_in",
-        memlet=dace.memlet.Memlet.simple(
-            C_pipe_in,
-            'p',
-            num_accesses=dace.symbolic.pystr_to_symbolic("(N / P) * M * p")))
-    state.add_memlet_path(compute_sdfg_node,
-                          A_pipe_out,
-                          src_conn="A_stream_out",
-                          memlet=dace.memlet.Memlet.simple(
-                              A_pipe_out,
-                              'p + 1',
-                              num_accesses=dace.symbolic.pystr_to_symbolic(
-                                  "(N / P) * K * (P - p - 1)")))
-    state.add_memlet_path(compute_sdfg_node,
-                          B_pipe_out,
-                          src_conn="B_stream_out",
-                          memlet=dace.memlet.Memlet.simple(
-                              B_pipe_out,
-                              'p + 1',
-                              num_accesses=dace.symbolic.pystr_to_symbolic(
-                                  "(p // (P - 1)) * (N / P) * K * M")))
-    state.add_memlet_path(compute_sdfg_node,
-                          C_pipe_out,
-                          src_conn="C_stream_out",
-                          memlet=dace.memlet.Memlet.simple(
-                              C_pipe_out,
-                              'p + 1',
-                              num_accesses=dace.symbolic.pystr_to_symbolic(
-                                  "(N / P) * M * (p + 1)")))
+
+def make_fpga_state(sdfg):
+
+    state = sdfg.add_state("gemm")
+
+    sdfg.add_stream("A_pipe",
+                    dace.float32,
+                    transient=True,
+                    shape=(P + 1, ),
+                    storage=dace.dtypes.StorageType.FPGA_Local,
+                    buffer_size="P")
+    sdfg.add_stream("B_pipe",
+                    dace.float32,
+                    transient=True,
+                    shape=(P + 1, ),
+                    storage=dace.dtypes.StorageType.FPGA_Local)
+    sdfg.add_stream("C_pipe",
+                    dace.float32,
+                    transient=True,
+                    shape=(P + 1, ),
+                    storage=dace.dtypes.StorageType.FPGA_Local)
+
+    make_read_A(state)
+    make_read_B(state)
+    make_compute(sdfg, state)
+    make_write_C(state)
 
     return state
 

--- a/tests/intel_fpga/simple_systolic_array.py
+++ b/tests/intel_fpga/simple_systolic_array.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 """
-Simple systolic array of P processing element, each one increments by 1 the 
+Simple systolic array of P processing element, each one increments by 1 the
 incoming element.
 """
 


### PR DESCRIPTION
Modernize the systolic GEMM sample, and fix a handful of issues that popped up along the way:
- Handling of `StreamArray` in Xilinx wrongly removed the index
- Stream buffer sizes was not being symbolically evaluated before checking if the value is compile-time fixed
- Processing element unrolling for Intel FPGA made a wrong assumption
- Intel codegen should actually use the memlet name when generating channel accesses
- Intel codegen was defining memlets accessing stream arrays as stream arrays, when they should be streams
- Added missing undefines causing warnings