### PR TITLE
Remove FPGA_Registers

### DIFF
--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -241,7 +241,7 @@ DACE_EXPORTED void __dace_exit_intel_fpga({sdfg.name}_t *__state) {{
     def define_local_array(self, var_name, desc, array_size, function_stream,
                            kernel_stream, sdfg, state_id, node):
         vec_type = self.make_vector_type(desc.dtype, False)
-        if desc.storage == dace.dtypes.StorageType.FPGA_Registers:
+        if desc.storage == dace.dtypes.StorageType.Register:
             attributes = " __attribute__((register))"
         else:
             attributes = ""

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -221,7 +221,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         dtype = desc.dtype
         kernel_stream.write("{} {}[{}];\n".format(dtype.ctype, var_name,
                                                   cpp.sym2cpp(array_size)))
-        if desc.storage == dace.dtypes.StorageType.FPGA_Registers:
+        if desc.storage == dace.dtypes.StorageType.Register:
             kernel_stream.write("#pragma HLS ARRAY_PARTITION variable={} "
                                 "complete\n".format(var_name))
         elif desc.storage == dace.dtypes.StorageType.FPGA_Local:

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -32,7 +32,6 @@ class StorageType(aenum.AutoNumberEnum):
     GPU_Shared = ()  #: Shared memory
     FPGA_Global = ()  #: Off-chip global memory (DRAM)
     FPGA_Local = ()  #: On-chip memory (bulk storage)
-    FPGA_Registers = ()  #: On-chip memory (fully partitioned registers)
     FPGA_ShiftRegister = ()  #: Only accessible at constant indices
 
 
@@ -1153,7 +1152,7 @@ def can_access(schedule: ScheduleType, storage: StorageType):
     elif schedule in [ScheduleType.FPGA_Device]:
         return storage in [
             StorageType.FPGA_Local, StorageType.FPGA_Global,
-            StorageType.FPGA_Registers, StorageType.FPGA_ShiftRegister,
+            StorageType.Register, StorageType.FPGA_ShiftRegister,
             StorageType.CPU_Pinned
         ]
     elif schedule == ScheduleType.Sequential:
@@ -1184,7 +1183,7 @@ def can_allocate(storage: StorageType, schedule: ScheduleType):
         ]
 
     # FPGA-local memory
-    if storage in [StorageType.FPGA_Local, StorageType.FPGA_Registers]:
+    if storage in [StorageType.FPGA_Local, StorageType.Register]:
         return schedule == ScheduleType.FPGA_Device
 
     # GPU-local memory

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -618,7 +618,7 @@ to_kernel = data""")
                                dtype=vec_type,
                                shape=[1],
                                transient=True,
-                               storage=dace.dtypes.StorageType.FPGA_Registers)
+                               storage=dace.dtypes.StorageType.Register)
             b_dummy = state.add_access("B_dummy")
             init_tasklet = state.add_tasklet("init_dummy_B", {}, {"init_data"},
                                              "init_data = 0")
@@ -752,7 +752,7 @@ if tm * {T} + m  < {M}  and  n0 * {P} + n1 < {N} :
             sdfg.add_scalar("A_reg",
                             dtype=dtype_a,
                             transient=True,
-                            storage=dace.dtypes.StorageType.FPGA_Registers)
+                            storage=dace.dtypes.StorageType.Register)
             A_reg = state.add_write("A_reg")
             A_reg_init = state.add_access("A_reg")
 
@@ -773,7 +773,7 @@ if tm * {T} + m  < {M}  and  n0 * {P} + n1 < {N} :
                                dtype=vec_type,
                                shape=[1],
                                transient=True,
-                               storage=dace.dtypes.StorageType.FPGA_Registers)
+                               storage=dace.dtypes.StorageType.Register)
             C_init = state.add_access("C_init")
             C_init_tasklet = state.add_tasklet("C_data_init", {}, {"init_data"},
                                                "init_data = 0")

--- a/dace/libraries/blas/nodes/gemv.py
+++ b/dace/libraries/blas/nodes/gemv.py
@@ -373,7 +373,7 @@ class ExpandGemvFpgaAccumulate(ExpandTransformation):
         # Partial sums
         sdfg.add_array("partial_sums", (num_partial_sums, ),
                        desc_y.dtype,
-                       storage=dace.StorageType.FPGA_Registers,
+                       storage=dace.StorageType.Register,
                        transient=True)
         partial_sum_read = state.add_read("partial_sums")
         partial_sum_write = state.add_access("partial_sums")

--- a/samples/fpga/filter_fpga.py
+++ b/samples/fpga/filter_fpga.py
@@ -75,7 +75,7 @@ def make_nested_sdfg(parent):
     sdfg.add_scalar("outsize_buffer",
                     dtype=dace.uint32,
                     transient=True,
-                    storage=dace.dtypes.StorageType.FPGA_Registers)
+                    storage=dace.dtypes.StorageType.Register)
     sdfg.add_array("outsize_nested", [1],
                    dtype=dace.uint32,
                    storage=dace.dtypes.StorageType.FPGA_Global)

--- a/samples/fpga/filter_fpga_vectorized.py
+++ b/samples/fpga/filter_fpga_vectorized.py
@@ -108,7 +108,7 @@ def make_compute_state(state):
 
     count = state.add_scalar("count",
                              dtype=dace.uint32,
-                             storage=StorageType.FPGA_Registers)
+                             storage=StorageType.Register)
 
     # Inline Vivado HLS code
     code = """\
@@ -279,7 +279,7 @@ def make_write_sdfg():
     i_write_zero = loop_begin.add_scalar("i_write",
                                          dtype=dace.dtypes.uint32,
                                          transient=True,
-                                         storage=StorageType.FPGA_Registers)
+                                         storage=StorageType.Register)
     zero_tasklet = loop_begin.add_tasklet("zero", {}, {"i_write_out"},
                                           "i_write_out = 0")
     loop_begin.add_memlet_path(zero_tasklet,
@@ -319,11 +319,11 @@ def make_write_sdfg():
     i_write_in = state.add_scalar("i_write",
                                   dtype=dace.dtypes.uint32,
                                   transient=True,
-                                  storage=StorageType.FPGA_Registers)
+                                  storage=StorageType.Register)
     i_write_out = state.add_scalar("i_write",
                                    dtype=dace.dtypes.uint32,
                                    transient=True,
-                                   storage=StorageType.FPGA_Registers)
+                                   storage=StorageType.Register)
 
     tasklet = state.add_tasklet(
         "write", {"b_in", "valid_in", "i_write_in"}, {"b_out", "i_write_out"},

--- a/samples/fpga/gemm_systolic_vectorized.py
+++ b/samples/fpga/gemm_systolic_vectorized.py
@@ -205,7 +205,7 @@ def make_compute(sdfg, state, vec_width=1):
     sdfg.add_scalar("A_reg",
                     dtype=dace.float32,
                     transient=True,
-                    storage=dace.dtypes.StorageType.FPGA_Registers)
+                    storage=dace.dtypes.StorageType.Register)
     A_reg = state.add_write("A_reg")
 
     # For C result we are going to use vectorized data type

--- a/samples/fpga/jacobi_fpga_stream.py
+++ b/samples/fpga/jacobi_fpga_stream.py
@@ -143,31 +143,31 @@ def make_compute_sdfg():
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_buffer_out = pre_shift.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_compute_in = loop_body.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_shift_in = post_shift.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_shift_out = post_shift.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
 
     code = """\

--- a/samples/fpga/jacobi_fpga_systolic.py
+++ b/samples/fpga/jacobi_fpga_systolic.py
@@ -141,31 +141,31 @@ def make_compute_sdfg():
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_buffer_out = pre_shift.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_compute_in = loop_body.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_shift_in = post_shift.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
     window_shift_out = post_shift.add_array(
         "sliding_window", (3, 3),
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers,
+        storage=dace.dtypes.StorageType.Register,
         lifetime=dace.dtypes.AllocationLifetime.SDFG)
 
     code = """\

--- a/samples/fpga/matrix_multiplication_systolic.py
+++ b/samples/fpga/matrix_multiplication_systolic.py
@@ -162,7 +162,7 @@ def make_compute(sdfg, state):
     sdfg.add_scalar("A_reg",
                     dtype=dace.float32,
                     transient=True,
-                    storage=dace.dtypes.StorageType.FPGA_Registers)
+                    storage=dace.dtypes.StorageType.Register)
     A_reg = state.add_write("A_reg")
     sdfg.add_array("C_buffer", [M],
                    dtype=dace.float32,

--- a/samples/fpga/spmv_fpga.py
+++ b/samples/fpga/spmv_fpga.py
@@ -93,7 +93,7 @@ def make_nested_sdfg(parent):
         "b_buffer",
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
+        storage=dace.dtypes.StorageType.Register)
     set_zero_tasklet = set_zero_state.add_tasklet("set_zero", {}, {"b_out"},
                                                   "b_out = 0")
     set_zero_state.add_memlet_path(set_zero_tasklet,
@@ -107,9 +107,9 @@ def make_nested_sdfg(parent):
         "b_buffer",
         dtype,
         transient=True,
-        storage=dace.dtypes.StorageType.FPGA_Registers)
+        storage=dace.dtypes.StorageType.Register)
     write_back_b = write_back_state.add_scalar(
-        "b_write", dtype, storage=dace.dtypes.StorageType.FPGA_Registers)
+        "b_write", dtype, storage=dace.dtypes.StorageType.Register)
     write_back_state.add_memlet_path(write_back_b_buffer,
                                      write_back_b,
                                      memlet=dace.memlet.Memlet.simple(
@@ -130,7 +130,7 @@ def make_nested_sdfg(parent):
 
     x_in = state.add_scalar("x_in",
                             dtype,
-                            storage=dace.dtypes.StorageType.FPGA_Registers,
+                            storage=dace.dtypes.StorageType.Register,
                             transient=True)
 
     compute_tasklet = state.add_tasklet("compute", {"a", "x_val_in"}, {"out"},
@@ -139,13 +139,13 @@ def make_nested_sdfg(parent):
     b_buffer = state.add_scalar("b_buffer",
                                 dtype,
                                 transient=True,
-                                storage=dace.dtypes.StorageType.FPGA_Registers)
+                                storage=dace.dtypes.StorageType.Register)
     rowptr = state.add_scalar("row_begin",
                               itype,
-                              storage=dace.dtypes.StorageType.FPGA_Registers)
+                              storage=dace.dtypes.StorageType.Register)
     rowend = state.add_scalar("row_end",
                               itype,
-                              storage=dace.dtypes.StorageType.FPGA_Registers)
+                              storage=dace.dtypes.StorageType.Register)
     a_val = state.add_array("A_val_read", (nnz, ),
                             dtype,
                             storage=dace.dtypes.StorageType.FPGA_Global)
@@ -237,11 +237,11 @@ def make_main_state(sdfg):
 
     rowptr = state.add_scalar("rowptr",
                               itype,
-                              storage=dace.dtypes.StorageType.FPGA_Registers,
+                              storage=dace.dtypes.StorageType.Register,
                               transient=True)
     rowend = state.add_scalar("rowend",
                               itype,
-                              storage=dace.dtypes.StorageType.FPGA_Registers,
+                              storage=dace.dtypes.StorageType.Register,
                               transient=True)
 
     nested_sdfg = make_nested_sdfg(state)

--- a/samples/fpga/spmv_fpga_stream.py
+++ b/samples/fpga/spmv_fpga_stream.py
@@ -176,7 +176,7 @@ def make_iteration_space(sdfg):
     row_end_first = pre_state.add_scalar("row_end",
                                          itype,
                                          transient=True,
-                                         storage=StorageType.FPGA_Registers)
+                                         storage=StorageType.Register)
     row_pipe_first = pre_state.add_stream("row_pipe",
                                           itype,
                                           storage=StorageType.FPGA_Local)
@@ -187,13 +187,13 @@ def make_iteration_space(sdfg):
     row_end_shift = shift_rowptr.add_scalar("row_end",
                                             itype,
                                             transient=True,
-                                            storage=StorageType.FPGA_Registers)
+                                            storage=StorageType.Register)
     row_begin_shift = shift_rowptr.add_scalar(
         "row_begin",
         itype,
         transient=True,
         lifetime=AllocationLifetime.SDFG,
-        storage=StorageType.FPGA_Registers)
+        storage=StorageType.Register)
     shift_rowptr.add_memlet_path(row_end_shift,
                                  row_begin_shift,
                                  memlet=Memlet.simple(row_begin_shift, "0"))
@@ -204,7 +204,7 @@ def make_iteration_space(sdfg):
     row_end = read_rowptr.add_scalar("row_end",
                                      itype,
                                      transient=True,
-                                     storage=StorageType.FPGA_Registers)
+                                     storage=StorageType.Register)
     read_rowptr.add_memlet_path(row_pipe,
                                 row_end,
                                 memlet=Memlet.simple(row_end, "0"))
@@ -234,14 +234,14 @@ def make_compute_nested_sdfg():
 
     a_in = if_state.add_scalar("a_in",
                                dtype,
-                               storage=StorageType.FPGA_Registers)
+                               storage=StorageType.Register)
     x_in = if_state.add_scalar("x_in",
                                dtype,
-                               storage=StorageType.FPGA_Registers)
+                               storage=StorageType.Register)
     b_tmp_out = if_state.add_scalar("b_tmp",
                                     dtype,
                                     transient=True,
-                                    storage=StorageType.FPGA_Registers)
+                                    storage=StorageType.Register)
     tasklet = if_state.add_tasklet("compute", {"_a_in", "_x_in"}, {"_b_out"},
                                    "_b_out = _a_in * _x_in")
     if_state.add_memlet_path(a_in,
@@ -260,10 +260,10 @@ def make_compute_nested_sdfg():
     b_tmp_then_in = then_state.add_scalar("b_tmp",
                                           dtype,
                                           transient=True,
-                                          storage=StorageType.FPGA_Registers)
+                                          storage=StorageType.Register)
     b_then_out = then_state.add_scalar("b_out",
                                        dtype,
-                                       storage=StorageType.FPGA_Registers)
+                                       storage=StorageType.Register)
     then_state.add_memlet_path(b_tmp_then_in,
                                b_then_out,
                                memlet=Memlet.simple(b_then_out, "0"))
@@ -271,13 +271,13 @@ def make_compute_nested_sdfg():
     b_tmp_else_in = else_state.add_scalar("b_tmp",
                                           dtype,
                                           transient=True,
-                                          storage=StorageType.FPGA_Registers)
+                                          storage=StorageType.Register)
     b_else_in = else_state.add_scalar("b_in",
                                       dtype,
-                                      storage=StorageType.FPGA_Registers)
+                                      storage=StorageType.Register)
     b_else_out = else_state.add_scalar("b_out",
                                        dtype,
-                                       storage=StorageType.FPGA_Registers)
+                                       storage=StorageType.Register)
     else_tasklet = else_state.add_tasklet("b_wcr", {"_b_in", "b_prev"},
                                           {"_b_out"}, "_b_out = b_prev + _b_in")
     else_state.add_memlet_path(b_tmp_else_in,
@@ -307,11 +307,11 @@ def make_compute_sdfg():
     b_buffer_in = body.add_scalar("b_buffer",
                                   dtype,
                                   transient=True,
-                                  storage=StorageType.FPGA_Registers)
+                                  storage=StorageType.Register)
     b_buffer_out = body.add_scalar("b_buffer",
                                    dtype,
                                    transient=True,
-                                   storage=StorageType.FPGA_Registers)
+                                   storage=StorageType.Register)
     nested_sdfg = make_compute_nested_sdfg()
     tasklet = body.add_nested_sdfg(nested_sdfg, sdfg, {"a_in", "x_in", "b_in"},
                                    {"b_out"})
@@ -335,7 +335,7 @@ def make_compute_sdfg():
     b_buffer_post_in = post_state.add_scalar("b_buffer",
                                              dtype,
                                              transient=True,
-                                             storage=StorageType.FPGA_Registers)
+                                             storage=StorageType.Register)
     b_pipe = post_state.add_stream("b_pipe",
                                    dtype,
                                    storage=StorageType.FPGA_Local)
@@ -755,11 +755,11 @@ def make_nested_compute_state(sdfg):
 
     rowptr = state.add_scalar("rowptr",
                               itype,
-                              storage=StorageType.FPGA_Registers,
+                              storage=StorageType.Register,
                               transient=True)
     rowend = state.add_scalar("rowend",
                               itype,
-                              storage=StorageType.FPGA_Registers,
+                              storage=StorageType.Register,
                               transient=True)
 
     nested_sdfg = make_nested_sdfg(sdfg)

--- a/tests/fpga/multiple_veclen_conversions.py
+++ b/tests/fpga/multiple_veclen_conversions.py
@@ -88,12 +88,12 @@ def make_sdfg(dtype=dace.float32, vec_width=4):
                    shape=[vec_width],
                    dtype=dtype,
                    transient=True,
-                   storage=dace.dtypes.StorageType.FPGA_Registers)
+                   storage=dace.dtypes.StorageType.Register)
     sdfg.add_array('inc_data',
                    shape=[vec_width],
                    dtype=dtype,
                    transient=True,
-                   storage=dace.dtypes.StorageType.FPGA_Registers)
+                   storage=dace.dtypes.StorageType.Register)
     vect_data = fpga_state_0.add_access("vec_data")
     inc_data = fpga_state_0.add_access("inc_data")
     # Read the data
@@ -169,12 +169,12 @@ def make_sdfg(dtype=dace.float32, vec_width=4):
                    shape=[vec_width],
                    dtype=dtype,
                    transient=True,
-                   storage=dace.dtypes.StorageType.FPGA_Registers)
+                   storage=dace.dtypes.StorageType.Register)
     sdfg.add_array('inc_data_B',
                    shape=[vec_width],
                    dtype=dtype,
                    transient=True,
-                   storage=dace.dtypes.StorageType.FPGA_Registers)
+                   storage=dace.dtypes.StorageType.Register)
 
     map_entry, map_exit = fpga_state_1.add_map(
         "read_B", {
@@ -236,7 +236,7 @@ def make_sdfg(dtype=dace.float32, vec_width=4):
                    shape=[vec_width],
                    dtype=dtype,
                    transient=True,
-                   storage=dace.dtypes.StorageType.FPGA_Registers)
+                   storage=dace.dtypes.StorageType.Register)
 
     map_entry, map_exit = fpga_state_2.add_map(
         "read_C", {

--- a/tests/fpga/veclen_conversion.py
+++ b/tests/fpga/veclen_conversion.py
@@ -65,11 +65,11 @@ def make_fpga_state(sdfg, vectorize_connector):
     sdfg.add_array("input_buffer", (VECTOR_LENGTH.get(), ),
                    DTYPE,
                    transient=True,
-                   storage=dace.StorageType.FPGA_Registers)
+                   storage=dace.StorageType.Register)
     sdfg.add_array("output_buffer", (VECTOR_LENGTH.get(), ),
                    DTYPE,
                    transient=True,
-                   storage=dace.StorageType.FPGA_Registers)
+                   storage=dace.StorageType.Register)
 
     read_input = state.add_read("A_device")
     read_buffer = state.add_access("input_buffer")

--- a/tests/memlet_propagation_volume_test.py
+++ b/tests/memlet_propagation_volume_test.py
@@ -87,7 +87,7 @@ def make_nested_sdfg():
                                             storage=StorageType.FPGA_Local)
     loop_bound = assign_loop_bound.add_scalar('loop_bound', dace.int32,
                                               transient=True,
-                                              storage=StorageType.FPGA_Registers)
+                                              storage=StorageType.Register)
     assign_loop_bound.add_memlet_path(
         in_bound,
         loop_bound,


### PR DESCRIPTION
Uses `Register` instead of `FPGA_Registers`. Removes `FPGA_Registers` from the possible Storage Types. 
