### PR TITLE
Type inference for pointer generated by OCL Keyword Remover

### DIFF
--- a/dace/codegen/tools/type_inference.py
+++ b/dace/codegen/tools/type_inference.py
@@ -224,8 +224,7 @@ def _If(t, symbols, inferred_symbols):
     _dispatch(t.test, symbols, inferred_symbols)
     _dispatch(t.body, symbols, inferred_symbols)
 
-    while (t.orelse and len(t.orelse) == 1
-           and isinstance(t.orelse[0], ast.If)):
+    while (t.orelse and len(t.orelse) == 1 and isinstance(t.orelse[0], ast.If)):
         t = t.orelse[0]
         _dispatch(t.test, symbols, inferred_symbols)
         _dispatch(t.body, symbols, inferred_symbols)
@@ -267,15 +266,18 @@ def _Name(t, symbols, inferred_symbols):
         # check if this name is a python type, it is in defined_symbols or in local symbols.
         # If yes, take the type
         inferred_type = None
-        if t.id.strip("()") in cppunparse._py2c_typeconversion:
-            inferred_type = cppunparse._py2c_typeconversion[t.id.strip("()")]
-        elif t.id in symbols:
+
+        # if this is a statement generated from a tasklet with a dynamic memlet, it could have a leading * (pointer)
+        t_id = t.id[1:] if t.id.startswith('*') else t.id
+        if t_id.strip("()") in cppunparse._py2c_typeconversion:
+            inferred_type = cppunparse._py2c_typeconversion[t_id.strip("()")]
+        elif t_id in symbols:
             # defined symbols could have dtypes, in case convert it to typeclass
-            inferred_type = symbols[t.id]
+            inferred_type = symbols[t_id]
             if isinstance(inferred_type, np.dtype):
                 inferred_type = dtypes.typeclass(inferred_type.type)
-        elif t.id in inferred_symbols:
-            inferred_type = inferred_symbols[t.id]
+        elif t_id in inferred_symbols:
+            inferred_type = inferred_symbols[t_id]
         return inferred_type
 
 
@@ -299,9 +301,8 @@ def _Constant(t, symbols, inferred_symbols):
 def _Num(t, symbols, inferred_symbols):
     # get the minimum between the minimum type needed to represent this number and the corresponding default data types
     # e.g., if num=1, then it will be represented by using the default integer type (int32 if C data types are used)
-    return dtypes.result_type_of(
-        dtypes.typeclass(type(t.n)),
-        dtypes.typeclass(np.min_scalar_type(t.n).name))
+    return dtypes.result_type_of(dtypes.typeclass(type(t.n)),
+                                 dtypes.typeclass(np.min_scalar_type(t.n).name))
 
 
 def _IfExp(t, symbols, inferred_symbols):
@@ -333,14 +334,13 @@ def _BinOp(t, symbols, inferred_symbols):
         return dtypes.result_type_of(type_left, type_right)
     # Special case for integer power
     elif t.op.__class__.__name__ == 'Pow':
-        if (isinstance(t.right, (ast.Num, ast.Constant)) and int(t.right.n) == t.right.n
-                and t.right.n >= 0):
+        if (isinstance(t.right, (ast.Num, ast.Constant))
+                and int(t.right.n) == t.right.n and t.right.n >= 0):
             if t.right.n != 0:
                 type_left = _dispatch(t.left, symbols, inferred_symbols)
                 for i in range(int(t.right.n) - 1):
                     _dispatch(t.left, symbols, inferred_symbols)
-            return dtypes.result_type_of(type_left,
-                                         dtypes.typeclass(np.uint32))
+            return dtypes.result_type_of(type_left, dtypes.typeclass(np.uint32))
         else:
             type_left = _dispatch(t.left, symbols, inferred_symbols)
             type_right = _dispatch(t.right, symbols, inferred_symbols)

--- a/tests/type_inference_test.py
+++ b/tests/type_inference_test.py
@@ -266,6 +266,21 @@ value3=5000000000"""
         # in any case, value3 needs uint64
         self.assertEqual(inf_symbols["value3"], dtypes.typeclass(np.uint64))
 
+    def testCCode(self):
+        # tests for situations that could arise from C/C++ tasklet codes
+
+        ###############################################################################################
+        # Pointer: this is a situation that could happen in FPGA backend due to OpenCL Keyword Remover:
+        # if in a tasklet, there is an assignment in which the right hand side is a connector and the
+        # corresponding memlet is dynamic, the OpenCL Keyword Remover, will update the code to be "target = *rhs"
+        # In a similar situation the type inference should not consider the leading *
+        stmt = ast.parse("value = float_var")
+        stmt.body[0].value.id="*float_var" # effect of OpenCL Keyword Remover
+        prev_symbols = {"float_var": dtypes.typeclass(float)}
+        inf_symbols = type_inference.infer_types(stmt, prev_symbols)
+        self.assertEqual(inf_symbols["value"], dtypes.typeclass(float))
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Solves #570 

This solutions takes into account that the OCL Keyword Remover updates the AST node, by maintaining the same type: in this particular case, it is an `ast.Name`, where the `id` is something like `*smtg`.

Therefore, in the type inference, if we find a leading `*` we simply remove it before inferring the type.

Another option could be to change the node type from `ast.Node` to `ast.Starred`. However, it is not clear to me where `Starred` is used, I guess it generates from `*args, **kwargs`. Furthermore, in `cppunparse`, an attempt to unparse an `ast.Starred` node will raise an exception (not valid C++)