### PR TITLE
Better subset composition

### DIFF
--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -89,8 +89,6 @@ class ExpandReducePure(pm.ExpandTransformation):
             nstate = nsdfg.add_state()
         # END OF INIT
 
-        keepdims = input_dims == output_dims
-
         # (If axes != all) Add outer map, which corresponds to the output range
         if len(axes) != input_dims:
             # Interleave input and output axes to match input memlet
@@ -100,46 +98,20 @@ class ExpandReducePure(pm.ExpandTransformation):
                 if i in axes:
                     input_subset.append('_i%d' % ictr)
                     ictr += 1
-                    if keepdims:
-                        octr += 1
                 else:
                     input_subset.append('_o%d' % octr)
                     octr += 1
 
             output_size = outedge.data.subset.size()
 
-            # NOTE: Support for keepdims and smart RedundantCopy
-            # Main idea: if the output length for some dimension is 1, then just
-            # plug index 0 in the output subset
-            if keepdims:
-                output_subset_str = ','.join(
-                    ['_o%d' % i if output_size[i] != 1 else '0'
-                     for i in range(output_dims)])
-                map_ranges = {
-                    '_o%d' % i: '0:%s' % symstr(sz)
-                    for i, sz in enumerate(output_size)
-                    if sz != 1
-                }
-            else:
-                output_subset_str = ','.join(
-                    ['_o%d' % i for i in range(output_dims)])
-                map_ranges = {
-                    '_o%d' % i: '0:%s' % symstr(sz)
-                    for i, sz in enumerate(output_size)
-                }
-
-
             ome, omx = nstate.add_map(
-                'reduce_output',
-                map_ranges)
-                # {
-                #     '_o%d' % i: '0:%s' % symstr(sz)
-                #     for i, sz in enumerate(outedge.data.subset.size())
-                # })
+                'reduce_output', {
+                    '_o%d' % i: '0:%s' % symstr(sz)
+                    for i, sz in enumerate(outedge.data.subset.size())
+                })
             outm = dace.Memlet.simple(
                 '_out',
-                # ','.join(['_o%d' % i for i in range(output_dims)]),
-                output_subset_str,
+                ','.join(['_o%d' % i for i in range(output_dims)]),
                 wcr_str=node.wcr)
             inmm = dace.Memlet.simple('_in', ','.join(input_subset))
         else:

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -7,9 +7,6 @@ import functools
 import networkx as nx
 import typing
 
-from networkx.algorithms.operators.binary import compose
-
-
 from dace import data, registry, subsets, dtypes, memlet as mm
 from dace.sdfg import nodes, SDFGState
 from dace.sdfg import utils as sdutil

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -13,7 +13,6 @@ from dace.sdfg import utils as sdutil
 from dace.sdfg import graph
 from dace.transformation import transformation as pm, helpers
 from dace.config import Config
-from dace.libraries.standard import Reduce
 
 # Helper methods #############################################################
 
@@ -264,6 +263,7 @@ class RedundantArray(pm.Transformation):
                 b_dims_to_pop = find_dims_to_pop(b_size, a_size)
                 bset, popped = pop_dims(b_subset, b_dims_to_pop)
 
+        from dace.libraries.standard import Reduce
         reduction = False
         for e in graph.in_edges(in_array):
             if isinstance(e.src, Reduce):

--- a/tests/transformations/redundant_copy_test.py
+++ b/tests/transformations/redundant_copy_test.py
@@ -272,7 +272,8 @@ def conv2d(input: dace.float32[N, H, W, C_in],
 def test_conv2d():
     sdfg = conv2d.to_sdfg(strict=True)
     access_nodes = [n for n, _ in sdfg.all_nodes_recursive()
-                    if isinstance(n, nodes.AccessNode)]
+                    if isinstance(n, nodes.AccessNode) and
+                    not isinstance(sdfg.arrays[n.data], dace.data.View)]
     assert(len(access_nodes) == 4)
 
 

--- a/tests/transformations/redundant_copy_test.py
+++ b/tests/transformations/redundant_copy_test.py
@@ -2,6 +2,7 @@
 import numpy as np
 
 import dace
+from dace import nodes
 from dace.libraries.blas import Transpose
 from dace.transformation.dataflow import RedundantArray, RedundantSecondArray
 
@@ -245,6 +246,36 @@ def test_reverse_copy():
     assert np.allclose(p, pp)
 
 
+C_in, C_out, H, K, N, W = (dace.symbol(s, dace.int64)
+                           for s in ('C_in', 'C_out', 'H', 'K', 'N', 'W'))
+
+
+# Deep learning convolutional operator (stride = 1)
+@dace.program
+def conv2d(input: dace.float32[N, H, W, C_in],
+           weights: dace.float32[K, K, C_in, C_out]):
+    output = np.ndarray((N, H-K+1, W-K+1, C_out), dtype=np.float32)
+
+    # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
+    # for i, j in dace.map[0:H-K+1, 0:W-K+1]:
+    for i in range(H-K+1):
+        for j in range(W-K+1):
+            output[:, i, j, :] = np.sum(
+                input[:, i:i + K, j:j + K, :, np.newaxis] *
+                weights[np.newaxis, :, :, :],
+                axis=(1, 2, 3),
+            )
+
+    return output
+
+
+def test_conv2d():
+    sdfg = conv2d.to_sdfg(strict=True)
+    access_nodes = [n for n, _ in sdfg.all_nodes_recursive()
+                    if isinstance(n, nodes.AccessNode)]
+    assert(len(access_nodes) == 4)
+
+
 if __name__ == '__main__':
     test_in()
     test_out()
@@ -255,3 +286,4 @@ if __name__ == '__main__':
     test_view_array_array()
     test_array_array_view()
     test_reverse_copy()
+    test_conv2d()


### PR DESCRIPTION
This PR attempts to address issue #575. The fix is done through `Redundant(Second)Array` instead of `Range.compose`, because it becomes impossible to infer the correct composition when reaching the innermost Memlets, where subsets are `Indices`.