### PR TITLE
Consistent symbols

### DIFF
--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -100,12 +100,12 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
             try:
                 if (rb < 0) == True:
                     rb += array.shape[indices[idx]]
-            except:
+            except (TypeError, ValueError):
                 pass
             try:
                 if (re < 0) == True:
                     re += array.shape[indices[idx]]
-            except:
+            except (TypeError, ValueError):
                 pass
             ndslice[idx] = (rb, re, rs)
             offsets.append(idx)

--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -72,6 +72,13 @@ def _ndslice_to_subset(ndslice):
                 if not is_tuple[i]:
                     ndslice[i] = (ndslice[i], ndslice[i], 1)
         return subsets.Range(ndslice)
+    
+
+def _parse_dim_atom(das, atom):
+    result = pyexpr_to_symbolic(das, atom)
+    if isinstance(result, data.Data):
+        return pystr_to_symbolic(astutils.unparse(atom))
+    return result
 
 
 def _fill_missing_slices(das, ast_ndslice, array, indices):
@@ -85,14 +92,21 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
     has_ellipsis = False
     for dim in ast_ndslice:
         if isinstance(dim, tuple):
-            rb = pyexpr_to_symbolic(das, dim[0] or 0)
-            re = pyexpr_to_symbolic(das, dim[1]
+            rb = _parse_dim_atom(das, dim[0] or 0)
+            re = _parse_dim_atom(das, dim[1]
                                     or array.shape[indices[idx]]) - 1
-            rs = pyexpr_to_symbolic(das, dim[2] or 1)
-            if (rb < 0) == True:
-                rb += array.shape[indices[idx]]
-            if (re < 0) == True:
-                re += array.shape[indices[idx]]
+            rs = _parse_dim_atom(das, dim[2] or 1)
+            # NOTE: try/except for cases where rb/re are not symbols/numbers
+            try:
+                if (rb < 0) == True:
+                    rb += array.shape[indices[idx]]
+            except:
+                pass
+            try:
+                if (re < 0) == True:
+                    re += array.shape[indices[idx]]
+            except:
+                pass
             ndslice[idx] = (rb, re, rs)
             offsets.append(idx)
             idx += 1

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -798,7 +798,7 @@ class TaskletTransformer(ExtNodeTransformer):
             sym_rng = []
             for i, r in enumerate(rng):
                 for s, sr in self.symbols.items():
-                    if s in symbolic.symlist(r).keys():
+                    if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
                         sym_rng.append(sr)
 
@@ -2263,7 +2263,8 @@ class ProgramVisitor(ExtNodeVisitor):
                 integer=integer, nonnegative=nonnegative, positive=positive)
 
             # TODO: What if two consecutive loops use the same symbol?
-            if sym_name in self.symbols.keys():
+            # if sym_name in self.symbols.keys():
+            if sym_obj in self.symbols.keys():
                 warnings.warn("Two for-loops using the same symbol ({}) in the "
                               "same nested SDFG level. This is not officially "
                               "supported (yet).".format(sym_name))
@@ -2272,9 +2273,7 @@ class ProgramVisitor(ExtNodeVisitor):
 
             extra_syms = {sym_name: sym_obj}
 
-            # self.symbols[sym_name] = subsets.Range([(b, "({}) - 1".format(e), s)
-            #                                         for b, e, s in ranges])
-            self.symbols[sym_name] = subsets.Range([(start, stop - 1, step)])
+            self.symbols[sym_obj] = subsets.Range([(start, stop - 1, step)])
 
             # Add range symbols as necessary
             for rng in ranges[0]:
@@ -2901,7 +2900,7 @@ class ProgramVisitor(ExtNodeVisitor):
             sym_rng = []
             for i, r in enumerate(rng):
                 for s, sr in self.symbols.items():
-                    if s in symbolic.symlist(r).keys():
+                    if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
                         sym_rng.append(sr)
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2789,6 +2789,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     if op is not None:
                         memlet.wcr = LambdaProperty.from_string(
                             'lambda x, y: x {} y'.format(op))
+                        memlet.wcr_nonatomic = True
                     state.add_nedge(op1, op2, memlet)
             else:
                 in1_subset = copy.deepcopy(rtarget_subset)

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -3937,6 +3937,8 @@ def reshape(pv: 'ProgramVisitor',
             newshape: Union[str, symbolic.SymbolicType,
                             Tuple[Union[str, symbolic.SymbolicType]]],
             order='C') -> str:
+    if isinstance(arr, (list, tuple)) and len(arr) == 1:
+        arr = arr[0]
     desc = sdfg.arrays[arr]
 
     # "order" determines stride orders

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -181,6 +181,7 @@ class Memlet(object):
         node._other_subset = dcpy(self._other_subset, memo=memo)
         node._data = dcpy(self._data, memo=memo)
         node._wcr = dcpy(self._wcr, memo=memo)
+        node._wcr_nonatomic = dcpy(self._wcr_nonatomic, memo=memo)
         node._debuginfo = dcpy(self._debuginfo, memo=memo)
         node._wcr_nonatomic = self._wcr_nonatomic
         node._allow_oob = self._allow_oob

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -173,9 +173,10 @@ class InterstateEdge(object):
             if new_idx + length < len(condition):
                 if re.match("[A-Za-z0-9_]+$", condition[new_idx + length]):
                     matched = False
+            last_idx, new_idx = new_idx, condition.find(name, new_idx + length)
             if matched:
                 new_condition += new_name
-            last_idx, new_idx = new_idx, condition.find(name, new_idx + length)
+                last_idx += length
         if last_idx < len(condition):
             new_condition += condition[last_idx:]
         self.condition.as_string = new_condition

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -157,29 +157,11 @@ class InterstateEdge(object):
             newv = astutils.unparse(vast)
             if newv != v:
                 self.assignments[k] = newv
-        # condition = self.condition
-        # self.condition.as_string = condition.as_string.replace(name, new_name)
-        # NOTE: Experimental (converting to symbols and back still has issues)
-        condition = self.condition.as_string
-        new_condition = ""
-        length = len(name)
-        last_idx, new_idx = 0, condition.find(name)
-        while new_idx >= 0:
-            matched = True
-            if new_idx - last_idx > 0:
-                new_condition += condition[last_idx:new_idx]
-                if re.match("[A-Za-z0-9_]+$", condition[new_idx - 1]):
-                    matched = False
-            if new_idx + length < len(condition):
-                if re.match("[A-Za-z0-9_]+$", condition[new_idx + length]):
-                    matched = False
-            last_idx, new_idx = new_idx, condition.find(name, new_idx + length)
-            if matched:
-                new_condition += new_name
-                last_idx += length
-        if last_idx < len(condition):
-            new_condition += condition[last_idx:]
-        self.condition.as_string = new_condition
+        condition = ast.parse(self.condition.as_string)
+        condition = astutils.ASTFindReplace({name: new_name}).visit(condition)
+        newc = astutils.unparse(condition)
+        if newc != condition:
+            self.condition.as_string = newc
 
     def new_symbols(self, symbols) -> Dict[str, dtypes.typeclass]:
         """

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -157,8 +157,28 @@ class InterstateEdge(object):
             newv = astutils.unparse(vast)
             if newv != v:
                 self.assignments[k] = newv
-        condition = self.condition
-        self.condition.as_string = condition.as_string.replace(name, new_name)
+        # condition = self.condition
+        # self.condition.as_string = condition.as_string.replace(name, new_name)
+        # NOTE: Experimental (converting to symbols and back still has issues)
+        condition = self.condition.as_string
+        new_condition = ""
+        length = len(name)
+        last_idx, new_idx = 0, condition.find(name)
+        while new_idx >= 0:
+            matched = True
+            if new_idx - last_idx > 0:
+                new_condition += condition[last_idx:new_idx]
+                if re.match("[A-Za-z0-9_]+$", condition[new_idx - 1]):
+                    matched = False
+            if new_idx + length < len(condition):
+                if re.match("[A-Za-z0-9_]+$", condition[new_idx + length]):
+                    matched = False
+            if matched:
+                new_condition += new_name
+            last_idx, new_idx = new_idx, condition.find(name, new_idx + length)
+        if last_idx < len(condition):
+            new_condition += condition[last_idx:]
+        self.condition.as_string = new_condition
 
     def new_symbols(self, symbols) -> Dict[str, dtypes.typeclass]:
         """

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -3,10 +3,11 @@
 import copy
 from dace.dtypes import StorageType
 import os
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 import warnings
 
 from dace import dtypes
+from dace import symbolic
 
 ###########################################
 # Validation
@@ -523,10 +524,11 @@ def validate_state(state: 'dace.sdfg.SDFGState',
              and isinstance(sdfg.arrays[src_node.data], dt.Stream)) or
             (isinstance(dst_node, nd.AccessNode)
              and isinstance(sdfg.arrays[dst_node.data], dt.Stream))):
-            if (e.data.src_subset.num_elements() *
-                    sdfg.arrays[src_node.data].veclen !=
-                    e.data.dst_subset.num_elements() *
-                    sdfg.arrays[dst_node.data].veclen):
+            src_expr = (e.data.src_subset.num_elements() *
+                        sdfg.arrays[src_node.data].veclen)
+            dst_expr = (e.data.dst_subset.num_elements() *
+                        sdfg.arrays[dst_node.data].veclen)
+            if symbolic.inequal_symbols(src_expr, dst_expr):
                 raise InvalidSDFGEdgeError(
                     'Dimensionality mismatch between src/dst subsets', sdfg,
                     state_id, eid)

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -617,14 +617,13 @@ class Range(Subset):
                              rs * other[idx][2], rt))
                     else:
                         new_subset.append(rb + rs * other[idx])
-        elif (self.data_dims() == 0 and other.data_dims() == 0 and
+        elif (other.data_dims() == 0 and
                 all([r == (0, 0, 1) if isinstance(other, Range) else r == 0
                 for r in other])):
-            # NOTE: This is a special case where both subsets contain a single
-            # element, while the other subset is the (multidimensional) index
-            # zero. For example, A[i, j] -> tmp[0]. The result of such a
-            # composition should be equal to the first subset. Perhaps this
-            # can be generalized.
+            # NOTE: This is a special case where the other subset is the
+            # (potentially multidimensional) index zero.
+            # For example, A[i, j] -> tmp[0]. The result of such a
+            # composition should be equal to the first subset.
             if isinstance(other, Range):
                 new_subset.extend(self.ranges)
             else:

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -216,6 +216,10 @@ class Range(Subset):
 
     def num_elements(self):
         return reduce(sp.Mul, self.size(), 1)
+    
+    def num_elements_true(self):
+        # return reduce(sp.Mul, self.bounding_box_size(), 1)
+        return reduce(sp.Mul, self.size(), 1)
 
     def size(self, for_codegen=False):
         """ Returns the number of elements in each dimension. """
@@ -770,6 +774,9 @@ class Indices(Subset):
         return hash(tuple(i for i in self.indices))
 
     def num_elements(self):
+        return 1
+    
+    def num_elements_true(self):
         return 1
 
     def bounding_box_size(self):

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -217,9 +217,8 @@ class Range(Subset):
     def num_elements(self):
         return reduce(sp.Mul, self.size(), 1)
     
-    def num_elements_true(self):
-        # return reduce(sp.Mul, self.bounding_box_size(), 1)
-        return reduce(sp.Mul, self.size(), 1)
+    def num_elements_exact(self):
+        return reduce(sp.Mul, self.bounding_box_size(), 1)
 
     def size(self, for_codegen=False):
         """ Returns the number of elements in each dimension. """
@@ -776,7 +775,7 @@ class Indices(Subset):
     def num_elements(self):
         return 1
     
-    def num_elements_true(self):
+    def num_elements_exact(self):
         return 1
 
     def bounding_box_size(self):

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -832,8 +832,9 @@ def _sunpickle(obj):
 
 
 class SympyAwarePickler(pickle.Pickler):
-    """ Custom Pickler class that safely saves SymPy expressions
-        with function definitions in expressions (e.g., int_ceil).
+    """
+    Custom Pickler class that safely saves SymPy expressions
+    with function definitions in expressions (e.g., int_ceil).
     """
     def persistent_id(self, obj):
         if isinstance(obj, sympy.Basic):
@@ -845,8 +846,9 @@ class SympyAwarePickler(pickle.Pickler):
 
 
 class SympyAwareUnpickler(pickle.Unpickler):
-    """ Custom Unpickler class that safely restores SymPy expressions
-        with function definitions in expressions (e.g., int_ceil).
+    """
+    Custom Unpickler class that safely restores SymPy expressions
+    with function definitions in expressions (e.g., int_ceil).
     """
     def persistent_load(self, pid):
         type_tag, value = pid
@@ -857,9 +859,10 @@ class SympyAwareUnpickler(pickle.Unpickler):
     
 
 def equalize_symbol(sym: sympy.Expr) -> sympy.Expr:
-    """ If a symbol or symbolic expressions has multiple symbols with the same
-        name, it substitutes them with the last symbol (as they appear in
-        s.free_symbols).
+    """
+    If a symbol or symbolic expressions has multiple symbols with the same
+    name, it substitutes them with the last symbol (as they appear in
+    s.free_symbols).
     """
     symdict = {s.name: s for s in sym.free_symbols}
     repldict = {s: symdict[s.name] for s in sym.free_symbols}
@@ -868,9 +871,10 @@ def equalize_symbol(sym: sympy.Expr) -> sympy.Expr:
 
 def equalize_symbols(a: sympy.Expr, b: sympy.Expr) -> Tuple[sympy.Expr,
                                                             sympy.Expr]:
-    """ If the 2 input expressions use different symbols but with the same name,
-        it substitutes the symbols of the second expressions with those of the
-        first expression.
+    """
+    If the 2 input expressions use different symbols but with the same name,
+    it substitutes the symbols of the second expressions with those of the
+    first expression.
     """
     a = equalize_symbol(a)
     b = equalize_symbol(b)
@@ -887,10 +891,15 @@ def equalize_symbols(a: sympy.Expr, b: sympy.Expr) -> Tuple[sympy.Expr,
 
 def inequal_symbols(a: Union[sympy.Expr, Any],
                     b: Union[sympy.Expr, Any]) -> bool:
-    """ Compares 2 symbolic expressions and returns True if they are not equal.
+    """
+    Compares 2 symbolic expressions and returns True if they are not equal.
     """
     if not isinstance(a, sympy.Expr) or not isinstance(b, sympy.Expr):
         return a != b
     else:
         a, b = equalize_symbols(a, b)
+        # NOTE: We simplify in an attempt to remove inconvenient methods, such
+        # as `ceiling` and `floor`, if the symbol assumptions allow it.
+        # We subtract and compare to zero according to the SymPy documentation
+        # (https://docs.sympy.org/latest/tutorial/gotchas.html).
         return (a - b).simplify() != 0

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 import sympy
 import pickle
 import re
-from typing import Dict, Optional, Set, Union
+from typing import Any, Dict, Optional, Set, Tuple, Union
 import warnings
 import numpy
 
@@ -854,3 +854,43 @@ class SympyAwareUnpickler(pickle.Unpickler):
             return _sunpickle(value)
         else:
             raise pickle.UnpicklingError("unsupported persistent object")
+    
+
+def equalize_symbol(sym: sympy.Expr) -> sympy.Expr:
+    """ If a symbol or symbolic expressions has multiple symbols with the same
+        name, it substitutes them with the last symbol (as they appear in
+        s.free_symbols).
+    """
+    symdict = {s.name: s for s in sym.free_symbols}
+    repldict = {s: symdict[s.name] for s in sym.free_symbols}
+    return sym.subs(repldict)
+
+
+def equalize_symbols(a: sympy.Expr, b: sympy.Expr) -> Tuple[sympy.Expr,
+                                                            sympy.Expr]:
+    """ If the 2 input expressions use different symbols but with the same name,
+        it substitutes the symbols of the second expressions with those of the
+        first expression.
+    """
+    a = equalize_symbol(a)
+    b = equalize_symbol(b)
+    a_syms = {s.name: s for s in a.free_symbols}
+    b_syms = {s.name: s for s in b.free_symbols}
+    common_names = set(a_syms.keys()).intersection(set(b_syms.keys()))
+    if common_names:
+        repldict = dict()
+        for name in common_names:
+            repldict[b_syms[name]] = a_syms[name]
+        b = b.subs(repldict)
+    return a, b
+
+
+def inequal_symbols(a: Union[sympy.Expr, Any],
+                    b: Union[sympy.Expr, Any]) -> bool:
+    """ Compares 2 symbolic expressions and returns True if they are not equal.
+    """
+    if not isinstance(a, sympy.Expr) or not isinstance(b, sympy.Expr):
+        return a != b
+    else:
+        a, b = equalize_symbols(a, b)
+        return (a - b).simplify() != 0

--- a/dace/transformation/dataflow/map_fusion.py
+++ b/dace/transformation/dataflow/map_fusion.py
@@ -3,7 +3,7 @@
 """
 
 from copy import deepcopy as dcpy
-from dace import dtypes, registry, symbolic, subsets
+from dace import data, dtypes, registry, symbolic, subsets
 from dace.sdfg import nodes
 from dace.memlet import Memlet
 from dace.sdfg import replace
@@ -193,17 +193,43 @@ class MapFusion(transformation.Transformation):
 
         # Checking for stencil pattern and common input/output data
         # (after fusing the maps)
-        first_map_inputs = set([e.src.data
+        first_map_inputnodes = {e.src: e.src.data
                                 for e in graph.in_edges(first_map_entry)
-                                if isinstance(e.src, nodes.AccessNode)])
-        second_map_outputs = set([e.dst.data
+                                if isinstance(e.src, nodes.AccessNode)}
+        input_views = set()
+        viewed_inputnodes = dict()
+        for n in first_map_inputnodes.keys():
+            if isinstance(n.desc(sdfg), data.View):
+                input_views.add(n)
+        for v in input_views:
+            del first_map_inputnodes[v]
+            e = sdutil.get_view_edge(graph, v)
+            if e:
+                first_map_inputnodes[e.src] = e.src.data
+                viewed_inputnodes[e.src.data] = v
+        second_map_outputnodes = {e.dst: e.dst.data
                                   for e in graph.out_edges(second_map_exit)
-                                  if isinstance(e.dst, nodes.AccessNode)])
-        common_data = first_map_inputs.intersection(second_map_outputs)
+                                  if isinstance(e.dst, nodes.AccessNode)}
+        output_views = set()
+        viewed_outputnodes = dict()
+        for n in second_map_outputnodes:
+            if isinstance(n.desc(sdfg), data.View):
+                output_views.add(n)
+        for v in output_views:
+            del second_map_outputnodes[v]
+            e = sdutil.get_view_edge(graph, v)
+            if e:
+                second_map_outputnodes[e.dst] = e.dst.data
+                viewed_outputnodes[e.dst.data] = v
+        common_data = set(first_map_inputnodes.values()).intersection(
+            set(second_map_outputnodes.values()))
         if common_data:
+            input_data = [viewed_inputnodes[d].data
+                          if d in viewed_inputnodes.keys() else d
+                          for d in common_data]
             input_accesses = [graph.memlet_path(e)[-1].data.src_subset
                               for e in graph.out_edges(first_map_entry)
-                              if e.data.data in common_data]
+                              if e.data.data in input_data]
             if len(input_accesses) > 1:
                 for i, a in enumerate(input_accesses[:-1]):
                     for b in input_accesses[i+1:]:
@@ -216,9 +242,12 @@ class MapFusion(transformation.Transformation):
                             if r != (0, 0, 1):
                                 return False
 
+            output_data = [viewed_outputnodes[d].data
+                           if d in viewed_outputnodes.keys() else d
+                           for d in common_data]
             output_accesses = [graph.memlet_path(e)[0].data.dst_subset
                                for e in graph.in_edges(second_map_exit)
-                               if e.data.data in common_data]
+                               if e.data.data in output_data]
 
             # Compute output accesses with respect to first map's symbols
             oacc_permuted = [dcpy(a) for a in output_accesses]

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -56,8 +56,8 @@ def _validate_subsets(edge: graph.MultiConnectorEdge,
                 if (src_expr != dst_expr and symbolic.inequal_symbols(
                         src_expr_exact, dst_expr_exact)):
                     raise ValueError(
-                        "Destination subset is missing (src_subset: {}, "
-                        "dst_shape: {}".format(src_subset, desc.shape))
+                        "Source subset is missing (dst_subset: {}, "
+                        "src_shape: {}".format(dst_subset, desc.shape))
             else:
                 src_subset = copy.deepcopy(dst_subset)
                 padding = len(desc.shape) - len(src_subset)

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -82,7 +82,6 @@ def _validate_subsets(edge: graph.MultiConnectorEdge,
             desc = arrays[dst_name]
             if isinstance(desc, data.View) or edge.data.data == src_name:
                 dst_subset = subsets.Range.from_array(desc)
-                src_subset = subsets.Range.from_array(desc)
                 src_expr = src_subset.num_elements()
                 src_expr_exact = src_subset.num_elements_exact()
                 dst_expr = dst_subset.num_elements()


### PR DESCRIPTION
This PR attempts to address the fact that symbols are being converted to string and back to symbols again in the whole DaCe stack. This is a serious issue because important symbolic assumptions are lost. A characteristic example is the NPBench benchmark `stockham_fft` which has symbolic sizes with either powers or logarithms. This sample can only work with the array sizes being explicitly defined as positive integers and the loop-indices implicitly defined as non-negative integers.