### PR TITLE
Dependency pragma and hlslib header

### DIFF
--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -431,12 +431,15 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                    var_name=None):
         pass
 
-    @staticmethod
-    def generate_no_dependence_post(kernel_stream, sdfg, state_id, node,
+    def generate_no_dependence_post(self, kernel_stream, sdfg, state_id, node,
                                     var_name):
         '''
         Adds post loop pragma for ignoring loop carried dependencies on a given variable
         '''
+        defined_type, _ = self._dispatcher.defined_vars.get(var_name)
+        if defined_type == DefinedType.ArrayInterface:
+            var_name = cpp.array_interface_variable(var_name, True,
+                                                    self._dispatcher)
         kernel_stream.write(
             "#pragma HLS DEPENDENCE variable={} false".format(var_name), sdfg,
             state_id, node)

--- a/dace/runtime/include/dace/xilinx/host.h
+++ b/dace/runtime/include/dace/xilinx/host.h
@@ -3,7 +3,7 @@
 
 #include <vector>  // For concurrent kernel launches
 
-#include "hlslib/xilinx/SDAccel.h"
+#include "hlslib/xilinx/OpenCL.h"
 
 #include <dace/fpga_host.h>  // Must be included after hlslib/xilinx/SDAccel.h
 #include <dace/os.h>

--- a/dace/runtime/include/dace/xilinx/host.h
+++ b/dace/runtime/include/dace/xilinx/host.h
@@ -5,6 +5,6 @@
 
 #include "hlslib/xilinx/OpenCL.h"
 
-#include <dace/fpga_host.h>  // Must be included after hlslib/xilinx/SDAccel.h
+#include <dace/fpga_host.h>  // Must be included after hlslib/xilinx/OpenCL.h
 #include <dace/os.h>
 #include <dace/types.h>


### PR DESCRIPTION
Fix the dependency pragma to correctly reference `ArrayInterface` names, and change the included hlslib OpenCL header for Xilinx.