### PR TITLE
Streamline FPGA kernel argument generation

### DIFF
--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -367,6 +367,9 @@ class FPGACodeGen(TargetCodeGenerator):
             # from the host and passed to the device code, while the latter are
             # (statically) allocated on the device side.
             for is_output, dataname, desc in candidates:
+                # Ignore views, as these never need to explicitly passed
+                if isinstance(desc, dt.View):
+                    continue
                 # Only distinguish between inputs and outputs for arrays
                 if not isinstance(desc, dt.Array):
                     is_output = None

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -12,8 +12,7 @@ from typing import Dict
 
 import dace
 from dace.codegen.targets import cpp
-from dace import subsets, data as dt
-from dace.dtypes import deduplicate
+from dace import subsets, data as dt, dtypes
 from dace.config import Config
 from dace.frontend import operations
 from dace.sdfg import nodes, SDFG
@@ -29,13 +28,12 @@ from dace.properties import Property, make_properties, indirect_properties
 from dace.symbolic import evaluate
 
 _CPU_STORAGE_TYPES = {
-    dace.dtypes.StorageType.CPU_Heap, dace.dtypes.StorageType.CPU_ThreadLocal,
-    dace.dtypes.StorageType.CPU_Pinned
+    dtypes.StorageType.CPU_Heap, dtypes.StorageType.CPU_ThreadLocal,
+    dtypes.StorageType.CPU_Pinned
 }
 _FPGA_STORAGE_TYPES = {
-    dace.dtypes.StorageType.FPGA_Global, dace.dtypes.StorageType.FPGA_Local,
-    dace.dtypes.StorageType.FPGA_Registers,
-    dace.dtypes.StorageType.FPGA_ShiftRegister
+    dtypes.StorageType.FPGA_Global, dtypes.StorageType.FPGA_Local,
+    dtypes.StorageType.FPGA_Registers, dtypes.StorageType.FPGA_ShiftRegister
 }
 
 
@@ -88,56 +86,56 @@ class FPGACodeGen(TargetCodeGenerator):
 
         # Register additional FPGA dispatchers
         self._dispatcher.register_map_dispatcher(
-            [dace.dtypes.ScheduleType.FPGA_Device], self)
+            [dtypes.ScheduleType.FPGA_Device], self)
 
         self._dispatcher.register_state_dispatcher(
             self,
             predicate=lambda sdfg, state: len(state.data_nodes()) > 0 and
-            ("is_FPGA_kernel" not in state.location or state.
-             location["is_FPGA_kernel"] is True) and all([
-                 n.desc(sdfg).storage in [
-                     dace.dtypes.StorageType.FPGA_Global, dace.dtypes.
-                     StorageType.FPGA_Local, dace.dtypes.StorageType.
-                     FPGA_Registers, dace.dtypes.StorageType.FPGA_ShiftRegister
-                 ] for n in state.data_nodes()
-             ]))
+            ("is_FPGA_kernel" not in state.location or state.location[
+                "is_FPGA_kernel"] is True) and all([
+                    n.desc(sdfg).storage in [
+                        dtypes.StorageType.FPGA_Global, dtypes.StorageType.
+                        FPGA_Local, dtypes.StorageType.FPGA_Registers, dtypes.
+                        StorageType.FPGA_ShiftRegister
+                    ] for n in state.data_nodes()
+                ]))
 
         self._dispatcher.register_node_dispatcher(
             self,
             predicate=lambda sdfg, state, node: self._in_device_code and not (
-                isinstance(node, nodes.Tasklet) and node.language == dace.dtypes
-                .Language.SystemVerilog))
+                isinstance(node, nodes.Tasklet) and node.language == dtypes.
+                Language.SystemVerilog))
 
         fpga_storage = [
-            dace.dtypes.StorageType.FPGA_Global,
-            dace.dtypes.StorageType.FPGA_Local,
-            dace.dtypes.StorageType.FPGA_Registers,
-            dace.dtypes.StorageType.FPGA_ShiftRegister,
+            dtypes.StorageType.FPGA_Global,
+            dtypes.StorageType.FPGA_Local,
+            dtypes.StorageType.FPGA_Registers,
+            dtypes.StorageType.FPGA_ShiftRegister,
         ]
         self._dispatcher.register_array_dispatcher(fpga_storage, self)
 
         # Register permitted copies
         for storage_from in itertools.chain(fpga_storage,
-                                            [dace.dtypes.StorageType.Register]):
-            for storage_to in itertools.chain(
-                    fpga_storage, [dace.dtypes.StorageType.Register]):
-                if (storage_from == dace.dtypes.StorageType.Register
-                        and storage_to == dace.dtypes.StorageType.Register):
+                                            [dtypes.StorageType.Register]):
+            for storage_to in itertools.chain(fpga_storage,
+                                              [dtypes.StorageType.Register]):
+                if (storage_from == dtypes.StorageType.Register
+                        and storage_to == dtypes.StorageType.Register):
                     continue
                 self._dispatcher.register_copy_dispatcher(
                     storage_from, storage_to, None, self)
         self._dispatcher.register_copy_dispatcher(
-            dace.dtypes.StorageType.FPGA_Global,
-            dace.dtypes.StorageType.CPU_Heap, None, self)
+            dtypes.StorageType.FPGA_Global, dtypes.StorageType.CPU_Heap, None,
+            self)
         self._dispatcher.register_copy_dispatcher(
-            dace.dtypes.StorageType.FPGA_Global,
-            dace.dtypes.StorageType.CPU_ThreadLocal, None, self)
+            dtypes.StorageType.FPGA_Global, dtypes.StorageType.CPU_ThreadLocal,
+            None, self)
         self._dispatcher.register_copy_dispatcher(
-            dace.dtypes.StorageType.CPU_Heap,
-            dace.dtypes.StorageType.FPGA_Global, None, self)
+            dtypes.StorageType.CPU_Heap, dtypes.StorageType.FPGA_Global, None,
+            self)
         self._dispatcher.register_copy_dispatcher(
-            dace.dtypes.StorageType.CPU_ThreadLocal,
-            dace.dtypes.StorageType.FPGA_Global, None, self)
+            dtypes.StorageType.CPU_ThreadLocal, dtypes.StorageType.FPGA_Global,
+            None, self)
 
         # Memory width converters (gearboxing) to generate globally
         self.converters_to_generate = set()
@@ -176,13 +174,13 @@ class FPGACodeGen(TargetCodeGenerator):
                 data = node.desc(sdfg)
                 if node.data not in all_transients or node.data in allocated:
                     continue
-                if data.storage != dace.dtypes.StorageType.FPGA_Global or isinstance(
-                        data, dace.data.View):
-                    continue
-                allocated.add(node.data)
-                self._dispatcher.dispatch_allocate(sdfg, state, state_id, node,
-                                                   function_stream,
-                                                   callsite_stream)
+                if (data.storage == dtypes.StorageType.FPGA_Global
+                        # and isinstance(data, dt.Array)
+                        and not isinstance(data, dt.View)):
+                    allocated.add(node.data)
+                    self._dispatcher.dispatch_allocate(sdfg, state, state_id,
+                                                       node, function_stream,
+                                                       callsite_stream)
 
             # Create a unique kernel name to avoid name clashes
             # If this kernels comes from a Nested SDFG, use that name also
@@ -222,8 +220,8 @@ class FPGACodeGen(TargetCodeGenerator):
                     continue
                 # Make sure there are no global transients in the nested state
                 # that are thus not gonna be allocated
-                if data.storage == dace.dtypes.StorageType.FPGA_Global and not isinstance(
-                        data, dace.data.View):
+                if data.storage == dtypes.StorageType.FPGA_Global and not isinstance(
+                        data, dt.View):
                     raise cgx.CodegenError(
                         "Cannot allocate global memory from device code.")
                 allocated.add(node.data)
@@ -252,35 +250,46 @@ class FPGACodeGen(TargetCodeGenerator):
                             seen[node.data] = sg
         return shared
 
-    @classmethod
-    def make_parameters(cls, sdfg, state, subgraphs):
-        """Determines the parameters that must be passed to the passed list of
-           subgraphs, as well as to the global kernel."""
+    def make_parameters(self, sdfg, state, subgraphs):
+        """
+        Determines the parameters that must be passed to the passed list of
+        subgraphs, as well as to the global kernel.
+        :return: A tuple with the following six entries:
+                 - Data container parameters that should be passed from the
+                   host to the FPGA kernel.
+                 - Data containers that are local to the kernel, but must be
+                   allocated by the host prior to invoking the kernel.
+                 - A dictionary mapping from each processing element subgraph
+                   to which parameters it needs (from the total list of
+                   parameters).
+                 - Symbol parameters that must be passed from the host to the
+                   kernel.
+                 - Parameters that must be passed to the kernel from the host,
+                   but that do not exist before the CPU calls the kernel
+                   wrapper.
+                 - External streams that connect different FPGA kernels, and
+                   must be defined during the compilation flow.
+        """
 
         # Get a set of data nodes that are shared across subgraphs
-        shared_data = cls.shared_data(subgraphs)
-
-        # Find scalar parameters (to filter out from data parameters)
-        scalar_parameters = [(k, v) for k, v in sdfg.arrays.items()
-                             if isinstance(v, dt.Scalar) and not v.transient]
-        scalar_set = set(p[0] for p in scalar_parameters)
+        shared_data = self.shared_data(subgraphs)
+        # Transients that are accessed in other states in this SDFG
+        used_outside = sdfg.shared_transients()
 
         # For some reason the array allocation dispatcher takes nodes, not
         # arrays. Build a dictionary of arrays to arbitrary data nodes
         # referring to them.
         data_to_node = {}
 
-        global_data_parameters = []
-        global_data_names = set()
+        global_data_parameters = set()
         # Count appearances of each global array to create multiple interfaces
         global_interfaces: Dict[str, int] = collections.defaultdict(int)
 
-        top_level_local_data = []
+        top_level_local_data = set()
         subgraph_parameters = collections.OrderedDict()  # {subgraph: [params]}
-        nested_global_transients = []
-        nested_global_transients_seen = set()
+        nested_global_transients = set()
         # [(Is an output, dataname string, data object, interface)]
-        external_streams: list[tuple[bool, str, dt, dict[str, int]]] = []
+        external_streams: Set[tuple[bool, str, dt, dict[str, int]]] = set()
 
         for subgraph in subgraphs:
             data_to_node.update({
@@ -300,15 +309,14 @@ class FPGACodeGen(TargetCodeGenerator):
                     t for t in dsts + srcs if isinstance(t, dace.nodes.Tasklet)
                 ]
                 external = any([
-                    t.language == dace.dtypes.Language.SystemVerilog
-                    for t in tasks
+                    t.language == dtypes.Language.SystemVerilog for t in tasks
                 ])
                 if external:
-                    external_streams += [
+                    external_streams |= {
                         (True, e.data.data, subsdfg.arrays[e.data.data], None)
                         for e in state.out_edges(n)
                         if isinstance(subsdfg.arrays[e.data.data], dt.Stream)
-                    ]
+                    }
                 else:
                     candidates += [(False, e.data.data,
                                     subsdfg.arrays[e.data.data])
@@ -322,15 +330,14 @@ class FPGACodeGen(TargetCodeGenerator):
                     t for t in dsts + srcs if isinstance(t, dace.nodes.Tasklet)
                 ]
                 external = any([
-                    t.language == dace.dtypes.Language.SystemVerilog
-                    for t in tasks
+                    t.language == dtypes.Language.SystemVerilog for t in tasks
                 ])
                 if external:
-                    external_streams += [
+                    external_streams |= {
                         (False, e.data.data, subsdfg.arrays[e.data.data], None)
                         for e in state.in_edges(n)
                         if isinstance(subsdfg.arrays[e.data.data], dt.Stream)
-                    ]
+                    }
                 else:
                     candidates += [(True, e.data.data,
                                     subsdfg.arrays[e.data.data])
@@ -349,82 +356,95 @@ class FPGACodeGen(TargetCodeGenerator):
                         if scope.in_degree(n) > 0:
                             candidates.append((True, n.data, n.desc(scope)))
                         if scope != subgraph:
-                            if (isinstance(n.desc(scope), dace.data.Array)
+                            if (isinstance(n.desc(scope), dt.Array)
                                     and n.desc(scope).storage
-                                    == dace.dtypes.StorageType.FPGA_Global and
-                                    n.data not in nested_global_transients_seen
-                                    and not isinstance(n.desc(scope),
-                                                       dace.data.View)):
-                                nested_global_transients.append(n)
-                            nested_global_transients_seen.add(n.data)
-            subgraph_parameters[subgraph] = []
+                                    == dtypes.StorageType.FPGA_Global
+                                    and not isinstance(n.desc(scope), dt.View)):
+                                nested_global_transients.add(n)
+            subgraph_parameters[subgraph] = set()
             # For each subgraph, keep a listing of array to current interface ID
             data_to_interface: Dict[str, int] = {}
 
             # Differentiate global and local arrays. The former are allocated
             # from the host and passed to the device code, while the latter are
             # (statically) allocated on the device side.
-            for is_output, dataname, data in candidates:
-                if dataname in scalar_set:
-                    continue  # Skip already-parsed scalars
-                if (isinstance(data, dace.data.Array)
-                        or isinstance(data, dace.data.Scalar)
-                        or isinstance(data, dace.data.Stream)):
-                    if data.storage == dace.dtypes.StorageType.FPGA_Global:
-                        if dataname in data_to_interface:
-                            interface_id = data_to_interface[dataname]
+            for is_output, dataname, desc in candidates:
+                # Only distinguish between inputs and outputs for arrays
+                if not isinstance(desc, dt.Array):
+                    is_output = None
+                if isinstance(desc, (dt.Array, dt.Scalar, dt.Stream)):
+                    if desc.storage == dtypes.StorageType.FPGA_Global:
+                        # If this is a global array, assign the correct
+                        # interface ID
+                        if isinstance(desc, dt.Array):
+                            if dataname in data_to_interface:
+                                interface_id = data_to_interface[dataname]
+                            else:
+                                # Get and update global memory interface ID
+                                interface_id = global_interfaces[dataname]
+                                global_interfaces[dataname] += 1
+                                data_to_interface[dataname] = interface_id
                         else:
-                            # Get and update global memory interface ID
-                            interface_id = global_interfaces[dataname]
-                            global_interfaces[dataname] += 1
-                            data_to_interface[dataname] = interface_id
-                        if not isinstance(data, dace.data.View):
-                            subgraph_parameters[subgraph].append(
-                                (is_output, dataname, data, interface_id))
-                            global_data_parameters.append(
-                                (is_output, dataname, data, interface_id))
-                            global_data_names.add(dataname)
-                    elif (data.storage
-                          in (dace.dtypes.StorageType.FPGA_Local,
-                              dace.dtypes.StorageType.FPGA_Registers,
-                              dace.dtypes.StorageType.FPGA_ShiftRegister)):
+                            interface_id = None
+                        # Add the data as a parameter to this PE
+                        subgraph_parameters[subgraph].add(
+                            (is_output, dataname, desc, interface_id))
+                        # TODO: Find a way to handle scalar outputs?
+                        if (isinstance(desc, dt.Scalar) and is_output
+                                and (dataname in used_outside
+                                     or dataname in shared_data)):
+                            raise ValueError(
+                                "Scalar containers are not supported as "
+                                "outputs from FPGA kernels. You can replace"
+                                f" {dataname} with an array of shape [1].")
+                        # Global data is passed from outside the kernel
+                        global_data_parameters.add(
+                            (is_output, dataname, desc, interface_id))
+                    elif (desc.storage
+                          in (dtypes.StorageType.FPGA_Local,
+                              dtypes.StorageType.FPGA_Registers,
+                              dtypes.StorageType.FPGA_ShiftRegister)):
                         if dataname in shared_data:
                             # Only transients shared across multiple components
                             # need to be allocated outside and passed as
                             # parameters
-                            subgraph_parameters[subgraph].append(
-                                (is_output, dataname, data, None))
-                            # Resolve the data to some corresponding node to be
+                            subgraph_parameters[subgraph].add(
+                                (is_output, dataname, desc, None))
+                            # Resolve the desc to some corresponding node to be
                             # passed to the allocator
-                            top_level_local_data.append(dataname)
+                            top_level_local_data.add(dataname)
                     else:
                         raise ValueError("Unsupported storage type for "
-                                         f"{dataname}: {data.storage}")
+                                         f"{dataname}: {desc.storage}")
                 else:
-                    raise TypeError("Unsupported data type: {}".format(
-                        type(data).__name__))
-            subgraph_parameters[subgraph] = dace.dtypes.deduplicate(
-                subgraph_parameters[subgraph])
+                    raise TypeError("Unsupported desc type: {}".format(
+                        type(desc).__name__))
+            # Order by name
+            subgraph_parameters[subgraph] = list(
+                sorted(subgraph_parameters[subgraph], key=lambda t: t[1]))
 
-        # Deduplicate
-        global_data_parameters = dace.dtypes.deduplicate(global_data_parameters)
-        top_level_local_data = dace.dtypes.deduplicate(top_level_local_data)
-        external_streams = dace.dtypes.deduplicate(external_streams)
+        # Order by name
+        global_data_parameters = list(
+            sorted(global_data_parameters, key=lambda t: t[1]))
+        external_streams = list(sorted(external_streams, key=lambda t: t[1]))
+        nested_global_transients = list(sorted(nested_global_transients))
 
-        stream_names = [sname for _, sname, _, _ in external_streams]
+        stream_names = {sname for _, sname, _, _ in external_streams}
         top_level_local_data = [
             data_to_node[name] for name in top_level_local_data
             if name not in stream_names
         ]
 
-        symbol_parameters = {
-            k: dt.Scalar(v)
-            for k, v in sdfg.symbols.items() if k not in sdfg.constants
-        }
+        # Append sorted symbols to parameters
+        for k, v in sorted(sdfg.symbols.items()):
+            if k not in sdfg.constants:
+                param = (False, k, dt.Scalar(v), None)
+                global_data_parameters.append(param)
+                for sgp in subgraph_parameters.values():
+                    sgp.append(param)
 
         return (global_data_parameters, top_level_local_data,
-                subgraph_parameters, scalar_parameters, symbol_parameters,
-                nested_global_transients, external_streams)
+                subgraph_parameters, nested_global_transients, external_streams)
 
     def generate_nested_state(self, sdfg, state, nest_name, subgraphs,
                               function_stream, callsite_stream):
@@ -470,7 +490,7 @@ class FPGACodeGen(TargetCodeGenerator):
         is_dynamically_sized = dace.symbolic.issymbolic(arrsize, sdfg.constants)
         dataname = node.data
 
-        if not isinstance(nodedesc, dace.data.Stream):
+        if not isinstance(nodedesc, dt.Stream):
             # Unless this is a Stream, if the variable has been already defined we can return
             # For Streams, we still allocate them to keep track of their names across
             # nested SDFGs (needed by Intel FPGA backend for channel mangling)
@@ -482,11 +502,11 @@ class FPGACodeGen(TargetCodeGenerator):
 
         allocname = cpp.ptr(dataname, nodedesc)
 
-        if isinstance(nodedesc, dace.data.View):
+        if isinstance(nodedesc, dt.View):
             return self.allocate_view(sdfg, dfg, state_id, node,
                                       function_stream, declaration_stream,
                                       allocation_stream)
-        elif isinstance(nodedesc, dace.data.Stream):
+        elif isinstance(nodedesc, dt.Stream):
 
             if not self._in_device_code:
                 raise cgx.CodegenError(
@@ -520,9 +540,9 @@ class FPGACodeGen(TargetCodeGenerator):
             else:
                 self._dispatcher.defined_vars.add(dataname, def_type, ctype)
 
-        elif isinstance(nodedesc, dace.data.Array):
+        elif isinstance(nodedesc, dt.Array):
 
-            if nodedesc.storage == dace.dtypes.StorageType.FPGA_Global:
+            if nodedesc.storage == dtypes.StorageType.FPGA_Global:
 
                 if self._in_device_code:
 
@@ -532,7 +552,7 @@ class FPGACodeGen(TargetCodeGenerator):
                                                node.label, sdfg.name))
 
                 else:
-                    if isinstance(nodedesc, dace.data.Array):
+                    if isinstance(nodedesc, dt.Array):
 
                         # TODO: Distinguish between read, write, and read+write
                         self._allocated_global_arrays.add(node.data)
@@ -569,10 +589,9 @@ class FPGACodeGen(TargetCodeGenerator):
                             dataname, DefinedType.Pointer,
                             'hlslib::ocl::Buffer <{}, hlslib::ocl::Access::readWrite>'
                             .format(nodedesc.dtype.ctype))
-            elif (nodedesc.storage
-                  in (dace.dtypes.StorageType.FPGA_Local,
-                      dace.dtypes.StorageType.FPGA_Registers,
-                      dace.dtypes.StorageType.FPGA_ShiftRegister)):
+            elif (nodedesc.storage in (dtypes.StorageType.FPGA_Local,
+                                       dtypes.StorageType.FPGA_Registers,
+                                       dtypes.StorageType.FPGA_ShiftRegister)):
 
                 if not self._in_device_code:
                     raise cgx.CodegenError(
@@ -596,7 +615,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 else:
                     # Language-specific
                     if (nodedesc.storage ==
-                            dace.dtypes.StorageType.FPGA_ShiftRegister):
+                            dtypes.StorageType.FPGA_ShiftRegister):
                         self.define_shift_register(dataname, nodedesc, arrsize,
                                                    function_stream, result_decl,
                                                    sdfg, state_id, node)
@@ -609,7 +628,7 @@ class FPGACodeGen(TargetCodeGenerator):
                 raise NotImplementedError("Unimplemented storage type " +
                                           str(nodedesc.storage))
 
-        elif isinstance(nodedesc, dace.data.Scalar):
+        elif isinstance(nodedesc, dt.Scalar):
 
             result_decl.write("{} {};\n".format(nodedesc.dtype.ctype, dataname))
             self._dispatcher.defined_vars.add(dataname, DefinedType.Scalar,
@@ -647,14 +666,14 @@ class FPGACodeGen(TargetCodeGenerator):
         data_to_data = (isinstance(src_node, dace.sdfg.nodes.AccessNode)
                         and isinstance(dst_node, dace.sdfg.nodes.AccessNode))
 
-        host_to_device = (data_to_data and src_storage in _CPU_STORAGE_TYPES and
-                          dst_storage == dace.dtypes.StorageType.FPGA_Global)
+        host_to_device = (data_to_data and src_storage in _CPU_STORAGE_TYPES
+                          and dst_storage == dtypes.StorageType.FPGA_Global)
         device_to_host = (data_to_data
-                          and src_storage == dace.dtypes.StorageType.FPGA_Global
+                          and src_storage == dtypes.StorageType.FPGA_Global
                           and dst_storage in _CPU_STORAGE_TYPES)
-        device_to_device = (
-            data_to_data and src_storage == dace.dtypes.StorageType.FPGA_Global
-            and dst_storage == dace.dtypes.StorageType.FPGA_Global)
+        device_to_device = (data_to_data
+                            and src_storage == dtypes.StorageType.FPGA_Global
+                            and dst_storage == dtypes.StorageType.FPGA_Global)
 
         if (host_to_device or device_to_host) and self._in_device_code:
             raise RuntimeError(
@@ -747,15 +766,15 @@ class FPGACodeGen(TargetCodeGenerator):
                     [src_node, dst_node])
 
         # Reject copying to/from local memory from/to outside the FPGA
-        elif (data_to_data and
-              (((src_storage in (dace.dtypes.StorageType.FPGA_Local,
-                                 dace.dtypes.StorageType.FPGA_Registers,
-                                 dace.dtypes.StorageType.FPGA_ShiftRegister))
-                and dst_storage not in _FPGA_STORAGE_TYPES) or
-               ((dst_storage in (dace.dtypes.StorageType.FPGA_Local,
-                                 dace.dtypes.StorageType.FPGA_Registers,
-                                 dace.dtypes.StorageType.FPGA_ShiftRegister))
-                and src_storage not in _FPGA_STORAGE_TYPES))):
+        elif (data_to_data
+              and (((src_storage in (dtypes.StorageType.FPGA_Local,
+                                     dtypes.StorageType.FPGA_Registers,
+                                     dtypes.StorageType.FPGA_ShiftRegister))
+                    and dst_storage not in _FPGA_STORAGE_TYPES) or
+                   ((dst_storage in (dtypes.StorageType.FPGA_Local,
+                                     dtypes.StorageType.FPGA_Registers,
+                                     dtypes.StorageType.FPGA_ShiftRegister))
+                    and src_storage not in _FPGA_STORAGE_TYPES))):
             raise NotImplementedError(
                 "Copies between host memory and FPGA "
                 "local memory not supported: from {} to {}".format(
@@ -766,7 +785,7 @@ class FPGACodeGen(TargetCodeGenerator):
             if memlet.wcr is not None:
                 raise NotImplementedError("WCR not implemented for copy edges")
 
-            if src_storage == dace.dtypes.StorageType.FPGA_ShiftRegister:
+            if src_storage == dtypes.StorageType.FPGA_ShiftRegister:
                 raise NotImplementedError(
                     "Reads from shift registers only supported from tasklets.")
 
@@ -782,7 +801,7 @@ class FPGACodeGen(TargetCodeGenerator):
             dtype = src_node.desc(sdfg).dtype
             ctype = dtype.ctype
 
-            if dst_storage == dace.dtypes.StorageType.FPGA_ShiftRegister:
+            if dst_storage == dtypes.StorageType.FPGA_ShiftRegister:
                 if len(copy_shape) != 1:
                     raise ValueError(
                         "Only single-dimensional writes "
@@ -823,9 +842,9 @@ class FPGACodeGen(TargetCodeGenerator):
 
             # TODO: detect in which cases we shouldn't unroll
             register_to_register = (src_node.desc(sdfg).storage
-                                    == dace.dtypes.StorageType.FPGA_Registers
+                                    == dtypes.StorageType.FPGA_Registers
                                     or dst_node.desc(sdfg).storage
-                                    == dace.dtypes.StorageType.FPGA_Registers)
+                                    == dtypes.StorageType.FPGA_Registers)
 
             num_loops = len([dim for dim in copy_shape if dim != 1])
             if num_loops > 0:
@@ -838,9 +857,9 @@ class FPGACodeGen(TargetCodeGenerator):
                     self.generate_flatten_loop_pre(callsite_stream, sdfg,
                                                    state_id, dst_node)
                 for node in [src_node, dst_node]:
-                    if (isinstance(node.desc(sdfg), dace.data.Array)
+                    if (isinstance(node.desc(sdfg), dt.Array)
                             and node.desc(sdfg).storage in [
-                                dace.dtypes.StorageType.FPGA_Local,
+                                dtypes.StorageType.FPGA_Local,
                                 dace.StorageType.FPGA_Registers
                             ]):
                         # Language-specific
@@ -861,8 +880,8 @@ class FPGACodeGen(TargetCodeGenerator):
                     ignore_dependencies = src_node.data == dst_node.data and not dace.subsets.intersects(
                         memlet.src_subset, memlet.dst_subset)
                     if ignore_dependencies:
-                        self.generate_no_dependence_pre(callsite_stream, sdfg, state_id,
-                                                        dst_node)
+                        self.generate_no_dependence_pre(callsite_stream, sdfg,
+                                                        state_id, dst_node)
                     callsite_stream.write(
                         "for (int __dace_copy{} = 0; __dace_copy{} < {}; "
                         "++__dace_copy{}) {{".format(i, i,
@@ -870,8 +889,9 @@ class FPGACodeGen(TargetCodeGenerator):
                         sdfg, state_id, dst_node)
 
                     if ignore_dependencies:
-                        self.generate_no_dependence_post(callsite_stream, sdfg, state_id,
-                                                         dst_node, node.data)
+                        self.generate_no_dependence_post(
+                            callsite_stream, sdfg, state_id, dst_node,
+                            node.data)
 
                     if register_to_register:
                         # Language-specific
@@ -915,7 +935,7 @@ class FPGACodeGen(TargetCodeGenerator):
                                        packing_factor)
 
             # Language specific
-            if dst_storage == dace.dtypes.StorageType.FPGA_ShiftRegister:
+            if dst_storage == dtypes.StorageType.FPGA_ShiftRegister:
                 write_expr = self.make_shift_register_write(
                     dst_def_type, dtype, dst_node.label, dst_expr, dst_index,
                     read_expr, None, is_unpack, packing_factor, sdfg)
@@ -929,9 +949,9 @@ class FPGACodeGen(TargetCodeGenerator):
 
             # Inject dependence pragmas (DACE semantics implies no conflict)
             for node in [src_node, dst_node]:
-                if (isinstance(node.desc(sdfg), dace.data.Array)
+                if (isinstance(node.desc(sdfg), dt.Array)
                         and node.desc(sdfg).storage in [
-                            dace.dtypes.StorageType.FPGA_Local,
+                            dtypes.StorageType.FPGA_Local,
                             dace.StorageType.FPGA_Registers
                         ]):
                     # Language-specific
@@ -950,7 +970,7 @@ class FPGACodeGen(TargetCodeGenerator):
 
     @staticmethod
     def make_opencl_parameter(name, desc):
-        if isinstance(desc, dace.data.Array):
+        if isinstance(desc, dt.Array):
             return ("hlslib::ocl::Buffer<{}, "
                     "hlslib::ocl::Access::readWrite> &{}".format(
                         desc.dtype.ctype, name))
@@ -977,8 +997,7 @@ class FPGACodeGen(TargetCodeGenerator):
         if hasattr(self, method_name):
 
             if hasattr(node, "schedule") and node.schedule not in [
-                    dace.dtypes.ScheduleType.Default,
-                    dace.dtypes.ScheduleType.FPGA_Device
+                    dtypes.ScheduleType.Default, dtypes.ScheduleType.FPGA_Device
             ]:
                 warnings.warn("Found schedule {} on {} node in FPGA code. "
                               "Ignoring.".format(node.schedule,
@@ -999,7 +1018,7 @@ class FPGACodeGen(TargetCodeGenerator):
                     function_stream, callsite_stream):
 
         if isinstance(src_node, dace.sdfg.nodes.CodeNode):
-            src_storage = dace.dtypes.StorageType.Register
+            src_storage = dtypes.StorageType.Register
             try:
                 src_parent = dfg.entry_node(src_node)
             except KeyError:
@@ -1010,7 +1029,7 @@ class FPGACodeGen(TargetCodeGenerator):
             src_storage = src_node.desc(sdfg).storage
 
         if isinstance(dst_node, dace.sdfg.nodes.CodeNode):
-            dst_storage = dace.dtypes.StorageType.Register
+            dst_storage = dtypes.StorageType.Register
         else:
             dst_storage = dst_node.desc(sdfg).storage
 
@@ -1118,9 +1137,9 @@ class FPGACodeGen(TargetCodeGenerator):
             for _, _, _, _, memlet in state.in_edges(node):
                 if memlet.data is not None:
                     desc = sdfg.arrays[memlet.data]
-                    if (isinstance(desc, dace.data.Array) and
-                        (desc.storage == dace.dtypes.StorageType.FPGA_Global
-                         or desc.storage == dace.dtypes.StorageType.FPGA_Local)
+                    if (isinstance(desc, dt.Array) and
+                        (desc.storage == dtypes.StorageType.FPGA_Global
+                         or desc.storage == dtypes.StorageType.FPGA_Local)
                             and memlet.wcr is None):
                         candidates_in.add(memlet.data)
                     elif memlet.wcr is not None:
@@ -1129,9 +1148,9 @@ class FPGACodeGen(TargetCodeGenerator):
             for _, _, _, _, memlet in state.out_edges(map_exit_node):
                 if memlet.data is not None:
                     desc = sdfg.arrays[memlet.data]
-                    if (isinstance(desc, dace.data.Array) and
-                        (desc.storage == dace.dtypes.StorageType.FPGA_Global
-                         or desc.storage == dace.dtypes.StorageType.FPGA_Local)
+                    if (isinstance(desc, dt.Array) and
+                        (desc.storage == dtypes.StorageType.FPGA_Global
+                         or desc.storage == dtypes.StorageType.FPGA_Local)
                             and memlet.wcr is None):
                         candidates_out.add(memlet.data)
                     elif memlet.wcr is not None:
@@ -1262,7 +1281,7 @@ class FPGACodeGen(TargetCodeGenerator):
                     # add pragmas for data read/written inside this map, but only for local arrays
                     for candidate in in_out_data:
                         if sdfg.arrays[
-                                candidate].storage != dace.dtypes.StorageType.FPGA_Global:
+                                candidate].storage != dtypes.StorageType.FPGA_Global:
                             self.generate_no_dependence_post(
                                 result, sdfg, state_id, node, candidate)
 
@@ -1343,8 +1362,7 @@ class FPGACodeGen(TargetCodeGenerator):
         self._allocated_global_arrays = set()
 
     def generate_modules(self, sdfg, state, kernel_name, subgraphs,
-                         subgraph_parameters, scalar_parameters,
-                         symbol_parameters, module_stream, entry_stream,
+                         subgraph_parameters, module_stream, entry_stream,
                          host_stream):
         """Main entry function for generating a Xilinx kernel."""
 
@@ -1382,27 +1400,9 @@ class FPGACodeGen(TargetCodeGenerator):
                 raise RuntimeError("Expected at least one tasklet or data node")
             module_name = "_".join(labels)
 
-            # Consider only the scalars that are actually used in this subgraph
-            subgraph_scalar_parameters = []
-            for is_output, pname, p, *other in scalar_parameters:
-                if any(item.data == pname for item in subgraph.data_nodes()):
-                    if len(other) > 0:  # Xilinx: we indicate also the interface
-                        subgraph_scalar_parameters.append(
-                            (is_output, pname, p, *other))
-                    else:
-                        subgraph_scalar_parameters.append((is_output, pname, p))
-
-            # Consider only the symbols that are actually used in this subgraph
-            subgraph_symbol_parameters = {}
-            for symb, type in symbol_parameters.items():
-                if symb in subgraph.free_symbols:
-                    subgraph_symbol_parameters[symb] = type
-
-            self.generate_module(
-                sdfg, state, module_name, subgraph,
-                subgraph_parameters[subgraph] + subgraph_scalar_parameters,
-                subgraph_symbol_parameters, module_stream, entry_stream,
-                host_stream)
+            self.generate_module(sdfg, state, module_name, subgraph,
+                                 subgraph_parameters[subgraph], module_stream,
+                                 entry_stream, host_stream)
 
     def generate_nsdfg_header(self, sdfg, state, state_id, node,
                               memlet_references, sdfg_label):
@@ -1428,8 +1428,7 @@ class FPGACodeGen(TargetCodeGenerator):
             sdfg, state, dfg, node)
 
     def generate_host_function_boilerplate(self, sdfg, state, kernel_name,
-                                           parameters, symbol_parameters,
-                                           nested_global_transients,
+                                           parameters, nested_global_transients,
                                            host_code_stream, header_stream,
                                            callsite_stream):
 
@@ -1450,29 +1449,15 @@ class FPGACodeGen(TargetCodeGenerator):
         kernel_args_opencl.append(f'{self._global_sdfg.name}_t *__state')
         kernel_args_call_host.append(f'__state')
 
-        # Split into arrays and scalars
-        arrays = sorted(
-            [(t[0], t[1], t[2])
-             for t in parameters if not isinstance(t[2], dace.data.Scalar)],
-            key=lambda t: t[1])
-        scalars = [(t[0], t[1], t[2]) for t in parameters
-                   if isinstance(t[2], dace.data.Scalar)]
-        scalars += ((False, k, v) for k, v in symbol_parameters.items())
-        scalars = list(sorted(scalars, key=lambda t: t[1]))
-        for is_output, argname, arg in itertools.chain(arrays, scalars):
-            # Only pass each array once from the host code
-            if arg in seen:
-                continue
-            seen.add(arg)
+        for is_output, argname, arg, _ in parameters:
             # Streams and Views are not passed as arguments
-            if not isinstance(arg, dace.data.Stream) and not isinstance(
-                    arg, dace.data.View):
+            if not isinstance(arg, dt.Stream) and not isinstance(arg, dt.View):
                 kernel_args_call_host.append(arg.as_arg(False, name=argname))
                 kernel_args_opencl.append(
                     FPGACodeGen.make_opencl_parameter(argname, arg))
 
-        kernel_args_call_host = dace.dtypes.deduplicate(kernel_args_call_host)
-        kernel_args_opencl = dace.dtypes.deduplicate(kernel_args_opencl)
+        kernel_args_call_host = dtypes.deduplicate(kernel_args_call_host)
+        kernel_args_opencl = dtypes.deduplicate(kernel_args_opencl)
 
         host_function_name = "__dace_runkernel_{}".format(kernel_name)
         # Write OpenCL host function
@@ -1519,7 +1504,7 @@ DACE_EXPORTED void {host_function_name}({kernel_args_opencl}) {{
         # Inject dependency pragmas on memlets
         for edge in dfg.out_edges(node):
             datadesc = sdfg.arrays[edge.data.data]
-            if (isinstance(datadesc, dace.data.Array)
+            if (isinstance(datadesc, dt.Array)
                     and (datadesc.storage == dace.StorageType.FPGA_Local
                          or datadesc.storage == dace.StorageType.FPGA_Registers)
                     and not cpp.is_write_conflicted(dfg, edge)

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -262,8 +262,6 @@ class FPGACodeGen(TargetCodeGenerator):
                  - A dictionary mapping from each processing element subgraph
                    to which parameters it needs (from the total list of
                    parameters).
-                 - Symbol parameters that must be passed from the host to the
-                   kernel.
                  - Parameters that must be passed to the kernel from the host,
                    but that do not exist before the CPU calls the kernel
                    wrapper.

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -470,19 +470,8 @@ for (int u_{name} = 0; u_{name} < {size} - {veclen}; ++u_{name}) {{
         kernel_header_stream.write("\n", sdfg)
 
         (global_data_parameters, top_level_local_data, subgraph_parameters,
-         scalar_parameters, symbol_parameters, nested_global_transients,
+         nested_global_transients,
          external_streams) = self.make_parameters(sdfg, state, subgraphs)
-
-        # Ignore interface ID in this backend
-        global_data_parameters = [tuple(p[:3]) for p in global_data_parameters]
-        subgraph_parameters = {
-            k: [tuple(vv[:3]) for vv in v]
-            for k, v in subgraph_parameters.items()
-        }
-
-        # Scalar parameters are never output
-        sc_parameters = [(False, pname, param)
-                         for pname, param in scalar_parameters]
 
         host_code_header_stream = CodeIOStream()
         host_code_body_stream = CodeIOStream()
@@ -497,16 +486,16 @@ for (int u_{name} = 0; u_{name} < {size} - {veclen}; ++u_{name}) {{
 
         # Generate host code
         self.generate_host_function_boilerplate(
-            sdfg, state, kernel_name, global_data_parameters + sc_parameters,
-            symbol_parameters, nested_global_transients, host_code_body_stream,
-            function_stream, callsite_stream)
+            sdfg, state, kernel_name, global_data_parameters,
+            nested_global_transients, host_code_body_stream, function_stream,
+            callsite_stream)
 
         self.generate_host_function_prologue(sdfg, state, host_code_body_stream)
 
         self.generate_modules(sdfg, state, kernel_name, subgraphs,
-                              subgraph_parameters, sc_parameters,
-                              symbol_parameters, kernel_body_stream,
-                              host_code_header_stream, host_code_body_stream)
+                              subgraph_parameters,
+                              kernel_body_stream, host_code_header_stream,
+                              host_code_body_stream)
 
         kernel_body_stream.write("\n")
 
@@ -566,7 +555,7 @@ for (int u_{name} = 0; u_{name} < {size} - {veclen}; ++u_{name}) {{
 }""", sdfg, sdfg.node_id(state))
 
     def generate_module(self, sdfg, state, name, subgraph, parameters,
-                        symbol_parameters, module_stream, host_header_stream,
+                        module_stream, host_header_stream,
                         host_body_stream):
 
         state_id = sdfg.node_id(state)
@@ -575,18 +564,9 @@ for (int u_{name} = 0; u_{name} < {size} - {veclen}; ++u_{name}) {{
         kernel_args_opencl = []
         kernel_args_host = []
         kernel_args_call = []
-        added = set()
-        # Split into arrays and scalars
-        arrays = sorted(
-            [t for t in parameters if not isinstance(t[2], dace.data.Scalar)],
-            key=lambda t: t[1])
-        scalars = [t for t in parameters if isinstance(t[2], dace.data.Scalar)]
-        scalars += [(False, k, v) for k, v in symbol_parameters.items()]
-        scalars = list(sorted(scalars, key=lambda t: t[1]))
-        for is_output, pname, p in itertools.chain(arrays, scalars):
-            if pname in added or isinstance(p, dace.data.View):
+        for is_output, pname, p, _ in parameters:
+            if isinstance(p, dace.data.View):
                 continue
-            added.add(pname)
             arg = self.make_kernel_argument(p, pname, is_output, True)
             if arg is not None:
                 kernel_args_opencl.append(arg)

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -468,8 +468,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                     array_args.append((kernel_arg, dataname))
 
         stream_args = []
-        for is_output, dataname, data, interface in sorted(external_streams,
-                                                           key=lambda t: t[1]):
+        for is_output, dataname, data, interface in external_streams:
             kernel_arg = self.make_kernel_argument(data, dataname, is_output,
                                                    True, interface)
             if kernel_arg:

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -445,10 +445,8 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
             state_id, node)
 
     def generate_kernel_boilerplate_pre(self, sdfg, state_id, kernel_name,
-                                        global_data_parameters,
-                                        scalar_parameters, symbol_parameters,
-                                        module_stream, kernel_stream,
-                                        external_streams):
+                                        parameters, module_stream,
+                                        kernel_stream, external_streams):
 
         # Write header
         module_stream.write(
@@ -458,28 +456,20 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         self._frame.generate_fileheader(sdfg, module_stream, 'xilinx_device')
         module_stream.write("\n", sdfg)
 
-        symbol_params = [
-            v.as_arg(with_types=True, name=k)
-            for k, v in symbol_parameters.items()
-        ]
-        arrays = list(sorted(global_data_parameters, key=lambda t: t[1]))
-        scalars = scalar_parameters + list(symbol_parameters.items())
-        scalars = list(sorted(scalars, key=lambda t: t[0]))
-
         # Build kernel signature
+        kernel_args = []
         array_args = []
-        for is_output, dataname, data, interface in arrays:
+        for is_output, dataname, data, interface in parameters:
             kernel_arg = self.make_kernel_argument(data, dataname, is_output,
                                                    True, interface)
             if kernel_arg:
-                array_args.append(kernel_arg)
-        kernel_args = array_args + [
-            v.as_arg(with_types=True, name=k) for k, v in scalars
-        ]
-        kernel_args = dace.dtypes.deduplicate(kernel_args)
+                kernel_args.append(kernel_arg)
+                if isinstance(data, dace.data.Array):
+                    array_args.append((kernel_arg, dataname))
 
         stream_args = []
-        for is_output, dataname, data, interface in external_streams:
+        for is_output, dataname, data, interface in sorted(external_streams,
+                                                           key=lambda t: t[1]):
             kernel_arg = self.make_kernel_argument(data, dataname, is_output,
                                                    True, interface)
             if kernel_arg:
@@ -493,7 +483,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         # Insert interface pragmas
         num_mapped_args = 0
-        for arg, (_, dataname, _, _) in zip(array_args, arrays):
+        for arg, dataname in array_args:
             var_name = re.findall(r"\w+", arg)[-1]
             if "*" in arg:
                 interface_name = "gmem{}".format(num_mapped_args)
@@ -534,24 +524,10 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         kernel_stream.write("HLSLIB_DATAFLOW_FINALIZE();\n}\n", sdfg, state_id)
 
     def generate_host_function_body(self, sdfg, state, kernel_name, parameters,
-                                    symbol_parameters, kernel_stream,
-                                    rtl_tasklets):
+                                    kernel_stream, rtl_tasklets):
 
-        # Just collect all variable names for calling the kernel function
-        added = set()
-        arrays = list(
-            sorted([
-                p for p in parameters if not isinstance(p[2], dace.data.Scalar)
-            ],
-                   key=lambda t: t[1]))
-        scalars = [p for p in parameters if isinstance(p[2], dace.data.Scalar)]
-        scalars += ((False, k, v, None) for k, v in symbol_parameters.items())
-        scalars = dace.dtypes.deduplicate(sorted(scalars, key=lambda t: t[1]))
         kernel_args = []
-        for _, name, p, _ in itertools.chain(arrays, scalars):
-            if not isinstance(p, dace.data.Array) and name in added:
-                continue
-            added.add(name)
+        for _, name, p, _ in parameters:
             kernel_args.append(p.as_arg(False, name=name))
 
         kernel_function_name = kernel_name
@@ -577,8 +553,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
              rtl_waits="\n  ".join(rtl_waits)), sdfg, sdfg.node_id(state))
 
     def generate_module(self, sdfg, state, name, subgraph, parameters,
-                        symbol_parameters, module_stream, entry_stream,
-                        host_stream):
+                        module_stream, entry_stream, host_stream):
         """Generates a module that will run as a dataflow function in the FPGA
            kernel."""
 
@@ -587,7 +562,6 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         kernel_args_call = []
         kernel_args_module = []
-        added = set()
 
         # Check if we are generating an RTL module, in which case only the
         # accesses to the streams should be handled
@@ -642,14 +616,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                                skip_entry_node=False)
             return
 
-        parameters = list(sorted(parameters, key=lambda t: t[1]))
-        arrays = dtypes.deduplicate(
-            [p for p in parameters if not isinstance(p[2], dace.data.Scalar)])
-        scalars = [p for p in parameters if isinstance(p[2], dace.data.Scalar)]
-        scalars += ((False, k, v, None) for k, v in symbol_parameters.items())
-        scalars = dace.dtypes.deduplicate(sorted(scalars, key=lambda t: t[1]))
-        for is_output, pname, p, interface_id in itertools.chain(
-                arrays, scalars):
+        for is_output, pname, p, interface_id in parameters:
             if isinstance(p, dace.data.Array):
                 arr_name = cpp.array_interface_variable(pname, is_output, None)
                 # Add interface ID to called module, but not to the module
@@ -663,10 +630,6 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                 kernel_args_module.append("{} {}*{}".format(
                     dtype.ctype, "const " if not is_output else "", arr_name))
             else:
-                # Don't make duplicate arguments for other types than arrays
-                if pname in added:
-                    continue
-                added.add(pname)
                 if isinstance(p, dace.data.Stream):
                     kernel_args_call.append(
                         p.as_arg(with_types=False, name=pname))
@@ -789,12 +752,8 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         """Main entry function for generating a Xilinx kernel."""
 
         (global_data_parameters, top_level_local_data, subgraph_parameters,
-         scalar_parameters, symbol_parameters, nested_global_transients,
+         nested_global_transients,
          external_streams) = self.make_parameters(sdfg, state, subgraphs)
-
-        # Scalar parameters are never output
-        sc_parameters = [(False, pname, param, None)
-                         for pname, param in scalar_parameters]
 
         host_code_stream = CodeIOStream()
         rtl_tasklets = [
@@ -804,17 +763,17 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         ]
 
         # Generate host code
-        self.generate_host_header(sdfg, kernel_name,
-                                  global_data_parameters + sc_parameters,
-                                  symbol_parameters, host_code_stream)
-        self.generate_host_function_boilerplate(
-            sdfg, state, kernel_name, global_data_parameters + sc_parameters,
-            symbol_parameters, nested_global_transients, host_code_stream,
-            function_stream, callsite_stream)
+        self.generate_host_header(sdfg, kernel_name, global_data_parameters,
+                                  host_code_stream)
+        self.generate_host_function_boilerplate(sdfg, state, kernel_name,
+                                                global_data_parameters,
+                                                nested_global_transients,
+                                                host_code_stream,
+                                                function_stream,
+                                                callsite_stream)
         self.generate_host_function_body(sdfg, state, kernel_name,
-                                         global_data_parameters + sc_parameters,
-                                         symbol_parameters, host_code_stream,
-                                         rtl_tasklets)
+                                         global_data_parameters,
+                                         host_code_stream, rtl_tasklets)
         # Store code to be passed to compilation phase
         self._host_codes.append((kernel_name, host_code_stream.getvalue()))
 
@@ -826,9 +785,8 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         self.generate_kernel_boilerplate_pre(sdfg, state_id, kernel_name,
                                              global_data_parameters,
-                                             scalar_parameters,
-                                             symbol_parameters, module_stream,
-                                             entry_stream, external_streams)
+                                             module_stream, entry_stream,
+                                             external_streams)
 
         # Emit allocations
         for node in top_level_local_data:
@@ -843,8 +801,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                 0 if is_output else 1] = '{}_1.{}'.format(kernel_name, name)
 
         self.generate_modules(sdfg, state, kernel_name, subgraphs,
-                              subgraph_parameters, sc_parameters,
-                              symbol_parameters, module_stream, entry_stream,
+                              subgraph_parameters, module_stream, entry_stream,
                               host_code_stream)
 
         kernel_stream.write(module_stream.getvalue())
@@ -853,30 +810,17 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         self.generate_kernel_boilerplate_post(kernel_stream, sdfg, state_id)
 
     def generate_host_header(self, sdfg, kernel_function_name, parameters,
-                             symbol_parameters, host_code_stream):
-
-        arrays = [
-            p for p in parameters if not isinstance(p[2], dace.data.Scalar)
-        ]
-        arrays = list(sorted(arrays, key=lambda t: t[1]))
-        scalars = [p for p in parameters if isinstance(p[2], dace.data.Scalar)]
-        scalars += ((False, k, v, None) for k, v in symbol_parameters.items())
-        scalars = list(sorted(scalars, key=lambda t: t[1]))
+                             host_code_stream):
 
         kernel_args = []
-
-        seen = set()
-        for is_output, name, arg, if_id in itertools.chain(arrays, scalars):
+        for is_output, name, arg, if_id in parameters:
             if isinstance(arg, dace.data.Array):
                 argname = cpp.array_interface_variable(name, is_output, None)
                 if if_id is not None:
-                    argname += "_%d" % if_id
+                    argname = f"{argname}_{if_id}"
 
                 kernel_args.append(arg.as_arg(with_types=True, name=argname))
             else:
-                if name in seen:
-                    continue
-                seen.add(name)
                 kernel_args.append(arg.as_arg(with_types=True, name=name))
 
         host_code_stream.write(

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 
 import dace
-from dace import registry, dtypes
+from dace import data as dt, registry, dtypes
 from dace.config import Config
 from dace.frontend import operations
 from dace.sdfg import nodes
@@ -259,7 +259,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                              is_output,
                              with_vectorization,
                              interface_id=None):
-        if isinstance(data, dace.data.Array):
+        if isinstance(data, dt.Array):
             var_name = cpp.array_interface_variable(var_name, is_output, None)
             if interface_id is not None:
                 var_name = var_name = f"{var_name}_{interface_id}"
@@ -268,7 +268,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
             else:
                 dtype = data.dtype.base_type
             return "{} *{}".format(dtype.ctype, var_name)
-        if isinstance(data, dace.data.Stream):
+        if isinstance(data, dt.Stream):
             ctype = "dace::FIFO<{}, {}, {}>".format(data.dtype.base_type.ctype,
                                                     data.dtype.veclen,
                                                     data.buffer_size)
@@ -464,7 +464,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                                    True, interface)
             if kernel_arg:
                 kernel_args.append(kernel_arg)
-                if isinstance(data, dace.data.Array):
+                if isinstance(data, dt.Array):
                     array_args.append((kernel_arg, dataname))
 
         stream_args = []
@@ -523,7 +523,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         kernel_stream.write("HLSLIB_DATAFLOW_FINALIZE();\n}\n", sdfg, state_id)
 
     def generate_host_function_body(self, sdfg, state, kernel_name, parameters,
-                                    kernel_stream, rtl_tasklets):
+                                    rtl_tasklet_names, kernel_stream):
 
         kernel_args = []
         for _, name, p, _ in parameters:
@@ -532,24 +532,23 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         kernel_function_name = kernel_name
         kernel_file_name = "{}.xclbin".format(kernel_name)
 
-        rtl_starts = []
-        rtl_waits = []
-        for rtl_tasklet in rtl_tasklets:
-            rtl_starts.append(
-                f"  auto kernel_{rtl_tasklet} = program.MakeKernel(\"{rtl_tasklet}_top\"{', '.join([''] + [name for _, name, p, _ in parameters if isinstance(p, dace.data.Scalar)])}).ExecuteTaskFork();"
-            )
-            rtl_waits.append(f"  kernel_{rtl_tasklet}.wait();")
+        # Launch HLS kernel
+        kernel_stream.write(
+            f"""\
+  auto kernel = program.MakeKernel({kernel_function_name}, "{kernel_function_name}", {", ".join(kernel_args)});
+  const std::pair<double, double> elapsed = kernel.ExecuteTask();""", sdfg,
+            sdfg.node_id(state))
+
+        # Join RTL tasklets
+        for name in rtl_tasklet_names:
+            kernel_stream.write(f"kernel_{name}.wait();\n", sdfg,
+                                sdfg.node_id(state))
+
+        # Report performance
         kernel_stream.write(
             """\
-  {rtl_starts}
-  auto kernel = program.MakeKernel({kernel_function_name}, "{kernel_function_name}", {kernel_args});
-  const std::pair<double, double> elapsed = kernel.ExecuteTask();
-  {rtl_waits}
   std::cout << "Kernel executed in " << elapsed.second << " seconds.\\n" << std::flush;
-}}""".format(kernel_function_name=kernel_function_name,
-             kernel_args=", ".join(kernel_args),
-             rtl_starts="\n  ".join(rtl_starts),
-             rtl_waits="\n  ".join(rtl_waits)), sdfg, sdfg.node_id(state))
+}""", sdfg, sdfg.node_id(state))
 
     def generate_module(self, sdfg, state, name, subgraph, parameters,
                         module_stream, entry_stream, host_stream):
@@ -562,7 +561,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         kernel_args_call = []
         kernel_args_module = []
         for is_output, pname, p, interface_id in parameters:
-            if isinstance(p, dace.data.Array):
+            if isinstance(p, dt.Array):
                 arr_name = cpp.array_interface_variable(pname, is_output, None)
                 # Add interface ID to called module, but not to the module
                 # arguments
@@ -575,7 +574,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                 kernel_args_module.append("{} {}*{}".format(
                     dtype.ctype, "const " if not is_output else "", arr_name))
             else:
-                if isinstance(p, dace.data.Stream):
+                if isinstance(p, dt.Stream):
                     kernel_args_call.append(
                         p.as_arg(with_types=False, name=pname))
                     if p.is_stream_array():
@@ -596,14 +595,13 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         # Check if we are generating an RTL module, in which case only the
         # accesses to the streams should be handled
-        rtl_module = False
+        rtl_tasklet = None
         for n in subgraph.nodes():
-            if isinstance(
-                    n, dace.nodes.Tasklet
-            ) and n.language == dace.dtypes.Language.SystemVerilog:
-                rtl_module = True
+            if (isinstance(n, dace.nodes.Tasklet)
+                    and n.language == dace.dtypes.Language.SystemVerilog):
+                rtl_tasklet = n
                 break
-        if rtl_module:
+        if rtl_tasklet:
             entry_stream.write(
                 f'// [RTL] HLSLIB_DATAFLOW_FUNCTION({name}, {", ".join(kernel_args_call)});'
             )
@@ -612,7 +610,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
             # _1 in names are due to vitis
             for node in subgraph.source_nodes():
-                if isinstance(sdfg.arrays[node.data], dace.data.Stream):
+                if isinstance(sdfg.arrays[node.data], dt.Stream):
                     if node.data not in self._stream_connections:
                         self._stream_connections[node.data] = [None, None]
                     for edge in state.out_edges(node):
@@ -624,7 +622,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                 rtl_name, edge.dst_conn)
 
             for node in subgraph.sink_nodes():
-                if isinstance(sdfg.arrays[node.data], dace.data.Stream):
+                if isinstance(sdfg.arrays[node.data], dt.Stream):
                     if node.data not in self._stream_connections:
                         self._stream_connections[node.data] = [None, None]
                     for edge in state.in_edges(node):
@@ -645,6 +643,13 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                                ignore_stream,
                                                ignore_stream,
                                                skip_entry_node=False)
+
+            # Launch the kernel from the host code
+            rtl_name = self.rtl_tasklet_name(rtl_tasklet, state, sdfg)
+            host_stream.write(
+                f"  auto kernel_{rtl_name} = program.MakeKernel(\"{rtl_name}_top\", {', '.join([name for _, name, p, _ in parameters if not isinstance(p, dt.Stream)])}).ExecuteTaskFork();",
+                sdfg, state_id, rtl_tasklet)
+
             return
 
         # create a unique module name to prevent name clashes
@@ -699,7 +704,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
         # FPGA kernel
         interfaces_added = set()
         for is_output, argname, arg, _ in parameters:
-            if (not (isinstance(arg, dace.data.Array)
+            if (not (isinstance(arg, dt.Array)
                      and arg.storage == dace.dtypes.StorageType.FPGA_Global)):
                 continue
             ctype = dtypes.pointer(arg.dtype).ctype
@@ -744,6 +749,10 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         self._dispatcher.defined_vars.exit_scope(subgraph)
 
+    def rtl_tasklet_name(self, node: nodes.RTLTasklet, state, sdfg):
+        return "{}_{}_{}_{}".format(node.name, sdfg.sdfg_id,
+                                    sdfg.node_id(state), state.node_id(node))
+
     def generate_kernel_internal(self, sdfg, state, kernel_name, subgraphs,
                                  kernel_stream, function_stream,
                                  callsite_stream):
@@ -753,12 +762,13 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
          nested_global_transients,
          external_streams) = self.make_parameters(sdfg, state, subgraphs)
 
-        host_code_stream = CodeIOStream()
-        rtl_tasklets = [
-            "{}_{}_{}_{}".format(nd.name, sdfg.sdfg_id, sdfg.node_id(state),
-                                 state.node_id(nd)) for nd in state.nodes()
+        # Detect RTL tasklets, which will be launched as individual kernels
+        rtl_tasklet_names = [
+            self.rtl_tasklet_name(nd, state, sdfg) for nd in state.nodes()
             if isinstance(nd, nodes.RTLTasklet)
         ]
+
+        host_code_stream = CodeIOStream()
 
         # Generate host code
         self.generate_host_header(sdfg, kernel_name, global_data_parameters,
@@ -769,11 +779,6 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                                 host_code_stream,
                                                 function_stream,
                                                 callsite_stream)
-        self.generate_host_function_body(sdfg, state, kernel_name,
-                                         global_data_parameters,
-                                         host_code_stream, rtl_tasklets)
-        # Store code to be passed to compilation phase
-        self._host_codes.append((kernel_name, host_code_stream.getvalue()))
 
         # Now we write the device code
         module_stream = CodeIOStream()
@@ -802,6 +807,12 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                               subgraph_parameters, module_stream, entry_stream,
                               host_code_stream)
 
+        self.generate_host_function_body(sdfg, state, kernel_name,
+                                         global_data_parameters,
+                                         rtl_tasklet_names, host_code_stream)
+
+        # Store code to be passed to compilation phase
+        self._host_codes.append((kernel_name, host_code_stream.getvalue()))
         kernel_stream.write(module_stream.getvalue())
         kernel_stream.write(entry_stream.getvalue())
 
@@ -812,7 +823,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         kernel_args = []
         for is_output, name, arg, if_id in parameters:
-            if isinstance(arg, dace.data.Array):
+            if isinstance(arg, dt.Array):
                 argname = cpp.array_interface_variable(name, is_output, None)
                 if if_id is not None:
                     argname = f"{argname}_{if_id}"
@@ -859,8 +870,7 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
             if in_memlet.data is None:
                 continue
             desc = sdfg.arrays[in_memlet.data]
-            is_memory_interface = (isinstance(desc, dace.data.Array)
-                                   and desc.storage
+            is_memory_interface = (isinstance(desc, dt.Array) and desc.storage
                                    == dtypes.StorageType.FPGA_Global)
             if is_memory_interface:
                 interface_name = cpp.array_interface_variable(
@@ -899,8 +909,7 @@ DACE_EXPORTED void {kernel_function_name}({kernel_args});\n\n""".format(
                                             conntype=node.out_connectors[uconn],
                                             is_write=True)
             desc = sdfg.arrays[out_memlet.data]
-            is_memory_interface = (isinstance(desc, dace.data.Array)
-                                   and desc.storage
+            is_memory_interface = (isinstance(desc, dt.Array) and desc.storage
                                    == dtypes.StorageType.FPGA_Global)
             if is_memory_interface:
                 interface_name = cpp.array_interface_variable(uconn, True, None)


### PR DESCRIPTION
* Improve handling of global scalars, as this occurs with some frontends.
* Don't distinguish between array, scalar, and symbol arguments, in how they are handled across the FPGA codegen.
* Deduplicate kernel arguments centrally, instead of all over the FPGA codegens.
* Detect and fail if the kernel expects scalar outputs from the kernel, as this is not currently supported.
* Update how RTL tasklets are called to use the specific subgraph parameters