### PR TITLE
RedundantArray transformations copy WCR to new edge and memlet path

### DIFF
--- a/dace/libraries/blas/nodes/matmul.py
+++ b/dace/libraries/blas/nodes/matmul.py
@@ -2,6 +2,7 @@
 import dace
 from copy import deepcopy as dc
 from typing import Any, Dict, Optional
+import warnings
 
 
 def _get_matmul_operands(node,
@@ -93,9 +94,8 @@ def _get_codegen_gemm_opts(node, state, sdfg, adesc, bdesc, cdesc, alpha, beta,
     from dace.codegen.targets.common import sym2cpp
     from dace.libraries.blas.blas_helpers import get_gemm_opts
 
-    (_, _, ashape,
-     astride), (_, _, bshape,
-                bstride), _ = _get_matmul_operands(node, state, sdfg)
+    (_, _, ashape, astride), (_, _, bshape, bstride), (
+        _, _, cshape, cstride) = _get_matmul_operands(node, state, sdfg)
 
     if getattr(node, 'transA', False):
         ashape = list(reversed(ashape))
@@ -104,9 +104,8 @@ def _get_codegen_gemm_opts(node, state, sdfg, adesc, bdesc, cdesc, alpha, beta,
         bshape = list(reversed(bshape))
         bstride = list(reversed(bstride))
 
-    opt = get_gemm_opts(astride, bstride, cdesc.strides)
-    bopt = _get_batchmm_opts(ashape, astride, bshape, bstride, cdesc.shape,
-                             cdesc.strides)
+    opt = get_gemm_opts(astride, bstride, cstride)
+    bopt = _get_batchmm_opts(ashape, astride, bshape, bstride, cshape, cstride)
 
     opt['x'] = '_a'
     opt['y'] = '_b'
@@ -153,10 +152,19 @@ class SpecializeMatMul(dace.transformation.transformation.ExpandTransformation):
         if len(size_a) == 2 and len(size_b) == 2:
             # Matrix and matrix -> GEMM
             from dace.libraries.blas.nodes.gemm import Gemm
+            beta = 0.0
+            if c[0].data.wcr:
+                from dace.frontend import operations
+                redtype = operations.detect_reduction_type(c[0].data.wcr)
+                if redtype == dace.dtypes.ReductionType.Sum:
+                    beta = 1.0
+                else:
+                    warnings.warn("Unsupported WCR in output of MatMul "
+                                  "library node: {}".format(c[0].data.wcr))
             gemm = Gemm(node.name + 'gemm',
                         location=node.location,
                         alpha=1.0,
-                        beta=0.0)
+                        beta=beta)
             return gemm
         elif len(size_b) == 3 and (len(size_a) in [2, 3]):
             # Batched matrix and matrix -> batched matrix multiplication

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -937,12 +937,6 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # Add free state symbols
         for state in self.nodes():
             free_syms |= state.free_symbols
-            # Add defined nested SDFG symbols
-            for n in state.nodes():
-                if isinstance(n, dace.nodes.NestedSDFG):
-                    for s in n.sdfg.symbols:
-                        if s not in n.symbol_mapping.keys():
-                            defined_syms.add(s)
 
         # Add free inter-state symbols
         for e in self.edges():

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -937,6 +937,12 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # Add free state symbols
         for state in self.nodes():
             free_syms |= state.free_symbols
+            # Add defined nested SDFG symbols
+            for n in state.nodes():
+                if isinstance(n, dace.nodes.NestedSDFG):
+                    for s in n.sdfg.symbols:
+                        if s not in n.symbol_mapping.keys():
+                            defined_syms.add(s)
 
         # Add free inter-state symbols
         for e in self.edges():

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -615,13 +615,17 @@ class Range(Subset):
                     else:
                         new_subset.append(rb + rs * other[idx])
         elif (self.data_dims() == 0 and other.data_dims() == 0 and
-                all([r == (0, 0, 1) for r in other.ranges])):
+                all([r == (0, 0, 1) if isinstance(other, Range) else r == 0
+                for r in other])):
             # NOTE: This is a special case where both subsets contain a single
             # element, while the other subset is the (multidimensional) index
             # zero. For example, A[i, j] -> tmp[0]. The result of such a
             # composition should be equal to the first subset. Perhaps this
             # can be generalized.
-            new_subset.extend(self.ranges)
+            if isinstance(other, Range):
+                new_subset.extend(self.ranges)
+            else:
+                new_subset.extend([rb for rb, _, _ in self.ranges])
         else:
             raise ValueError("Dimension mismatch in composition: "
                              "Subset composed must be either completely "

--- a/dace/transformation/dataflow/map_fusion.py
+++ b/dace/transformation/dataflow/map_fusion.py
@@ -222,10 +222,9 @@ class MapFusion(transformation.Transformation):
 
             # Compute output accesses with respect to first map's symbols
             oacc_permuted = [dcpy(a) for a in output_accesses]
-            oacc_permuted = [a.replace(repldict) if a else a
-                             for a in oacc_permuted]
-            oacc_permuted = [a.replace(repldict_inv) if a else a
-                             for a in oacc_permuted]
+            for a in oacc_permuted:
+                a.replace(repldict)
+                a.replace(repldict_inv)
             
             a = input_accesses[0]
             for b in oacc_permuted:

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -332,9 +332,13 @@ class RedundantArray(pm.Transformation):
                 e3.data.data = dname
                 e3.data.subset = subset
                 e3.data.other_subset = other_subset
+                e3.data.wcr = e1.data.wcr
+                e3.data.wcr_nonatomic = e1.data.wcr_nonatomic
 
             # 2-c. Remove edge and add new one
             graph.remove_edge(e2)
+            e2.data.wcr = e1.data.wcr
+            e2.data.wcr_nonatomic = e1.data.wcr_nonatomic
             graph.add_edge(e2.src, e2.src_conn, out_array, e2.dst_conn, e2.data)
 
         # Finally, remove in_array node
@@ -541,8 +545,13 @@ class RedundantSecondArray(pm.Transformation):
                     e3.data.other_subset = other_subset
                 else:
                     e3.data.other_subset = None
+                e3.data.wcr = e1.data.wcr
+                e3.data.wcr_nonatomic = e1.data.wcr_nonatomic
+
             # 2-c. Remove edge and add new one
             graph.remove_edge(e2)
+            e2.data.wcr = e1.data.wcr
+            e2.data.wcr_nonatomic = e1.data.wcr_nonatomic
             graph.add_edge(in_array, e2.src_conn, e2.dst, e2.dst_conn, e2.data)
 
         # Finally, remove out_array node

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -13,6 +13,7 @@ from dace.sdfg import utils as sdutil
 from dace.sdfg import graph
 from dace.transformation import transformation as pm, helpers
 from dace.config import Config
+from networkx.exception import NodeNotFound
 
 # Helper methods #############################################################
 
@@ -230,8 +231,14 @@ class RedundantArray(pm.Transformation):
                 G = helpers.simplify_state(graph)
                 # Loop over the accesses
                 for a in accesses:
-                    has_bward_path = nx.has_path(G, a, out_array)
-                    has_fward_path = nx.has_path(G, out_array, a)
+                    try:
+                        has_bward_path = nx.has_path(G, a, out_array)
+                    except NodeNotFound:
+                        has_bward_path = nx.has_path(graph.nx, a, out_array)
+                    try:
+                        has_fward_path = nx.has_path(G, out_array, a)
+                    except NodeNotFound:
+                        has_fward_path = nx.has_path(graph.nx, out_array, a)
                     # If there is no path between the access nodes (disconnected
                     # components), then it is definitely possible to have data
                     # races. Abort.
@@ -409,8 +416,14 @@ class RedundantSecondArray(pm.Transformation):
                     G = helpers.simplify_state(graph)
                     # Loop over the accesses
                     for a in accesses:
-                        has_bward_path = nx.has_path(G, a, in_array)
-                        has_fward_path = nx.has_path(G, in_array, a)
+                        try:
+                            has_bward_path = nx.has_path(G, a, in_array)
+                        except NodeNotFound:
+                            has_bward_path = nx.has_path(graph.nx, a, in_array)
+                        try:
+                            has_fward_path = nx.has_path(G, in_array, a)
+                        except NodeNotFound:
+                            has_fward_path = nx.has_path(graph.nx, in_array, a)
                         # If there is no path between the access nodes
                         # (disconnected components), then it is definitely
                         # possible to have data races. Abort.

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -139,13 +139,13 @@ def compose_and_push_back(first, second, dims=None, popped=None):
     if dims and popped and len(dims) == len(popped):
         if isinstance(first, subsets.Indices):
             indices = subset.Indices
-            for d, p in zip(dims, popped):
+            for d, p in zip(reversed(dims), reversed(popped)):
                 indices.insert(d, p)
             subset = subsets.Indices(indices)
         else:
             ranges = subset.ranges
             tsizes = subset.tile_sizes
-            for d, (r, t) in zip(dims, popped):
+            for d, (r, t) in zip(reversed(dims), reversed(popped)):
                 ranges.insert(d, r)
                 tsizes.insert(d, t)
             subset = subsets.Range(ranges)


### PR DESCRIPTION
What the title says pretty much. If the matched edge `A ----> B` has WCR, then the new edge `A0 ----> B` or `A ----> B0` (depending on which array is removed) and the corresponding memlet path must inherit the WCR.

I am also addressing in this PR a small bug in MapFusion, an issue with SDFG.free_symbols considering nested SDFG defined symbols to be undefined, and an issue where popped indices in RedundantArray are not pushed back in the correct order, an output shape issue with MatMul (GEMM), and an issue with MatMul output edge having WCR.