### PR TITLE
Gemm related fixes

### DIFF
--- a/dace/codegen/prettycode.py
+++ b/dace/codegen/prettycode.py
@@ -14,6 +14,9 @@ class CodeIOStream(StringIO):
         self._indent = 0
         self._spaces = int(Config.get('compiler', 'indentation_spaces'))
 
+    def __repr__(self):
+        return self.getvalue()
+
     def write(self, contents, sdfg=None, state_id=None, node_id=None):
         # Delete single trailing newline, as this will be implicitly inserted
         # anyway

--- a/dace/codegen/prettycode.py
+++ b/dace/codegen/prettycode.py
@@ -14,9 +14,6 @@ class CodeIOStream(StringIO):
         self._indent = 0
         self._spaces = int(Config.get('compiler', 'indentation_spaces'))
 
-    def __repr__(self):
-        return self.getvalue()
-
     def write(self, contents, sdfg=None, state_id=None, node_id=None):
         # Delete single trailing newline, as this will be implicitly inserted
         # anyway

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -746,6 +746,14 @@ def unparse_tasklet(sdfg, state_id, dfg, node, function_stream, callsite_stream,
                 state_id,
                 node,
             )
+        else:
+            callsite_stream.write(
+                '%sStream_t __dace_current_stream = nullptr;' %
+                Config.get('compiler', 'cuda', 'backend'),
+                sdfg,
+                state_id,
+                node,
+            )
 
         if node.language != dtypes.Language.CPP:
             raise ValueError(

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -213,7 +213,9 @@ def ptr(name: str, desc: data.Data) -> str:
     # struct to name
     if (desc.transient and desc.lifetime is dtypes.AllocationLifetime.Persistent
             and desc.storage != dtypes.StorageType.CPU_ThreadLocal):
-        return f'__state->{name}'
+        from dace.codegen.targets.cuda import CUDACodeGen # Avoid import loop
+        if not CUDACodeGen._in_device_code: # GPU kernels cannot access state
+            return f'__state->{name}'
 
     return name
 

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -736,24 +736,24 @@ def unparse_tasklet(sdfg, state_id, dfg, node, function_stream, callsite_stream,
         # set the stream to a local variable.
         max_streams = int(
             Config.get("compiler", "cuda", "max_concurrent_streams"))
-        if (max_streams >= 0 and not is_devicelevel_gpu(sdfg, state_dfg, node)
-                and hasattr(node, "_cuda_stream")):
-            callsite_stream.write(
-                'int __dace_current_stream_id = %d;\n%sStream_t __dace_current_stream = __state->gpu_context->streams[__dace_current_stream_id];'
-                %
-                (node._cuda_stream, Config.get('compiler', 'cuda', 'backend')),
-                sdfg,
-                state_id,
-                node,
-            )
-        else:
-            callsite_stream.write(
-                '%sStream_t __dace_current_stream = nullptr;' %
-                Config.get('compiler', 'cuda', 'backend'),
-                sdfg,
-                state_id,
-                node,
-            )
+        if not is_devicelevel_gpu(sdfg, state_dfg, node):
+            if (max_streams >= 0 and hasattr(node, "_cuda_stream")):
+                callsite_stream.write(
+                    'int __dace_current_stream_id = %d;\n%sStream_t __dace_current_stream = __state->gpu_context->streams[__dace_current_stream_id];'
+                    %
+                    (node._cuda_stream, Config.get('compiler', 'cuda', 'backend')),
+                    sdfg,
+                    state_id,
+                    node,
+                )
+            else:
+                callsite_stream.write(
+                    '%sStream_t __dace_current_stream = nullptr;' %
+                    Config.get('compiler', 'cuda', 'backend'),
+                    sdfg,
+                    state_id,
+                    node,
+                )
 
         if node.language != dtypes.Language.CPP:
             raise ValueError(

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -736,8 +736,8 @@ def unparse_tasklet(sdfg, state_id, dfg, node, function_stream, callsite_stream,
         # set the stream to a local variable.
         max_streams = int(
             Config.get("compiler", "cuda", "max_concurrent_streams"))
-        if not is_devicelevel_gpu(sdfg, state_dfg, node):
-            if (max_streams >= 0 and hasattr(node, "_cuda_stream")):
+        if not is_devicelevel_gpu(sdfg, state_dfg, node) and hasattr(node, "_cuda_stream"):
+            if max_streams >= 0:
                 callsite_stream.write(
                     'int __dace_current_stream_id = %d;\n%sStream_t __dace_current_stream = __state->gpu_context->streams[__dace_current_stream_id];'
                     %

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -53,6 +53,7 @@ class CUDACodeGen(TargetCodeGenerator):
     """ GPU (CUDA/HIP) code generator. """
     target_name = 'cuda'
     title = 'CUDA'
+    _in_device_code = False
 
     def __init__(self, frame_codegen, sdfg: SDFG):
         self.backend = Config.get('compiler', 'cuda', 'backend')
@@ -63,7 +64,7 @@ class CUDACodeGen(TargetCodeGenerator):
 
         self.create_grid_barrier = False
         self.extra_nsdfg_args = []
-        self._in_device_code = False
+        CUDACodeGen._in_device_code = False
         self._cpu_codegen = None
         self._block_dims = None
         self._grid_dims = None
@@ -267,7 +268,7 @@ void __dace_exit_cuda({sdfg.name}_t *__state) {{
         if hasattr(node, 'schedule'):  # NOTE: Works on nodes and scopes
             if node.schedule in dtypes.GPU_SCHEDULES:
                 return True
-        if isinstance(node, nodes.NestedSDFG) and self._in_device_code:
+        if isinstance(node, nodes.NestedSDFG) and CUDACodeGen._in_device_code:
             return True
         return False
 
@@ -694,7 +695,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
 
         if (isinstance(src_node, nodes.AccessNode)
                 and isinstance(dst_node, nodes.AccessNode)
-                and not self._in_device_code and
+                and not CUDACodeGen._in_device_code and
             (src_storage
              in [dtypes.StorageType.GPU_Global, dtypes.StorageType.CPU_Pinned]
              or dst_storage
@@ -791,33 +792,34 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                                               'not supported for N-dimensions')
                 else:
                     # Write for-loop headers
-                    for d in range(dims-2):
-                        callsite_stream.write(
-                            f"for (int __copyidx{d} = 0; "
-                            f"__copyidx{d} < {copy_shape[d]};"
-                            f"++__copyidx{d}) {{"
-                        )
+                    for d in range(dims - 2):
+                        callsite_stream.write(f"for (int __copyidx{d} = 0; "
+                                              f"__copyidx{d} < {copy_shape[d]};"
+                                              f"++__copyidx{d}) {{")
                     # Write Memcopy2DAsync
-                    current_src_expr = src_expr + " + " + " + ".join(
-                        ["(__copyidx{} * ({}))".format(d, sym2cpp(s))
-                         for d, s in enumerate(src_strides[:-2])])
-                    current_dst_expr = dst_expr + " + " + "+ " .join(
-                        ["(__copyidx{} * ({}))".format(d, sym2cpp(s))
-                         for d, s in enumerate(dst_strides[:-2])])
+                    current_src_expr = src_expr + " + " + " + ".join([
+                        "(__copyidx{} * ({}))".format(d, sym2cpp(s))
+                        for d, s in enumerate(src_strides[:-2])
+                    ])
+                    current_dst_expr = dst_expr + " + " + "+ ".join([
+                        "(__copyidx{} * ({}))".format(d, sym2cpp(s))
+                        for d, s in enumerate(dst_strides[:-2])
+                    ])
                     callsite_stream.write(
                         '%sMemcpy2DAsync(%s, %s, %s, %s, %s, %s, %sMemcpy%sTo%s, %s);\n'
-                        % (self.backend, current_dst_expr, _topy(dst_strides[-2]) +
-                            ' * sizeof(%s)' % dst_node.desc(sdfg).dtype.ctype,
-                            current_src_expr, sym2cpp(src_strides[-2]) + ' * sizeof(%s)' %
-                            src_node.desc(sdfg).dtype.ctype, sym2cpp(copy_shape[-1]) +
-                            ' * sizeof(%s)' % dst_node.desc(sdfg).dtype.ctype,
-                            sym2cpp(copy_shape[-2]), self.backend, src_location,
-                            dst_location, cudastream), sdfg, state_id,
+                        %
+                        (self.backend, current_dst_expr, _topy(dst_strides[-2])
+                         + ' * sizeof(%s)' % dst_node.desc(sdfg).dtype.ctype,
+                         current_src_expr, sym2cpp(src_strides[-2]) +
+                         ' * sizeof(%s)' % src_node.desc(sdfg).dtype.ctype,
+                         sym2cpp(copy_shape[-1]) +
+                         ' * sizeof(%s)' % dst_node.desc(sdfg).dtype.ctype,
+                         sym2cpp(copy_shape[-2]), self.backend, src_location,
+                         dst_location, cudastream), sdfg, state_id,
                         [src_node, dst_node])
                     # Write for-loop footers
-                    for d in range(dims-2):
+                    for d in range(dims - 2):
                         callsite_stream.write("}")
-
 
             if dims == 1 and not (src_strides[-1] != 1 or dst_strides[-1] != 1):
                 copysize = ' * '.join([
@@ -868,8 +870,8 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                     '%sMemcpy2DAsync(%s, %s, %s, %s, %s, %s, %sMemcpy%sTo%s, %s);\n'
                     % (self.backend, dst_expr, _topy(dst_strides[0]) +
                        ' * sizeof(%s)' % dst_node.desc(sdfg).dtype.ctype,
-                       src_expr, sym2cpp(src_strides[0]) + ' * sizeof(%s)' %
-                       src_node.desc(sdfg).dtype.ctype,
+                       src_expr, sym2cpp(src_strides[0]) +
+                       ' * sizeof(%s)' % src_node.desc(sdfg).dtype.ctype,
                        'sizeof(%s)' % dst_node.desc(sdfg).dtype.ctype,
                        sym2cpp(copy_shape[0]), self.backend, src_location,
                        dst_location, cudastream), sdfg, state_id,
@@ -1024,7 +1026,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
 
     def generate_state(self, sdfg, state, function_stream, callsite_stream):
         # Two modes: device-level state and if this state has active streams
-        if self._in_device_code:
+        if CUDACodeGen._in_device_code:
             self.generate_devicelevel_state(sdfg, state, function_stream,
                                             callsite_stream)
         else:
@@ -1445,9 +1447,10 @@ void  *{kname}_args[] = {{ {kargs} }};
 
         # Invoke kernel call
         callsite_stream.write(
-            '__dace_runkernel_%s(%s);\n' %
-            (kernel_name, ', '.join(['__state'] + list(kernel_args))), sdfg,
-            state_id, scope_entry)
+            '__dace_runkernel_%s(%s);\n' % (kernel_name, ', '.join(
+                ['__state'] +
+                [cpp.ptr(aname, arg) for aname, arg in kernel_args.items()])),
+            sdfg, state_id, scope_entry)
 
         synchronize_streams(sdfg, state, state_id, scope_entry, scope_exit,
                             callsite_stream)
@@ -1691,8 +1694,8 @@ void  *{kname}_args[] = {{ {kargs} }};
                                                       DefinedType.Scalar, 'int')
 
         # Dispatch internal code
-        assert self._in_device_code is False
-        self._in_device_code = True
+        assert CUDACodeGen._in_device_code is False
+        CUDACodeGen._in_device_code = True
         self._kernel_map = node
         self._block_dims = block_dims
         self._grid_dims = grid_dims
@@ -1752,7 +1755,7 @@ void  *{kname}_args[] = {{ {kargs} }};
 
         self._block_dims = None
         self._kernel_map = None
-        self._in_device_code = False
+        CUDACodeGen._in_device_code = False
         self._grid_dims = None
 
     def get_next_scope_entries(self, dfg, scope_entry):
@@ -1777,7 +1780,7 @@ void  *{kname}_args[] = {{ {kargs} }};
     def generate_devicelevel_scope(self, sdfg, dfg_scope, state_id,
                                    function_stream, callsite_stream):
         # Sanity check
-        assert self._in_device_code == True
+        assert CUDACodeGen._in_device_code == True
 
         dfg = sdfg.nodes()[state_id]
         sdict = dfg.scope_dict()
@@ -2148,14 +2151,14 @@ void  *{kname}_args[] = {{ {kargs} }};
             gen(sdfg, dfg, state_id, node, function_stream, callsite_stream)
             return
 
-        if not self._in_device_code:
+        if not CUDACodeGen._in_device_code:
             self._cpu_codegen.generate_node(sdfg, dfg, state_id, node,
                                             function_stream, callsite_stream)
             return
 
         self._locals.clear_scope(self._code_state.indentation + 1)
 
-        if self._in_device_code and isinstance(node, nodes.MapExit):
+        if CUDACodeGen._in_device_code and isinstance(node, nodes.MapExit):
             return  # skip
 
         self._cpu_codegen.generate_node(sdfg, dfg, state_id, node,

--- a/dace/config.py
+++ b/dace/config.py
@@ -1,7 +1,26 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import contextlib
 import os
 import platform
 import yaml
+
+
+@contextlib.contextmanager
+def set_temporary(*path, value):
+    """ Temporarily set configuration value at ``path`` to value, and reset it after the context manager exits.
+
+        :Example:
+
+            print(Config.get("compiler", "build_type")
+            with set_temporary("compiler", "build_type", value=Debug):
+                print(Config.get("compiler", "build_type")
+            print(Config.get("compiler", "build_type")
+
+    """
+    old_value = Config.get(*path)
+    Config.set(*path, value=value)
+    yield
+    Config.set(*path, value=old_value)
 
 
 def _env2bool(envval):
@@ -80,8 +99,7 @@ class Config(object):
         Config._cfg_filename = cfg_filename
 
         dace_path = os.path.dirname(os.path.abspath(__file__))
-        Config._metadata_filename = os.path.join(dace_path,
-                                                 'config_schema.yml')
+        Config._metadata_filename = os.path.join(dace_path, 'config_schema.yml')
 
         # Load configuration schema (for validation and defaults)
         Config.load_schema()

--- a/dace/config.py
+++ b/dace/config.py
@@ -12,7 +12,7 @@ def set_temporary(*path, value):
         :Example:
 
             print(Config.get("compiler", "build_type")
-            with set_temporary("compiler", "build_type", value=Debug):
+            with set_temporary("compiler", "build_type", value="Debug"):
                 print(Config.get("compiler", "build_type")
             print(Config.get("compiler", "build_type")
 

--- a/dace/data.py
+++ b/dace/data.py
@@ -622,3 +622,8 @@ class View(Array):
         if self.lifetime != dtypes.AllocationLifetime.Scope:
             raise ValueError('Only Scope allocation lifetime is supported for '
                              'Views')
+
+    def as_array(self):
+        copy = cp.deepcopy(self)
+        copy.__class__ = Array
+        return copy

--- a/dace/libraries/blas/blas_helpers.py
+++ b/dace/libraries/blas/blas_helpers.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import numpy as np
-from dace import dtypes
+from dace import dtypes, data
 from dace.data import Array
 from typing import Any, Dict, Tuple
 
@@ -164,3 +164,15 @@ def get_gemm_opts(a_strides, b_strides, c_strides) -> Dict[str, Any]:
         raise Exception("sCM or sCN should be 1")
 
     return opts[optA + optB + optC]
+
+
+def check_access(schedule: dtypes.ScheduleType, *descs: data.Data):
+    """ If schedule cannot access all passed descriptors, through an error.
+
+        :param schedule: the schedule.
+        :param descs: the descriptors to check.
+    """
+    for desc in descs:
+        if not dtypes.can_access(schedule, desc.storage):
+            raise ValueError(
+                f"Schedule mismatch: {schedule} cannot access {desc.storage}")

--- a/dace/libraries/blas/environments/intel_mkl.py
+++ b/dace/libraries/blas/environments/intel_mkl.py
@@ -56,7 +56,7 @@ class IntelMKL:
             prefix = Config.get('compiler', 'library_prefix')
             suffix = Config.get('compiler', 'library_extension')
             libfile = os.path.join(os.environ['MKLROOT'], 'lib',
-                                   prefix + 'mkl_rt' + suffix)
+                                   prefix + 'mkl_rt.' + suffix)
             if os.path.isfile(libfile):
                 return [libfile]
 

--- a/dace/libraries/blas/nodes/batched_matmul.py
+++ b/dace/libraries/blas/nodes/batched_matmul.py
@@ -255,6 +255,7 @@ class ExpandBatchedMatMulCuBLAS(ExpandTransformation):
                 else:
                     dcopy = dc(desc)
                 dcopy.transient = False
+                dcopy.lifetime = dtypes.AllocationLifetime.Scope
                 dcopy_gpu = dc(dcopy)
                 nsdfg.add_datadesc(name, dcopy)
                 dcopy_gpu.transient = True

--- a/dace/libraries/blas/nodes/batched_matmul.py
+++ b/dace/libraries/blas/nodes/batched_matmul.py
@@ -255,8 +255,8 @@ class ExpandBatchedMatMulCuBLAS(ExpandTransformation):
                 else:
                     dcopy = dc(desc)
                 dcopy.transient = False
+                dcopy_gpu = dc(dcopy)
                 nsdfg.add_datadesc(name, dcopy)
-                dcopy_gpu = dc(desc)
                 dcopy_gpu.transient = True
                 dcopy_gpu.storage = dace.StorageType.GPU_Global
                 nsdfg.add_datadesc(name + '_gpu', dcopy_gpu)

--- a/dace/libraries/blas/nodes/batched_matmul.py
+++ b/dace/libraries/blas/nodes/batched_matmul.py
@@ -1,14 +1,13 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 from copy import deepcopy as dc
-from dace import dtypes
+from dace import dtypes, data as dt
 from typing import Any, Dict, Optional
-from dace.data import Array
 from dace.symbolic import symstr
 import dace.library
 import dace.properties
 import dace.sdfg.nodes
 from dace.transformation.transformation import ExpandTransformation
-from dace.libraries.blas.blas_helpers import (to_blastype, get_gemm_opts)
+from dace.libraries.blas.blas_helpers import (to_blastype, get_gemm_opts, check_access)
 from dace.libraries.blas.nodes.matmul import (_get_matmul_operands,
                                               _get_batchmm_opts,
                                               _get_codegen_gemm_opts)
@@ -122,6 +121,7 @@ class ExpandBatchedMatMulMKL(ExpandTransformation):
          astrides), (_, bdesc, bshape,
                      bstrides), _ = _get_matmul_operands(node, state, sdfg)
         cdesc = sdfg.arrays[state.out_edges(node)[0].data.data]
+        check_access(dtypes.ScheduleType.CPU_Multicore, adesc, bdesc, cdesc)
         dtype = cdesc.dtype.base_type
         func = to_blastype(dtype.type).lower() + 'gemm'
         if dtype == dace.float32:
@@ -178,16 +178,16 @@ class ExpandBatchedMatMulCuBLAS(ExpandTransformation):
             if e.dst_conn == '_a':
                 anode = state.memlet_path(e)[0].src
                 if isinstance(anode, dace.sdfg.nodes.AccessNode):
-                    adesc: Array = sdfg.arrays[anode.data]
+                    adesc: dt.Array = sdfg.arrays[anode.data]
             elif e.dst_conn == '_b':
                 bnode = state.memlet_path(e)[0].src
                 if isinstance(bnode, dace.sdfg.nodes.AccessNode):
-                    bdesc: Array = sdfg.arrays[bnode.data]
+                    bdesc: dt.Array = sdfg.arrays[bnode.data]
         for e in state.out_edges(node):
             if e.src_conn == '_c':
                 cnode = state.memlet_path(e)[-1].dst
                 if isinstance(cnode, dace.sdfg.nodes.AccessNode):
-                    cdesc: Array = sdfg.arrays[cnode.data]
+                    cdesc: dt.Array = sdfg.arrays[cnode.data]
         if not adesc or not bdesc or not cdesc:
             raise ValueError('Unsupported input/output arrays')
 
@@ -250,7 +250,10 @@ class ExpandBatchedMatMulCuBLAS(ExpandTransformation):
                                               language=dace.dtypes.Language.CPP)
 
             for name, desc in [('_a', adesc), ('_b', bdesc), ('_c', cdesc)]:
-                dcopy = dc(desc)
+                if isinstance(desc, dt.View):
+                    dcopy = desc.as_array()
+                else:
+                    dcopy = dc(desc)
                 dcopy.transient = False
                 nsdfg.add_datadesc(name, dcopy)
                 dcopy_gpu = dc(desc)

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -366,9 +366,9 @@ cublasSetPointerMode(__dace_cublas_handle, CUBLAS_POINTER_MODE_DEVICE);
                     dcopy = desc.as_array()
                 else:
                     dcopy = dc(desc)
+                dcopy_gpu = dc(dcopy)
                 dcopy.transient = False
                 nsdfg.add_datadesc(name, dcopy)
-                dcopy_gpu = dc(desc)
                 dcopy_gpu.transient = True
                 dcopy_gpu.storage = dace.StorageType.GPU_Global
                 nsdfg.add_datadesc(name + '_gpu', dcopy_gpu)

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -366,6 +366,7 @@ cublasSetPointerMode(__dace_cublas_handle, CUBLAS_POINTER_MODE_DEVICE);
                     dcopy = desc.as_array()
                 else:
                     dcopy = dc(desc)
+                dcopy.lifetime = dtypes.AllocationLifetime.Scope
                 dcopy_gpu = dc(dcopy)
                 dcopy.transient = False
                 nsdfg.add_datadesc(name, dcopy)

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -9,7 +9,7 @@ from dace import SDFG, SDFGState
 from dace.frontend.common import op_repository as oprepo
 import dace.sdfg.nodes
 from dace.transformation.transformation import ExpandTransformation
-from dace.libraries.blas.blas_helpers import to_blastype, get_gemm_opts
+from dace.libraries.blas.blas_helpers import to_blastype, get_gemm_opts, check_access
 from dace.libraries.blas.nodes.matmul import (_get_matmul_operands,
                                               _get_codegen_gemm_opts)
 from .. import environments
@@ -209,6 +209,8 @@ class ExpandGemmOpenBLAS(ExpandTransformation):
 
         cdesc = sdfg.arrays[state.out_edges(node)[0].data.data]
 
+        check_access(dtypes.ScheduleType.CPU_Multicore, adesc, bdesc, cdesc)
+
         opt = _get_codegen_gemm_opts(node, state, sdfg, adesc, bdesc, cdesc,
                                      alpha, beta, dtype.ctype, func)
 
@@ -275,6 +277,8 @@ class ExpandGemmCuBLAS(ExpandTransformation):
                     cdesc: Array = sdfg.arrays[cnode.data]
         if not adesc or not bdesc or not cdesc:
             raise ValueError('Unsupported input/output arrays')
+
+        check_access(dtypes.ScheduleType.GPU_Default, adesc, bdesc, cdesc)
 
         dtype = adesc.dtype.base_type
         func = '%sgemm' % to_blastype(dtype.type)

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -278,8 +278,6 @@ class ExpandGemmCuBLAS(ExpandTransformation):
         if not adesc or not bdesc or not cdesc:
             raise ValueError('Unsupported input/output arrays')
 
-        check_access(dtypes.ScheduleType.GPU_Default, adesc, bdesc, cdesc)
-
         dtype = adesc.dtype.base_type
         func = '%sgemm' % to_blastype(dtype.type)
         if dtype == dace.float16:

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -167,6 +167,9 @@ class MultiConnectorEdge(MultiEdge, Generic[T]):
     def __len__():
         return 5
 
+    def __repr__(self):
+        return f"{self.src}:{self.src_conn}  -({self.data})->  {self.dst}:{self.dst_conn}"
+
 
 @dace.serialize.serializable
 class Graph(Generic[NodeT, EdgeT]):

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -409,9 +409,10 @@ class InlineSDFG(transformation.Transformation):
         # replacing memlets in outgoing/incoming paths
         modified_edges = set()
         modified_edges |= self._modify_memlet_path(new_incoming_edges, nstate,
-                                                   state, True)
+                                                   state, sink_to_outer, True)
         modified_edges |= self._modify_memlet_path(new_outgoing_edges, nstate,
-                                                   state, False)
+                                                   state, source_to_outer,
+                                                   False)
 
         # Reshape: add connections to viewed data
         self._modify_reshape_data(reshapes, repldict, inputs, nstate, state,

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -403,6 +403,8 @@ class InlineSDFG(transformation.Transformation):
         #######################################################
         # Reconnect inlined SDFG
 
+        source_to_outer = {n: e.src for n, e in new_incoming_edges.items()}
+        sink_to_outer = {n: e.dst for n, e in new_outgoing_edges.items()}
         # If a source/sink node is one of the inputs/outputs, reconnect it,
         # replacing memlets in outgoing/incoming paths
         modified_edges = set()
@@ -499,6 +501,8 @@ class InlineSDFG(transformation.Transformation):
     def _modify_memlet_path(self, new_edges: Dict[nodes.Node,
                                                   MultiConnectorEdge],
                             nstate: SDFGState, state: SDFGState,
+                            inner_to_outer: Dict[nodes.Node,
+                                                 MultiConnectorEdge],
                             inputs: bool) -> Set[MultiConnectorEdge]:
         """ Modifies memlet paths in an inlined SDFG. Returns set of modified
             edges.
@@ -511,11 +515,20 @@ class InlineSDFG(transformation.Transformation):
                 new_memlet = helpers.unsqueeze_memlet(inner_edge.data,
                                                       top_edge.data)
                 if inputs:
+                    if inner_edge.dst in inner_to_outer:
+                        dst = inner_to_outer[inner_edge.dst]
+                    else:
+                        dst = inner_edge.dst
+
                     new_edge = state.add_edge(top_edge.src, top_edge.src_conn,
-                                              inner_edge.dst,
-                                              inner_edge.dst_conn, new_memlet)
+                                              dst, inner_edge.dst_conn,
+                                              new_memlet)
                     mtree = state.memlet_tree(new_edge)
                 else:
+                    if inner_edge.src in inner_to_outer:
+                        # don't add edges twice
+                        continue
+
                     new_edge = state.add_edge(inner_edge.src,
                                               inner_edge.src_conn, top_edge.dst,
                                               top_edge.dst_conn, new_memlet)
@@ -554,8 +567,8 @@ class InlineSDFG(transformation.Transformation):
 @registry.autoregister_params(singlestate=True)
 @make_properties
 class InlineTransients(transformation.Transformation):
-    """ 
-    Inlines all transient arrays that are not used anywhere else into a 
+    """
+    Inlines all transient arrays that are not used anywhere else into a
     nested SDFG.
     """
 
@@ -686,7 +699,7 @@ class InlineTransients(transformation.Transformation):
 
 
 class ASTRefiner(ast.NodeTransformer):
-    """ 
+    """
     Python AST transformer used in ``RefineNestedAccess`` to reduce (refine) the
     subscript ranges based on the specification given in the transformation.
     """
@@ -716,9 +729,9 @@ class ASTRefiner(ast.NodeTransformer):
 @registry.autoregister_params(singlestate=True)
 @make_properties
 class RefineNestedAccess(transformation.Transformation):
-    """ 
+    """
     Reduces memlet shape when a memlet is connected to a nested SDFG, but not
-    using all of the contents. Makes the outer memlet smaller in shape and 
+    using all of the contents. Makes the outer memlet smaller in shape and
     ensures that the offsets in the nested SDFG start with zero.
     This helps with subsequent transformations on the outer SDFGs.
 
@@ -727,12 +740,12 @@ class RefineNestedAccess(transformation.Transformation):
         @dace.program
         def func_a(y):
             return y[1:5] + 1
-        
+
         @dace.program
         def main(x: dace.float32[N]):
             return func_a(x)
 
-    The memlet pointing to ``func_a`` will contain all of ``x`` (``x[0:N]``), 
+    The memlet pointing to ``func_a`` will contain all of ``x`` (``x[0:N]``),
     and it is offset to ``y[1:5]`` in the function, with ``y``'s size being
     ``N``. After the transformation, the memlet connected to the nested SDFG of
     ``func_a`` would contain ``x[1:5]`` directly and the internal ``y`` array

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 from dace.config import set_temporary, Config
 
 
@@ -7,3 +8,6 @@ def test_set_temporary():
     with set_temporary(*path, value="I'm not a build type"):
         assert Config.get(*path) == "I'm not a build type"
     assert Config.get(*path) == current_value
+
+if __name__ == '__main__':
+    test_set_temporary()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,9 @@
+from dace.config import set_temporary, Config
+
+
+def test_set_temporary():
+    path = ["compiler", "build_type"]
+    current_value = Config.get(*path)
+    with set_temporary(*path, value="I'm not a build type"):
+        assert Config.get(*path) == "I'm not a build type"
+    assert Config.get(*path) == current_value

--- a/tests/library/einsum_blas_test.py
+++ b/tests/library/einsum_blas_test.py
@@ -1,0 +1,60 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+"""
+These tests are mostly from daceml, testing that the einsums for the BERT encoder are correctly specialized to BLAS
+nodes.
+"""
+
+import pytest
+import numpy as np
+import dace
+from dace.library import change_default
+from dace.libraries import blas
+
+
+def assert_used_environment(sdfg, impl):
+    implementation_to_env = {"MKL": "IntelMKL", "cuBLAS": "cuBLAS"}
+    all_tasklets = (n for n, _ in sdfg.all_nodes_recursive()
+                    if isinstance(n, dace.nodes.Tasklet))
+    environments = {env for n in all_tasklets for env in n.environments}
+
+    assert implementation_to_env[impl] in environments
+
+
+@pytest.mark.mkl
+def test_gemm_fails_storage_mkl():
+
+    with change_default(blas, "MKL"):
+        with pytest.raises(ValueError) as info:
+
+            @dace.program
+            def test_failing_mkl(A: dace.float32[10, 5], B: dace.float32[5, 3],
+                                 C: dace.float32[10, 3]):
+                C[:] = A @ B
+
+            sdfg = test_failing_mkl.to_sdfg()
+            sdfg.apply_gpu_transformations()
+            A = np.random.rand(10, 5).astype(np.float32)
+            B = np.random.rand(5, 3).astype(np.float32)
+            C = np.zeros((10, 3)).astype(np.float32)
+            sdfg(A=A, B=B, C=C)
+        assert "cannot access" in str(info.value)
+
+
+@pytest.mark.gpu
+def test_gemm_fails_storage_cuda():
+
+    with change_default(blas, "cuBLAS"):
+        with pytest.raises(ValueError) as info:
+
+            @dace.program
+            def test_failing_cublas(A: dace.float32[10, 5],
+                                    B: dace.float32[5, 3], C: dace.float32[10,
+                                                                           3]):
+                C[:] = A @ B
+
+            sdfg = test_failing_cublas.to_sdfg()
+            A = np.random.rand(10, 5).astype(np.float32)
+            B = np.random.rand(5, 3).astype(np.float32)
+            C = np.zeros((10, 3)).astype(np.float32)
+            sdfg(A=A, B=B, C=C)
+        assert "cannot access" in str(info.value)

--- a/tests/library/einsum_blas_test.py
+++ b/tests/library/einsum_blas_test.py
@@ -10,6 +10,22 @@ import dace
 from dace.library import change_default
 from dace.libraries import blas
 
+MKL_AND_CUBLAS = [
+    pytest.param("cuBLAS", marks=pytest.mark.gpu),
+    pytest.param("MKL", marks=pytest.mark.mkl)
+]
+
+
+def test_change_default():
+    old_default = blas.default_implementation
+
+    blas.default_implementation = "hello"
+
+    with change_default(blas, "MKL"):
+        assert blas.default_implementation == "MKL"
+    assert blas.default_implementation == "hello"
+    blas.default_implementation = old_default
+
 
 def assert_used_environment(sdfg, impl):
     implementation_to_env = {"MKL": "IntelMKL", "cuBLAS": "cuBLAS"}
@@ -40,21 +56,82 @@ def test_gemm_fails_storage_mkl():
         assert "cannot access" in str(info.value)
 
 
-@pytest.mark.gpu
-def test_gemm_fails_storage_cuda():
+@pytest.mark.parametrize("impl", MKL_AND_CUBLAS)
+def test_simple(impl):
+    A_desc = dace.float32[10, 5]
+    B_desc = dace.float32[5, 3]
+    C_desc = dace.float32[10, 3]
+    with change_default(blas, impl):
 
-    with change_default(blas, "cuBLAS"):
-        with pytest.raises(ValueError) as info:
+        @dace.program
+        def test_simple_einsum(A: A_desc, B: B_desc, C: C_desc):
+            C[:] = np.einsum("ik,kj->ij", A, B)
 
-            @dace.program
-            def test_failing_cublas(A: dace.float32[10, 5],
-                                    B: dace.float32[5, 3], C: dace.float32[10,
-                                                                           3]):
-                C[:] = A @ B
+        A = np.random.rand(*A_desc.shape).astype(np.float32)
+        B = np.random.rand(*B_desc.shape).astype(np.float32)
+        C = np.zeros(C_desc.shape).astype(np.float32)
 
-            sdfg = test_failing_cublas.to_sdfg()
-            A = np.random.rand(10, 5).astype(np.float32)
-            B = np.random.rand(5, 3).astype(np.float32)
-            C = np.zeros((10, 3)).astype(np.float32)
-            sdfg(A=A, B=B, C=C)
-        assert "cannot access" in str(info.value)
+        sdfg: dace.SDFG = test_simple_einsum.to_sdfg()
+        sdfg.name = impl + "_einsum_simple"
+        if impl == "cuBLAS":
+            sdfg.apply_gpu_transformations()
+        sdfg.expand_library_nodes()
+
+        assert_used_environment(sdfg, impl)
+
+        sdfg(A=A, B=B, C=C)
+        assert np.allclose(A @ B, C)
+
+
+@pytest.mark.parametrize("impl", MKL_AND_CUBLAS)
+def test_3x2(impl):
+    A_desc = dace.float32[8, 10, 12]
+    B_desc = dace.float32[12, 5]
+    C_desc = dace.float32[8, 10, 5]
+    with change_default(blas, impl):
+
+        @dace.program
+        def test_3x2(A: A_desc, B: B_desc, C: C_desc):
+            C[:] = np.einsum("aik,kj->aij", A, B)
+
+        A = np.random.rand(*A_desc.shape).astype(np.float32)
+        B = np.random.rand(*B_desc.shape).astype(np.float32)
+        C = np.zeros(C_desc.shape).astype(np.float32)
+
+        sdfg: dace.SDFG = test_3x2.to_sdfg()
+        sdfg.name = impl + "_einsum_simple"
+        if impl == "cuBLAS":
+            sdfg.apply_gpu_transformations()
+        sdfg.expand_library_nodes()
+
+        assert_used_environment(sdfg, impl)
+
+        sdfg(A=A, B=B, C=C)
+        assert np.allclose(A @ B, C)
+
+
+@pytest.mark.parametrize("impl", MKL_AND_CUBLAS)
+def test_4x4(impl):
+    A_desc = dace.float32[8, 12, 5, 3]
+    B_desc = dace.float32[8, 12, 3, 6]
+    C_desc = dace.float32[8, 12, 5, 6]
+    with change_default(blas, impl):
+
+        @dace.program
+        def test_4x4(A: A_desc, B: B_desc, C: C_desc):
+            C[:] = np.einsum("abik,abkj->abij", A, B)
+
+        A = np.random.rand(*A_desc.shape).astype(np.float32)
+        B = np.random.rand(*B_desc.shape).astype(np.float32)
+        C = np.zeros(C_desc.shape).astype(np.float32)
+
+        sdfg: dace.SDFG = test_4x4.to_sdfg()
+        sdfg.name = impl + "_einsum_simple"
+        if impl == "cuBLAS":
+            sdfg.apply_gpu_transformations()
+        sdfg.expand_library_nodes()
+
+        assert_used_environment(sdfg, impl)
+
+        sdfg(A=A, B=B, C=C)
+        assert np.allclose(A @ B, C)

--- a/tests/library/matmul_cudatest.py
+++ b/tests/library/matmul_cudatest.py
@@ -241,6 +241,7 @@ if __name__ == '__main__':
     try:
         test_batchmm()
         test_types()
+        test_default_stream_blas_node()
         for dl in LAYOUTS:
             test_layouts(dl)
     except SystemExit as ex:

--- a/tests/library/matmul_cudatest.py
+++ b/tests/library/matmul_cudatest.py
@@ -1,5 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
+from dace.config import set_temporary
+from dace.library import change_default
 from dace.memlet import Memlet
 from dace.codegen.exceptions import CompilerConfigurationError, CompilationError
 import dace.libraries.blas as blas
@@ -137,27 +139,25 @@ def _test_matmul(implementation,
 
 @pytest.mark.gpu
 def test_types():
-    old_impl = blas.default_implementation
-    blas.default_implementation = "cuBLAS"
-    # Try different data types
-    _test_matmul('cuBLAS double',
-                 dace.float64,
-                 'cuBLAS',
-                 dace.StorageType.GPU_Global,
-                 eps=1e-6)
-    _test_matmul('cuBLAS half',
-                 dace.float16,
-                 'cuBLAS',
-                 dace.StorageType.GPU_Global,
-                 eps=1)
-    _test_matmul('cuBLAS scmplx', dace.complex64, 'cuBLAS',
-                 dace.StorageType.GPU_Global)
-    _test_matmul('cuBLAS dcmplx',
-                 dace.complex128,
-                 'cuBLAS',
-                 dace.StorageType.GPU_Global,
-                 eps=1e-6)
-    blas.default_implementation = old_impl
+    with change_default(blas, "cuBLAS"):
+        # Try different data types
+        _test_matmul('cuBLAS double',
+                     dace.float64,
+                     'cuBLAS',
+                     dace.StorageType.GPU_Global,
+                     eps=1e-6)
+        _test_matmul('cuBLAS half',
+                     dace.float16,
+                     'cuBLAS',
+                     dace.StorageType.GPU_Global,
+                     eps=1)
+        _test_matmul('cuBLAS scmplx', dace.complex64, 'cuBLAS',
+                     dace.StorageType.GPU_Global)
+        _test_matmul('cuBLAS dcmplx',
+                     dace.complex128,
+                     'cuBLAS',
+                     dace.StorageType.GPU_Global,
+                     eps=1e-6)
 
 
 # Try all data layouts
@@ -167,46 +167,71 @@ LAYOUTS = map(lambda t: ''.join(t), itertools.product(*([['C', 'F']] * 3)))
 @pytest.mark.gpu
 @pytest.mark.parametrize('dl', LAYOUTS)
 def test_layouts(dl):
-    old_impl = blas.default_implementation
-    blas.default_implementation = "cuBLAS"
-    _test_matmul('cuBLAS float ' + dl,
-                 dace.float32,
-                 'cuBLAS',
-                 dace.StorageType.GPU_Global,
-                 data_layout=dl)
-    blas.default_implementation = old_impl
+    with change_default(blas, "cuBLAS"):
+        _test_matmul('cuBLAS float ' + dl,
+                     dace.float32,
+                     'cuBLAS',
+                     dace.StorageType.GPU_Global,
+                     data_layout=dl)
 
 
 @pytest.mark.gpu
 def test_batchmm():
     b, m, n, k = tuple(dace.symbol(k) for k in 'bmnk')
 
-    old_impl = blas.default_implementation
-    blas.default_implementation = "cuBLAS"
+    with change_default(blas, "cuBLAS"):
 
-    @dace.program
-    def bmmtest(A: dace.float64[b, m, k], B: dace.float64[b, k, n],
-                C: dace.float64[b, m, n]):
-        C[:] = A @ B
+        @dace.program
+        def bmmtest(A: dace.float64[b, m, k], B: dace.float64[b, k, n],
+                    C: dace.float64[b, m, n]):
+            C[:] = A @ B
 
-    sdfg = bmmtest.to_sdfg()
-    sdfg.apply_gpu_transformations()
-    csdfg = sdfg.compile()
+        sdfg = bmmtest.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        csdfg = sdfg.compile()
 
-    b, m, n, k = 3, 32, 31, 30
+        b, m, n, k = 3, 32, 31, 30
 
-    x = np.random.rand(b, m, k)
-    y = np.random.rand(b, k, n)
-    z = np.zeros([b, m, n], np.float64)
-    csdfg(A=x, B=y, C=z, b=b, m=m, n=n, k=k)
-
-    blas.default_implementation = old_impl
+        x = np.random.rand(b, m, k)
+        y = np.random.rand(b, k, n)
+        z = np.zeros([b, m, n], np.float64)
+        csdfg(A=x, B=y, C=z, b=b, m=m, n=n, k=k)
 
     ref = x @ y
 
     diff = np.linalg.norm(ref - z)
     print('Difference:', diff)
     assert diff < 1e-6
+
+
+@pytest.mark.gpu
+def test_default_stream_blas_node():
+    A_desc = dace.float32[10, 5]
+    B_desc = dace.float32[5, 3]
+    C_desc = dace.float32[10, 3]
+    with set_temporary("compiler", "cuda", "max_concurrent_streams", value=-1):
+        with change_default(blas, "cuBLAS"):
+
+            @dace.program
+            def test_default_stream_blas_node(A: A_desc, B: B_desc, C: C_desc):
+                C[:] = A @ B
+
+            A = np.random.rand(*A_desc.shape).astype(np.float32)
+            B = np.random.rand(*B_desc.shape).astype(np.float32)
+            C = np.zeros(C_desc.shape).astype(np.float32)
+
+            sdfg: dace.SDFG = test_default_stream_blas_node.to_sdfg()
+            sdfg.apply_gpu_transformations()
+            sdfg.expand_library_nodes()
+
+            all_tasklets = (n for n, _ in sdfg.all_nodes_recursive()
+                            if isinstance(n, dace.nodes.Tasklet))
+            environments = {env for n in all_tasklets for env in n.environments}
+
+            assert "cuBLAS" in environments
+
+            sdfg(A=A, B=B, C=C)
+            assert np.allclose(A @ B, C)
 
 
 ###############################################################################


### PR DESCRIPTION
- Make MKL expansion check their storage types before expanding
- Properly set the ``__dace_cuda_stream`` variable in codegen (in particular when `max_concurrent_streams==-1`)
- Fix einsum to BMM expansion
- Fix accessing persistent GPU global memory in kernels
- Connect src->sink edges in InlineSDFG
- Allow ``init_code`` and ``finalize_code`` properties of environments be callable, they take the sdfg that code is being generated for as an argument.