### PR TITLE
Improvements to Redundant Array transformations.

### DIFF
--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -43,47 +43,49 @@ def _validate_subsets(edge: graph.MultiConnectorEdge,
     # dimensionality of the subset and we pop or pad indices/ranges accordingly.
     # In that case, we also set the subset to start from 0 in each dimension. 
     if not src_subset:
-        src_subset = copy.deepcopy(dst_subset)
         if src_name:
             desc = arrays[src_name]
-            padding = len(desc.shape) - len(src_subset)
-            if padding != 0:
-                if padding > 0:
-                    if isinstance(src_subset, subsets.Indices):
-                        indices = [0] * padding + src_subset.indices
-                        src_subset = subsets.Indices(indices)
-                    elif isinstance(src_subset, subsets.Range):
-                        ranges = [(0, 0, 1)] * padding + src_subset.ranges
-                        src_subset = subsets.Range(ranges)
-                elif padding < 0:
-                    if isinstance(src_subset, subsets.Indices):
-                        indices = src_subset.indices[-padding:]
-                        src_subset = subsets.Indices(indices)
-                    elif isinstance(src_subset, subsets.Range):
-                        ranges = src_subset.ranges[-padding:]
-                        src_subset = subsets.Range(ranges)
-                src_subset.offset(src_subset, True)
+            if not isinstance(desc, data.View):
+                src_subset = copy.deepcopy(dst_subset)
+                padding = len(desc.shape) - len(src_subset)
+                if padding != 0:
+                    if padding > 0:
+                        if isinstance(src_subset, subsets.Indices):
+                            indices = [0] * padding + src_subset.indices
+                            src_subset = subsets.Indices(indices)
+                        elif isinstance(src_subset, subsets.Range):
+                            ranges = [(0, 0, 1)] * padding + src_subset.ranges
+                            src_subset = subsets.Range(ranges)
+                    elif padding < 0:
+                        if isinstance(src_subset, subsets.Indices):
+                            indices = src_subset.indices[-padding:]
+                            src_subset = subsets.Indices(indices)
+                        elif isinstance(src_subset, subsets.Range):
+                            ranges = src_subset.ranges[-padding:]
+                            src_subset = subsets.Range(ranges)
+                    src_subset.offset(src_subset, True)
     elif not dst_subset:
-        dst_subset = copy.deepcopy(src_subset)
         if dst_name:
             desc = arrays[dst_name]
-            padding = len(desc.shape) - len(dst_subset)
-            if padding != 0:
-                if padding > 0:
-                    if isinstance(dst_subset, subsets.Indices):
-                        indices = [0] * padding + dst_subset.indices
-                        dst_subset = subsets.Indices(indices)
-                    elif isinstance(dst_subset, subsets.Range):
-                        ranges = [(0, 0, 1)] * padding + dst_subset.ranges
-                        dst_subset = subsets.Range(ranges)
-                elif padding < 0:
-                    if isinstance(dst_subset, subsets.Indices):
-                        indices = dst_subset.indices[-padding:]
-                        dst_subset = subsets.Indices(indices)
-                    elif isinstance(dst_subset, subsets.Range):
-                        ranges = dst_subset.ranges[-padding:]
-                        dst_subset = subsets.Range(ranges)
-                dst_subset.offset(dst_subset, True)
+            if not isinstance(desc, data.View):
+                dst_subset = copy.deepcopy(src_subset)
+                padding = len(desc.shape) - len(dst_subset)
+                if padding != 0:
+                    if padding > 0:
+                        if isinstance(dst_subset, subsets.Indices):
+                            indices = [0] * padding + dst_subset.indices
+                            dst_subset = subsets.Indices(indices)
+                        elif isinstance(dst_subset, subsets.Range):
+                            ranges = [(0, 0, 1)] * padding + dst_subset.ranges
+                            dst_subset = subsets.Range(ranges)
+                    elif padding < 0:
+                        if isinstance(dst_subset, subsets.Indices):
+                            indices = dst_subset.indices[-padding:]
+                            dst_subset = subsets.Indices(indices)
+                        elif isinstance(dst_subset, subsets.Range):
+                            ranges = dst_subset.ranges[-padding:]
+                            dst_subset = subsets.Range(ranges)
+                    dst_subset.offset(dst_subset, True)
 
     return src_subset, dst_subset
 

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -47,41 +47,43 @@ def _validate_subsets(edge: graph.MultiConnectorEdge,
         if src_name:
             desc = arrays[src_name]
             padding = len(desc.shape) - len(src_subset)
-            if padding > 0:
-                if isinstance(src_subset, subsets.Indices):
-                    indices = [0] * padding + src_subset.indices
-                    src_subset = subsets.Indices(indices)
-                elif isinstance(src_subset, subsets.Range):
-                    ranges = [(0, 0, 1)] * padding + src_subset.ranges
-                    src_subset = subsets.Range(ranges)
-            elif padding < 0:
-                if isinstance(src_subset, subsets.Indices):
-                    indices = src_subset.indices[-padding:]
-                    src_subset = subsets.Indices(indices)
-                elif isinstance(src_subset, subsets.Range):
-                    ranges = src_subset.ranges[-padding:]
-                    src_subset = subsets.Range(ranges)
-            src_subset.offset(src_subset, True)
+            if padding != 0:
+                if padding > 0:
+                    if isinstance(src_subset, subsets.Indices):
+                        indices = [0] * padding + src_subset.indices
+                        src_subset = subsets.Indices(indices)
+                    elif isinstance(src_subset, subsets.Range):
+                        ranges = [(0, 0, 1)] * padding + src_subset.ranges
+                        src_subset = subsets.Range(ranges)
+                elif padding < 0:
+                    if isinstance(src_subset, subsets.Indices):
+                        indices = src_subset.indices[-padding:]
+                        src_subset = subsets.Indices(indices)
+                    elif isinstance(src_subset, subsets.Range):
+                        ranges = src_subset.ranges[-padding:]
+                        src_subset = subsets.Range(ranges)
+                src_subset.offset(src_subset, True)
     elif not dst_subset:
         dst_subset = copy.deepcopy(src_subset)
         if dst_name:
             desc = arrays[dst_name]
             padding = len(desc.shape) - len(dst_subset)
-            if padding > 0:
-                if isinstance(dst_subset, subsets.Indices):
-                    indices = [0] * padding + dst_subset.indices
-                    dst_subset = subsets.Indices(indices)
-                elif isinstance(dst_subset, subsets.Range):
-                    ranges = [(0, 0, 1)] * padding + dst_subset.ranges
-                    dst_subset = subsets.Range(ranges)
-            elif padding < 0:
-                if isinstance(dst_subset, subsets.Indices):
-                    indices = dst_subset.indices[-padding:]
-                    dst_subset = subsets.Indices(indices)
-                elif isinstance(dst_subset, subsets.Range):
-                    ranges = dst_subset.ranges[-padding:]
-                    dst_subset = subsets.Range(ranges)
-            dst_subset.offset(dst_subset, True)
+            if padding != 0:
+                if padding > 0:
+                    if isinstance(dst_subset, subsets.Indices):
+                        indices = [0] * padding + dst_subset.indices
+                        dst_subset = subsets.Indices(indices)
+                    elif isinstance(dst_subset, subsets.Range):
+                        ranges = [(0, 0, 1)] * padding + dst_subset.ranges
+                        dst_subset = subsets.Range(ranges)
+                elif padding < 0:
+                    if isinstance(dst_subset, subsets.Indices):
+                        indices = dst_subset.indices[-padding:]
+                        dst_subset = subsets.Indices(indices)
+                    elif isinstance(dst_subset, subsets.Range):
+                        ranges = dst_subset.ranges[-padding:]
+                        dst_subset = subsets.Range(ranges)
+                dst_subset.offset(dst_subset, True)
 
     return src_subset, dst_subset
 

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -177,7 +177,7 @@ class RedundantArray(pm.Transformation):
         e1 = graph.edges_between(in_array, out_array)[0]
         a1_subset, b_subset = _validate_subsets(e1, sdfg.arrays)
 
-        # If the memlet does not cover the remove array, create a view.
+        # If the memlet does not cover the removed array, create a view.
         if any(m != a for m, a in zip(a1_subset.size(), in_desc.shape)):
             sdfg.arrays[in_array.data] = data.View(
                 in_desc.dtype, in_desc.shape, True, in_desc.allow_conflicts,
@@ -198,9 +198,7 @@ class RedundantArray(pm.Transformation):
                 e3.data.data = out_array.data
                 a3_subset.offset(a1_subset, negative=True)
                 if isinstance(b_subset, subsets.Indices):
-                    tmp = copy.deepcopy(b_subset)
-                    tmp.offset(a3_subset, negative=False)
-                    e3.data.subset = tmp
+                    e3.data.subset = b_subset.new_offset(a3_subset, False)
                 else:
                     e3.data.subset = b_subset.compose(a3_subset)
                 # NOTE: This fixes the following case:
@@ -347,9 +345,7 @@ class RedundantSecondArray(pm.Transformation):
                 b3_subset.offset(b1_subset, negative=True)
                 # (0, a:b)(d) = (0, a+d) (or offset for indices)
                 if isinstance(a_subset, subsets.Indices):
-                    tmp = copy.deepcopy(a_subset)
-                    tmp.offset(b3_subset, negative=False)
-                    e3.data.subset = tmp
+                    e3.data.subset = a_subset.new_offset(b3_subset, False)
                 else:
                     e3.data.subset = a_subset.compose(b3_subset)
                 # NOTE: This fixes the following case:

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -35,12 +35,53 @@ def _validate_subsets(edge: graph.MultiConnectorEdge,
     dst_subset = copy.deepcopy(edge.data.dst_subset)
 
     if not src_subset and not dst_subset:
-        # This should never happen
+        # NOTE: This should never happen
         raise NotImplementedError
+    # NOTE: If any of the subsets is None, it means that we proceed in 
+    # experimental mode. The base case here is that we just copy the other
+    # subset. However, if we can locate the other array, we check the
+    # dimensionality of the subset and we pop or pad indices/ranges accordingly.
+    # In that case, we also set the subset to start from 0 in each dimension. 
     if not src_subset:
         src_subset = copy.deepcopy(dst_subset)
+        if src_name:
+            desc = arrays[src_name]
+            padding = len(desc.shape) - len(src_subset)
+            if padding > 0:
+                if isinstance(src_subset, subsets.Indices):
+                    indices = [0] * padding + src_subset.indices
+                    src_subset = subsets.Indices(indices)
+                elif isinstance(src_subset, subsets.Range):
+                    ranges = [(0, 0, 1)] * padding + src_subset.ranges
+                    src_subset = subsets.Range(ranges)
+            elif padding < 0:
+                if isinstance(src_subset, subsets.Indices):
+                    indices = src_subset.indices[-padding:]
+                    src_subset = subsets.Indices(indices)
+                elif isinstance(src_subset, subsets.Range):
+                    ranges = src_subset.ranges[-padding:]
+                    src_subset = subsets.Range(ranges)
+            src_subset.offset(src_subset, True)
     elif not dst_subset:
         dst_subset = copy.deepcopy(src_subset)
+        if dst_name:
+            desc = arrays[dst_name]
+            padding = len(desc.shape) - len(dst_subset)
+            if padding > 0:
+                if isinstance(dst_subset, subsets.Indices):
+                    indices = [0] * padding + dst_subset.indices
+                    dst_subset = subsets.Indices(indices)
+                elif isinstance(dst_subset, subsets.Range):
+                    ranges = [(0, 0, 1)] * padding + dst_subset.ranges
+                    dst_subset = subsets.Range(ranges)
+            elif padding < 0:
+                if isinstance(dst_subset, subsets.Indices):
+                    indices = dst_subset.indices[-padding:]
+                    dst_subset = subsets.Indices(indices)
+                elif isinstance(dst_subset, subsets.Range):
+                    ranges = dst_subset.ranges[-padding:]
+                    dst_subset = subsets.Range(ranges)
+            dst_subset.offset(dst_subset, True)
 
     return src_subset, dst_subset
 


### PR DESCRIPTION
The redundant array transformations should always work when the shape of the array to-be-removed is a subset of the shape of the array to-stay:
- RedundantSecondArray now checks that output shape is a subset of input shape in strict mode.
- RedundantArray now doesn't create Views when the input shape is a subset of the output shape. Instead, it uses subset composition, exactly the same way as RedundantSecondArray.