### PR TITLE
Add dependency support to environments

### DIFF
--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -15,6 +15,8 @@ from .sdfg.propagation import propagate_memlets_sdfg, propagate_memlet
 from .memlet import Memlet
 from .symbolic import symbol
 
+import dace.library
+
 # Run Jupyter notebook code
 from .jupyter import *
 

--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -15,8 +15,6 @@ from .sdfg.propagation import propagate_memlets_sdfg, propagate_memlet
 from .memlet import Memlet
 from .symbolic import symbol
 
-import dace.library
-
 # Run Jupyter notebook code
 from .jupyter import *
 

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -163,21 +163,7 @@ def configure_and_compile(program_folder, program_name=None,
     environments = set(l.strip() for l in open(
         os.path.join(program_folder, "dace_environments.csv"), "r"))
 
-    environments = {
-        dace.library.get_environment(env_name)
-        for env_name in environments
-    }
-
-    # add dependencies until no new dependencies are found
-    while True:
-        added = {
-            dep
-            for env in environments for dep in env.dependencies
-            if dep not in environments
-        }
-        if len(added) == 0:
-            break
-        environments = environments.union(added)
+    environments = dace.library.get_environments_and_dependencies(environments)
 
     cmake_minimum_version = [0]
     cmake_variables = dict()

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -162,6 +162,23 @@ def configure_and_compile(program_folder, program_name=None,
     # Get required environments are retrieve the CMake information
     environments = set(l.strip() for l in open(
         os.path.join(program_folder, "dace_environments.csv"), "r"))
+
+    environments = {
+        dace.library.get_environment(env_name)
+        for env_name in environments
+    }
+
+    # add dependencies until no new dependencies are found
+    while True:
+        added = {
+            dep
+            for env in environments for dep in env.dependencies
+            if dep not in environments
+        }
+        if len(added) == 0:
+            break
+        environments = environments.union(added)
+
     cmake_minimum_version = [0]
     cmake_variables = dict()
     cmake_packages = set()
@@ -171,8 +188,7 @@ def configure_and_compile(program_folder, program_name=None,
     cmake_link_flags = set()
     cmake_files = set()
     cmake_module_paths = set()
-    for env_name in environments:
-        env = dace.library.get_environment(env_name)
+    for env in environments:
         if (env.cmake_minimum_version is not None
                 and len(env.cmake_minimum_version) > 0):
             version_list = list(map(int, env.cmake_minimum_version.split(".")))

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -110,6 +110,7 @@ class DaCeCodeGenerator(object):
             :param callsite_stream: Stream to write to (at call site).
         """
 
+        import dace.library
         environments = dace.library.get_environments_and_dependencies(
             used_environments)
 
@@ -144,6 +145,7 @@ class DaCeCodeGenerator(object):
             :param global_stream: Stream to write to (global).
             :param callsite_stream: Stream to write to (at call site).
         """
+        import dace.library
         fname = sdfg.name
         params = sdfg.signature()
         paramnames = sdfg.signature(False, for_call=True)

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -238,7 +238,7 @@ DACE_EXPORTED void __dace_exit_%s(%s)
             if env.finalize_code:
                 callsite_stream.write("{  // Environment: " + env.__name__,
                                       sdfg)
-                callsite_stream.write(env.init_code)
+                callsite_stream.write(env.finalize_code)
                 callsite_stream.write("}")
 
         callsite_stream.write('}\n', sdfg)

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -110,10 +110,8 @@ class DaCeCodeGenerator(object):
             :param callsite_stream: Stream to write to (at call site).
         """
 
-        environments = [
-            dace.library.get_environment(env_name)
-            for env_name in used_environments
-        ]
+        environments = dace.library.get_environments_and_dependencies(
+            used_environments)
 
         # Write frame code - header
         global_stream.write(
@@ -149,10 +147,8 @@ class DaCeCodeGenerator(object):
         fname = sdfg.name
         params = sdfg.signature()
         paramnames = sdfg.signature(False, for_call=True)
-        environments = [
-            dace.library.get_environment(env_name)
-            for env_name in used_environments
-        ]
+        environments = dace.library.get_environments_and_dependencies(
+            used_environments)
 
         # Invoke all instrumentation providers
         for instr in self._dispatcher.instrumentation.values():
@@ -234,7 +230,7 @@ DACE_EXPORTED void __dace_exit_%s(%s)
                 callsite_stream.write(
                     '__dace_exit_%s(%s);' % (target.target_name, paramnames),
                     sdfg)
-        for env in environments:
+        for env in reversed(environments):
             if env.finalize_code:
                 callsite_stream.write("{  // Environment: " + env.__name__,
                                       sdfg)
@@ -706,7 +702,7 @@ DACE_EXPORTED void __dace_exit_%s(%s)
 
         # Generate code
         ###########################
-        
+
         # Keep track of allocated variables
         allocated = set()
 
@@ -951,7 +947,7 @@ DACE_EXPORTED void __dace_exit_%s(%s)
                     # Not all paths lead to the next dominator
                     continue
                 right_nodes.add(right) # right also belong to scope
-                
+
                 # Make sure there is no overlap between left and right nodes
                 if len(left_nodes & right_nodes) > 0:
                     continue

--- a/dace/libraries/blas/environments/cublas.py
+++ b/dace/libraries/blas/environments/cublas.py
@@ -17,6 +17,7 @@ class cuBLAS:
     headers = ["../include/dace_cublas.h"]
     init_code = ""
     finalize_code = ""
+    dependencies = []
 
     @staticmethod
     def handle_setup_code(node):

--- a/dace/libraries/blas/environments/intel_mkl.py
+++ b/dace/libraries/blas/environments/intel_mkl.py
@@ -23,3 +23,4 @@ class IntelMKL:
     headers = ["mkl.h", "../include/dace_blas.h"]
     init_code = ""
     finalize_code = ""
+    dependencies = []

--- a/dace/libraries/blas/environments/openblas.py
+++ b/dace/libraries/blas/environments/openblas.py
@@ -17,3 +17,4 @@ class OpenBLAS:
     headers = ["cblas.h", "../include/dace_blas.h"]
     init_code = ""
     finalize_code = ""
+    dependencies = []

--- a/dace/libraries/standard/environments/cuda.py
+++ b/dace/libraries/standard/environments/cuda.py
@@ -17,3 +17,4 @@ class CUDA:
     headers = []
     init_code = ""
     finalize_code = ""
+    dependencies = []

--- a/dace/library.py
+++ b/dace/library.py
@@ -214,7 +214,7 @@ def get_environments_and_dependencies(names: Set[str]) -> List:
         }
         if len(added) == 0:
             break
-        environments = environments.extend(added)
+        environments = environments.union(added)
 
     # construct dependency graph
     dep_graph = nx.DiGraph()

--- a/dace/library.py
+++ b/dace/library.py
@@ -187,15 +187,6 @@ def environment(env):
     return env
 
 
-# Mapping from string to DaCe environment
-def get_environment(env_name):
-    try:
-        env = dace.library._DACE_REGISTERED_ENVIRONMENTS[env_name]
-    except KeyError:
-        raise KeyError("Undefined DaCe environment {}.".format(env_name))
-    return env
-
-
 def get_environments_and_dependencies(names: Set[str]) -> List:
     """ Get the environment objects from names. Also resolve the dependencies.
 
@@ -228,6 +219,15 @@ def get_environments_and_dependencies(names: Set[str]) -> List:
         return list(nx.topological_sort(dep_graph))
     except nx.NetworkXUnfeasible:
         raise ValueError("Detected cycle in dependency graph.")
+
+
+# Mapping from string to DaCe environment
+def get_environment(env_name):
+    try:
+        env = dace.library._DACE_REGISTERED_ENVIRONMENTS[env_name]
+    except KeyError:
+        raise KeyError("Undefined DaCe environment {}.".format(env_name))
+    return env
 
 
 # Mapping from string to library

--- a/dace/library.py
+++ b/dace/library.py
@@ -170,6 +170,7 @@ def environment(env):
             "headers",
             "init_code",
             "finalize_code",
+            "dependencies"
     ]:
         if not hasattr(env, field):
             raise ValueError(


### PR DESCRIPTION
This PR adds a dependency field to dace environments, which is a list of environments.

When generating the framecode, the initialization and exit code ordering respects the dependencies.
This is required for a change in daceml: https://github.com/spcl/daceml/pull/30