### PR TITLE
Fix Xilinx codegen trailing comma

### DIFF
--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -639,7 +639,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
             # Launch the kernel from the host code
             rtl_name = self.rtl_tasklet_name(rtl_tasklet, state, sdfg)
             host_stream.write(
-                f"  auto kernel_{rtl_name} = program.MakeKernel(\"{rtl_name}_top\", {', '.join([name for _, name, p, _ in parameters if not isinstance(p, dt.Stream)])}).ExecuteTaskFork();",
+                f"  auto kernel_{rtl_name} = program.MakeKernel(\"{rtl_name}_top\"{', '.join([''] + [name for _, name, p, _ in parameters if not isinstance(p, dt.Stream)])}).ExecuteTaskFork();",
                 sdfg, state_id, rtl_tasklet)
 
             return


### PR DESCRIPTION
In part of the Xilinx codegen, a trailing comma is mistakingly generated in some cases (if "parameters" is empty), which breaks the syntax of the generated code.

This fix ensures, that no such trailing comma is generated.

Example of such a broken syntax:
`auto kernel_rtl_ma_0_1_26 = program.MakeKernel("rtl_ma_0_1_26_top", ).ExecuteTaskFork();`
