### PR TITLE
Pipeline scope: user can define additional variables 

### DIFF
--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -321,7 +321,7 @@ class CPPUnparser:
                     target.id, self._indent):
 
                 # if the target is already defined, do not redefine it
-                if target.id not in self.defined_symbols:
+                if self.defined_symbols is None or target.id not in self.defined_symbols:
                     # we should try to infer the type
                     if self.type_inference is True:
                         # Perform type inference

--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -320,10 +320,10 @@ class CPPUnparser:
                 (ast.Subscript, ast.Attribute)) and not self.locals.is_defined(
                     target.id, self._indent):
 
-                # the target is not already defined: we should try to infer the type
-                if self.type_inference is True:
-                    # if the target type is already known, no need to perform type inference
-                    if target.id not in self.defined_symbols:
+                # if the target is already defined, do not redefine it
+                if target.id not in self.defined_symbols:
+                    # we should try to infer the type
+                    if self.type_inference is True:
                         # Perform type inference
                         # Build dictionary with symbols
                         def_symbols = {}
@@ -346,9 +346,9 @@ class CPPUnparser:
                         else:
                             self.write(dace.dtypes._CTYPES[inferred_type.type] +
                                        " ")
-                else:
-                    self.locals.define(target.id, t.lineno, self._indent)
-                    self.write("auto ")
+                    else:
+                        self.locals.define(target.id, t.lineno, self._indent)
+                        self.write("auto ")
 
             # dispatch target
             self.dispatch(target)

--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -322,27 +322,30 @@ class CPPUnparser:
 
                 # the target is not already defined: we should try to infer the type
                 if self.type_inference is True:
-                    # Perform type inference
-                    # Build dictionary with symbols
-                    def_symbols = {}
-                    def_symbols.update(self.locals.get_name_type_associations())
-                    def_symbols.update(self.defined_symbols)
-                    inferred_symbols = type_inference.infer_types(
-                        t, def_symbols)
-                    inferred_type = inferred_symbols[target.id]
+                    # if the target type is already known, no need to perform type inference
+                    if target.id not in self.defined_symbols:
+                        # Perform type inference
+                        # Build dictionary with symbols
+                        def_symbols = {}
+                        def_symbols.update(
+                            self.locals.get_name_type_associations())
+                        def_symbols.update(self.defined_symbols)
+                        inferred_symbols = type_inference.infer_types(
+                            t, def_symbols)
+                        inferred_type = inferred_symbols[target.id]
 
-                    self.locals.define(target.id, t.lineno, self._indent,
-                                       inferred_type)
-                    if self.language == dace.dtypes.Language.OpenCL and (
-                            inferred_type is not None
-                            and inferred_type.veclen > 1):
-                        # if the veclen is greater than one, this should be defined with a vector data type
-                        self.write("{}{} ".format(
-                            dace.dtypes._OCL_VECTOR_TYPES[inferred_type.type],
-                            inferred_type.veclen))
-                    else:
-                        self.write(dace.dtypes._CTYPES[inferred_type.type] +
-                                   " ")
+                        self.locals.define(target.id, t.lineno, self._indent,
+                                           inferred_type)
+                        if self.language == dace.dtypes.Language.OpenCL and (
+                                inferred_type is not None
+                                and inferred_type.veclen > 1):
+                            # if the veclen is greater than one, this should be defined with a vector data type
+                            self.write("{}{} ".format(
+                                dace.dtypes._OCL_VECTOR_TYPES[
+                                    inferred_type.type], inferred_type.veclen))
+                        else:
+                            self.write(dace.dtypes._CTYPES[inferred_type.type] +
+                                       " ")
                 else:
                     self.locals.define(target.id, t.lineno, self._indent)
                     self.write("auto ")

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -986,7 +986,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 for i in range(len(node.map.range)):
                     result.write("long {} = {};\n".format(
                         node.map.params[i], node.map.range[i][0]))
-                for var, value in node.pipeline.additional_variables.items():
+                for var, value in node.pipeline.additional_iterators.items():
                     result.write("long {} = {};\n".format(
                         var, value))
 

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -986,6 +986,9 @@ class FPGACodeGen(TargetCodeGenerator):
                 for i in range(len(node.map.range)):
                     result.write("long {} = {};\n".format(
                         node.map.params[i], node.map.range[i][0]))
+                for var, value in node.pipeline.additional_variables.items():
+                    result.write("long {} = {};\n".format(
+                        var, value))
 
             is_degenerate = []
             degenerate_values = []

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -539,7 +539,8 @@ class NestedSDFG(CodeNode):
         extra_symbols = self.symbol_mapping.keys() - symbols
         if len(extra_symbols) > 0:
             # TODO: Elevate to an error?
-            warnings.warn(f"{self.label} maps to unused symbol(s): {extra_symbols}")
+            warnings.warn(
+                f"{self.label} maps to unused symbol(s): {extra_symbols}")
 
         # Recursively validate nested SDFG
         self.sdfg.validate()
@@ -1005,6 +1006,8 @@ class PipelineEntry(MapEntry):
         result = super().new_symbols(sdfg, state, symbols)
         for param in self.map.params:
             result[param] = dtypes.int64  # Overwrite params from Map
+        for param in self.pipeline.additional_variables:
+            result[param] = dtypes.int64
         result[self.pipeline.iterator_str()] = dtypes.int64
         try:
             result[self.pipeline.init_condition()] = dtypes.bool
@@ -1050,6 +1053,9 @@ class Pipeline(Map):
         dtype=bool,
         default=True,
         desc="Whether to increment regular map indices during pipeline drain.")
+    additional_variables = Property(
+        dtype=dict,
+        desc="Additional variables, managed by the user inside the scope.")
 
     def __init__(self,
                  *args,
@@ -1057,12 +1063,14 @@ class Pipeline(Map):
                  init_overlap=False,
                  drain_size=0,
                  drain_overlap=False,
+                 additional_variables={},
                  **kwargs):
         super(Pipeline, self).__init__(*args, **kwargs)
         self.init_size = init_size
         self.init_overlap = init_overlap
         self.drain_size = drain_size
         self.drain_overlap = drain_overlap
+        self.additional_variables = additional_variables
 
     def iterator_str(self):
         return "__" + "".join(self.params)

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -1006,7 +1006,7 @@ class PipelineEntry(MapEntry):
         result = super().new_symbols(sdfg, state, symbols)
         for param in self.map.params:
             result[param] = dtypes.int64  # Overwrite params from Map
-        for param in self.pipeline.additional_variables:
+        for param in self.pipeline.additional_iterators:
             result[param] = dtypes.int64
         result[self.pipeline.iterator_str()] = dtypes.int64
         try:
@@ -1053,9 +1053,9 @@ class Pipeline(Map):
         dtype=bool,
         default=True,
         desc="Whether to increment regular map indices during pipeline drain.")
-    additional_variables = Property(
+    additional_iterators = Property(
         dtype=dict,
-        desc="Additional variables, managed by the user inside the scope.")
+        desc="Additional iterators, managed by the user inside the scope.")
 
     def __init__(self,
                  *args,
@@ -1063,14 +1063,14 @@ class Pipeline(Map):
                  init_overlap=False,
                  drain_size=0,
                  drain_overlap=False,
-                 additional_variables={},
+                 additional_iterators={},
                  **kwargs):
         super(Pipeline, self).__init__(*args, **kwargs)
         self.init_size = init_size
         self.init_overlap = init_overlap
         self.drain_size = drain_size
         self.drain_overlap = drain_overlap
-        self.additional_variables = additional_variables
+        self.additional_iterators = additional_iterators
 
     def iterator_str(self):
         return "__" + "".join(self.params)

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -431,14 +431,12 @@ class StateGraphView(object):
                 freesyms |= set(map(str, n.desc(sdfg).free_symbols))
 
             freesyms |= n.free_symbols
-
         # Free symbols from memlets
         for e in self.edges():
             freesyms |= e.data.free_symbols
 
         # Do not consider SDFG constants as symbols
         new_symbols.update(set(sdfg.constants.keys()))
-
         return freesyms - new_symbols
 
     def defined_symbols(self) -> Dict[str, dt.Data]:
@@ -1426,6 +1424,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
                      init_overlap=False,
                      drain_size=0,
                      drain_overlap=False,
+                     additional_variables = {},
                      schedule=dtypes.ScheduleType.FPGA_Device,
                      debuginfo=None,
                      **kwargs) -> Tuple[nd.PipelineEntry, nd.PipelineExit]:
@@ -1446,6 +1445,10 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
             :param drain_size:    Number of iterations of draining phase.
             :param drain_overlap: Whether the draining phase overlaps with
                                   the "main" streaming phase of the loop.
+            :param additional_variables: a dictionary contanining the additional
+                                  variables that will be created for this scope and that are not
+                                  handled by the scope guards it self.
+                                  The dictionary is in the form 'variable_name' -> init_value
             :return: (map_entry, map_exit) node 2-tuple
         """
         debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
@@ -1455,6 +1458,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
                                init_overlap=init_overlap,
                                drain_size=drain_size,
                                drain_overlap=drain_overlap,
+                               additional_variables = additional_variables,
                                schedule=schedule,
                                debuginfo=debuginfo,
                                **kwargs)

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1424,7 +1424,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
                      init_overlap=False,
                      drain_size=0,
                      drain_overlap=False,
-                     additional_variables = {},
+                     additional_iterators={},
                      schedule=dtypes.ScheduleType.FPGA_Device,
                      debuginfo=None,
                      **kwargs) -> Tuple[nd.PipelineEntry, nd.PipelineExit]:
@@ -1445,10 +1445,10 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
             :param drain_size:    Number of iterations of draining phase.
             :param drain_overlap: Whether the draining phase overlaps with
                                   the "main" streaming phase of the loop.
-            :param additional_variables: a dictionary contanining the additional
-                                  variables that will be created for this scope and that are not
-                                  handled by the scope guards it self.
-                                  The dictionary is in the form 'variable_name' -> init_value
+            :param additional_iterators: a dictionary containing additional
+                                  iterators that will be created for this scope and that are not
+                                  automatically managed by the scope code.
+                                  The dictionary takes the form 'variable_name' -> init_value
             :return: (map_entry, map_exit) node 2-tuple
         """
         debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
@@ -1458,7 +1458,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
                                init_overlap=init_overlap,
                                drain_size=drain_size,
                                drain_overlap=drain_overlap,
-                               additional_variables = additional_variables,
+                               additional_iterators=additional_iterators,
                                schedule=schedule,
                                debuginfo=debuginfo,
                                **kwargs)

--- a/tests/fpga/pipeline_scope.py
+++ b/tests/fpga/pipeline_scope.py
@@ -43,8 +43,8 @@ def make_sdfg(dtype, name="pipeline_test"):
     post_write = post_state.add_write("b")
     post_state.add_memlet_path(post_read,
                                post_write,
-                               memlet=dace.Memlet.simple(post_write,
-                                                         "0:N, 0:K, 0:M"))
+                               memlet=dace.Memlet.simple(
+                                   post_write, "0:N, 0:K, 0:M"))
 
     # Compute state
     read_memory = state.add_read("a_device")
@@ -73,11 +73,17 @@ def make_sdfg(dtype, name="pipeline_test"):
                                      init_size=k * m,
                                      init_overlap=True,
                                      drain_size=k * m,
-                                     drain_overlap=True, additional_variables={'user_var':0})
-
+                                     drain_overlap=True,
+                                     additional_variables={'user_var': 0})
+    # for the sake of testing, use the additional user_var to set to zero the last element of each row
     tasklet = state.add_tasklet(
-        name, {"_in"}, {"_out"},
-        """_out = _in + (1 if {} else (3 if {} else 2))""".format(
+        name, {"_in"}, {"_out"},"""\
+_out = _in + (0 if user_var==M-1 else (1 if {} else (3 if {} else 2)))
+if user_var == M-1:
+    user_var = 0
+else:
+    user_var = user_var + 1 
+""".format(
             entry.pipeline.init_condition(), entry.pipeline.drain_condition()))
 
     # Container-to-container copies between arrays and streams
@@ -99,20 +105,18 @@ def make_sdfg(dtype, name="pipeline_test"):
                           entry,
                           tasklet,
                           dst_conn="_in",
-                          memlet=dace.Memlet.simple(
-                              consume_input_stream.data,
-                              "0",
-                              num_accesses=-1))
+                          memlet=dace.Memlet.simple(consume_input_stream.data,
+                                                    "0",
+                                                    num_accesses=-1))
 
     # Buffer to output stream
     state.add_memlet_path(tasklet,
                           exit,
                           produce_output_stream,
                           src_conn="_out",
-                          memlet=dace.Memlet.simple(
-                              produce_output_stream.data,
-                              "0",
-                              num_accesses=-1))
+                          memlet=dace.Memlet.simple(produce_output_stream.data,
+                                                    "0",
+                                                    num_accesses=-1))
 
     return sdfg
 
@@ -129,15 +133,15 @@ if __name__ == "__main__":
     jacobi = make_sdfg(dtype=dtype)
     jacobi.specialize({"N": n, "K": k, "M": m})
 
-    a = np.arange(n*k*m, dtype=dtype).reshape((n, k, m))
+    a = np.arange(n * k * m, dtype=dtype).reshape((n, k, m))
     b = np.empty((n, k, m), dtype=dtype)
 
     jacobi(a=a, b=b)
 
     ref = copy.copy(a)
-    ref[0, :, :] += 1
-    ref[1:-1, :, :] += 2
-    ref[-1, :, :] += 3
+    ref[0, :, 0:-1] += 1
+    ref[1:-1, :, 0:-1] += 2
+    ref[-1, :, 0:-1] += 3
 
     if (b != ref).any():
         print(b)

--- a/tests/fpga/pipeline_scope.py
+++ b/tests/fpga/pipeline_scope.py
@@ -73,7 +73,7 @@ def make_sdfg(dtype, name="pipeline_test"):
                                      init_size=k * m,
                                      init_overlap=True,
                                      drain_size=k * m,
-                                     drain_overlap=True)
+                                     drain_overlap=True, additional_variables={'user_var':0})
 
     tasklet = state.add_tasklet(
         name, {"_in"}, {"_out"},

--- a/tests/fpga/pipeline_scope.py
+++ b/tests/fpga/pipeline_scope.py
@@ -35,16 +35,14 @@ def make_sdfg(dtype, name="pipeline_test"):
     pre_write = pre_state.add_write("a_device")
     pre_state.add_memlet_path(pre_read,
                               pre_write,
-                              memlet=dace.Memlet.simple(pre_write,
-                                                        "0:N, 0:K, 0:M"))
+                              memlet=dace.Memlet("a_device[0:N, 0:K, 0:M]"))
 
     # Device to host
     post_read = post_state.add_read("b_device")
     post_write = post_state.add_write("b")
     post_state.add_memlet_path(post_read,
                                post_write,
-                               memlet=dace.Memlet.simple(
-                                   post_write, "0:N, 0:K, 0:M"))
+                               memlet=dace.Memlet("b[0:N, 0:K, 0:M]"))
 
     # Compute state
     read_memory = state.add_read("a_device")
@@ -74,49 +72,42 @@ def make_sdfg(dtype, name="pipeline_test"):
                                      init_overlap=True,
                                      drain_size=k * m,
                                      drain_overlap=True,
-                                     additional_variables={'user_var': 0})
+                                     additional_iterators={'user_var': 0})
     # for the sake of testing, use the additional user_var to set to zero the last element of each row
     tasklet = state.add_tasklet(
-        name, {"_in"}, {"_out"},"""\
+        name, {"_in"}, {"_out"}, """\
 _out = _in + (0 if user_var==M-1 else (1 if {} else (3 if {} else 2)))
 if user_var == M-1:
     user_var = 0
 else:
     user_var = user_var + 1 
-""".format(
-            entry.pipeline.init_condition(), entry.pipeline.drain_condition()))
+""".format(entry.pipeline.init_condition(), entry.pipeline.drain_condition()))
 
     # Container-to-container copies between arrays and streams
     state.add_memlet_path(read_memory,
                           produce_input_stream,
-                          memlet=dace.Memlet.simple(read_memory.data,
-                                                    "0:N, 0:K, 0:M",
-                                                    other_subset_str="0",
-                                                    num_accesses=n * k * m))
+                          memlet=dace.Memlet("a_device[0:N, 0:K, 0:M]",
+                                             other_subset="0",
+                                             volume=n * k * m))
     state.add_memlet_path(consume_output_stream,
                           write_memory,
-                          memlet=dace.Memlet.simple(write_memory.data,
-                                                    "0:N, 0:K, 0:M",
-                                                    other_subset_str="0",
-                                                    num_accesses=n * k * m))
+                          memlet=dace.Memlet("b_device[0:N, 0:K, 0:M]",
+                                             other_subset="0",
+                                             volume=n * k * m))
 
     # Input stream to buffer
     state.add_memlet_path(consume_input_stream,
                           entry,
                           tasklet,
                           dst_conn="_in",
-                          memlet=dace.Memlet.simple(consume_input_stream.data,
-                                                    "0",
-                                                    num_accesses=-1))
+                          memlet=dace.Memlet("a_stream[0]", dynamic=True))
 
     # Buffer to output stream
     state.add_memlet_path(tasklet,
                           exit,
                           produce_output_stream,
                           src_conn="_out",
-                          memlet=dace.Memlet.simple(produce_output_stream.data,
-                                                    "0",
-                                                    num_accesses=-1))
+                          memlet=dace.Memlet("b_stream[0]", dynamic=True))
 
     return sdfg
 


### PR DESCRIPTION
- Resolves #548 
- Resolves a bug in cppunparse: if a symbol is already defined, there is no need to re-define it (or perform type inference when needed). Before, this was causing the re-definition of already defined variables.

