### PR TITLE
Various fixes for GPU code generation and miscellaneous things

### DIFF
--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -110,6 +110,9 @@ def generate_code(sdfg) -> List[CodeObject]:
         os.remove('test2.sdfg')
 
         # Run with the deserialized version
+        # NOTE: This means that all subsequent modifications to `sdfg`
+        # are not reflected outside of this function (e.g., library
+        # node expansion).
         sdfg = sdfg2
 
     # Before generating the code, run type inference on the SDFG connectors

--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -118,6 +118,14 @@ def generate_code(sdfg) -> List[CodeObject]:
     # Set default storage/schedule types in SDFG
     infer_types.set_default_schedule_and_storage_types(sdfg, None)
 
+    # Recursively expand library nodes that have not yet been expanded
+    sdfg.expand_library_nodes()
+
+    # After expansion, run another pass of connector/type inference
+    infer_types.infer_connector_types(sdfg)
+    infer_types.set_default_schedule_and_storage_types(sdfg, None)
+
+
     frame = framecode.DaCeCodeGenerator()
 
     # Instantiate CPU first (as it is used by the other code generators)

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -341,7 +341,12 @@ class CompiledSDFG(object):
         self._return_arrays = []
         self._return_kwarrays = {}
         for arrname, arr in sorted(self.sdfg.arrays.items()):
-            if arrname.startswith('__return'):
+            if arrname.startswith('__return') and not arr.transient:
+                if arrname in kwargs:
+                    self._return_arrays.append(kwargs[arrname])
+                    self._return_kwarrays[arrname] = kwargs[arrname]
+                    continue
+                
                 if isinstance(arr, dt.Stream):
                     raise NotImplementedError('Return streams are unsupported')
                 if arr.storage in [

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3424,7 +3424,7 @@ class ProgramVisitor(ExtNodeVisitor):
             # Add return values as additional outputs
             rets = []
             for arrname, arr in sdfg.arrays.items():
-                if arrname.startswith('__return'):
+                if arrname.startswith('__return') and not arr.transient:
                     # Add a transient to the current SDFG
                     new_arrname = '%s_ret_%d' % (sdfg.name, len(rets))
                     newarr = copy.deepcopy(arr)

--- a/dace/libraries/blas/nodes/batched_matmul.py
+++ b/dace/libraries/blas/nodes/batched_matmul.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 from copy import deepcopy as dc
+from dace import dtypes
 from typing import Any, Dict, Optional
 from dace.data import Array
 from dace.symbolic import symstr
@@ -237,11 +238,17 @@ class ExpandBatchedMatMulCuBLAS(ExpandTransformation):
                                           language=dace.dtypes.Language.CPP)
 
         # If buffers are not on the GPU, copy them
-        # TODO: This creates variable shadowing
         if any(desc.storage not in
                [dace.StorageType.GPU_Global, dace.StorageType.CPU_Pinned]
                for desc in [adesc, bdesc, cdesc]):
             nsdfg = dace.SDFG('nested_batched_matmul')
+            tasklet = dace.sdfg.nodes.Tasklet(node.name, {
+                '__a': dtypes.pointer(adesc.dtype),
+                '__b': dtypes.pointer(bdesc.dtype)
+            }, {'__c': dtypes.pointer(cdesc.dtype)},
+                                              code,
+                                              language=dace.dtypes.Language.CPP)
+
             for name, desc in [('_a', adesc), ('_b', bdesc), ('_c', cdesc)]:
                 dcopy = dc(desc)
                 dcopy.transient = False
@@ -260,11 +267,11 @@ class ExpandBatchedMatMulCuBLAS(ExpandTransformation):
             nstate.add_node(tasklet)
             nstate.add_nedge(a, ga, dace.Memlet.from_array('_a', adesc))
             nstate.add_nedge(b, gb, dace.Memlet.from_array('_b', bdesc))
-            nstate.add_edge(ga, None, tasklet, '_a',
+            nstate.add_edge(ga, None, tasklet, '__a',
                             dace.Memlet.from_array('_a_gpu', adesc))
-            nstate.add_edge(gb, None, tasklet, '_b',
+            nstate.add_edge(gb, None, tasklet, '__b',
                             dace.Memlet.from_array('_b_gpu', bdesc))
-            nstate.add_edge(tasklet, '_c', gc, None,
+            nstate.add_edge(tasklet, '__c', gc, None,
                             dace.Memlet.from_array('_c_gpu', cdesc))
             nstate.add_nedge(gc, c, dace.Memlet.from_array('_c', cdesc))
 

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -14,10 +14,11 @@ from dace.libraries.blas.nodes.matmul import (_get_matmul_operands,
                                               _get_codegen_gemm_opts)
 from .. import environments
 import numpy as np
+from numbers import Number
 
 
 def _is_complex(dtype):
-    if hasattr(dtype, "is_complex"):
+    if hasattr(dtype, "is_complex") and callable(dtype.is_complex):
         return dtype.is_complex()
     else:
         return dtype in [np.complex64, np.complex128]
@@ -391,11 +392,11 @@ class Gemm(dace.sdfg.nodes.LibraryNode):
         dtype=bool, desc="Whether to transpose A before multiplying")
     transB = properties.Property(
         dtype=bool, desc="Whether to transpose B before multiplying")
-    alpha = properties.SymbolicProperty(
+    alpha = properties.Property(
         allow_none=False,
         default=1,
         desc="A scalar which will be multiplied with A @ B before adding C")
-    beta = properties.SymbolicProperty(
+    beta = properties.Property(
         allow_none=False,
         default=0,
         desc="A scalar which will be multiplied with C before adding C")

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -2,9 +2,8 @@
 from copy import deepcopy as dc
 from typing import Any, Dict, Optional
 from dace.data import Array
-from dace import memlet as mm
+from dace import memlet as mm, properties
 from dace.symbolic import symstr
-from dace.properties import Property
 import dace.library
 from dace import SDFG, SDFGState
 from dace.frontend.common import op_repository as oprepo
@@ -74,25 +73,23 @@ class ExpandGemmPure(ExpandTransformation):
         M, K, N = trans_shape_a[0], trans_shape_a[1], trans_shape_b[1]
         shape_c = (M, N)
 
-        if outer_array_a.storage != outer_array_b.storage:
-            raise ValueError("Input matrices must have same storage")
         storage = outer_array_a.storage
 
         _, array_a = sdfg.add_array("_a",
                                     shape_a,
                                     dtype_a,
                                     strides=strides_a,
-                                    storage=storage)
+                                    storage=outer_array_a.storage)
         _, array_b = sdfg.add_array("_b",
                                     shape_b,
                                     dtype_b,
                                     strides=strides_b,
-                                    storage=storage)
+                                    storage=outer_array_b.storage)
         _, array_c = sdfg.add_array("_c",
                                     shape_c,
                                     dtype_c,
                                     strides=cdata[-1],
-                                    storage=storage)
+                                    storage=cdata[1].storage)
 
         if node.alpha == 1.0:
             mul_program = "__out = __a * __b"
@@ -198,11 +195,11 @@ class ExpandGemmMKL(ExpandTransformation):
         func = to_blastype(dtype.type).lower() + 'gemm'
         # TODO: Fix w.r.t. other alpha/beta values
         if dtype == dace.float32:
-            alpha = "1.0f"
-            beta = "0.0f"
+            alpha = f'(float)({node.alpha})'
+            beta = f'(float)({node.beta})'
         elif dtype == dace.float64:
-            alpha = "1.0"
-            beta = "0.0"
+            alpha = f'(double)({node.alpha})'
+            beta = f'(double)({node.beta})'
         elif dtype == dace.complex64:
             alpha = "dace::blas::BlasConstants::Get().Complex64Pone()"
             beta = "dace::blas::BlasConstants::Get().Complex64Zero()"
@@ -390,17 +387,17 @@ class Gemm(dace.sdfg.nodes.LibraryNode):
     default_implementation = None
 
     # Object fields
-    transA = Property(dtype=bool,
-                      desc="Whether to transpose A before multiplying")
-    transB = Property(dtype=bool,
-                      desc="Whether to transpose B before multiplying")
-    alpha = Property(
-        dtype=tuple(dace.dtypes._CONSTANT_TYPES),
+    transA = properties.Property(
+        dtype=bool, desc="Whether to transpose A before multiplying")
+    transB = properties.Property(
+        dtype=bool, desc="Whether to transpose B before multiplying")
+    alpha = properties.SymbolicProperty(
+        allow_none=False,
         default=1,
         desc="A scalar which will be multiplied with A @ B before adding C")
-    beta = Property(
-        dtype=tuple(dace.dtypes._CONSTANT_TYPES),
-        default=1,
+    beta = properties.SymbolicProperty(
+        allow_none=False,
+        default=0,
         desc="A scalar which will be multiplied with C before adding C")
 
     def __init__(self,

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -1137,7 +1137,7 @@ class SymbolicProperty(Property):
 
     def __set__(self, obj, val):
         if (val is not None and not isinstance(val, sp.Expr)
-                and not isinstance(val, Integral) and not isinstance(val, str)):
+                and not isinstance(val, Number) and not isinstance(val, str)):
             raise TypeError(f"Property {self.attr_name} must be a literal "
                             f"or symbolic expression, got: {type(val)}")
         if isinstance(val, (Number, str)):

--- a/dace/sdfg/__init__.py
+++ b/dace/sdfg/__init__.py
@@ -12,7 +12,7 @@ from dace.sdfg.utils import (has_dynamic_map_inputs, dynamic_map_inputs,
                              is_parallel, concurrent_subgraphs,
                              find_input_arraynode, find_output_arraynode,
                              trace_nested_access, is_array_stream_view,
-                             local_transients)
+                             local_transients, load_precompiled_sdfg)
 
 from dace.sdfg.validation import (InvalidSDFGError, InvalidSDFGNodeError,
                                   InvalidSDFGEdgeError,

--- a/dace/sdfg/infer_types.py
+++ b/dace/sdfg/infer_types.py
@@ -157,14 +157,14 @@ def _set_default_schedule_in_scope(parent_node: nodes.Node,
                                            reverse_scope_dict)
         elif isinstance(node, nodes.NestedSDFG):
             # Nested SDFGs retain same schedule as their parent scope
-            # TODO: and parent_schedule is not None?
             if node.schedule is dtypes.ScheduleType.Default:
-                node.schedule = parent_schedule
+                node.schedule = parent_schedule or child_schedule
             _set_default_schedule_types(node.sdfg, node.schedule)
         elif getattr(node, 'schedule', False):
             if node.schedule is dtypes.ScheduleType.Default:
-                # TODO: and parent_schedule is not None?
-                node.schedule = child_schedule if isinstance(node, nodes.EntryNode) else parent_schedule
+                node.schedule = (
+                    child_schedule if isinstance(node, nodes.EntryNode)
+                    or parent_schedule is None else parent_schedule)
 
 
 def _set_default_schedule_types(sdfg: SDFG,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1688,9 +1688,6 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # Fill in scope entry/exit connectors
         sdfg.fill_scope_connectors()
 
-        # Recursively expand library nodes that haven't been expanded yet
-        sdfg.expand_library_nodes()
-
         # Generate code for the program by traversing the SDFG state by state
         program_objects = codegen.generate_code(sdfg)
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -3,6 +3,7 @@
 
 import collections
 import copy
+import os
 import networkx as nx
 from dace.sdfg.graph import MultiConnectorEdge
 from dace.sdfg.sdfg import SDFG
@@ -837,8 +838,9 @@ def local_transients(sdfg, dfg, entry_node):
     return sorted(list(transients - defined_transients))
 
 
-def trace_nested_access(node: nd.AccessNode, state: SDFGState,
-                        sdfg: SDFG) -> List[Tuple[nd.AccessNode, SDFGState, SDFG]]:
+def trace_nested_access(
+        node: nd.AccessNode, state: SDFGState,
+        sdfg: SDFG) -> List[Tuple[nd.AccessNode, SDFGState, SDFG]]:
     """
     Given an AccessNode in a nested SDFG, trace the accessed memory
     back to the outermost scope in which it is defined.
@@ -910,6 +912,7 @@ def trace_nested_access(node: nd.AccessNode, state: SDFGState,
         curr_sdfg = curr_state.parent  # Recurse
     return list(reversed(trace))
 
+
 def fuse_states(sdfg: SDFG) -> int:
     """
     Fuses all possible states of an SDFG (and all sub-SDFGs) using an optimized
@@ -917,7 +920,7 @@ def fuse_states(sdfg: SDFG) -> int:
     :param sdfg: The SDFG to transform.
     :return: The total number of states fused.
     """
-    from dace.transformation.interstate import StateFusion # Avoid import loop
+    from dace.transformation.interstate import StateFusion  # Avoid import loop
     counter = 0
     for sd in sdfg.all_sdfgs_recursive():
         id = sd.sdfg_id
@@ -944,3 +947,22 @@ def fuse_states(sdfg: SDFG) -> int:
     if config.Config.get_bool('debugprint'):
         print(f'Applied {counter} State Fusions')
     return counter
+
+
+def load_precompiled_sdfg(folder: str):
+    """ 
+    Loads a pre-compiled SDFG from an output folder (e.g. ".dacecache/program").
+    Folder must contain a file called "program.sdfg" and a subfolder called
+    "build" with the shared object.
+
+    :param folder: Path to SDFG output folder.
+    :return: A callable CompiledSDFG object.
+    """
+    from dace.codegen import compiled_sdfg as csdfg
+    sdfg = SDFG.from_file(os.path.join(folder, 'program.sdfg'))
+    suffix = config.Config.get('compiler', 'library_extension')
+    return csdfg.CompiledSDFG(
+        sdfg,
+        csdfg.ReloadableDLL(
+            os.path.join(folder, 'build', f'lib{sdfg.name}.{suffix}'),
+            sdfg.name))

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -337,7 +337,12 @@ class InlineSDFG(transformation.Transformation):
         # Add views whenever reshapes are necessary
         for dname in reshapes:
             desc = nsdfg.arrays[dname]
-            newname, _ = sdfg.add_view(dname,
+            # To avoid potential confusion, rename protected __return keyword
+            if dname.startswith('__return'):
+                newname = f'{nsdfg.name}_ret{dname[8:]}'
+            else:
+                newname = dname
+            newname, _ = sdfg.add_view(newname,
                                        desc.shape,
                                        desc.dtype,
                                        storage=desc.storage,

--- a/tests/inline_nonsink_access_test.py
+++ b/tests/inline_nonsink_access_test.py
@@ -2,54 +2,64 @@
 import dace
 import numpy as np
 
-sdfg = dace.SDFG('inline_nonsink_access_test')
-sdfg.add_array('A', [1], dace.float32)
-sdfg.add_array('B', [1], dace.float32)
 
-state = sdfg.add_state()
-A = state.add_access('A')
-B = state.add_access('B')
-B_out = state.add_write('B')
-t = state.add_tasklet('add', {'a', 'b'}, {'c'}, 'c = a + b')
+def make_sdfg(outer_shape, inner_shape, outer_index, inner_index):
+    sdfg = dace.SDFG('inline_nonsink_access_test')
+    sdfg.add_array('A', outer_shape, dace.float32)
+    sdfg.add_array('B', outer_shape, dace.float32)
 
-state.add_edge(A, None, t, 'a', dace.Memlet.simple('A', '0'))
-state.add_edge(B, None, t, 'b', dace.Memlet.simple('B', '0'))
-state.add_edge(t, 'c', B_out, None, dace.Memlet.simple('B', '0'))
+    state = sdfg.add_state()
+    A = state.add_access('A')
+    B = state.add_access('B')
+    B_out = state.add_write('B')
+    t = state.add_tasklet('add', {'a', 'b'}, {'c'}, 'c = a + b')
 
-# Add nested SDFG
-nsdfg = dace.SDFG('nested_ina_test')
-nsdfg.add_array('C', [1], dace.float32)
-nsdfg.add_array('D', [1], dace.float32)
+    state.add_edge(A, None, t, 'a', dace.Memlet.simple('A', outer_index))
+    state.add_edge(B, None, t, 'b', dace.Memlet.simple('B', outer_index))
+    state.add_edge(t, 'c', B_out, None, dace.Memlet.simple('B', outer_index))
 
-nstate = nsdfg.add_state()
-t_init = nstate.add_tasklet('init', {}, {'o'}, 'o = 2')
-t_square = nstate.add_tasklet('square', {'i'}, {'o'}, 'o = i * i')
-t_cube = nstate.add_tasklet('cube', {'i'}, {'o'}, 'o = i * i * i')
-C = nstate.add_access('C')
-C2 = nstate.add_access('C')
-D = nstate.add_write('D')
+    # Add nested SDFG
+    nsdfg = dace.SDFG('nested_ina_test')
+    nsdfg.add_array('C', inner_shape, dace.float32)
+    nsdfg.add_array('D', inner_shape, dace.float32)
 
-nstate.add_edge(t_init, 'o', C, None, dace.Memlet.simple('C', '0'))
-nstate.add_edge(C, None, t_square, 'i', dace.Memlet.simple('C', '0'))
-nstate.add_edge(t_square, 'o', C2, None, dace.Memlet.simple('C', '0'))
-nstate.add_edge(C2, None, t_cube, 'i', dace.Memlet.simple('C', '0'))
-nstate.add_edge(t_cube, 'o', D, None, dace.Memlet.simple('D', '0'))
+    nstate = nsdfg.add_state()
+    t_init = nstate.add_tasklet('init', {}, {'o'}, 'o = 2')
+    t_square = nstate.add_tasklet('square', {'i'}, {'o'}, 'o = i * i')
+    t_cube = nstate.add_tasklet('cube', {'i'}, {'o'}, 'o = i * i * i')
+    C = nstate.add_access('C')
+    C2 = nstate.add_access('C')
+    D = nstate.add_write('D')
 
-# Add nested SDFG to SDFG
-nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'C', 'D'})
-state.add_edge(nsdfg_node, 'C', A, None, dace.Memlet.simple('A', '0'))
-state.add_edge(nsdfg_node, 'D', B, None, dace.Memlet.simple('B', '0'))
+    nstate.add_edge(t_init, 'o', C, None, dace.Memlet.simple('C', inner_index))
+    nstate.add_edge(C, None, t_square, 'i',
+                    dace.Memlet.simple('C', inner_index))
+    nstate.add_edge(t_square, 'o', C2, None,
+                    dace.Memlet.simple('C', inner_index))
+    nstate.add_edge(C2, None, t_cube, 'i', dace.Memlet.simple('C', inner_index))
+    nstate.add_edge(t_cube, 'o', D, None, dace.Memlet.simple('D', inner_index))
+
+    # Add nested SDFG to SDFG
+    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'C', 'D'})
+    state.add_edge(nsdfg_node, 'C', A, None, dace.Memlet('A'))
+    state.add_edge(nsdfg_node, 'D', B, None, dace.Memlet('B'))
+
+    sdfg.save('_dacegraphs/program.sdfg')
+    return sdfg
 
 
-def test():
+def test_same_shape():
     A = np.random.rand(1).astype(np.float32)
     B = np.random.rand(1).astype(np.float32)
 
+    sdfg = make_sdfg([1], [1], '0', '0')
     sdfg.apply_strict_transformations()
+
+    sdfg.save('_dacegraphs/program.sdfg')
     sdfg(A=A, B=B)
 
     assert len(sdfg.node(0).nodes()) == 8
-    
+
     expected = np.array([2**2, (2**2) + (2**6)], dtype=np.float32)
     result = np.array([A[0], B[0]], dtype=np.float32)
     diff = np.linalg.norm(expected - result)
@@ -57,5 +67,25 @@ def test():
     assert diff <= 1e-6
 
 
+def test_different_shape():
+    A = np.random.rand(20, 3).astype(np.float32)
+    B = np.random.rand(20, 3).astype(np.float32)
+
+    sdfg = make_sdfg([20, 3], [60], '1, 0', '3')
+    sdfg.apply_strict_transformations()
+
+    sdfg(A=A, B=B)
+
+    assert all(not isinstance(node, dace.nodes.NestedSDFG)
+               for node in sdfg.node(0).nodes())
+
+    expected = np.array([2**2, (2**2) + (2**6)], dtype=np.float32)
+    result = np.array([A[1, 0], B[1, 0]], dtype=np.float32)
+    diff = np.linalg.norm(expected - result)
+    print('Difference:', diff)
+    assert diff <= 1e-6
+
+
 if __name__ == "__main__":
-    test()
+    test_same_shape()
+    test_different_shape()

--- a/tests/library/codelibnode_test.py
+++ b/tests/library/codelibnode_test.py
@@ -14,7 +14,7 @@ class MyNode(CodeLibraryNode):
                             default=5,
                             desc="Value to add in custom code")
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         super().__init__(input_names=['inp'], output_names=['out'])
 
     def generate_code(self, inputs: Dict[str, Array], outputs: Dict[str,
@@ -52,7 +52,7 @@ class MyNode2(CodeLibraryNode):
                             default=2,
                             desc="Value to mul in custom code")
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         super().__init__(input_names=['inp'], output_names=['out'])
 
     def generate_code(self, inputs: Dict[str, Array], outputs: Dict[str,

--- a/tests/numpy/retval_test.py
+++ b/tests/numpy/retval_test.py
@@ -43,7 +43,7 @@ def test_return_override():
     result = np.random.rand(20)
     result2 = oneret(A, __return=result)
     assert np.allclose(result, A * 2)
-    assert not np.allclose(result2, A * 2)
+    assert np.allclose(result2, A * 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [x] Expand library nodes only after setting schedules
- [x] Fix API for GPU return values
- [x] New API for loading precompiled SDFGs
- [x] Fix longstanding variable shadowing in GPU batched matmul
- [x] Fix schedule type inference for top-level schedules
- [x] `InlineSDFG` creates reshapes when possible, applies in more cases
- [x] Add test for inout reshape in inline SDFG