### PR TITLE
More ArrayInterface Fixes

### DIFF
--- a/dace/codegen/dispatcher.py
+++ b/dace/codegen/dispatcher.py
@@ -44,9 +44,9 @@ class DefinedMemlets:
                 "Exited scope {} mismatched current scope {}".format(
                     parent.name, expected.name))
 
-    def has(self, name):
+    def has(self, name, ancestor: int = 0):
         try:
-            self.get(name)
+            self.get(name, ancestor)
             return True
         except KeyError:
             return False

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1274,6 +1274,6 @@ def array_interface_variable(var_name: str, is_write: bool,
             return ptr_in
     else:
         # We might call this before the variable is even defined (e.g., because
-        # we are about to define it, so if the dispatcher is not passed, just
+        # we are about to define it), so if the dispatcher is not passed, just
         # return the appropriate string
         return ptr_out if is_write else ptr_in

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -275,7 +275,8 @@ def emit_memlet_reference(dispatcher,
         else:
             base_ctype = conntype.base_type.ctype
             typedef = f"{base_ctype}*" if is_write else f"const {base_ctype}*"
-            datadef = array_interface_variable(datadef, is_write, dispatcher)
+            datadef = array_interface_variable(datadef, is_write, dispatcher,
+                                               ancestor)
         is_scalar = False
     elif defined_type == DefinedType.Scalar:
         typedef = defined_ctype if is_scalar else (defined_ctype + '*')
@@ -1253,7 +1254,8 @@ def synchronize_streams(sdfg, dfg, state_id, node, scope_exit, callsite_stream):
 
 
 def array_interface_variable(var_name: str, is_write: bool,
-                             dispatcher: Optional["TargetDispatcher"]):
+                             dispatcher: Optional["TargetDispatcher"],
+                             ancestor: int = 0):
     """
     Generates the variable name of an ArrayInterface variable.
     """
@@ -1263,9 +1265,9 @@ def array_interface_variable(var_name: str, is_write: bool,
         # DaCe allows reading from an output connector, even though it
         # is not an input connector. If this occurs, panic and read
         # from the output interface instead
-        if is_write or not dispatcher.defined_vars.has(ptr_in):
+        if is_write or not dispatcher.defined_vars.has(ptr_in, ancestor):
             # Throw a KeyError if this pointer also doesn't exist
-            dispatcher.defined_vars.get(ptr_out)
+            dispatcher.defined_vars.get(ptr_out, ancestor)
             # Otherwise use it
             return ptr_out
         else:

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -11,7 +11,7 @@ import warnings
 
 import sympy as sp
 from six import StringIO
-from typing import IO, Tuple, Union
+from typing import IO, Optional, Tuple, Union
 
 import dace
 from dace import data, subsets, symbolic, dtypes, memlet as mmlt, nodes
@@ -67,7 +67,7 @@ def copy_expr(
             if not isinstance(datadesc, data.View):
                 if is_write is None:
                     raise ValueError("is_write must be set for ArrayInterface.")
-                expr = f"__{expr}_out" if is_write else f"__{expr}_in"
+                expr = array_interface_variable(expr, is_write, dispatcher)
         return "{}{}{}".format(
             dt, expr, " + {}".format(offset_cppstr) if add_offset else "")
 
@@ -240,7 +240,8 @@ def emit_memlet_reference(dispatcher,
                           pointer_name: str,
                           conntype: dtypes.typeclass,
                           ancestor: int = 1,
-                          is_write=None, device_code=False) -> Tuple[str, str, str]:
+                          is_write=None,
+                          device_code=False) -> Tuple[str, str, str]:
     """
     Returns a tuple of three strings with a definition of a reference to an
     existing memlet. Used in nested SDFG arguments.
@@ -255,12 +256,13 @@ def emit_memlet_reference(dispatcher,
     is_scalar = not isinstance(conntype, dtypes.pointer)
     ref = ''
 
-
     # Get defined type (pointer, stream etc.) and change the type definition
     # accordingly.
     defined_type, defined_ctype = dispatcher.defined_vars.get(
         memlet.data, ancestor)
-    if defined_type == DefinedType.Pointer:
+    if (defined_type == DefinedType.Pointer
+            or (defined_type == DefinedType.ArrayInterface
+                and isinstance(desc, data.View))):
         if not is_scalar and desc.dtype == conntype.base_type:
             # Cast potential consts
             typedef = defined_ctype
@@ -272,12 +274,8 @@ def emit_memlet_reference(dispatcher,
             raise ValueError("is_write must be defined for ArrayInterface.")
         else:
             base_ctype = conntype.base_type.ctype
-            if is_write:
-                typedef = f"{base_ctype}*"
-                datadef = f"__{datadef}_out"
-            else:
-                typedef = f"const {base_ctype}*"
-                datadef = f"__{datadef}_in"
+            typedef = f"{base_ctype}*" if is_write else f"const {base_ctype}*"
+            datadef = array_interface_variable(datadef, is_write, dispatcher)
         is_scalar = False
     elif defined_type == DefinedType.Scalar:
         typedef = defined_ctype if is_scalar else (defined_ctype + '*')
@@ -554,7 +552,7 @@ def cpp_ptr_expr(sdfg,
     if defined_type == DefinedType.ArrayInterface:
         if is_write is None:
             raise ValueError("is_write must be set for ArrayInterface.")
-        dname = f"__{dname}_out" if is_write else f"__{dname}_in"
+        dname = array_interface_variable(dname, is_write, None)
 
     if defined_type == DefinedType.Scalar:
         dname = '&' + dname
@@ -1252,3 +1250,28 @@ def synchronize_streams(sdfg, dfg, state_id, node, scope_exit, callsite_stream):
                         [e.src, e.dst],
                     )
                 # Otherwise, no synchronization necessary
+
+
+def array_interface_variable(var_name: str, is_write: bool,
+                             dispatcher: Optional["TargetDispatcher"]):
+    """
+    Generates the variable name of an ArrayInterface variable.
+    """
+    ptr_in = f"__{var_name}_in"
+    ptr_out = f"__{var_name}_out"
+    if dispatcher is not None:
+        # DaCe allows reading from an output connector, even though it
+        # is not an input connector. If this occurs, panic and read
+        # from the output interface instead
+        if is_write or not dispatcher.defined_vars.has(ptr_in):
+            # Throw a KeyError if this pointer also doesn't exist
+            dispatcher.defined_vars.get(ptr_out)
+            # Otherwise use it
+            return ptr_out
+        else:
+            return ptr_in
+    else:
+        # We might call this before the variable is even defined (e.g., because
+        # we are about to define it, so if the dispatcher is not passed, just
+        # return the appropriate string
+        return ptr_out if is_write else ptr_in

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1129,18 +1129,8 @@ class CPUCodeGen(TargetCodeGenerator):
         if var_type == DefinedType.ArrayInterface:
             # Views have already been renamed
             if not isinstance(desc, data.View):
-                ptr_in = f"__{ptr}_in"
-                ptr_out = f"__{ptr}_out"
-                # DaCe allows reading from an output connector, even though it
-                # is not an input connector. If this occurs, panic and read
-                # from the output interface instead
-                if output or not self._dispatcher.defined_vars.has(ptr_in):
-                    # Throw a KeyError if this pointer also doesn't exist
-                    self._dispatcher.defined_vars.get(ptr_out)
-                    # Otherwise use it
-                    ptr = ptr_out
-                else:
-                    ptr = ptr_in
+                ptr = cpp.array_interface_variable(ptr, output,
+                                                   self._dispatcher)
         if expr != _ptr:
             expr = '%s[%s]' % (ptr, expr)
         # If there is a type mismatch, cast pointer

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -858,7 +858,7 @@ class FPGACodeGen(TargetCodeGenerator):
                     if ignore_dependencies:
                         self.generate_no_dependence_post(callsite_stream, sdfg, state_id,
                                                          dst_node)
-                        
+
                     if register_to_register:
                         # Language-specific
                         self.generate_unroll_loop_post(callsite_stream, None,

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -260,7 +260,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                              with_vectorization,
                              interface_id=None):
         if isinstance(data, dace.data.Array):
-            var_name = f"__{var_name}_out" if is_output else f"__{var_name}_in"
+            var_name = cpp.array_interface_variable(var_name, is_output, None)
             if interface_id is not None:
                 var_name = var_name = f"{var_name}_{interface_id}"
             if with_vectorization:
@@ -642,7 +642,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         for is_output, pname, p, interface_id in itertools.chain(
                 arrays, scalars):
             if isinstance(p, dace.data.Array):
-                arr_name = f"__{pname}_out" if is_output else f"__{pname}_in"
+                arr_name = cpp.array_interface_variable(pname, is_output, None)
                 # Add interface ID to called module, but not to the module
                 # arguments
                 argname = arr_name
@@ -860,7 +860,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         seen = set()
         for is_output, name, arg, if_id in itertools.chain(arrays, scalars):
             if isinstance(arg, dace.data.Array):
-                argname = f"__{name}_out" if is_output else f"__{name}__in"
+                argname = cpp.array_interface_variable(name, is_output, None)
                 if if_id is not None:
                     argname += "_%d" % if_id
 
@@ -913,7 +913,8 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
                                    and desc.storage
                                    == dtypes.StorageType.FPGA_Global)
             if is_memory_interface:
-                interface_name = f"__{vconn}_in"
+                interface_name = cpp.array_interface_variable(
+                    vconn, False, None)
                 self._dispatcher.defined_vars.add(
                     interface_name, DefinedType.Pointer,
                     node.in_connectors[vconn].ctype)
@@ -951,7 +952,8 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
                                    and desc.storage
                                    == dtypes.StorageType.FPGA_Global)
             if is_memory_interface:
-                interface_name = f"__{uconn}_out"
+                interface_name = cpp.array_interface_variable(
+                    uconn, False, None)
                 self._dispatcher.defined_vars.add(
                     interface_name, DefinedType.Pointer,
                     node.out_connectors[uconn].ctype)

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -734,10 +734,8 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                      and arg.storage == dace.dtypes.StorageType.FPGA_Global)):
                 continue
             ctype = dtypes.pointer(arg.dtype).ctype
-            if is_output:
-                ptr_name = f"__{argname}_out"
-            else:
-                ptr_name = f"__{argname}_in"
+            ptr_name = cpp.array_interface_variable(argname, is_output, None)
+            if not is_output:
                 ctype = f"const {ctype}"
             self._dispatcher.defined_vars.add(ptr_name, DefinedType.Pointer,
                                               ctype)
@@ -917,7 +915,7 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
             if is_memory_interface:
                 interface_name = f"__{vconn}_in"
                 self._dispatcher.defined_vars.add(
-                    interface_name, DefinedType.ArrayInterface,
+                    interface_name, DefinedType.Pointer,
                     node.in_connectors[vconn].ctype)
                 interface_ref = cpp.emit_memlet_reference(
                     self._dispatcher,
@@ -955,7 +953,7 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
             if is_memory_interface:
                 interface_name = f"__{uconn}_out"
                 self._dispatcher.defined_vars.add(
-                    interface_name, DefinedType.ArrayInterface,
+                    interface_name, DefinedType.Pointer,
                     node.out_connectors[uconn].ctype)
                 memlet_references.append(
                     cpp.emit_memlet_reference(

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -915,6 +915,7 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
             if is_memory_interface:
                 interface_name = cpp.array_interface_variable(
                     vconn, False, None)
+                # Register the raw pointer as a defined variable
                 self._dispatcher.defined_vars.add(
                     interface_name, DefinedType.Pointer,
                     node.in_connectors[vconn].ctype)
@@ -953,7 +954,8 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
                                    == dtypes.StorageType.FPGA_Global)
             if is_memory_interface:
                 interface_name = cpp.array_interface_variable(
-                    uconn, False, None)
+                    uconn, True, None)
+                # Register the raw pointer as a defined variable
                 self._dispatcher.defined_vars.add(
                     interface_name, DefinedType.Pointer,
                     node.out_connectors[uconn].ctype)


### PR DESCRIPTION
Centralize generation of references to `ArrayInterface` to make sure we always follow the same procedure when possible.