### PR TITLE
bugfix: memlet propagation, LocalStorage: added prefix and create_array properties

### DIFF
--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -867,9 +867,8 @@ def propagate_states(sdfg) -> None:
                     loop_executions = loop_executions.doit()
 
                     loop_state = state.condition_edge.dst
-                    end_state = (out_edges[0].dst
-                                 if out_edges[1].dst == loop_state else
-                                 out_edges[1].dst)
+                    end_state = (out_edges[0].dst if out_edges[1].dst
+                                 == loop_state else out_edges[1].dst)
 
                     traversal_q.append((end_state, state.executions,
                                         proposed_dynamic, itvar_stack))
@@ -1436,8 +1435,9 @@ def propagate_subset(memlets: List[Memlet],
     # Propagate volume:
     # Number of accesses in the propagated memlet is the sum of the internal
     # number of accesses times the size of the map range set (unbounded dynamic)
-    new_memlet.volume = (sum(m.volume for m in memlets) *
-                         functools.reduce(lambda a, b: a * b, rng.size(), 1))
+    new_memlet.volume = (
+        sum(m.volume for m in memlets) *
+        functools.reduce(lambda a, b: a * b, rng.size(), 1)).simplify()
     if any(m.dynamic for m in memlets):
         new_memlet.dynamic = True
     elif symbolic.issymbolic(new_memlet.volume) and any(

--- a/dace/transformation/dataflow/local_storage.py
+++ b/dace/transformation/dataflow/local_storage.py
@@ -31,7 +31,7 @@ class LocalStorage(xf.Transformation, ABC):
     prefix = Property(dtype=str,
                       default="trans_",
                       allow_none=True,
-                      desc='Prefix for new')
+                      desc='Prefix for new data node')
 
     create_array = Property(dtype=bool,
                             default=True,

--- a/dace/transformation/dataflow/local_storage.py
+++ b/dace/transformation/dataflow/local_storage.py
@@ -28,6 +28,16 @@ class LocalStorage(xf.Transformation, ABC):
         default=None,
         allow_none=True)
 
+    prefix = Property(dtype=str,
+                      default="trans_",
+                      allow_none=True,
+                      desc='Prefix for new')
+
+    create_array = Property(dtype=bool,
+                            default=True,
+                            desc="if false, it does not create a new array.",
+                            allow_none=True)
+
     def __init__(self, sdfg_id, state_id, subgraph, expr_index):
         super().__init__(sdfg_id, state_id, subgraph, expr_index)
         self._local_name = None
@@ -49,6 +59,7 @@ class LocalStorage(xf.Transformation, ABC):
         graph = sdfg.nodes()[self.state_id]
         node_a = self.node_a(sdfg)
         node_b = self.node_b(sdfg)
+        prefix = self.prefix
 
         # Determine direction of new memlet
         scope_dict = graph.scope_dict()
@@ -77,17 +88,20 @@ class LocalStorage(xf.Transformation, ABC):
                 break
         if invariant_memlet is None:
             raise NameError('Array %s not found!' % array)
+        if self.create_array:
+            # Add transient array
+            new_data, _ = sdfg.add_array(
+                prefix + invariant_memlet.data, [
+                    symbolic.overapproximate(r).simplify()
+                    for r in invariant_memlet.bounding_box_size()
+                ],
+                sdfg.arrays[invariant_memlet.data].dtype,
+                transient=True,
+                find_new_name=True)
 
-        # Add transient array
-        new_data, _ = sdfg.add_array('trans_' + invariant_memlet.data, [
-            symbolic.overapproximate(r)
-            for r in invariant_memlet.bounding_box_size()
-        ],
-                                     sdfg.arrays[invariant_memlet.data].dtype,
-                                     transient=True,
-                                     find_new_name=True)
+        else:
+            new_data = prefix + invariant_memlet.data
         data_node = nodes.AccessNode(new_data)
-
         # Store as fields so that other transformations can use them
         self._local_name = new_data
         self._data_node = data_node

--- a/dace/transformation/dataflow/strip_mining.py
+++ b/dace/transformation/dataflow/strip_mining.py
@@ -474,7 +474,7 @@ class StripMining(transformation.Transformation):
                     if memlet.dynamic:
                         new_memlet.num_accesses = memlet.num_accesses
                     else:
-                        new_memlet.num_accesses = new_memlet.num_elements()
+                        new_memlet.num_accesses = new_memlet.num_elements().simplify()
                     new_in_edges[key] = new_memlet
             else:
                 if src_conn is not None and src_conn[:4] == 'OUT_':
@@ -520,7 +520,7 @@ class StripMining(transformation.Transformation):
                     if memlet.dynamic:
                         new_memlet.num_accesses = memlet.num_accesses
                     else:
-                        new_memlet.num_accesses = new_memlet.num_elements()
+                        new_memlet.num_accesses = new_memlet.num_elements().simplify()
                     new_out_edges[key] = new_memlet
             else:
                 if dst_conn is not None and dst_conn[:3] == 'IN_':


### PR DESCRIPTION
Bugfix:
- memlets now show the correct volume/num_accesses
- fixed by calling `.simplify()` in `strip_mining` and `propagate_subsets`


LocalStorage:
- no also simplifies the array size
- prefix property
- create_array property