### PR TITLE
Support for constant negative indices

### DIFF
--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -1,7 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ Various AST parsing utilities for DaCe. """
 import ast
-from tokenize import Number
 import astunparse
 from collections import OrderedDict
 import inspect
@@ -223,13 +222,13 @@ def astrange_to_symrange(astrange, arrays, arrname=None):
                 begin = symbolic.pystr_to_symbolic(0)
             else:
                 begin = symbolic.pystr_to_symbolic(unparse(begin))
-                if isinstance(begin, numbers.Number) and begin < 0:
+                if (begin < 0) == True:
                     begin += arrdesc.shape[i]
             if end is None and arrname is None:
                 raise SyntaxError('Cannot define range without end')
             elif end is not None:
                 end = symbolic.pystr_to_symbolic(unparse(end)) - 1
-                if isinstance(end, numbers.Number) and end < 0:
+                if (end < 0) == True:
                     end += arrdesc.shape[i]
             else:
                 end = symbolic.pystr_to_symbolic(
@@ -241,7 +240,7 @@ def astrange_to_symrange(astrange, arrays, arrname=None):
         else:
             # In the case where a single element is given
             begin = symbolic.pystr_to_symbolic(unparse(r))
-            if isinstance(begin, numbers.Number) and begin < 0:
+            if (begin < 0) == True:
                 begin += arrdesc.shape[i]
             end = begin
             skip = symbolic.pystr_to_symbolic(1)

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ Various AST parsing utilities for DaCe. """
 import ast
+from tokenize import Number
 import astunparse
 from collections import OrderedDict
 import inspect
@@ -222,10 +223,14 @@ def astrange_to_symrange(astrange, arrays, arrname=None):
                 begin = symbolic.pystr_to_symbolic(0)
             else:
                 begin = symbolic.pystr_to_symbolic(unparse(begin))
+                if isinstance(begin, numbers.Number) and begin < 0:
+                    begin += arrdesc.shape[i]
             if end is None and arrname is None:
                 raise SyntaxError('Cannot define range without end')
             elif end is not None:
                 end = symbolic.pystr_to_symbolic(unparse(end)) - 1
+                if isinstance(end, numbers.Number) and end < 0:
+                    end += arrdesc.shape[i]
             else:
                 end = symbolic.pystr_to_symbolic(
                     symbolic.symbol_name_or_value(arrdesc.shape[i])) - 1
@@ -236,6 +241,8 @@ def astrange_to_symrange(astrange, arrays, arrname=None):
         else:
             # In the case where a single element is given
             begin = symbolic.pystr_to_symbolic(unparse(r))
+            if isinstance(begin, numbers.Number) and begin < 0:
+                begin += arrdesc.shape[i]
             end = begin
             skip = symbolic.pystr_to_symbolic(1)
 

--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -76,11 +76,18 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
             rb = pyexpr_to_symbolic(das, dim[0] or 0)
             re = pyexpr_to_symbolic(das, dim[1] or array.shape[indices[i]]) - 1
             rs = pyexpr_to_symbolic(das, dim[2] or 1)
+            if rb < 0:
+                rb += array.shape[indices[i]]
+            if re < 0:
+                re += array.shape[indices[i]]
             ndslice[i] = (rb, re, rs)
             offsets.append(i)
             idx += 1
         else:
-            ndslice[i] = pyexpr_to_symbolic(das, dim)
+            r = pyexpr_to_symbolic(das, dim)
+            if r < 0:
+                r += array.shape[indices[i]]
+            ndslice[i] = r
 
     # Extend slices to unspecified dimensions
     for i in range(len(ast_ndslice), len(array.shape)):

--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -76,16 +76,16 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
             rb = pyexpr_to_symbolic(das, dim[0] or 0)
             re = pyexpr_to_symbolic(das, dim[1] or array.shape[indices[i]]) - 1
             rs = pyexpr_to_symbolic(das, dim[2] or 1)
-            if rb < 0:
+            if (rb < 0) == True:
                 rb += array.shape[indices[i]]
-            if re < 0:
+            if (re < 0) == True:
                 re += array.shape[indices[i]]
             ndslice[i] = (rb, re, rs)
             offsets.append(i)
             idx += 1
         else:
             r = pyexpr_to_symbolic(das, dim)
-            if r < 0:
+            if (r < 0) == True:
                 r += array.shape[indices[i]]
             ndslice[i] = r
 

--- a/tests/numpy/negative_indices_test.py
+++ b/tests/numpy/negative_indices_test.py
@@ -1,0 +1,87 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import numpy as np
+import dace
+
+
+@dace.program
+def negative_index(A: dace.int64[10]):
+    return A[-2]
+
+
+def test_negative_index():
+    A = np.random.randint(0, 100, size=10, dtype=np.int64)
+    out = negative_index(A)
+    assert out[0] == A[-2]
+
+
+@dace.program
+def nested_negative_index(A: dace.int64[10]):
+    out = np.ndarray([2], dtype=np.int64)
+    for i in dace.map[0:2]:
+        out[i] = A[-1]
+    return out
+
+
+def test_nested_negative_index():
+    A = np.random.randint(0, 100, size=10, dtype=np.int64)
+    out = nested_negative_index(A)
+    assert out[0] == A[-1]
+    assert out[1] == A[-1]
+
+
+@dace.program
+def negative_range(A: dace.int64[10]):
+    return A[-5:-1]
+
+def test_negative_range():
+    A = np.random.randint(0, 100, size=10, dtype=np.int64)
+    out = negative_range(A)
+    assert np.array_equal(out, A[-5:-1])
+
+
+@dace.program
+def nested_negative_range(A: dace.int64[10]):
+    out = np.ndarray([10], dtype=np.int64)
+    for i in dace.map[0:2]:
+        out[i*5:i*5+5] = A[-6:-1]
+    return out
+
+
+def test_nested_negative_range():
+    A = np.random.randint(0, 100, size=10, dtype=np.int64)
+    out = nested_negative_range(A)
+    assert np.array_equal(out[:5], A[-6:-1])
+    assert np.array_equal(out[5:], A[-6:-1])
+
+
+@dace.program
+def jacobi_2d(A: dace.float64[10, 10], B: dace.float64[10, 10]):
+    for t in range(1, 10):
+        B[1:-1, 1:-1] = 0.2 * (A[1:-1, 1:-1] + A[1:-1, :-2] +
+                                 A[1:-1, 2:] + A[2:, 1:-1] + A[:-2, 1:-1])
+        A[1:-1, 1:-1] = 0.2 * (B[1:-1, 1:-1] + B[1:-1, :-2] +
+                                 B[1:-1, 2:] + B[2:, 1:-1] + B[:-2, 1:-1])
+
+
+def test_jacobi_2d():
+    A = np.ones([10, 10], dtype=np.float64)
+    B = np.ones([10, 10], dtype=np.float64)
+    Ar = np.ones([10, 10], dtype=np.float64)
+    Br = np.ones([10, 10], dtype=np.float64)
+    jacobi_2d(A, B)
+    for t in range(1, 10):
+        Br[1:-1, 1:-1] = 0.2 * (Ar[1:-1, 1:-1] + Ar[1:-1, :-2] +
+                                Ar[1:-1, 2:] + Ar[2:, 1:-1] + Ar[:-2, 1:-1])
+        Ar[1:-1, 1:-1] = 0.2 * (Br[1:-1, 1:-1] + Br[1:-1, :-2] +
+                                Br[1:-1, 2:] + Br[2:, 1:-1] + Br[:-2, 1:-1])
+    assert np.allclose(A, Ar)
+    assert np.allclose(B, Br)
+
+
+
+if __name__ == '__main__':
+    test_negative_index()
+    test_nested_negative_index()
+    test_negative_range()
+    test_nested_negative_range()
+    test_jacobi_2d()


### PR DESCRIPTION
Adds support to the Python frontend for accessing arrays with constant negative indices, e.g. `A[-2]`.
This PR does not include support for non-constant negative indices, e.g. `A[-i]`, where `i` is a map index variable or something similar.