### PR TITLE
Remove useless FPGA copies

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1107,7 +1107,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         return result
 
-    def shared_transients(self):
+    def shared_transients(self) -> List[str]:
         """ Returns a list of transient data that appears in more than one
             state. """
         seen = {}
@@ -1303,13 +1303,13 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         return name + ('_%d' % index)
 
     def find_new_constant(self, name: str):
-        """ 
+        """
         Tries to find a new constant name by adding an underscore and a number.
         """
         constants = self.constants
         if name not in constants:
             return name
-            
+
         index = 0
         while (name + ('_%d' % index)) in constants:
             index += 1
@@ -2060,8 +2060,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                 except InvalidSDFGError as err:
                     raise InvalidSDFGError(
                         "Validation failed after applying {}.".format(
-                            match_name), sdfg,
-                        match.state_id) from err
+                            match_name), sdfg, match.state_id) from err
 
         if order_by_transformation:
             applied_anything = True
@@ -2088,11 +2087,10 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
             while applied:
                 applied = False
                 # Find and apply one of the chosen transformations
-                for match in opt.get_pattern_matches(
-                        strict=strict,
-                        patterns=xforms,
-                        states=states,
-                        options=options):
+                for match in opt.get_pattern_matches(strict=strict,
+                                                     patterns=xforms,
+                                                     states=states,
+                                                     options=options):
                     _apply_and_validate(match)
                     applied = True
                     break

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -127,9 +127,17 @@ class FPGATransformState(transformation.Transformation):
     def apply(self, sdfg):
         state = sdfg.nodes()[self.subgraph[FPGATransformState._state]]
 
-        # Find source/sink (data) nodes
-        input_nodes = sdutil.find_source_nodes(state)
-        output_nodes = sdutil.find_sink_nodes(state)
+        # Find source/sink (data) nodes that are relevant outside this FPGA
+        # kernel
+        shared_transients = set(sdfg.shared_transients())
+        input_nodes = [
+            n for n in sdutil.find_source_nodes(state)
+            if not sdfg.arrays[n.data].transient or n.data in shared_transients
+        ]
+        output_nodes = [
+            n for n in sdutil.find_sink_nodes(state)
+            if not sdfg.arrays[n.data].transient or n.data in shared_transients
+        ]
 
         fpga_data = {}
 

--- a/dace/transformation/interstate/fpga_transform_state.py
+++ b/dace/transformation/interstate/fpga_transform_state.py
@@ -132,11 +132,11 @@ class FPGATransformState(transformation.Transformation):
         shared_transients = set(sdfg.shared_transients())
         input_nodes = [
             n for n in sdutil.find_source_nodes(state)
-            if not sdfg.arrays[n.data].transient or n.data in shared_transients
+            if isinstance(n, nodes.AccessNode) and (not sdfg.arrays[n.data].transient or n.data in shared_transients)
         ]
         output_nodes = [
             n for n in sdutil.find_sink_nodes(state)
-            if not sdfg.arrays[n.data].transient or n.data in shared_transients
+            if isinstance(n, nodes.AccessNode) and (not sdfg.arrays[n.data].transient or n.data in shared_transients)
         ]
 
         fpga_data = {}


### PR DESCRIPTION
Don't copy transients to/from the FPGA that are never used outside the FPGA kernel.