### PR TITLE
NumPy array creation routines

### DIFF
--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+from sympy.simplify.fu import L
 import dace
 
 import ast
@@ -16,7 +17,7 @@ from dace import data, dtypes, subsets, symbolic, sdfg as sd
 from dace.frontend.common import op_repository as oprepo
 import dace.frontend.python.memlet_parser as mem_parser
 from dace.frontend.python.memlet_parser import parse_memlet_subset
-from dace.frontend.python import astutils
+from dace.frontend.python import astutils, newast
 from dace.frontend.python.nested_call import NestedCall
 from dace.memlet import Memlet
 from dace.sdfg import nodes, SDFG, SDFGState
@@ -209,6 +210,165 @@ def eye(pv: 'ProgramVisitor',
 
     return name
 
+
+@oprepo.replaces('numpy.empty')
+def _numpy_empty(pv: 'ProgramVisitor',
+                 sdfg: SDFG,
+                 state: SDFGState,
+                 shape: Shape,
+                 dtype: dace.typeclass):
+    """ Creates an unitialized array of the specificied shape and dtype. """
+    return _define_local(pv, sdfg, state, shape, dtype)
+
+
+@oprepo.replaces('numpy.empty_like')
+def _numpy_empty_like(pv: 'ProgramVisitor',
+                      sdfg: SDFG,
+                      state: SDFGState,
+                      prototype: str,
+                      dtype: dace.typeclass = None,
+                      shape: Shape = None):
+    """ Creates an unitialized array of the same shape and dtype as prototype.
+        The optional dtype and shape inputs allow overriding the corresponding
+        attributes of prototype.
+    """
+    if prototype not in sdfg.arrays.keys():
+        raise mem_parser.DaceSyntaxError(
+            pv, None, "Prototype argument {a} is not SDFG data!".format(
+                a=prototype))
+    desc = sdfg.arrays[prototype]
+    dtype = dtype or desc.dtype
+    shape = shape or desc.shape
+    return _define_local(pv, sdfg, state, shape, dtype)
+
+
+@oprepo.replaces('numpy.identity')
+def _numpy_identity(pv: 'ProgramVisitor',
+                    sdfg: SDFG,
+                    state: SDFGState,
+                    n,
+                    dtype=dace.float64):
+    """ Generates the nxn identity matrix. """
+    return eye(pv, sdfg, state, n, dtype=dtype)
+
+
+@oprepo.replaces('numpy.full')
+def _numpy_full(pv: 'ProgramVisitor',
+                sdfg: SDFG,
+                state: SDFGState,
+                shape: Shape,
+                fill_value: Number,
+                dtype: dace.typeclass = None):
+    """ Creates and array of the specified shape and initializes it with
+        the fill value.
+    """
+    if isinstance(fill_value, Number):
+        vtype = dtypes.DTYPE_TO_TYPECLASS[type(fill_value)]
+    else:
+        raise mem_parser.DaceSyntaxError(
+            pv, None, "Fill value {f} must be a number!".format(f=fill_value))
+    dtype = dtype or vtype
+    name, _ = sdfg.add_temp_transient(shape, dtype)
+
+    state.add_mapped_tasklet('_numpy_full_',
+                             {"__i{}".format(i): "0: {}".format(s)
+                             for i, s in enumerate(shape)},
+                             {},
+                             "__out = {}".format(fill_value),
+                             dict(__out=dace.Memlet.simple(
+                                 name, ",".join(["__i{}".format(i)
+                                                 for i in range(len(shape))]))),
+                             external_edges=True)
+
+    return name
+
+
+@oprepo.replaces('numpy.full_like')
+def _numpy_full_like(pv: 'ProgramVisitor',
+                     sdfg: SDFG,
+                     state: SDFGState,
+                     a: str,
+                     fill_value: Number,
+                     dtype: dace.typeclass = None,
+                     shape: Shape = None):
+    """ Creates and array of the same shape and dtype as a and initializes it
+        with the fill value.
+    """
+    if a not in sdfg.arrays.keys():
+        raise mem_parser.DaceSyntaxError(
+            pv, None, "Prototype argument {a} is not SDFG data!".format(a=a))
+    desc = sdfg.arrays[a]
+    dtype = dtype or desc.dtype
+    shape = shape or desc.shape
+    return _numpy_full(pv, sdfg, state, shape, fill_value, dtype)
+
+
+@oprepo.replaces('numpy.ones')
+def _numpy_ones(pv: 'ProgramVisitor',
+                sdfg: SDFG,
+                state: SDFGState,
+                shape: Shape,
+                dtype: dace.typeclass = dace.float64):
+    """ Creates and array of the specified shape and initializes it with ones.
+    """
+    return _numpy_full(pv, sdfg, state, shape, 1.0, dtype)
+
+
+@oprepo.replaces('numpy.ones_like')
+def _numpy_ones_like(pv: 'ProgramVisitor',
+                     sdfg: SDFG,
+                     state: SDFGState,
+                     a: str,
+                     dtype: dace.typeclass = None,
+                     shape: Shape = None):
+    """ Creates and array of the same shape and dtype as a and initializes it
+        with ones.
+    """
+    return _numpy_full_like(pv, sdfg, state, a, 1.0, dtype, shape)
+
+
+@oprepo.replaces('numpy.zeros')
+def _numpy_zeros(pv: 'ProgramVisitor',
+                 sdfg: SDFG,
+                 state: SDFGState,
+                 shape: Shape,
+                 dtype: dace.typeclass = dace.float64):
+    """ Creates and array of the specified shape and initializes it with zeros.
+    """
+    return _numpy_full(pv, sdfg, state, shape, 0.0, dtype)
+
+
+@oprepo.replaces('numpy.zeros_like')
+def _numpy_zeros_like(pv: 'ProgramVisitor',
+                      sdfg: SDFG,
+                      state: SDFGState,
+                      a: str,
+                      dtype: dace.typeclass = None,
+                      shape: Shape = None):
+    """ Creates and array of the same shape and dtype as a and initializes it
+        with zeros.
+    """
+    return _numpy_full_like(pv, sdfg, state, a, 0.0, dtype, shape)
+
+
+@oprepo.replaces('numpy.copy')
+def _numpy_copy(pv: 'ProgramVisitor',
+                sdfg: SDFG,
+                state: SDFGState,
+                a: str):
+    """ Creates a copy of array a.
+    """
+    if a not in sdfg.arrays.keys():
+        raise mem_parser.DaceSyntaxError(
+            pv, None, "Prototype argument {a} is not SDFG data!".format(a=a))
+    # TODO: The whole AddTransientMethod class should be move in replacements.py
+    from dace.frontend.python.newast import _add_transient_data
+    name, desc = _add_transient_data(sdfg, sdfg.arrays[a])
+    rnode = state.add_read(a)
+    wnode = state.add_write(name)
+    state.add_nedge(rnode, wnode, dace.Memlet.from_array(name, desc))
+    return name
+    
 
 @oprepo.replaces('elementwise')
 @oprepo.replaces('dace.elementwise')

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -16,7 +16,7 @@ from dace import data, dtypes, subsets, symbolic, sdfg as sd
 from dace.frontend.common import op_repository as oprepo
 import dace.frontend.python.memlet_parser as mem_parser
 from dace.frontend.python.memlet_parser import parse_memlet_subset
-from dace.frontend.python import astutils, newast
+from dace.frontend.python import astutils
 from dace.frontend.python.nested_call import NestedCall
 from dace.memlet import Memlet
 from dace.sdfg import nodes, SDFG, SDFGState

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -1,5 +1,4 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-from sympy.simplify.fu import L
 import dace
 
 import ast

--- a/tests/numpy/array_creation_test.py
+++ b/tests/numpy/array_creation_test.py
@@ -1,0 +1,113 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import numpy as np
+from common import compare_numpy_output
+
+
+# M = dace.symbol('M')
+# N = dace.symbol('N')
+
+M = 10
+N = 20
+
+
+@dace.program
+def empty():
+    return np.empty([M, N], dtype=np.uint32)
+
+
+def test_empty():
+    out = empty()
+    assert(list(out.shape) == [M, N])
+    assert(out.dtype == np.uint32)
+
+
+@dace.program
+def empty_like1(A: dace.complex64[N, M, 2]):
+    return np.empty_like(A)
+
+
+def test_empty_like1():
+    A = np.ndarray([N, M, 2], dtype=np.complex64)
+    out = empty_like1(A)
+    assert(list(out.shape) == [N, M, 2])
+    assert(out.dtype == np.complex64)
+
+
+@dace.program
+def empty_like2(A: dace.complex64[N, M, 2]):
+    return np.empty_like(A, shape=[2, N, N])
+
+
+def test_empty_like2():
+    A = np.ndarray([N, M, 2], dtype=np.complex64)
+    out = empty_like2(A)
+    assert(list(out.shape) == [2, N, N])
+    assert(out.dtype == np.complex64)
+
+
+@dace.program
+def empty_like3(A: dace.complex64[N, M, 2]):
+    return np.empty_like(A, dtype=np.uint8)
+
+
+def test_empty_like3():
+    A = np.ndarray([N, M, 2], dtype=np.complex64)
+    out = empty_like3(A)
+    assert(list(out.shape) == [N, M, 2])
+    assert(out.dtype == np.uint8)
+
+
+@compare_numpy_output()
+def test_ones():
+    return np.ones([N, N], dtype=np.float32)
+
+
+@compare_numpy_output()
+def test_ones_like(A: dace.complex64[N, M, 2]):
+    return np.ones_like(A)
+
+
+@compare_numpy_output()
+def test_zeros():
+    return np.zeros([N, N], dtype=np.float32)
+
+
+@compare_numpy_output()
+def test_zeros_like(A: dace.complex64[N, M, 2]):
+    return np.zeros_like(A)
+
+
+@compare_numpy_output()
+def test_full():
+    return np.full([N, N], fill_value=np.complex32(5 + 6j))
+
+
+@compare_numpy_output()
+def test_full_like(A: dace.complex64[N, M, 2]):
+    return np.full_like(A, fill_value=5)
+
+
+@compare_numpy_output()
+def test_copy(A: dace.complex64[N, M, 2]):
+    return np.copy(A)
+
+
+@compare_numpy_output()
+def test_identity():
+    return np.identity(M)
+
+
+if __name__ == "__main__":
+    test_empty()
+    test_empty_like1()
+    test_empty_like2()
+    test_empty_like3()
+    test_ones()
+    test_ones_like()
+    test_zeros()
+    test_zeros_like()
+    test_full()
+    test_full_like()
+    test_copy()
+    test_identity()


### PR DESCRIPTION
Adds support for the following NumPy array creation routines:
- empty
- empty_like
- ones
- ones_like
- zeros
- zeros_like
- full
- full_like
- copy
- identity
