### PR TITLE
Fix memlet update while nesting

### DIFF
--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -1027,7 +1027,7 @@ class NestSDFG(transformation.Transformation):
                             and src.data == inputs[mem.data]):
                         mem.data = inputs[mem.data]
                     elif (mem.data in outputs.keys()
-                          and src.data == outputs[mem.data]):
+                          and (src.data == outputs[mem.data] or dst.data == outputs[mem.data])):
                         mem.data = outputs[mem.data]
                 elif (isinstance(dst, nodes.AccessNode)
                       and mem.data in outputs.keys()


### PR DESCRIPTION
While nesting, memlets are updated according to the new array names.
Previously, this was not considering the case in which the memlet was referring to the destination array
