### PR TITLE
Nesting and Inline fixes

### DIFF
--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -1055,3 +1055,17 @@ class NestSDFG(transformation.Transformation):
             outer_state.add_edge(
                 nested_node, val, arrnode, None,
                 memlet.Memlet.from_array(key, arrnode.desc(outer_sdfg)))
+
+        # Remove from the parent SDFG the symbols that are defined in the nested one
+        defined_syms = set()
+
+        for name, desc in nested_sdfg.arrays.items():
+            defined_syms.add(name)
+
+        for e in nested_sdfg.edges():
+            defined_syms |= set(e.data.new_symbols({}).keys())
+
+        defined_syms |= set(nested_sdfg.constants.keys())
+
+        for s in defined_syms:
+            outer_sdfg.symbols.pop(s, None)

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -79,6 +79,9 @@ class InlineSDFG(transformation.Transformation):
 
         if len(ostrides) == 0:
             ostrides = [1]
+        if len(istrides) == 0:
+            istrides = [1]
+
         if len(ostrides) != len(istrides):
             return False
 
@@ -99,7 +102,6 @@ class InlineSDFG(transformation.Transformation):
             istr.subs(repldict).subs(repldict_inv)
             if symbolic.issymbolic(istr) else istr for istr in istrides
         ]
-
 
         return all(istr == ostr for istr, ostr in zip(istrides, ostrides))
 
@@ -1033,7 +1035,8 @@ class NestSDFG(transformation.Transformation):
                             and src.data == inputs[mem.data]):
                         mem.data = inputs[mem.data]
                     elif (mem.data in outputs.keys()
-                          and (src.data == outputs[mem.data] or dst.data == outputs[mem.data])):
+                          and (src.data == outputs[mem.data]
+                               or dst.data == outputs[mem.data])):
                         mem.data = outputs[mem.data]
                 elif (isinstance(dst, nodes.AccessNode)
                       and mem.data in outputs.keys()

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -1068,4 +1068,7 @@ class NestSDFG(transformation.Transformation):
         defined_syms |= set(nested_sdfg.constants.keys())
 
         for s in defined_syms:
-            outer_sdfg.symbols.pop(s, None)
+            type = outer_sdfg.symbols.pop(s, None)
+            if type is not None:
+                # update or add the symbol in the nested sdfg
+                nested_sdfg.symbols[s] = type

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -72,9 +72,14 @@ class InlineSDFG(transformation.Transformation):
         ostrides = [
             os for i, os in enumerate(outer_strides) if i not in dims_to_ignore
         ]
+
+        istrides = [
+            os for i, os in enumerate(inner_strides) if i not in dims_to_ignore
+        ]
+
         if len(ostrides) == 0:
             ostrides = [1]
-        if len(ostrides) != len(inner_strides):
+        if len(ostrides) != len(istrides):
             return False
 
         # Replace all inner symbols based on symbol mapping
@@ -92,8 +97,9 @@ class InlineSDFG(transformation.Transformation):
 
         istrides = [
             istr.subs(repldict).subs(repldict_inv)
-            if symbolic.issymbolic(istr) else istr for istr in inner_strides
+            if symbolic.issymbolic(istr) else istr for istr in istrides
         ]
+
 
         return all(istr == ostr for istr, ostr in zip(istrides, ostrides))
 


### PR DESCRIPTION
- When inlining, if inner/outer strides are equal, don't check for unsqueezing, that could add unneeded views
- When Nesting, removes from the parent SDFG the symbols that are defined in the nested one