### PR TITLE
Fixing calculation of strides for 1D strided copies.

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -404,14 +404,30 @@ def ndcopy_to_strided_copy(
         if copy_shape == src_copy_shape:
             srcdim = copydim
         else:
-            srcdim = next(i for i, c in enumerate(src_copy_shape) if c != 1)
+            try:
+                srcdim = next(i for i, c in enumerate(src_copy_shape) if c != 1)
+            except StopIteration:
+                # NOTE: This is the old stride computation code for FPGA
+                # compatibility
+                if len(copy_shape) == len(src_shape):
+                    srcdim = copydim
+                else:
+                    srcdim = next(i for i, c in enumerate(src_shape) if c != 1)
 
         # In destination strides
         dst_copy_shape = dst_subset.size_exact()
         if copy_shape == dst_copy_shape:
             dstdim = copydim
         else:
-            dstdim = next(i for i, c in enumerate(dst_copy_shape) if c != 1)
+            try:
+                dstdim = next(i for i, c in enumerate(dst_copy_shape) if c != 1)
+            except StopIteration:
+                # NOTE: This is the old stride computation code for FPGA
+                # compatibility
+                if len(copy_shape) == len(dst_shape):
+                    dstdim = copydim
+                else:
+                    dstdim = next(i for i, c in enumerate(dst_shape) if c != 1)
 
         # Return new copy
         return [copy_shape[copydim]], [src_strides[srcdim]

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -400,16 +400,18 @@ def ndcopy_to_strided_copy(
         copydim = next(i for i, c in enumerate(copy_shape) if c != 1)
 
         # In source strides
-        if len(copy_shape) == len(src_shape):
+        src_copy_shape = src_subset.size_exact()
+        if copy_shape == src_copy_shape:
             srcdim = copydim
         else:
-            srcdim = next(i for i, c in enumerate(src_shape) if c != 1)
+            srcdim = next(i for i, c in enumerate(src_copy_shape) if c != 1)
 
         # In destination strides
-        if len(copy_shape) == len(dst_shape):
+        dst_copy_shape = dst_subset.size_exact()
+        if copy_shape == dst_copy_shape:
             dstdim = copydim
         else:
-            dstdim = next(i for i, c in enumerate(dst_shape) if c != 1)
+            dstdim = next(i for i, c in enumerate(dst_copy_shape) if c != 1)
 
         # Return new copy
         return [copy_shape[copydim]], [src_strides[srcdim]

--- a/tests/copynd_test.py
+++ b/tests/copynd_test.py
@@ -93,6 +93,30 @@ def test():
         dace.memlet.Memlet.simple(arrays[-2],
                                   '20:40, 10:30',
                                   other_subset_str='2, 10:30, 20:40'))
+    
+    # Copy 10: Copying from 2d array to another 2d array a 1d slice
+    # The src stride is 1, while the dst stride is N
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2],
+                                  '20, 10:30',
+                                  other_subset_str='10:30, 10'))
+    
+    # Copy 11: Copying from 2d array to another 2d array a 1d slice
+    # The src stride is N, while the dst stride is 1
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2],
+                                  '10:30, 20',
+                                  other_subset_str='10, 10:30'))
 
     array_data = [
         np.random.rand(*[
@@ -122,7 +146,11 @@ def test():
         np.linalg.norm(array_data[15] - array_data[14][4, 1, 2, 1:(N - 1):2]) /
         (N / 2 - 1),
         np.linalg.norm(array_data[17][2, 10:30, 20:40] -
-                       array_data[16][20:40, 10:30]) / 400
+                       array_data[16][20:40, 10:30]) / 400,
+        np.linalg.norm(array_data[19][10:30, 10] -
+                       array_data[18][20, 10:30]) / 20,
+        np.linalg.norm(array_data[21][10, 10:30] -
+                       array_data[20][10:30, 20]) / 20
     ]
 
     print('Differences: ', diffs)


### PR DESCRIPTION
This PR fixes the calculation of strides for 1D strided copies. Examples of copies that do not currently work properly in master:
- `q[1:N - 1, 0] = v[0, 1:N - 1]`
- `v[0, 1:N - 1] = q[1:N - 1, 0]`
