### PR TITLE
FPGA BLAS: GEMV tiles streamed by row

### DIFF
--- a/dace/libraries/blas/nodes/gemv.py
+++ b/dace/libraries/blas/nodes/gemv.py
@@ -1464,7 +1464,7 @@ class Gemv(dace.sdfg.nodes.LibraryNode):
             name,
             location=location,
             inputs={"_A", "_x", "_y"} if beta != 0 else {"_A", "_x"},
-            outputs={"_res"} if streaming else {"_y"})
+            outputs= {"_res"} if streaming else {"_y"})
 
         self.dtype = dtype
         self.transA = transA

--- a/dace/libraries/blas/nodes/gemv.py
+++ b/dace/libraries/blas/nodes/gemv.py
@@ -711,7 +711,8 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
     environments = []
 
     @staticmethod
-    def make_sdfg(dtype, n_tile, m_tile, partial_width, n, m, veclen, a, b, streaming):
+    def make_sdfg(dtype, n_tile, m_tile, partial_width, n, m, veclen, a, b,
+                  streaming):
         # ---------- ----------
         # SETUP GRAPH
         # ---------- ----------
@@ -727,34 +728,34 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
 
         gemv_state = gemv_sdfg.add_state()
 
-
         y_in = None
         if streaming:
             A_in = gemv_state.add_stream('_A',
-                                        vec_type,
-                                        buffer_size=32,
-                                        storage=dtypes.StorageType.FPGA_Local)
+                                         vec_type,
+                                         buffer_size=32,
+                                         storage=dtypes.StorageType.FPGA_Local)
 
             if b != 0:
-                y_in = gemv_state.add_stream('_y',
-                                            single_vec_type,
-                                            buffer_size=32,
-                                            storage=dtypes.StorageType.FPGA_Local,
-                                            transient=(True if b == 0 else False))
+                y_in = gemv_state.add_stream(
+                    '_y',
+                    single_vec_type,
+                    buffer_size=32,
+                    storage=dtypes.StorageType.FPGA_Local,
+                    transient=(True if b == 0 else False))
 
             # Must be received n/n_tile times
             x_in = gemv_state.add_stream('_x',
-                                        vec_type,
-                                        buffer_size=32,
-                                        storage=dtypes.StorageType.FPGA_Local)
+                                         vec_type,
+                                         buffer_size=32,
+                                         storage=dtypes.StorageType.FPGA_Local)
 
             res = gemv_state.add_stream('_res',
                                         single_vec_type,
                                         buffer_size=32,
                                         storage=dtypes.StorageType.FPGA_Local)
         else:
-            gemv_sdfg.add_array("_A", shape=[n*m/veclen], dtype=vec_type)
-            gemv_sdfg.add_array("_x", shape=[m/veclen], dtype=vec_type)
+            gemv_sdfg.add_array("_A", shape=[n * m / veclen], dtype=vec_type)
+            gemv_sdfg.add_array("_x", shape=[m / veclen], dtype=vec_type)
             gemv_sdfg.add_array("_y", shape=[n], dtype=dtype)
 
             A_in = gemv_state.add_read("_A")
@@ -763,7 +764,6 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
 
             if b != 0:
                 y_in = gemv_state.add_read("_y")
-
 
         # ---------- ----------
         # COMPUTE
@@ -812,7 +812,8 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         return gemv_sdfg
 
     @staticmethod
-    def make_y_tile(dtype, n_tile, m_tile, partial_width, n, m, veclen, a, b, streaming):
+    def make_y_tile(dtype, n_tile, m_tile, partial_width, n, m, veclen, a, b,
+                    streaming):
 
         y_tile_sdfg = dace.SDFG("y_tile_sdfg")
 
@@ -826,13 +827,13 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         if b != 0:
             y_tile_sdfg.add_symbol(b.name, b.dtype)
 
-
         y_in = None
         if streaming:
-            A_in = compute_state.add_stream('_A_tile',
-                                            vec_type,
-                                            buffer_size=32,
-                                            storage=dtypes.StorageType.FPGA_Local)
+            A_in = compute_state.add_stream(
+                '_A_tile',
+                vec_type,
+                buffer_size=32,
+                storage=dtypes.StorageType.FPGA_Local)
 
             if b != 0:
                 y_in = compute_state.add_stream(
@@ -841,23 +842,23 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
                     buffer_size=32,
                     storage=dtypes.StorageType.FPGA_Local)
 
-            x_in = compute_state.add_stream('_x_tile',
-                                            vec_type,
-                                            buffer_size=32,
-                                            storage=dtypes.StorageType.FPGA_Local)
-
-
+            x_in = compute_state.add_stream(
+                '_x_tile',
+                vec_type,
+                buffer_size=32,
+                storage=dtypes.StorageType.FPGA_Local)
 
             data_out = compute_state.add_stream(
                 'y_tile',
                 single_vec_type,
                 buffer_size=32,
-                storage=dtypes.StorageType.FPGA_Local
-            )
+                storage=dtypes.StorageType.FPGA_Local)
 
         else:
-            y_tile_sdfg.add_array("_A_tile", shape=[n*m/veclen], dtype=vec_type)
-            y_tile_sdfg.add_array("_x_tile", shape=[m/veclen], dtype=vec_type)
+            y_tile_sdfg.add_array("_A_tile",
+                                  shape=[n * m / veclen],
+                                  dtype=vec_type)
+            y_tile_sdfg.add_array("_x_tile", shape=[m / veclen], dtype=vec_type)
             y_tile_sdfg.add_array("y_tile", shape=[n], dtype=dtype)
 
             A_in = compute_state.add_read("_A_tile")
@@ -868,13 +869,11 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
                 y_tile_sdfg.add_array("_y_tile", shape=[n], dtype=dtype)
                 y_in = compute_state.add_read("_y_tile")
 
-
-
         y_tile_sdfg.add_array('y_tile_res',
-                    shape=[n_tile],
-                    dtype=single_vec_type if streaming else dtype,
-                    storage=dtypes.StorageType.FPGA_Local,
-                    transient=True)
+                              shape=[n_tile],
+                              dtype=single_vec_type if streaming else dtype,
+                              storage=dtypes.StorageType.FPGA_Local,
+                              transient=True)
 
         # ---------- ----------
         # INIT State
@@ -982,18 +981,19 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         write_empty_state = redTile_sdfg.add_state('write_empty_reduceTile')
         end_state = redTile_sdfg.add_state('end_reduceTile')
 
-
         y_in = None
         if streaming:
-            A_in = compute_state.add_stream('_A_red',
-                                            vec_type,
-                                            buffer_size=32,
-                                            storage=dtypes.StorageType.FPGA_Local)
+            A_in = compute_state.add_stream(
+                '_A_red',
+                vec_type,
+                buffer_size=32,
+                storage=dtypes.StorageType.FPGA_Local)
 
-            x_in = compute_state.add_stream('_x_red',
-                                            vec_type,
-                                            buffer_size=32,
-                                            storage=dtypes.StorageType.FPGA_Local)
+            x_in = compute_state.add_stream(
+                '_x_red',
+                vec_type,
+                buffer_size=32,
+                storage=dtypes.StorageType.FPGA_Local)
 
             if b != 0:
                 y_in = read_y_state.add_stream(
@@ -1009,8 +1009,10 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
                 storage=dtypes.StorageType.FPGA_Local)
 
         else:
-            redTile_sdfg.add_array("_A_red", shape=[n*m/veclen], dtype=vec_type)
-            redTile_sdfg.add_array("_x_red", shape=[m/veclen], dtype=vec_type)
+            redTile_sdfg.add_array("_A_red",
+                                   shape=[n * m / veclen],
+                                   dtype=vec_type)
+            redTile_sdfg.add_array("_x_red", shape=[m / veclen], dtype=vec_type)
             redTile_sdfg.add_array("_res_red", shape=[n], dtype=dtype)
 
             A_in = compute_state.add_read("_A_red")
@@ -1020,9 +1022,6 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
             if b != 0:
                 redTile_sdfg.add_array("_y_stream_red", shape=[n], dtype=dtype)
                 y_in = read_y_state.add_read("_y_stream_red")
-
-
-
 
         redTile_sdfg.add_array('_y_red',
                                shape=[n_tile],
@@ -1060,12 +1059,14 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
             'read_y_tasklet', (['in_con'] if b != 0 else []), ['out_con'], code)
 
         if b != 0:
-            read_y_state.add_memlet_path(y_in,
-                                         y_read_tasklet,
-                                         dst_conn='in_con',
-                                         memlet=Memlet.simple(y_in.data,
-                                                              "0" if streaming else "i * {} + ii".format(n_tile),
-                                                              num_accesses=-1))
+            read_y_state.add_memlet_path(
+                y_in,
+                y_read_tasklet,
+                dst_conn='in_con',
+                memlet=Memlet.simple(
+                    y_in.data,
+                    "0" if streaming else "i * {} + ii".format(n_tile),
+                    num_accesses=-1))
 
         read_y_state.add_memlet_path(y_read_tasklet,
                                      y_out,
@@ -1221,7 +1222,10 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         write_y_state.add_memlet_path(
             y_in,
             y_out_stream,
-            memlet=Memlet.simple(y_in.data, "ii", other_subset_str= "0" if streaming else "i * {} + ii".format(n_tile)))
+            memlet=Memlet.simple(y_in.data,
+                                 "ii",
+                                 other_subset_str="0" if streaming else
+                                 "i * {} + ii".format(n_tile)))
 
         redTile_sdfg.add_edge(
             store_state, write_y_state,
@@ -1241,7 +1245,6 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         redTile_sdfg.fill_scope_connectors()
 
         return redTile_sdfg
-
 
     @staticmethod
     def make_unrolledCompute(dtype, n_tile, m_tile, veclen, partial_width, n, m,
@@ -1263,21 +1266,25 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
 
         if streaming:
             A_in = init_state.add_stream('_A_unroll',
-                                        vec_type,
-                                        buffer_size=32,
-                                        storage=dtypes.StorageType.FPGA_Local)
+                                         vec_type,
+                                         buffer_size=32,
+                                         storage=dtypes.StorageType.FPGA_Local)
 
-            x_in = read_x_state.add_stream('_x_unroll',
-                                        vec_type,
-                                        buffer_size=32,
-                                        storage=dtypes.StorageType.FPGA_Local)
+            x_in = read_x_state.add_stream(
+                '_x_unroll',
+                vec_type,
+                buffer_size=32,
+                storage=dtypes.StorageType.FPGA_Local)
         else:
-            inner_sdfg.add_array("_A_unroll", shape=[n*m/veclen], dtype=vec_type)
-            inner_sdfg.add_array("_x_unroll", shape=[m/veclen], dtype=vec_type)
+            inner_sdfg.add_array("_A_unroll",
+                                 shape=[n * m / veclen],
+                                 dtype=vec_type)
+            inner_sdfg.add_array("_x_unroll",
+                                 shape=[m / veclen],
+                                 dtype=vec_type)
 
             A_in = init_state.add_read("_A_unroll")
             x_in = read_x_state.add_read("_x_unroll")
-
 
         inner_sdfg.add_array(
             '_buf_in_unroll',
@@ -1331,12 +1338,15 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         vec_buf_A = init_state.add_access("vec_buf_A")
         mem_buf_A = init_state.add_write("mem_buf_A")
 
-        init_state.add_memlet_path(A_in,
-                                   vec_buf_A,
-                                   memlet=Memlet.simple(vec_buf_A.data,
-                                                        "0",
-                                                        other_subset_str="0" if streaming else "(i *{0} + ii) * {1} / {3} + (j * {2} + jj * {3}) / {3}".format(
-                            n_tile, m, m_tile, veclen)))
+        init_state.add_memlet_path(
+            A_in,
+            vec_buf_A,
+            memlet=Memlet.simple(
+                vec_buf_A.data,
+                "0",
+                other_subset_str="0" if streaming else
+                "(i *{0} + ii) * {1} / {3} + (j * {2} + jj * {3}) / {3}".format(
+                    n_tile, m, m_tile, veclen)))
 
         init_state.add_memlet_path(vec_buf_A,
                                    mem_buf_A,
@@ -1346,11 +1356,13 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
         # -----------------------
         data_out = read_x_state.add_write('_x_buf')
 
-        read_x_state.add_memlet_path(x_in,
-                                     data_out,
-                                     memlet=Memlet.simple(data_out.data,
-                                                          "jj",
-                                                          other_subset_str="0" if streaming else "(j * {}/{} + jj)".format(m_tile, veclen)))
+        read_x_state.add_memlet_path(
+            x_in,
+            data_out,
+            memlet=Memlet.simple(data_out.data,
+                                 "jj",
+                                 other_subset_str="0" if streaming else
+                                 "(j * {}/{} + jj)".format(m_tile, veclen)))
 
         inner_sdfg.add_edge(init_state, read_x_state,
                             dace.InterstateEdge("ii == 0"))
@@ -1461,7 +1473,6 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
 
         return inner_sdfg
 
-
     @staticmethod
     def expansion(node, state, sdfg, **kwargs):
 
@@ -1470,15 +1481,15 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
 
         for e in state.in_edges(node):
 
-            if isinstance(sdfg.arrays[e.data.data],
-                          dace.data.Stream) and e.dst_conn in ["_x", "_y", "_A"]:
+            if isinstance(
+                    sdfg.arrays[e.data.data],
+                    dace.data.Stream) and e.dst_conn in ["_x", "_y", "_A"]:
                 streaming = True
                 streaming_nodes = streaming_nodes + 1
 
-
         for e in state.out_edges(node):
-            if isinstance(sdfg.arrays[e.data.data],
-                          dace.data.Stream) and e.src_conn == "_res" and node.streaming:
+            if isinstance(sdfg.arrays[e.data.data], dace.data.Stream
+                          ) and e.src_conn == "_res" and node.streaming:
                 streaming = True
                 streaming_nodes = streaming_nodes + 1
 
@@ -1493,8 +1504,8 @@ class ExpandGEMVFPGAStreamingRowTilesRowOrdered(ExpandTransformation):
                              ".")
         return ExpandGEMVFPGAStreamingRowTilesRowOrdered.make_sdfg(
             node.dtype, int(node.n_tile), int(node.m_tile), node.partial_width,
-            node.n, node.m, int(node.veclen), node.alpha, node.beta, (node.streaming  and streaming))
-    
+            node.n, node.m, int(node.veclen), node.alpha, node.beta,
+            (node.streaming and streaming))
 
 
 @dace.library.expansion
@@ -1678,7 +1689,6 @@ class ExpandGemvTilesByColumn(ExpandTransformation):
         return sdfg
 
 
-
 @dace.library.node
 class Gemv(dace.sdfg.nodes.LibraryNode):
 
@@ -1686,7 +1696,7 @@ class Gemv(dace.sdfg.nodes.LibraryNode):
     implementations = {
         "pure": ExpandGemvPure,
         "IntelFPGA": ExpandGEMVIntelFPGAVectorized,
-        "fpga_row": ExpandGEMVFPGAStreamingRowTilesRowOrdered,
+        "TilesByRow": ExpandGEMVFPGAStreamingRowTilesRowOrdered,
         "TilesByColumn": ExpandGemvTilesByColumn,
     }
     default_implementation = None
@@ -1715,7 +1725,7 @@ class Gemv(dace.sdfg.nodes.LibraryNode):
 
     # To set output connectors appropriately
     streaming = dace.properties.SymbolicProperty(allow_none=False,
-                                                     default=False)
+                                                 default=False)
 
     def __init__(self,
                  name,
@@ -1735,7 +1745,7 @@ class Gemv(dace.sdfg.nodes.LibraryNode):
             name,
             location=location,
             inputs={"_A", "_x", "_y"} if beta != 0 else {"_A", "_x"},
-            outputs= {"_res"} if streaming else {"_y"})
+            outputs={"_res"} if streaming else {"_y"})
 
         self.dtype = dtype
         self.transA = transA

--- a/dace/libraries/blas/nodes/gemv.py
+++ b/dace/libraries/blas/nodes/gemv.py
@@ -1274,10 +1274,10 @@ class Expand_GEMV_FPGA_Streaming_RowTiles(ExpandTransformation):
             storage=dtypes.StorageType.FPGA_Local
         )
 
-        inner_sdfg.add_array('_buf_in_unroll', shape=[max(2, partial_width)], dtype=single_vec_type,
+        inner_sdfg.add_array('_buf_in_unroll', shape=[max(2, partial_width)], dtype=dtype,
             storage=dtypes.StorageType.FPGA_Local if partial_width > 8 else dtypes.StorageType.FPGA_Registers
         )
-        inner_sdfg.add_array('buf_out', shape=[max(2, partial_width)], dtype=single_vec_type,
+        inner_sdfg.add_array('buf_out', shape=[max(2, partial_width)], dtype=dtype,
             storage=dtypes.StorageType.FPGA_Local if partial_width > 8 else dtypes.StorageType.FPGA_Registers
         )
 

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -464,7 +464,7 @@ class ExpandTransformation(Transformation):
         return str(node)
 
     @staticmethod
-    def expansion(node):
+    def expansion(node, state, sdfg, *args, **kwargs):
         raise NotImplementedError("Must be implemented by subclass")
 
     @staticmethod

--- a/tests/blas/nodes/gemv_test.py
+++ b/tests/blas/nodes/gemv_test.py
@@ -272,26 +272,262 @@ def fpga_row_streamd_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
 
 
 
-def run_test(sdfg, n, m, alpha, beta, separate_result_buf=False):
+def fpga_col_streamd_transposed_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
+
+    nRows = dace.symbol("n")
+    mCols = dace.symbol("m")
+
+    a = dace.symbol("alpha")
+    b = dace.symbol("beta")
+
+    rowTile = n_tile
+    colTile = m_tile
+    partial_width = 4
+
+    vec_type = dace.vector(dtype, vec_width)
+    single_vec_type = dace.vector(dtype, 1)
+
+    test_sdfg = dace.SDFG("gemv_testing_stream_col_" + vendor)
+    test_state = test_sdfg.add_state("test_state")
+
+    test_sdfg.add_symbol(a.name, dace.float32)
+
+    if b != 0:
+        test_sdfg.add_symbol(b.name, dace.float32)
+
+    test_sdfg.add_array('A', shape=[nRows * mCols / vec_width], dtype=vec_type)
+    test_sdfg.add_array('x', shape=[mCols], dtype=single_vec_type)
+    test_sdfg.add_array('y', shape=[nRows], dtype=single_vec_type)
+    test_sdfg.add_array('res', shape=[nRows], dtype=single_vec_type)
+
+    x_stream = streaming.StreamReadVector('x',
+                                          mCols,
+                                          dace.float32,
+                                          veclen=1,
+                                          repeat='{}/{}'.format(nRows, rowTile))
+
+    y_stream = None
+    if b != 0:
+        y_stream = streaming.StreamReadVector(
+            'y',
+            nRows,
+            dace.float32,
+            veclen=1,
+        )
+
+    A_stream = streaming.StreamReadMatrixFull('A',
+                                              nRows,
+                                              mCols,
+                                              rowTile,
+                                              colTile,
+                                              dace.float32,
+                                              blockByRow=False,
+                                              veclen=vec_width)
+
+    res_stream = streaming.StreamWriteVector('res', nRows, dace.float32)
+
+    gemv_node = blas.gemv.Gemv("blas_gemv",
+                               dtype=dace.float32,
+                               n_tile=rowTile,
+                               m_tile=colTile,
+                               partial_width=partial_width,
+                               n=nRows,
+                               m=mCols,
+                               veclen=vec_width,
+                               alpha=a,
+                               beta=b,
+                               streaming=True)
+    gemv_node.implementation = 'fpga_col'
+
+    if y_stream is not None:
+        preState, postState = streaming.fpga_setup_connect_streamers(
+            test_sdfg, test_state, gemv_node, [x_stream, y_stream, A_stream],
+            ['_x', '_y', '_A'], gemv_node, [res_stream], ['_res'])
+    else:
+        preState, postState = streaming.fpga_setup_connect_streamers(
+            test_sdfg, test_state, gemv_node, [x_stream, A_stream],
+            ['_x', '_A'], gemv_node, [res_stream], ['_res'])
+
+    test_sdfg.expand_library_nodes()
+
+    mode = "simulation" if vendor == "xilinx" else "emulator"
+    dace.config.Config.set("compiler", "fpga_vendor", value=vendor)
+    dace.config.Config.set("compiler", vendor, "mode", value=mode)
+
+    return test_sdfg
+
+
+
+def fpga_row_array_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
+
+    DATATYPE = dtype
+
+    n = dace.symbol("n")
+    m = dace.symbol("m")
+    a = dace.symbol("alpha")
+
+    vendor_mark = "x" if vendor == "xilinx" else "i"
+    test_sdfg = dace.SDFG("gemv_test_array_" + vendor_mark + "_" + testCase)
+
+    test_sdfg.add_symbol(a.name, DATATYPE)
+
+    vec_type = dace.vector(dtype, vec_width)
+    single_vec_type = dace.vector(dtype, 1)
+
+    test_sdfg.add_array('A', shape=[n*m/vec_width], dtype=vec_type)
+    test_sdfg.add_array('x', shape=[m/vec_width], dtype=vec_type)
+    test_sdfg.add_array('y', shape=[n], dtype=single_vec_type)
+    test_sdfg.add_array('res', shape=[n], dtype=single_vec_type)
+
+    ###########################################################################
+    # Copy data to FPGA
+
+    copy_in_state = test_sdfg.add_state("copy_to_device")
+
+    in_host_x = copy_in_state.add_read("x")
+    in_host_y = copy_in_state.add_read("y")
+    in_host_A = copy_in_state.add_read("A")
+
+    test_sdfg.add_array("device_x",
+                        shape=[m/vec_width],
+                        dtype=vec_type,
+                        storage=dace.dtypes.StorageType.FPGA_Global,
+                        transient=True)
+    test_sdfg.add_array("device_y",
+                        shape=[n],
+                        dtype=single_vec_type,
+                        storage=dace.dtypes.StorageType.FPGA_Global,
+                        transient=True)
+    test_sdfg.add_array("device_A",
+                        shape=[n],
+                        dtype=single_vec_type,
+                        storage=dace.dtypes.StorageType.FPGA_Global,
+                        transient=True)
+
+    in_device_x = copy_in_state.add_write("device_x")
+    in_device_y = copy_in_state.add_write("device_y")
+    in_device_A = copy_in_state.add_write("device_A")
+
+    copy_in_state.add_memlet_path(in_host_x,
+                                  in_device_x,
+                                  memlet=Memlet.simple(in_host_x,
+                                                       "0:{}/{}".format(m, vec_width)))
+    copy_in_state.add_memlet_path(in_host_y,
+                                  in_device_y,
+                                  memlet=Memlet.simple(in_host_y,
+                                                       "0:{}".format(n)))
+    copy_in_state.add_memlet_path(in_host_A,
+                                  in_device_A,
+                                  memlet=Memlet.simple(in_host_A,
+                                                       "0:{}".format(n*m/vec_width)))
+
+    ###########################################################################
+    # Copy data from FPGA
+    copy_out_state = test_sdfg.add_state("copy_to_host")
+
+    test_sdfg.add_array("device_r",
+                        shape=[n],
+                        dtype=single_vec_type,
+                        storage=dace.dtypes.StorageType.FPGA_Global,
+                        transient=True)
+
+    out_device = copy_out_state.add_read("device_r")
+    out_host = copy_out_state.add_write("res")
+
+    copy_out_state.add_memlet_path(out_device,
+                                   out_host,
+                                   memlet=Memlet.simple(out_host,
+                                                        "0:{}".format(n)))
+
+    ########################################################################
+    # FPGA State
+
+    fpga_state = test_sdfg.add_state("fpga_state")
+
+    x = fpga_state.add_read("device_x")
+    y = fpga_state.add_read("device_y")
+    A = fpga_state.add_read("device_A")
+    z = fpga_state.add_write("device_r")
+
+    gemv_node = blas.gemv.Gemv("blas_gemv",
+                               dtype=dace.float32,
+                               n_tile=rowTile,
+                               m_tile=colTile,
+                               partial_width=partial_width,
+                               n=nRows,
+                               m=mCols,
+                               veclen=vec_width,
+                               alpha=a,
+                               beta=b,
+                               streaming=True)
+    gemv_node.implementation = 'fpga_row'
+
+    fpga_state.add_memlet_path(x,
+                               gemv_node,
+                               dst_conn="_x",
+                               memlet=Memlet.simple(x, "0:{}".format(m/vec_width)))
+    fpga_state.add_memlet_path(y,
+                               gemv_node,
+                               dst_conn="_y",
+                               memlet=Memlet.simple(y, "0:{}".format(n)))
+    fpga_state.add_memlet_path(A,
+                               gemv_node,
+                               dst_conn="_A",
+                               memlet=Memlet.simple(A, "0:{}".format(n*m/vec_width)))
+    fpga_state.add_memlet_path(gemv_node,
+                               z,
+                               src_conn="_res",
+                               memlet=Memlet.simple(z, "0:{}".format(n)))
+
+    ######################################
+    # Interstate edges
+    test_sdfg.add_edge(copy_in_state, fpga_state,
+                       dace.sdfg.sdfg.InterstateEdge())
+    test_sdfg.add_edge(fpga_state, copy_out_state,
+                       dace.sdfg.sdfg.InterstateEdge())
+
+    #########
+    # Validate
+    test_sdfg.fill_scope_connectors()
+    test_sdfg.validate()
+
+    gemv_node.expand(test_sdfg, fpga_state)
+
+    mode = "simulation" if vendor == "xilinx" else "emulator"
+    dace.config.Config.set("compiler", "fpga_vendor", value=vendor)
+    dace.config.Config.set("compiler", vendor, "mode", value=mode)
+
+    return test_sdfg
+
+
+def run_test(sdfg, n, m, alpha, beta, trans=False, separate_result_buf=False):
 
     A = np.random.rand(n, m).astype(np.float32)
-    x = np.random.rand(n if transposed else m).astype(np.float32)
-    y = np.random.rand(m if transposed else n).astype(np.float32)
-    res = np.random.rand(m if transposed else n).astype(np.float32)
+    x = np.random.rand(n if trans else m).astype(np.float32)
+    y = np.random.rand(m if trans else n).astype(np.float32)
+    res = np.random.rand(m if trans else n).astype(np.float32)
 
     # A = np.ones((n,m), dtype=np.float32)
+    # A = np.array([
+    #     [1,2,3,4],
+    #     [1,2,3,4],
+    #     [1,2,3,4],
+    #     [1,2,3,4]
+    # ], dtype=np.float32)
     # x = np.array([1,2,3,4], dtype=np.float32)
-    # y = np.zeros(4, dtype=np.float32)
+    # x = np.ones(4, dtype=np.float32)
+    # y = np.ones(4, dtype=np.float32)
 
     y_copy = np.copy(y)
-    ref = scipy.linalg.blas.sgemv(alpha, A, x, beta, y_copy, trans=transposed)
+    ref = scipy.linalg.blas.sgemv(alpha, A, x, beta, y_copy, trans=trans)
+
 
     if separate_result_buf:
         sdfg(A=A, x=x, y=y, n=n, m=m, res=res, alpha=alpha, beta=beta)
-        diff = np.linalg.norm(res - ref) / (m if transposed else n)
+        diff = np.linalg.norm(res - ref) / (m if trans else n)
     else:
         sdfg(A=A, x=x, y=y, n=n, m=m, alpha=alpha, beta=beta)
-        diff = np.linalg.norm(y - ref) / (m if transposed else n)
+        diff = np.linalg.norm(y - ref) / (m if trans else n)
 
     if diff >= 1e-5:
         result = res if args.target == "xilinx" else y
@@ -338,17 +574,26 @@ if __name__ == "__main__":
 
     if args.target == "pure":
         sdfg = pure_graph(dace.float32, transposed)
-        run_test(sdfg, n, m, alpha, beta)
+        run_test(sdfg, n, m, alpha, beta, trans=transposed)
     elif args.target == "intel_fpga":
         sdfg = intel_fpga_graph(dace.float32, transposed)
-        run_test(sdfg, n, m, alpha, beta)
+        run_test(sdfg, n, m, alpha, beta, trans=transposed)
     elif args.target == "xilinx":
-        sdfg = fpga_row_streamd_graph(dace.float32,
-                                      "xilinx",
-                                      n_tile=args.n_tile,
-                                      m_tile=args.m_tile,
-                                      vec_width=args.veclen)
-        run_test(sdfg, n, m, alpha, beta, separate_result_buf=True)
+        if not transposed:
+            sdfg = fpga_row_streamd_graph(dace.float32,
+                                        "xilinx",
+                                        n_tile=args.n_tile,
+                                        m_tile=args.m_tile,
+                                        vec_width=args.veclen)
+            run_test(sdfg, n, m, alpha, beta, trans=transposed, separate_result_buf=True)
+
+        else:
+            sdfg = fpga_col_streamd_transposed_graph(dace.float32,
+                                        "xilinx",
+                                        n_tile=args.n_tile,
+                                        m_tile=args.m_tile,
+                                        vec_width=args.veclen)
+            run_test(sdfg, n, m, alpha, beta, trans=transposed, separate_result_buf=True)
     else:
         print("Unsupported target")
         exit(-1)

--- a/tests/blas/nodes/gemv_test.py
+++ b/tests/blas/nodes/gemv_test.py
@@ -198,7 +198,7 @@ def fpga_graph(dtype, transposed, expansion, vec_width):
     sdfg.add_edge(copy_in_state, fpga_state, dace.sdfg.sdfg.InterstateEdge())
     sdfg.add_edge(fpga_state, copy_out_state, dace.sdfg.sdfg.InterstateEdge())
 
-    gemv_node.expand(sdfg, fpga_state, tile_size_x=16, tile_size_y=16)
+    gemv_node.expand(sdfg, fpga_state, tile_m_size=16, tile_n_size=16, vec_width=vec_width)
 
     sdfg.fill_scope_connectors()
     return sdfg

--- a/tests/blas/nodes/gemv_test.py
+++ b/tests/blas/nodes/gemv_test.py
@@ -260,12 +260,9 @@ def fpga_row_streamd_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
 
     gemv_node = blas.gemv.Gemv("blas_gemv",
                                dtype=dace.float32,
-                               n_tile=rowTile,
-                               m_tile=colTile,
                                partial_width=partial_width,
                                n=nRows,
                                m=mCols,
-                               veclen=vec_width,
                                alpha=a,
                                beta=b,
                                streaming=True)
@@ -280,7 +277,7 @@ def fpga_row_streamd_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
             test_sdfg, test_state, gemv_node, [x_stream, A_stream],
             ['_x', '_A'], gemv_node, [res_stream], ['_res'])
 
-    test_sdfg.expand_library_nodes()
+    gemv_node.expand(test_sdfg, test_state, tile_m_size=colTile, tile_n_size=rowTile, vec_width=vec_width)
 
     mode = "simulation" if vendor == "xilinx" else "emulator"
     dace.config.Config.set("compiler", "fpga_vendor", value=vendor)
@@ -386,12 +383,9 @@ def fpga_row_array_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
 
     gemv_node = blas.gemv.Gemv("blas_gemv",
                                dtype=dace.float32,
-                               n_tile=n_tile,
-                               m_tile=m_tile,
                                partial_width=8,
                                n=n,
                                m=m,
-                               veclen=vec_width,
                                alpha=a,
                                beta=b,
                                streaming=False)
@@ -428,7 +422,8 @@ def fpga_row_array_graph(dtype, vendor, n_tile=4, m_tile=4, vec_width=1):
     test_sdfg.fill_scope_connectors()
     test_sdfg.validate()
 
-    gemv_node.expand(test_sdfg, fpga_state)
+    
+    gemv_node.expand(test_sdfg, fpga_state, tile_m_size=m_tile, tile_n_size=n_tile, vec_width=vec_width)
 
     mode = "simulation" if vendor == "xilinx" else "emulator"
     dace.config.Config.set("compiler", "fpga_vendor", value=vendor)

--- a/tests/blas/nodes/ger_test.py
+++ b/tests/blas/nodes/ger_test.py
@@ -252,7 +252,6 @@ def fpga_graph_array_column(veclen, n_tile, m_tile, precision, vendor, testCase=
     test_sdfg.fill_scope_connectors()
     test_sdfg.validate()
 
-    # test_sdfg.~~~()
     ger_node.expand(test_sdfg, fpga_state)
 
     mode = "simulation" if vendor == "xilinx" else "emulator"

--- a/tests/blas/nodes/ger_test.py
+++ b/tests/blas/nodes/ger_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 
 import numpy as np
 
@@ -97,7 +98,7 @@ def fpga_graph_column(veclen, n_tile, m_tile, precision, vendor, testCase="0"):
         veclen=veclen,
         alpha=a
     )
-    ger_node.implementation = 'fpga_columns'
+    ger_node.implementation = 'fpga_column'
 
     preState, postState = streaming.fpga_setup_connect_streamers(
         test_sdfg,
@@ -220,7 +221,7 @@ def fpga_graph_array_column(veclen, n_tile, m_tile, precision, vendor, testCase=
         veclen=veclen,
         alpha=a
     )
-    ger_node.implementation = 'fpga_columns'
+    ger_node.implementation = 'fpga_column'
 
     fpga_state.add_memlet_path(x,
                                ger_node,
@@ -325,23 +326,6 @@ def run_test(ger, target):
     x[:] = np.random.rand(m).astype(np.float32)
     y[:] = np.random.rand(n).astype(np.float32)
     A[:] = np.random.rand(m, n).astype(np.float32)
-
-    # y = np.array([1, 2, 3, 4]).astype(np.float32)
-    # y = np.array([1, 1, 1, 1]).astype(np.float32)
-    # y = aligned_ndarray(np.ones(n).astype(np.float32), alignment=256)
-    # x = aligned_ndarray(np.ones(m).astype(np.float32), alignment=256)
-    # A = np.random.randint(low=0, high=10, size=n*m).reshape((n,m)).astype(np.float32)
-
-    # A = aligned_ndarray(np.array([
-    #     [1,2,3,4],
-    #     [5,6,7,8],
-    #     [9,10,11,12],
-    #     [13,14,15,16]
-    # ]).astype(np.float32), alignment=256)
-
-    # A = np.zeros(n*m).reshape(n,m).astype(np.float32)
-
-    # result[:] = aligned_ndarray(np.zeros((m, n)).astype(np.float32), alignment=256)
 
     ger(alpha=alpha, x=x, y=y, A=A, r=result, m=m, n=n)
 


### PR DESCRIPTION
Adds FPGA GEMV implementation for streaming tiles in by row and within tiles by row `(tiles, withinTiles)->(row, row)`. Status:
- Works for Xilinx
- Should in theory also work for Intel, but there seems to be a bug in the codegen, where instead of a `float*` only a `float` is passed in a function declaration and thus leads to compilation errors when trying to dereference.

- Side change, adjusted `transformation.py`s base function `expansion` to contain all three arguments.