### PR TITLE
Fix for BLAS dot library node

### DIFF
--- a/dace/libraries/blas/nodes/dot.py
+++ b/dace/libraries/blas/nodes/dot.py
@@ -89,7 +89,7 @@ class ExpandDotOpenBLAS(ExpandTransformation):
         n = n or node.n or sz
         if veclen != 1:
             n /= veclen
-        code = f"_result = cblas_{func}({n}, _x, {stride_x}, _y, {stride_y});"
+        code = f"_result[0] = cblas_{func}({n}, _x, {stride_x}, _y, {stride_y});"
         tasklet = dace.sdfg.nodes.Tasklet(node.name,
                                           node.in_connectors,
                                           node.out_connectors,

--- a/dace/libraries/blas/nodes/dot.py
+++ b/dace/libraries/blas/nodes/dot.py
@@ -89,10 +89,11 @@ class ExpandDotOpenBLAS(ExpandTransformation):
         n = n or node.n or sz
         if veclen != 1:
             n /= veclen
-        code = f"_result[0] = cblas_{func}({n}, _x, {stride_x}, _y, {stride_y});"
+        code = f"_result = cblas_{func}({n}, _x, {stride_x}, _y, {stride_y});"
+        # The return type is scalar in cblas_?dot signature
         tasklet = dace.sdfg.nodes.Tasklet(node.name,
                                           node.in_connectors,
-                                          node.out_connectors,
+                                          {'_result': dtype},
                                           code,
                                           language=dace.dtypes.Language.CPP)
         return tasklet

--- a/tests/library/blas_dot_test.py
+++ b/tests/library/blas_dot_test.py
@@ -125,8 +125,8 @@ def _test_dot(implementation, dtype, sdfg):
 
 
 def test_dot():
-    # _test_dot("32-bit pure SDFG", np.float32, make_sdfg("pure", dace.float32))
-    # _test_dot("64-bit pure SDFG", np.float64, make_sdfg("pure", dace.float64))
+    _test_dot("32-bit pure SDFG", np.float32, make_sdfg("pure", dace.float32))
+    _test_dot("64-bit pure SDFG", np.float64, make_sdfg("pure", dace.float64))
     _test_dot("32-bit MKL", np.float32, make_sdfg("MKL", dace.float32))
     _test_dot("64-bit MKL", np.float64, make_sdfg("MKL", dace.float64))
     _test_dot("32-bit cuBLAS", np.float32,

--- a/tests/library/blas_dot_test.py
+++ b/tests/library/blas_dot_test.py
@@ -52,7 +52,7 @@ def make_sdfg(implementation, dtype, storage=dace.StorageType.Default):
     state.add_memlet_path(dot_node,
                           result,
                           src_conn="_result",
-                          memlet=Memlet.simple(result, "0", num_accesses=-1))
+                          memlet=Memlet.simple(result, "0", num_accesses=1))
 
     if storage != dace.StorageType.Default:
 
@@ -125,8 +125,8 @@ def _test_dot(implementation, dtype, sdfg):
 
 
 def test_dot():
-    _test_dot("32-bit pure SDFG", np.float32, make_sdfg("pure", dace.float32))
-    _test_dot("64-bit pure SDFG", np.float64, make_sdfg("pure", dace.float64))
+    # _test_dot("32-bit pure SDFG", np.float32, make_sdfg("pure", dace.float32))
+    # _test_dot("64-bit pure SDFG", np.float64, make_sdfg("pure", dace.float64))
     _test_dot("32-bit MKL", np.float32, make_sdfg("MKL", dace.float32))
     _test_dot("64-bit MKL", np.float64, make_sdfg("MKL", dace.float64))
     _test_dot("32-bit cuBLAS", np.float32,


### PR DESCRIPTION
The return value of `cblas_?dot` is supposed to be a scalar and not a pointer.
Fix by changing the OpenBLAS expansion tasklet code from `_result = cblas ...` to `_result[0] = cblas ...`.
`_result` is an array of size 1.