### PR TITLE
Application of Redundant(Second)Array leads to data races

### DIFF
--- a/dace/sdfg/scope.py
+++ b/dace/sdfg/scope.py
@@ -196,7 +196,7 @@ def is_devicelevel_gpu(sdfg: 'dace.sdfg.SDFG', state: 'dace.sdfg.SDFGState',
         sdfg,
         state,
         node,
-        dtypes.GPU_SCHEDULES + [dtypes.ScheduleType.GPU_Default],
+        dtypes.GPU_SCHEDULES,
     )
 
 

--- a/dace/transformation/dataflow/map_fusion.py
+++ b/dace/transformation/dataflow/map_fusion.py
@@ -173,12 +173,9 @@ class MapFusion(transformation.Transformation):
 
             # Compute second subset with respect to first subset's symbols  
             sbs_permuted = dcpy(second_edge.data.subset)
-            print(sbs_permuted)
             if sbs_permuted:
                 sbs_permuted.replace(repldict)
-                print(sbs_permuted)
                 sbs_permuted.replace(repldict_inv)
-                print(sbs_permuted)
 
             for first_memlet in out_memlets:
                 if first_memlet.data != second_edge.data.data:

--- a/tests/transformations/mapfusion_data_races_test.py
+++ b/tests/transformations/mapfusion_data_races_test.py
@@ -1,0 +1,24 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import numpy as np
+
+from dace import nodes
+from dace.transformation.dataflow import MapFusion
+
+
+@dace.program
+def rw_data_race(A: dace.float32[10, 10], B: dace.float32[10, 10]):
+    tmp = A[:-1,:-1] + A[1:,1:]
+    B[1:-1, 1:-1] = tmp[:-1,:-1] + tmp[:-1,:-1]
+
+
+def test_rw_data_race():
+    sdfg = rw_data_race.to_sdfg(strict=True)
+    sdfg.apply_transformations_repeated([MapFusion])
+    map_entry_nodes = [n for n, _ in sdfg.all_nodes_recursive()
+                       if isinstance(n, nodes.MapEntry)]
+    assert(len(map_entry_nodes) > 1)
+
+
+if __name__ == "__main__":
+    test_rw_data_race()

--- a/tests/transformations/mapfusion_data_races_test.py
+++ b/tests/transformations/mapfusion_data_races_test.py
@@ -14,7 +14,7 @@ def rw_data_race(A: dace.float32[10, 10], B: dace.float32[10, 10]):
 
 def test_rw_data_race():
     sdfg = rw_data_race.to_sdfg(strict=True)
-    sdfg.apply_transformations_repeated([MapFusion])
+    sdfg.apply_transformations_repeated(MapFusion)
     map_entry_nodes = [n for n, _ in sdfg.all_nodes_recursive()
                        if isinstance(n, nodes.MapEntry)]
     assert(len(map_entry_nodes) > 1)

--- a/tests/transformations/redundant_copy_data_races_test.py
+++ b/tests/transformations/redundant_copy_data_races_test.py
@@ -1,0 +1,23 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import numpy as np
+
+from dace import nodes
+
+
+@dace.program
+def rw_data_race(A: dace.float32[10, 10]):
+    A2 = A.copy()
+    A[1:-1, 1:-1] = A2[:-2,:-2] + A2[2:,2:]
+
+
+def test_rw_data_race():
+    sdfg = rw_data_race.to_sdfg(strict=True)
+    sdfg.save("test.sdfg")
+    a2_nodes = [n for n, _ in sdfg.all_nodes_recursive()
+                if isinstance(n, nodes.AccessNode) and n.data == 'A2']
+    assert(a2_nodes)
+
+
+if __name__ == "__main__":
+    test_rw_data_race()

--- a/tests/transformations/redundant_copy_data_races_test.py
+++ b/tests/transformations/redundant_copy_data_races_test.py
@@ -14,9 +14,9 @@ def rw_data_race(A: dace.float32[10, 10]):
 def test_rw_data_race():
     sdfg = rw_data_race.to_sdfg(strict=True)
     sdfg.save("test.sdfg")
-    a2_nodes = [n for n, _ in sdfg.all_nodes_recursive()
-                if isinstance(n, nodes.AccessNode) and n.data == 'A2']
-    assert(a2_nodes)
+    access_nodes = [n for n, _ in sdfg.all_nodes_recursive()
+                    if isinstance(n, nodes.AccessNode)]
+    assert(len(access_nodes) > 3)
 
 
 if __name__ == "__main__":

--- a/tests/transformations/redundant_copy_data_races_test.py
+++ b/tests/transformations/redundant_copy_data_races_test.py
@@ -16,7 +16,7 @@ def test_rw_data_race():
     sdfg.save("test.sdfg")
     access_nodes = [n for n, _ in sdfg.all_nodes_recursive()
                     if isinstance(n, nodes.AccessNode)]
-    assert(len(access_nodes) > 3)
+    assert(len(access_nodes) > 2)
 
 
 if __name__ == "__main__":

--- a/tests/transformations/redundant_copy_data_races_test.py
+++ b/tests/transformations/redundant_copy_data_races_test.py
@@ -13,7 +13,6 @@ def rw_data_race(A: dace.float32[10, 10]):
 
 def test_rw_data_race():
     sdfg = rw_data_race.to_sdfg(strict=True)
-    sdfg.save("test.sdfg")
     access_nodes = [n for n, _ in sdfg.all_nodes_recursive()
                     if isinstance(n, nodes.AccessNode)]
     assert(len(access_nodes) > 2)


### PR DESCRIPTION
The PR attempts to address an issue that occurs with the following code:
```python
@dace.program
def rw_data_race(A: dace.float32[10, 10]):
    A2 = A.copy()
    A[1:-1, 1:-1] = A2[:-2,:-2] + A2[2:,2:]
```
The SDFG with fused states but not redundant copies removed will approximately have the following flow: 
``` 
A --> A2 --> tmp1 --> Map Entry --> i, j -----> Tasklet --> i+1, j+1 --> Map Exit --> A
         --> tmp2 --> Map Entry --> i+2,j+2 --> Tasklet
```
If `tmp1` and `tmp2` are removed, then the only thing holding the "double buffering" scheme is `A2`. However, RedundantSecondArray will trigger and remove it as well. In this case, a data race is produced due to the offsets accesses to A inside the Map. This PR attempts to fix this issue.