### PR TITLE
Support FPGA view

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -223,8 +223,7 @@ def emit_memlet_reference(dispatcher,
                           memlet: mmlt.Memlet,
                           pointer_name: str,
                           conntype: dtypes.typeclass,
-                          ancestor: int = 1,
-                          nodedesc: data = None) -> Tuple[str, str, str]:
+                          ancestor: int = 1) -> Tuple[str, str, str]:
     """
     Returns a tuple of three strings with a definition of a reference to an
     existing memlet. Used in nested SDFG arguments.
@@ -298,10 +297,7 @@ def emit_memlet_reference(dispatcher,
 
         # Device buffers are passed by reference
         expr = datadef
-
-        # if the target variable has storage FPGA Local, then it means that we are on the device
-        # and we can't use references
-        ref = '&' if nodedesc is None or not nodedesc.storage == dace.StorageType.FPGA_Local else ''
+        ref = '&'
     else:
         # Cast as necessary
         expr = make_ptr_vector_cast(datadef + offset_expr, desc.dtype, conntype,

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -301,7 +301,7 @@ def emit_memlet_reference(dispatcher,
 
         # if the target variable has storage FPGA Local, then it means that we are on the device
         # and we can't use references
-        ref = '&' if not nodedesc.storage == dace.StorageType.FPGA_Local else ''
+        ref = '&' if nodedesc is None or not nodedesc.storage == dace.StorageType.FPGA_Local else ''
     else:
         # Cast as necessary
         expr = make_ptr_vector_cast(datadef + offset_expr, desc.dtype, conntype,

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -167,15 +167,10 @@ class CPUCodeGen(TargetCodeGenerator):
         self._generated_nodes.add(node)
         self._locals.clear_scope(self._ldepth + 1)
 
-    def allocate_view(self,
-                      sdfg: SDFG,
-                      dfg: SDFGState,
-                      state_id: int,
-                      node: nodes.AccessNode,
-                      global_stream: CodeIOStream,
+    def allocate_view(self, sdfg: SDFG, dfg: SDFGState, state_id: int,
+                      node: nodes.AccessNode, global_stream: CodeIOStream,
                       declaration_stream: CodeIOStream,
-                      allocation_stream: CodeIOStream,
-                      codegen=None):
+                      allocation_stream: CodeIOStream):
         """
         Allocates (creates pointer and refers to original) a view of an
         existing array, scalar, or view.

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -167,10 +167,15 @@ class CPUCodeGen(TargetCodeGenerator):
         self._generated_nodes.add(node)
         self._locals.clear_scope(self._ldepth + 1)
 
-    def allocate_view(self, sdfg: SDFG, dfg: SDFGState, state_id: int,
-                      node: nodes.AccessNode, global_stream: CodeIOStream,
+    def allocate_view(self,
+                      sdfg: SDFG,
+                      dfg: SDFGState,
+                      state_id: int,
+                      node: nodes.AccessNode,
+                      global_stream: CodeIOStream,
                       declaration_stream: CodeIOStream,
-                      allocation_stream: CodeIOStream):
+                      allocation_stream: CodeIOStream,
+                      codegen=None):
         """
         Allocates (creates pointer and refers to original) a view of an
         existing array, scalar, or view.
@@ -196,10 +201,8 @@ class CPUCodeGen(TargetCodeGenerator):
                                                         name,
                                                         dtypes.pointer(
                                                             nodedesc.dtype),
-                                                        ancestor=0,
-                                                        nodedesc=nodedesc)
+                                                        ancestor=0)
         if declaration_stream == allocation_stream:
-            # Declare and define to guarantee compatibility with OpenCL
             declaration_stream.write(f'{atype} {aname} = {value};', sdfg,
                                      state_id, node)
         else:

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -196,10 +196,12 @@ class CPUCodeGen(TargetCodeGenerator):
                                                         name,
                                                         dtypes.pointer(
                                                             nodedesc.dtype),
-                                                        ancestor=0)
+                                                        ancestor=0,
+                                                        nodedesc=nodedesc)
         if declaration_stream == allocation_stream:
             # Declare and define to guarantee compatibility with OpenCL
-            declaration_stream.write(f'{atype} {aname} = {value};', sdfg, state_id, node)
+            declaration_stream.write(f'{atype} {aname} = {value};', sdfg,
+                                     state_id, node)
         else:
             declaration_stream.write(f'{atype} {aname};', sdfg, state_id, node)
             # Casting is already done in emit_memlet_reference
@@ -297,11 +299,12 @@ class CPUCodeGen(TargetCodeGenerator):
             self._dispatcher.defined_vars.add(name, DefinedType.Stream,
                                               ctypedef)
 
-        elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
-              or (nodedesc.storage == dtypes.StorageType.Register and
-                  ((symbolic.issymbolic(arrsize, sdfg.constants)) or
-                   ((arrsize_bytes > Config.get(
-                       "compiler", "max_stack_array_size")) == True)))):
+        elif (
+                nodedesc.storage == dtypes.StorageType.CPU_Heap or
+            (nodedesc.storage == dtypes.StorageType.Register and
+             ((symbolic.issymbolic(arrsize, sdfg.constants)) or
+              ((arrsize_bytes > Config.get("compiler", "max_stack_array_size"))
+               == True)))):
 
             if nodedesc.storage == dtypes.StorageType.Register:
 
@@ -538,8 +541,8 @@ class CPUCodeGen(TargetCodeGenerator):
             # Writing one index
             if (isinstance(memlet.subset, subsets.Indices)
                     and memlet.wcr is None
-                    and self._dispatcher.defined_vars.get(
-                        vconn)[0] == DefinedType.Scalar):
+                    and self._dispatcher.defined_vars.get(vconn)[0]
+                    == DefinedType.Scalar):
                 stream.write(
                     "%s = %s;" %
                     (vconn,
@@ -562,9 +565,8 @@ class CPUCodeGen(TargetCodeGenerator):
                     if is_array_stream_view(sdfg, dfg, src_node):
                         return  # Do nothing (handled by ArrayStreamView)
 
-                    array_subset = (memlet.subset
-                                    if memlet.data == dst_node.data else
-                                    memlet.other_subset)
+                    array_subset = (memlet.subset if memlet.data
+                                    == dst_node.data else memlet.other_subset)
                     if array_subset is None:  # Need to use entire array
                         array_subset = subsets.Range.from_array(dst_nodedesc)
 

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -197,10 +197,13 @@ class CPUCodeGen(TargetCodeGenerator):
                                                         dtypes.pointer(
                                                             nodedesc.dtype),
                                                         ancestor=0)
-
-        declaration_stream.write(f'{atype} {aname};', sdfg, state_id, node)
-        # Casting is already done in emit_memlet_reference
-        allocation_stream.write(f'{aname} = {value};', sdfg, state_id, node)
+        if declaration_stream == allocation_stream:
+            # Declare and define to guarantee compatibility with OpenCL
+            declaration_stream.write(f'{atype} {aname} = {value};', sdfg, state_id, node)
+        else:
+            declaration_stream.write(f'{atype} {aname};', sdfg, state_id, node)
+            # Casting is already done in emit_memlet_reference
+            allocation_stream.write(f'{aname} = {value};', sdfg, state_id, node)
 
     def allocate_array(self, sdfg, dfg, state_id, node, function_stream,
                        declaration_stream, allocation_stream):

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -398,8 +398,8 @@ class FPGACodeGen(TargetCodeGenerator):
         if isinstance(nodedesc, dace.data.View):
             return self._cpu_codegen.allocate_view(sdfg, dfg, state_id, node,
                                                    function_stream,
-                                                   callsite_stream,
-                                                   callsite_stream)
+                                                   declaration_stream,
+                                                   allocation_stream)
         elif isinstance(nodedesc, dace.data.Stream):
 
             if not self._in_device_code:

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -400,7 +400,9 @@ class FPGACodeGen(TargetCodeGenerator):
         dataname = node.data
 
         if not isinstance(nodedesc, dace.data.Stream):
-            # With the exception of streams, if the variable has been already defined we can return
+            # Unless this is a Stream, if the variable has been already defined we can return
+            # For Streams, we still allocate them to keep track of their names across
+            # nested SDFGs (needed by Intel FPGA backend for channel mangling)
             try:
                 self._dispatcher.defined_vars.get(dataname)
                 return

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -24,6 +24,7 @@ from dace.codegen.tools.type_inference import infer_expr_type
 from dace.frontend.python.astutils import rname, unparse
 from dace.frontend import operations
 from dace.sdfg import find_input_arraynode, find_output_arraynode
+from dace.sdfg import nodes, utils as sdutils
 from dace.sdfg import SDFGState
 import dace.sdfg.utils as utils
 from dace.symbolic import evaluate
@@ -582,7 +583,7 @@ for (int u_{name} = 0; u_{name} < {size} - {veclen}; ++u_{name}) {{
         scalars += [(False, k, v) for k, v in symbol_parameters.items()]
         scalars = list(sorted(scalars, key=lambda t: t[1]))
         for is_output, pname, p in itertools.chain(arrays, scalars):
-            if pname in added:
+            if pname in added or isinstance(p, dace.data.View):
                 continue
             added.add(pname)
             arg = self.make_kernel_argument(p, pname, is_output, True)
@@ -914,6 +915,58 @@ __kernel void \\
                     if p not in node.symbol_mapping.keys():
                         memlet_references.append((typedef, p, p))
         return memlet_references
+
+    def allocate_view(self, sdfg: dace.SDFG, dfg: SDFGState, state_id: int,
+                      node: dace.nodes.AccessNode, global_stream: CodeIOStream,
+                      declaration_stream: CodeIOStream,
+                      allocation_stream: CodeIOStream):
+        """
+        Allocates (creates pointer and refers to original) a view of an
+        existing array, scalar, or view. Specifically tailored for Intel FPGA
+        """
+        name = node.data
+        nodedesc = node.desc(sdfg)
+        if self._dispatcher.defined_vars.has(name):
+            return  # View was already allocated
+
+        # Check directionality of view (referencing dst or src)
+        edge = sdutils.get_view_edge(dfg, node)
+
+        # Allocate the viewed data before the view, if necessary
+        mpath = dfg.memlet_path(edge)
+        viewed_dnode = mpath[0].src if edge.dst is node else mpath[-1].dst
+        self._dispatcher.dispatch_allocate(sdfg, dfg, state_id, viewed_dnode,
+                                           global_stream, allocation_stream)
+
+        # Emit memlet as a reference and register defined variable
+        if nodedesc.storage == dace.dtypes.StorageType.FPGA_Global:
+            # If the viewed (hence the view) node has global storage type, we need to specifically
+            # derive the declaration/definition
+
+            qualifier = "__global volatile "
+            atype = dtypes.pointer(nodedesc.dtype).ctype
+            aname = name
+            viewed_desc = sdfg.arrays[edge.data.data]
+            value = cpp.ptr(edge.data.data, viewed_desc)
+            defined_type, _ = self._dispatcher.defined_vars.get(
+                edge.data.data, 0)
+            # Register defined variable
+            self._dispatcher.defined_vars.add(aname,
+                                              defined_type,
+                                              atype,
+                                              allow_shadowing=True)
+        else:
+            qualifier = ""
+            atype, aname, value = cpp.emit_memlet_reference(self._dispatcher,
+                                                            sdfg,
+                                                            edge.data,
+                                                            name,
+                                                            dtypes.pointer(
+                                                                nodedesc.dtype),
+                                                            ancestor=0,
+                                                            nodedesc=nodedesc)
+        declaration_stream.write(f'{qualifier}{atype} {aname}  = {value};',
+                                 sdfg, state_id, node)
 
     def generate_memlet_definition(self, sdfg, dfg, state_id, src_node,
                                    dst_node, edge, callsite_stream):
@@ -1500,8 +1553,8 @@ class OpenCLDaceKeywordRemover(cpp.DaCeKeywordRemover):
     def visit_BinOp(self, node):
         if node.op.__class__.__name__ == 'Pow':
             # Special case for integer power: do not generate dace namespaces (dace::math) but just call pow
-            if not (isinstance(node.right, (ast.Num, ast.Constant))
-                    and int(node.right.n) == node.right.n and node.right.n >= 0):
+            if not (isinstance(node.right, (ast.Num, ast.Constant)) and int(
+                    node.right.n) == node.right.n and node.right.n >= 0):
                 left_value = cppunparse.cppunparse(self.visit(node.left),
                                                    expr_semicolon=False)
                 right_value = cppunparse.cppunparse(self.visit(node.right),

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -316,7 +316,8 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         redtype = operations.detect_reduction_type(memlet.wcr)
         defined_type, _ = self._dispatcher.defined_vars.get(memlet.data)
         if isinstance(indices, str):
-            ptr = '%s + %s' % (cpp.cpp_ptr_expr(sdfg, memlet, defined_type), indices)
+            ptr = '%s + %s' % (cpp.cpp_ptr_expr(sdfg, memlet,
+                                                defined_type), indices)
         else:
             ptr = cpp.cpp_ptr_expr(sdfg, memlet, defined_type, indices=indices)
 
@@ -794,6 +795,15 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
         else:
             self._cpu_codegen.copy_memory(sdfg, dfg, state_id, src_node,
                                           dst_node, edge, None, callsite_stream)
+
+    def allocate_view(self, sdfg: dace.SDFG, dfg: dace.SDFGState, state_id: int,
+                      node: dace.nodes.AccessNode, global_stream: CodeIOStream,
+                      declaration_stream: CodeIOStream,
+                      allocation_stream: CodeIOStream):
+        return self._cpu_codegen.allocate_view(sdfg, dfg, state_id, node,
+                                               global_stream,
+                                               declaration_stream,
+                                               allocation_stream)
 
     def unparse_tasklet(self, *args, **kwargs):
         # Pass this object for callbacks into the Xilinx codegen

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -14,8 +14,7 @@ def fpga_update(sdfg, state, depth):
         if (isinstance(node, nodes.AccessNode)
                 and node.desc(sdfg).storage == dtypes.StorageType.Default):
             nodedesc = node.desc(sdfg)
-            # Views are transients, hence they should have local storage
-            if depth >= 2 or isinstance(nodedesc, data.View):
+            if depth >= 2:
                 nodedesc.storage = dtypes.StorageType.FPGA_Local
             else:
                 if scope_dict[node]:

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -77,7 +77,7 @@ class FPGATransformState(transformation.Transformation):
                     return False
 
                 # Streams cannot be unbounded on FPGA
-                if ndedesc.buffer_size < 1:
+                if nodedesc.buffer_size < 1:
                     return False
 
         for node in state.nodes():

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -18,6 +18,7 @@ from dace.sdfg import SDFG, SDFGState
 from dace.sdfg import utils as sdutil, infer_types
 from dace.transformation import transformation, helpers
 from dace.properties import make_properties, Property
+from dace import data
 
 
 @registry.autoregister_params(singlestate=True, strict=True)
@@ -997,8 +998,8 @@ class NestSDFG(transformation.Transformation):
                 scope_dict = state.scope_dict()
                 for node in state.nodes():
                     if (isinstance(node, nodes.AccessNode)
-                            and node.desc(nested_sdfg).transient):
-
+                            and node.desc(nested_sdfg).transient and
+                            not isinstance(node.desc(nested_sdfg), data.View)):
                         arrname = node.data
                         if arrname not in transients and not scope_dict[node]:
                             arrobj = nested_sdfg.arrays[arrname]
@@ -1006,7 +1007,6 @@ class NestSDFG(transformation.Transformation):
                             outer_sdfg.arrays[arrname] = dc(arrobj)
                             transients[arrname] = '__' + arrname + '_out'
                         node.data = '__' + arrname + '_out'
-
         for arrname in inputs.keys():
             nested_sdfg.arrays.pop(arrname)
         for arrname in outputs.keys():
@@ -1027,13 +1027,13 @@ class NestSDFG(transformation.Transformation):
                             and src.data == inputs[mem.data]):
                         mem.data = inputs[mem.data]
                     elif (mem.data in outputs.keys()
-                          and (src.data == outputs[mem.data] or dst.data == outputs[mem.data])):
+                          and (src.data == outputs[mem.data]
+                               or dst.data == outputs[mem.data])):
                         mem.data = outputs[mem.data]
                 elif (isinstance(dst, nodes.AccessNode)
                       and mem.data in outputs.keys()
                       and dst.data == outputs[mem.data]):
                     mem.data = outputs[mem.data]
-
         outer_state = outer_sdfg.add_state(outer_sdfg.label)
 
         nested_node = outer_state.add_nested_sdfg(nested_sdfg, outer_sdfg,

--- a/tests/fpga/reshape_view_fpga.py
+++ b/tests/fpga/reshape_view_fpga.py
@@ -158,6 +158,6 @@ def test_reshape_subset():
     assert np.allclose(expected, B)
 
 if __name__ == "__main__":
-    # test_reshape_np()
-    # test_view_fpga_sdfg()
+    test_reshape_np()
+    test_view_fpga_sdfg()
     test_reshape_dst_explicit()

--- a/tests/fpga/reshape_view_fpga.py
+++ b/tests/fpga/reshape_view_fpga.py
@@ -1,0 +1,163 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+""" FPGA Tests for reshaping and reinterpretation of existing arrays.
+    Part of the following tests are based on the ones in numpy/reshape_test.py"""
+import dace
+import numpy as np
+import pytest
+from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG, GPUTransformSDFG, NestSDFG
+
+N = dace.symbol('N')
+
+
+def test_view_fpga_sdfg():
+    '''
+    Manually built FPGA-SDFG with a view: Array -> view -> Array
+    :return:
+    '''
+
+    sdfg = dace.SDFG("view_fpga")
+
+    ###########################################################################
+    # Copy data to FPGA
+
+    copy_in_state = sdfg.add_state("copy_to_device")
+
+    sdfg.add_array('A', [2, 3, 4], dace.float32)
+
+
+    in_host_A = copy_in_state.add_read('A')
+
+    sdfg.add_array("device_A",
+                      shape= [2, 3, 4],
+                      dtype=dace.float32,
+                      storage=dace.dtypes.StorageType.FPGA_Global,
+                      transient=True)
+
+
+
+    in_device_A = copy_in_state.add_write("device_A")
+
+    copy_in_state.add_memlet_path(in_host_A,
+                                  in_device_A,
+                                  memlet=dace.Memlet("A[0:2,0:3,0:4]"))
+    ###########################################################################
+    # Copy data from FPGA
+
+    copy_out_state = sdfg.add_state("copy_from_device")
+    sdfg.add_array('B', [8, 3], dace.float32)
+    sdfg.add_array("device_B",
+                  shape=[8, 3],
+                  dtype=dace.float32,
+                  storage=dace.dtypes.StorageType.FPGA_Global,
+                  transient=True)
+
+    out_device = copy_out_state.add_read("device_B")
+    out_host = copy_out_state.add_write("B")
+
+    copy_out_state.add_memlet_path(out_device,
+                                   out_host,
+                                   memlet=dace.Memlet("B[0:8,0:3]"))
+
+    ########################################################################
+    # FPGA State
+
+    fpga_state = sdfg.add_state("fpga_state")
+
+    sdfg.add_view('Av', [8,3], dace.float32, storage=dace.dtypes.StorageType.FPGA_Global)
+    r = fpga_state.add_read('device_A')
+    v = fpga_state.add_access('Av')
+    w = fpga_state.add_write('device_B')
+    fpga_state.add_nedge(r, v, dace.Memlet(data='device_A'))
+    fpga_state.add_nedge(v, w, dace.Memlet(data='device_B'))
+
+    ######################################
+    # Interstate edges
+    sdfg.add_edge(copy_in_state, fpga_state,
+                         dace.sdfg.sdfg.InterstateEdge())
+    sdfg.add_edge(fpga_state, copy_out_state,
+                         dace.sdfg.sdfg.InterstateEdge())
+
+
+    sdfg.validate()
+
+    ###########################################################################################
+    # Execute
+
+    A = np.random.rand(2, 3, 4).astype(np.float32)
+    B = np.random.rand(8, 3).astype(np.float32)
+    sdfg(A=A, B=B)
+    assert np.allclose(A, np.reshape(B, [2, 3, 4]))
+
+
+def test_reshape_np():
+    '''
+    Dace program with numpy reshape, transformed for FPGA
+    :return:
+    '''
+
+    @dace.program
+    def reshp_np(A: dace.float32[3, 4], B: dace.float32[2, 6]):
+        B[:] = np.reshape(A, [2, 6])
+
+    A = np.random.rand(3, 4).astype(np.float32)
+    B = np.random.rand(2, 6).astype(np.float32)
+
+    sdfg = reshp_np.to_sdfg()
+    sdfg.apply_transformations([FPGATransformSDFG])
+    # sdfg.apply_transformations([GPUTransformSDFG], validate=False)
+    # sdfg.apply_transformations([NestSDFG])
+    sdfg.save('/tmp/out.sdfg')
+    sdfg(A=A, B=B)
+    assert np.allclose(np.reshape(A, [2, 6]), B)
+
+
+
+def test_reshape_dst_explicit():
+    """ Tasklet->View->Array """
+    sdfg = dace.SDFG('reshapedst')
+    sdfg.add_array('A', [2, 3, 4], dace.float64)
+    sdfg.add_view('Bv', [2, 3, 4], dace.float64)
+    sdfg.add_array('B', [8, 3], dace.float64)
+    state = sdfg.add_state()
+
+    me, mx = state.add_map('compute', dict(i='0:2', j='0:3', k='0:4'))
+    t = state.add_tasklet('add', {'a'}, {'b'}, 'b = a + 1')
+    state.add_memlet_path(state.add_read('A'),
+                          me,
+                          t,
+                          dst_conn='a',
+                          memlet=dace.Memlet('A[i,j,k]'))
+    v = state.add_access('Bv')
+    state.add_memlet_path(t,
+                          mx,
+                          v,
+                          src_conn='b',
+                          memlet=dace.Memlet('Bv[i,j,k]'))
+    state.add_nedge(v, state.add_write('B'), dace.Memlet('B'))
+    sdfg.validate()
+
+    A = np.random.rand(2, 3, 4)
+    B = np.random.rand(8, 3)
+    sdfg.apply_transformations([FPGATransformSDFG])
+    sdfg(A=A, B=B)
+    assert np.allclose(A + 1, np.reshape(B, [2, 3, 4]))
+
+def test_reshape_subset():
+    """ Tests reshapes on subsets of arrays. """
+    @dace.program
+    def reshp(A: dace.float64[2, 3, 4], B: dace.float64[12]):
+        C = np.reshape(A[1, :, :], [12])
+        B[:] += C
+
+    A = np.random.rand(2, 3, 4)
+    B = np.random.rand(12)
+    expected = np.reshape(A[1, :, :], [12]) + B
+    sdfg = reshp.to_sdfg()
+    sdfg.apply_transformations([FPGATransformSDFG])
+    sdfg(A, B)
+    assert np.allclose(expected, B)
+
+if __name__ == "__main__":
+    # test_reshape_np()
+    # test_view_fpga_sdfg()
+    test_reshape_dst_explicit()

--- a/tests/intel_fpga_test.sh
+++ b/tests/intel_fpga_test.sh
@@ -138,6 +138,8 @@ run_all() {
     # Constant Type inference
     run_sample intel_fpga/constant_type_inference constant_type_inference "\n"
 
+    # Views
+    run_sample fpga/reshape_view_fpga "\n"
 }
 
 # Check if aoc is vailable

--- a/tests/intel_fpga_test.sh
+++ b/tests/intel_fpga_test.sh
@@ -139,7 +139,7 @@ run_all() {
     run_sample intel_fpga/constant_type_inference constant_type_inference "\n"
 
     # Views
-    run_sample fpga/reshape_view_fpga "\n"
+    run_sample fpga/reshape_view_fpga reshape_view_fpga "\n\n\n"
 }
 
 # Check if aoc is vailable

--- a/tests/xilinx_test.sh
+++ b/tests/xilinx_test.sh
@@ -123,7 +123,7 @@ run_all() {
     run_sample fpga/multiple_veclen_conversions multiple_veclen_conversions 0
 
     # Views
-    run_multi_sample fpga/reshape_view_fpga 0 "view_fpga" "reshp_np_1" "reshape_dst_1"
+    run_multi_sample fpga/reshape_view_fpga 0 "view_fpga" "reshp_np_1" "reshapedst_1"
 }
 
 # Check if xocc is vailable

--- a/tests/xilinx_test.sh
+++ b/tests/xilinx_test.sh
@@ -90,6 +90,9 @@ run_all() {
 
     # Multiple gearboxing
     run_sample fpga/multiple_veclen_conversions multiple_veclen_conversions 0
+
+    # Views
+    run_sample fpga/reshape_view_fpga 0
 }
 
 # Check if xocc is vailable

--- a/tests/xilinx_test.sh
+++ b/tests/xilinx_test.sh
@@ -54,6 +54,37 @@ run_sample() {
     return 0
 }
 
+run_multi_sample(){
+    # Executes a test with multiple Dace programs inside
+    # Args:
+    #  1 - Name of FPGA sample located in samples/fpga
+    #  2 - Boolean flag whether to assert II=1 in all loops
+    #  3-x - Nome of the generated SDFGs
+
+    sdfgs=("${@:3}")
+    TESTS=`expr $TESTS + 1`
+    echo -e "${YELLOW}Running test $1...${NC}"
+    yes | $PYTHON_BINARY $1.py
+    if [ $? -ne 0 ]; then
+      bail "$1 (${RED}simulation failed${NC})"
+      return 1
+    fi
+    for i in "${sdfgs[@]}"; do
+        (cd .dacecache/$i/build && make xilinx_synthesis)
+        if [ $? -ne 0 ]; then
+          bail "$1 (${RED}high-level synthesis failed${NC})"
+          return 1
+        fi
+        if [ $2 -ne 0 ]; then
+          grep -n .dacecache/$2/build/*_hls.log -e "Final II = \([2-9]\|1[0-9]+\)"
+          if [ $? == 0 ]; then
+            bail "$1 (${RED}design was not fully pipelined${NC})"
+          fi
+        fi
+    done
+    return 0
+}
+
 run_all() {
 
     # Args:
@@ -82,17 +113,17 @@ run_all() {
     run_sample fpga/streaming_memory streamingcomp_1 1
 
     ## BLAS
-    run_sample blas/nodes/axpy_test axpy_test_fpga_1_w4_1 1 --target fpga 
+    run_sample blas/nodes/axpy_test axpy_test_fpga_1_w4_1 1 --target fpga
     run_sample blas/nodes/dot_test dot_FPGA_PartialSums_float_w16_1 1 --target xilinx
     run_sample blas/nodes/gemv_test gemv_FPGA_TilesByColumn_float_True_w4_1 1 --target tiles_by_column --transpose --vectorize 4
-    run_sample blas/nodes/gemv_test gemv_FPGA_Accumulate_float_False_w4_1 1 --target accumulate --vectorize 4 
-    run_sample blas/nodes/ger_test ger_test_1 1 --target fpga 
+    run_sample blas/nodes/gemv_test gemv_FPGA_Accumulate_float_False_w4_1 1 --target accumulate --vectorize 4
+    run_sample blas/nodes/ger_test ger_test_1 1 --target fpga
 
     # Multiple gearboxing
     run_sample fpga/multiple_veclen_conversions multiple_veclen_conversions 0
 
     # Views
-    run_sample fpga/reshape_view_fpga 0
+    run_multi_sample fpga/reshape_view_fpga 0 "view_fpga" "reshp_np_1" "reshape_dst_1"
 }
 
 # Check if xocc is vailable


### PR DESCRIPTION
This PR provides adds additional support for views in FPGA (solves #612):
- deals with views while nesting:
    - views are kept as transient
    - their storage type is the same as the viewed node
    - generates proper device code (for example, views with Global storage must not be generated on the host, or appear as kernel parameters)
- special attention for Intel FPGA codegeneration
-  adds tests for view on FPGA