### PR TITLE
Fix cudaMemcpy(2D) for strided copies

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -790,7 +790,6 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                     raise NotImplementedError('Copies between CPU and GPU are '
                                               'not supported for N-dimensions')
                 else:
-                    num_for_loops = dims - 2
                     # Write for-loop headers
                     for d in range(dims-2):
                         callsite_stream.write(
@@ -799,11 +798,11 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                             f"++__copyidx{d}) {{"
                         )
                     # Write Memcopy2DAsync
-                    current_src_expr = src_expr + " + " + "+".join(
-                        ["__copyidx{} * {}".format(d, s)
+                    current_src_expr = src_expr + " + " + " + ".join(
+                        ["(__copyidx{} * ({}))".format(d, sym2cpp(s))
                          for d, s in enumerate(src_strides[:-2])])
-                    current_dst_expr = dst_expr + " + " + "+".join(
-                        ["__copyidx{} * {}".format(d, s)
+                    current_dst_expr = dst_expr + " + " + "+ " .join(
+                        ["(__copyidx{} * ({}))".format(d, sym2cpp(s))
                          for d, s in enumerate(dst_strides[:-2])])
                     callsite_stream.write(
                         '%sMemcpy2DAsync(%s, %s, %s, %s, %s, %s, %sMemcpy%sTo%s, %s);\n'

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -423,11 +423,19 @@ namespace dace
             return (T)std::exp(a);
         }
 
+#ifdef __CUDACC__
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T pow(const T& a, const T& b)
+        {
+            return (T)thrust::pow(a, b);
+        }
+#else
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T pow(const T& a, const T& b)
         {
             return (T)std::pow(a, b);
         }
+#endif
 
 #ifndef DACE_XILINX
         static DACE_CONSTEXPR DACE_HDFI int pow(const int& a, const int& b)

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -425,17 +425,16 @@ namespace dace
 
 #ifdef __CUDACC__
         template<typename T>
-        DACE_CONSTEXPR DACE_HDFI T pow(const T& a, const T& b)
+        DACE_CONSTEXPR DACE_HDFI thrust::complex<T> pow(const thrust::complex<T>& a, const thrust::complex<T>& b)
         {
-            return (T)thrust::pow(a, b);
+            return (thrust::complex<T>)thrust::pow(a, b);
         }
-#else
+#endif
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T pow(const T& a, const T& b)
         {
             return (T)std::pow(a, b);
         }
-#endif
 
 #ifndef DACE_XILINX
         static DACE_CONSTEXPR DACE_HDFI int pow(const int& a, const int& b)

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -495,7 +495,11 @@ def sympy_numeric_fix(expr):
         Converts the float constants in a given expression to integers. """
     if not isinstance(expr, sympy.Basic):
         try:
-            if int(expr) == expr:
+            # NOTE: If expr is ~ 1.8e308, i.e. infinity, `numpy.int64(expr)`
+            # will throw OverflowError (which we want).
+            # `int(1.8e308) == expr` evaluates unfortunately to True
+            # because Python has variable-bit integers.
+            if numpy.int64(expr) == expr:
                 return int(expr)
         except OverflowError:
             if expr > 0:

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -494,8 +494,14 @@ def sympy_numeric_fix(expr):
     """ Fix for printing out integers as floats with ".00000000".
         Converts the float constants in a given expression to integers. """
     if not isinstance(expr, sympy.Basic):
-        if int(expr) == expr:
-            return int(expr)
+        try:
+            if int(expr) == expr:
+                return int(expr)
+        except OverflowError:
+            if expr > 0:
+                return sympy.oo
+            else:
+                return -sympy.oo
         return expr
 
     if isinstance(expr, sympy.Number) and expr == int(expr):
@@ -782,6 +788,12 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
 
     def _print_Not(self, expr):
         return '(not (%s))' % self._print(expr.args[0])
+    
+    def _print_Infinity(self, expr):
+        return 'INFINITY'
+    
+    def _print_NegativeInfinity(self, expr):
+        return '-INFINITY'
 
 
 def symstr(sym, arrayexprs: Optional[Set[str]] = None) -> str:

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -301,6 +301,11 @@ class RedundantArray(pm.Transformation):
                 return False
             elif isinstance(out_desc, data.View):
                 # Case Access -> View
+                # If the View points to the Access (and has a different shape?)
+                # then we should (probably) not remove the Access.
+                e = sdutil.get_view_edge(graph, out_array)
+                if e and e.src is in_array and in_desc.shape != out_desc.shape:
+                    return False
                 # Check that the View's immediate successors are Accesses.
                 # Otherwise, the application of the transformation will result
                 # in an ambiguous View.
@@ -622,9 +627,13 @@ class RedundantSecondArray(pm.Transformation):
         if in_desc.storage != out_desc.storage:
             return False
         if type(in_desc) != type(out_desc):
-            # We may proceed only in the case of View -> Access
             if isinstance(in_desc, data.View):
                 # Case View -> Access
+                # If the View points to the Access (and has a different shape?)
+                # then we should (probably) not remove the Access.
+                e = sdutil.get_view_edge(graph, in_array)
+                if e and e.dst is out_array and in_desc.shape != out_desc.shape:
+                    return False
                 # Check that the View's immediate ancestors are Accesses.
                 # Otherwise, the application of the transformation will result
                 # in an ambiguous View.

--- a/tests/copynd_test.py
+++ b/tests/copynd_test.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import dace
 import numpy as np
+import pytest
 
 
 def test():
@@ -158,5 +159,176 @@ def test():
     assert all([diff < 1e-7 for diff in diffs])
 
 
+@pytest.mark.gpu
+def test_gpu():
+    print("==== Program start ====")
+    print('Copy ND tests')
+
+    N = dace.symbol('N')
+    N.set(20)
+
+    sdfg = dace.SDFG('copynd_gpu')
+    state = sdfg.add_state()
+
+    arrays = []
+
+    # Copy 1: sub-2d array to sub-2d array
+    arrays.append(state.add_array('A_' + str(len(arrays)), [N, N],
+                                  dace.float32))
+    arrays.append(state.add_array('A_' + str(len(arrays)), [5, 7],
+                                  dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-2], '5:10, N-7:N'))
+
+    # Copy 2: 1d subset of a 4d array to a 1d array
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N, N, N, N], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N - 1], dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-2], '4,1,1:N,2'))
+
+    # Copy 3: 5d array to 5d array
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [2, 3, 4, 5, 6], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [2, 3, 4, 5, 6], dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-2], '0:2,0:3,0:4,0:5,0:6'))
+
+    # Copy 4: contiguous 1d subset of a 4d array to a 1d array
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N, N, N, N], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N - 1], dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-2], '4,1,2,1:N'))
+
+    # Copy 5: 1d array to a 1d subset of a 4d array
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N - 2], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N, N, N, N], dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-1], '4,1:N-1,1,2'))
+
+    # Copy 6: 4d array to a contiguous 1d subset of a 4d array
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N - 2], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N, N, N, N], dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-1], '4,1,2,1:N-1'))
+
+    # Copy 7: True 4d copy (4d subarray to 4d array)
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N, N, N, N], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N - 5, N - 4, 3, N - 2],
+                        dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2], '5:N,2:N-2,N-10:N-7,1:N-1'))
+
+    # Copy 8: 4d array with a stride to a 1d array
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N, N, N, N], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [N / 2 - 1], dace.float32))
+    state.add_edge(arrays[-2], None, arrays[-1], None,
+                   dace.memlet.Memlet.simple(arrays[-2], '4,1,2,1:N-1:2'))
+
+    # Copy 9: 2d array to a 3d array with an offset
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [3, 40, 40], dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2],
+                                  '20:40, 10:30',
+                                  other_subset_str='2, 10:30, 20:40'))
+    
+    # Copy 10: Copying from 2d array to another 2d array a 1d slice
+    # The src stride is 1, while the dst stride is N
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2],
+                                  '20, 10:30',
+                                  other_subset_str='10:30, 10'))
+    
+    # Copy 11: Copying from 2d array to another 2d array a 1d slice
+    # The src stride is N, while the dst stride is 1
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [40, 40], dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2],
+                                  '10:30, 20',
+                                  other_subset_str='10, 10:30'))
+
+    # Copy 12: (from resnet)
+    # padded[:, 1:H+1, 1:W+1, :] = conv2d(input, conv1)
+    # output shape is (N, H + 2,W + 2, C2)
+    # input shape is (N, H , W, C2)
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [5, 6, 7, 8], dace.float32))
+    arrays.append(
+        state.add_array('A_' + str(len(arrays)), [5, 8, 9, 8], dace.float32))
+    state.add_edge(
+        arrays[-2], None, arrays[-1], None,
+        dace.memlet.Memlet.simple(arrays[-2],
+                                  '0:5, 0:6, 0:7 , 0:8',
+                                  other_subset_str='0:5, 1:7, 1:8, 0:8'))
+
+    array_data = [
+        np.random.rand(*[
+            dace.symbolic.evaluate(s, {N: N.get()}) for s in a.desc(sdfg).shape
+        ]).astype(a.desc(sdfg).dtype.type) for a in arrays
+    ]
+
+    args = {anode.label: adata for anode, adata in zip(arrays, array_data)}
+    args['N'] = N.get()
+    sdfg.apply_gpu_transformations()
+    sdfg(**args)
+
+    N = N.get()
+
+    diffs = [
+        np.linalg.norm(array_data[1] - array_data[0][5:10, N - 7:N]) / 5.0 *
+        7.0,
+        np.linalg.norm(array_data[3] - array_data[2][4, 1, 1:, 2]) / (N - 1),
+        np.linalg.norm(array_data[5] - array_data[4]) / 2.0 * 3 * 4 * 5 * 6,
+        np.linalg.norm(array_data[7] - array_data[6][4, 1, 2, 1:]) / (N - 1),
+        np.linalg.norm(array_data[9][4, 1:N - 1, 1, 2] - array_data[8]) /
+        (N - 2),
+        np.linalg.norm(array_data[11][4, 1, 2, 1:N - 1] - array_data[10]) /
+        (N - 2),
+        np.linalg.norm(array_data[13] -
+                       array_data[12][5:N, 2:N - 2, N - 10:N - 7, 1:N - 1]) /
+        ((N - 5) * (N - 4) * 3 * (N - 2)),
+        np.linalg.norm(array_data[15] - array_data[14][4, 1, 2, 1:(N - 1):2]) /
+        (N / 2 - 1),
+        np.linalg.norm(array_data[17][2, 10:30, 20:40] -
+                       array_data[16][20:40, 10:30]) / 400,
+        np.linalg.norm(array_data[19][10:30, 10] -
+                       array_data[18][20, 10:30]) / 20,
+        np.linalg.norm(array_data[21][10, 10:30] -
+                       array_data[20][10:30, 20]) / 20,
+        np.linalg.norm(array_data[23][:, 1:-1, 1:-1, :] - array_data[22]) / 1680
+    ]
+
+    print('Differences: ', diffs)
+
+    assert all([diff < 1e-7 for diff in diffs])
+
+
 if __name__ == "__main__":
     test()
+    test_gpu()

--- a/tests/transformations/redundant_reshape_views_test.py
+++ b/tests/transformations/redundant_reshape_views_test.py
@@ -1,9 +1,20 @@
 import dace
+import numpy as np
 
 
 @dace.program
 def nested_add1(A: dace.float64[3, 3], B: dace.float64[3, 3]):
     return A + B
+
+
+@dace.program
+def nested_add2(A: dace.float64[9], B: dace.float64[9]):
+    return A + B
+
+
+@dace.program
+def reshape_node(A: dace.float64[9]):
+    return A.reshape([3, 3])
 
 
 def test_inline_reshape_views_work():
@@ -31,5 +42,24 @@ def test_inline_reshape_views_work():
     assert(views == 3)
 
 
+def test_views_between_maps_work():
+    @dace.program
+    def test_inline_reshape_views_work(A: dace.float64[3, 3], B: dace.float64[9]):
+        result = dace.define_local([9], dace.float64)
+        result[:] = nested_add2(A, B)
+        result_reshaped = reshape_node(result)
+
+        return np.transpose(result_reshaped)
+
+
+    sdfg = test_inline_reshape_views_work.to_sdfg(strict=False)
+    sdfg.expand_library_nodes()
+    sdfg.view()
+    sdfg.apply_strict_transformations()
+
+    assert(True)
+
+
 if __name__ == "__main__":
     test_inline_reshape_views_work()
+    test_views_between_maps_work()


### PR DESCRIPTION
This PR addresses the issue of pseudo-2D copies. These are copies where there are elements from only one dimension copied, which is not the last one. Therefore, the stride is greater than 1. These copies must be handled with `cudaMemcpy2D` and not `cudaMemcpy`.