### PR TITLE
FPGA: Gemm libnode expansion

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1003,9 +1003,17 @@ class DaCeKeywordRemover(ExtNodeTransformer):
                                 cppunparse.cppunparse(value,
                                                       expr_semicolon=False),
                             ))
-                        else:
+                        elif var_type != DefinedType.ArrayInterface:
                             newnode = ast.Name(id="%s = %s;" % (
                                 cpp_array_expr(self.sdfg, memlet),
+                                cppunparse.cppunparse(value,
+                                                      expr_semicolon=False),
+                            ))
+                        else:
+                            newnode = ast.Name(id="%s_out[%s] = %s;" % (
+                                memlet.data,
+                                cpp_array_expr(
+                                    self.sdfg, memlet, with_brackets=False),
                                 cppunparse.cppunparse(value,
                                                       expr_semicolon=False),
                             ))

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -1436,7 +1436,9 @@ DACE_EXPORTED void {host_function_name}({kernel_args_opencl}) {{
             if (isinstance(datadesc, dace.data.Array)
                     and (datadesc.storage == dace.StorageType.FPGA_Local
                          or datadesc.storage == dace.StorageType.FPGA_Registers)
-                    and not cpp.is_write_conflicted(dfg, edge)):
+                    and not cpp.is_write_conflicted(dfg, edge)
+                    and self._dispatcher.defined_vars.has(edge.src_conn)):
+
                 self.generate_no_dependence_post(after_memlets_stream, sdfg,
                                                  state_id, node, edge.src_conn)
 

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -1175,10 +1175,12 @@ class FPGACodeGen(TargetCodeGenerator):
                             result, sdfg, state_id, node)
                         self.generate_flatten_loop_post(result, sdfg, state_id,
                                                         node)
-                    # add pragmas for data read/written inside this map
+                    # add pragmas for data read/written inside this map, but only for local arrays
                     for candidate in in_out_data:
-                        self.generate_no_dependence_post(
-                            result, sdfg, state_id, node, candidate)
+                        if sdfg.arrays[
+                                candidate].storage != dace.dtypes.StorageType.FPGA_Global:
+                            self.generate_no_dependence_post(
+                                result, sdfg, state_id, node, candidate)
 
         # Emit internal transient array allocation
         to_allocate = dace.sdfg.local_transients(sdfg, sdfg.node(state_id),

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -379,6 +379,27 @@ def overapproximate(expr):
     return expr
 
 
+def resolve_symbol_to_constant(symb, start_sdfg):
+    """
+    Tries to resolve a symbol to constant, by looking up into SDFG's constants,
+    following nested SDFGs hierarchy if necessary.
+    :param symb: symbol to resolve to constant
+    :param start_sdfg: starting SDFG
+    :return: the constant value if the symbol is resolved, None otherwise
+    """
+    if not issymbolic(symb):
+        return symb
+    else:
+        sdfg = start_sdfg
+        while sdfg is not None:
+            if not issymbolic(symb, sdfg.constants):
+                return evaluate(symb, sdfg.constants)
+            else:
+                sdfg = sdfg.parent_sdfg
+        # can not be resolved
+        return None
+
+
 def symbols_in_ast(tree):
     """ Walks an AST and finds all names, excluding function names. """
     to_visit = list(tree.__dict__.items())
@@ -792,10 +813,10 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
 
     def _print_Not(self, expr):
         return '(not (%s))' % self._print(expr.args[0])
-    
+
     def _print_Infinity(self, expr):
         return 'INFINITY'
-    
+
     def _print_NegativeInfinity(self, expr):
         return '-INFINITY'
 
@@ -872,7 +893,7 @@ class SympyAwareUnpickler(pickle.Unpickler):
             return _sunpickle(value)
         else:
             raise pickle.UnpicklingError("unsupported persistent object")
-    
+
 
 def equalize_symbol(sym: sympy.Expr) -> sympy.Expr:
     """
@@ -885,8 +906,8 @@ def equalize_symbol(sym: sympy.Expr) -> sympy.Expr:
     return sym.subs(repldict)
 
 
-def equalize_symbols(a: sympy.Expr, b: sympy.Expr) -> Tuple[sympy.Expr,
-                                                            sympy.Expr]:
+def equalize_symbols(a: sympy.Expr,
+                     b: sympy.Expr) -> Tuple[sympy.Expr, sympy.Expr]:
     """
     If the 2 input expressions use different symbols but with the same name,
     it substitutes the symbols of the second expressions with those of the
@@ -905,8 +926,8 @@ def equalize_symbols(a: sympy.Expr, b: sympy.Expr) -> Tuple[sympy.Expr,
     return a, b
 
 
-def inequal_symbols(a: Union[sympy.Expr, Any],
-                    b: Union[sympy.Expr, Any]) -> bool:
+def inequal_symbols(a: Union[sympy.Expr, Any], b: Union[sympy.Expr,
+                                                        Any]) -> bool:
     """
     Compares 2 symbolic expressions and returns True if they are not equal.
     """

--- a/tests/fpga/gemm_fpga.py
+++ b/tests/fpga/gemm_fpga.py
@@ -1,0 +1,156 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+
+# Tests GEMM expansions for FPGA
+import dace
+import numpy as np
+import dace.libraries.blas as blas
+
+
+def create_gemm_sdfg(sdfg_name,
+                     alpha,
+                     beta,
+                     A,
+                     B,
+                     C,
+                     dtype,
+                     transA=False,
+                     transB=False,
+                     vec_width=1):
+    '''
+    Build an SDFG that perform the given GEMM operation along the given axis
+    Input data A, B, and C is not vectorized
+    '''
+    sdfg = dace.SDFG(sdfg_name)
+
+    ###########################################################################
+    # Copy data to FPGA
+
+    copy_in_state = sdfg.add_state("copy_to_device")
+    A_shape = A.shape
+    B_shape = B.shape
+    C_shape = C.shape
+    N = A_shape[0]
+    K = A_shape[1]
+    M = B_shape[1]
+    vec_type = dace.vector(dtype, vec_width)
+
+    # Create data containers
+    sdfg.add_array('A', A_shape, dtype)
+    sdfg.add_array("A_device",
+                   shape=A_shape,
+                   dtype=dtype,
+                   storage=dace.dtypes.StorageType.FPGA_Global,
+                   transient=True)
+    sdfg.add_array("B", [K, M / vec_width], dtype=vec_type)
+    sdfg.add_array("B_device", [K, M / vec_width],
+                   dtype=vec_type,
+                   transient=True,
+                   storage=dace.dtypes.StorageType.FPGA_Global)
+
+    sdfg.add_array("C", [N, M / vec_width], dtype=vec_type)
+    sdfg.add_array("C_device", [N, M / vec_width],
+                   dtype=vec_type,
+                   transient=True,
+                   storage=dace.dtypes.StorageType.FPGA_Global)
+
+    # Copy A
+    in_host_A = copy_in_state.add_read("A")
+    in_device_A = copy_in_state.add_write("A_device")
+    copy_in_state.add_memlet_path(in_host_A,
+                                  in_device_A,
+                                  memlet=dace.Memlet(f"A[0:{N}, 0:{K}]"))
+
+    # Copy B
+    in_host_B = copy_in_state.add_read("B")
+    in_device_B = copy_in_state.add_write("B_device")
+    copy_in_state.add_memlet_path(
+        in_host_B,
+        in_device_B,
+        memlet=dace.Memlet(f"B[0:{K}, 0:{M}/{vec_width}]"))
+
+    # Copy C
+    in_host_C = copy_in_state.add_read("C")
+    in_device_C = copy_in_state.add_write("C_device")
+    copy_in_state.add_memlet_path(
+        in_host_C,
+        in_device_C,
+        memlet=dace.Memlet(f"C[0:{N}, 0:{M}/{vec_width}]"))
+
+    ###########################################################################
+    # Copy data from FPGA
+    copy_out_state = sdfg.add_state("copy_from_device")
+
+    out_device = copy_out_state.add_read("C_device")
+    out_host = copy_out_state.add_write("C")
+    copy_out_state.add_memlet_path(
+        out_device,
+        out_host,
+        memlet=dace.Memlet(f"C[0:{N}, 0:{M}//{vec_width}]"))
+
+    ########################################################################
+    # FPGA State
+
+    fpga_state = sdfg.add_state("fpga_state")
+    in_A = fpga_state.add_read("A_device")
+    in_B = fpga_state.add_read("B_device")
+    in_C = fpga_state.add_read("C_device")
+    out_C = fpga_state.add_read("C_device")
+
+    gemm_node = blas.Gemm("gemm",
+                          transA=transA,
+                          transB=transB,
+                          alpha=alpha,
+                          beta=beta)
+    gemm_node.implementation = "FPGA1DSystolic"
+
+    fpga_state.add_memlet_path(in_A,
+                               gemm_node,
+                               dst_conn="_a",
+                               memlet=dace.Memlet(f"A_device[0:{N}, 0:{K}]"))
+    fpga_state.add_memlet_path(
+        in_B,
+        gemm_node,
+        dst_conn="_b",
+        memlet=dace.Memlet(f"B_device[0:{K}, 0:{M}/{vec_width}]"))
+    fpga_state.add_memlet_path(
+        in_C,
+        gemm_node,
+        dst_conn="_cin",
+        memlet=dace.Memlet(f"C_device[0:{N}, 0:{M}/{vec_width}]"))
+    fpga_state.add_memlet_path(
+        gemm_node,
+        out_C,
+        src_conn="_c",
+        memlet=dace.Memlet(f"C_device[0:{N}, 0:{M}/{vec_width}]"))
+
+
+
+    ######################################
+    # Interstate edges
+    sdfg.add_edge(copy_in_state, fpga_state, dace.sdfg.sdfg.InterstateEdge())
+    sdfg.add_edge(fpga_state, copy_out_state, dace.sdfg.sdfg.InterstateEdge())
+    sdfg.save("/tmp/out.sdfg")
+    sdfg.validate()
+
+    return sdfg
+
+
+
+def test_reduce_gemm():
+    A = np.random.rand(128, 128).astype(np.float32)
+    B = np.random.rand(128, 128).astype(np.float32)
+    C = np.random.rand(128, 128).astype(np.float32)
+    sdfg = create_gemm_sdfg("gemm_simple", 1, 1, A, B, C, dace.float32)
+    sdfg.expand_library_nodes()
+    from dace.transformation.interstate import InlineSDFG
+    # sdfg.apply_transformations_repeated([InlineSDFG])
+    sdfg.save("/tmp/fpga.sdfg")
+    # compute ground truth
+    C_regression = A @ B + C
+
+    sdfg(A=A, B=B, C=C)
+
+    assert np.allclose(C, C_regression, atol=1e-6)
+
+if __name__ == "__main__":
+    test_reduce_gemm()

--- a/tests/intel_fpga_test.sh
+++ b/tests/intel_fpga_test.sh
@@ -144,6 +144,9 @@ run_all() {
     # Views
     run_sample fpga/reshape_view_fpga reshape_view_fpga "\n\n\n"
 
+     # Tests that have to run without transform on call:
+     DACE_optimizer_transform_on_call=0
+     run_sample fpga/gemm_fpga gemm_fpga ""
 
 }
 

--- a/tests/intel_fpga_test.sh
+++ b/tests/intel_fpga_test.sh
@@ -122,6 +122,7 @@ run_all() {
     run_sample blas/nodes/gemv_test gemv_fpga_test "\n" --target tiles_by_column --transpose --vectorize 4
     run_sample blas/nodes/gemv_test gemv_FPGA_Accumulate_float_False_w4_1 "\n" --target accumulate --vectorize 4
     run_sample blas/nodes/ger_test ger_test_w8_x16_y32 "\n" --target fpga
+    run_sample fpga/gemm_fpga gemm_fpga ""
 
     ## STD LibNodes
     run_sample fpga/reduce_fpga reduce_fpga "\n\n\n\n"
@@ -143,10 +144,6 @@ run_all() {
 
     # Views
     run_sample fpga/reshape_view_fpga reshape_view_fpga "\n\n\n"
-
-    # Tests that have to run without transform on call:
-    DACE_optimizer_transform_on_call=0
-    run_sample fpga/gemm_fpga gemm_fpga ""
 
 }
 

--- a/tests/intel_fpga_test.sh
+++ b/tests/intel_fpga_test.sh
@@ -144,9 +144,9 @@ run_all() {
     # Views
     run_sample fpga/reshape_view_fpga reshape_view_fpga "\n\n\n"
 
-     # Tests that have to run without transform on call:
-     DACE_optimizer_transform_on_call=0
-     run_sample fpga/gemm_fpga gemm_fpga ""
+    # Tests that have to run without transform on call:
+    DACE_optimizer_transform_on_call=0
+    run_sample fpga/gemm_fpga gemm_fpga ""
 
 }
 

--- a/tests/xilinx_test.sh
+++ b/tests/xilinx_test.sh
@@ -119,6 +119,9 @@ run_all() {
     run_sample blas/nodes/gemv_test gemv_FPGA_Accumulate_float_False_w4_1 1 --target accumulate --vectorize 4
     run_sample blas/nodes/ger_test ger_test_1 1 --target fpga
 
+    # This test contains three SDFGs: full check only the first one for the sake of testing time
+    run_multi_sample fpga/gemm_fpga 1 "gemm_vectorized"
+
     ## STD LibNodes
     run_multi_sample fpga/reduce_fpga 1 "reduction_sum_one_axis" "reduction_sum_all_axis" "reduction_sum_4D" "reduction_max"
 


### PR DESCRIPTION
This PR adds a GEMM expansion for FPGA and some small fixed for Xilinx backend:
- the expansion uses a 1D systolic array architecture, with tunable number of PEs and Tile sizes
- for Xilinx, in the generated code:
    - when writing to an array interface we refer the `_out` array
    - we don't generate useless dep pragmas
