### PR TITLE
Use pytest-xdist to run some pytest tests in parallel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,20 +87,20 @@ jobs:
         papi_avail
         nvidia-smi
 
-    - name: Test with pytest
+    - name: Run parallel pytest 
       run: |
         export DACE_testing_single_cache=0
         export DACE_optimizer_interface=" "
         . /opt/setupenv
-        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "gpu or verilator or mkl"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "verilator or mkl or papi"
         codecov
 
-    - name: Run PAPI tests
+    - name: Run pytest GPU
       run: |
-        export DACE_testing_single_cache=0
+        export DACE_testing_single_cache=1
         export DACE_optimizer_interface=" "
         . /opt/setupenv
-        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "papi"
+        pytest --cov-report=xml --cov=dace --tb=short -m "gpu"
         codecov
 
     - name: Run extra GPU tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,7 +67,7 @@ jobs:
         codecov
 
   test-heterogeneous:
-    runs-on: [self-hosted, linux, gpu, intel-fpga, xilinx-fpga]
+    runs-on: [self-hosted, linux]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -85,7 +85,6 @@ jobs:
     - name: Test dependencies
       run: |
         papi_avail
-        nvidia-smi
 
     - name: Run parallel pytest 
       run: |
@@ -94,6 +93,42 @@ jobs:
         . /opt/setupenv
         pytest -n auto --cov-report=xml --cov=dace --tb=short -m "verilator or mkl or papi"
         codecov
+
+    - name: Run MPI tests
+      run: |
+        export NOSTATUSBAR=1
+        export DACE_testing_single_cache=1
+        export COVERAGE_RCFILE=`pwd`/.coveragerc
+        export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
+        . /opt/setupenv
+        ./tests/mpi_test.sh
+
+    - name: Report overall coverage
+      run: |
+        export COVERAGE_RCFILE=`pwd`/.coveragerc
+        . /opt/setupenv
+        coverage combine . */; coverage report; coverage xml
+        codecov
+
+  test-gpu:
+    runs-on: [self-hosted, linux, gpu]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: |
+        rm -rf .dacecache tests/.dacecache
+        . /opt/setupenv
+        python -m pip install --upgrade pip
+        pip install flake8 pytest-xdist coverage codecov
+        pip install mpi4py
+        pip uninstall -y dace
+        pip install -e ".[testing]"
+
+    - name: Test dependencies
+      run: |
+        nvidia-smi
 
     - name: Run pytest GPU
       run: |
@@ -112,14 +147,28 @@ jobs:
         . /opt/setupenv
         ./tests/cuda_test.sh
 
-    - name: Run MPI tests
+    - name: Report overall coverage
       run: |
-        export NOSTATUSBAR=1
-        export DACE_testing_single_cache=1
         export COVERAGE_RCFILE=`pwd`/.coveragerc
-        export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv
-        ./tests/mpi_test.sh
+        coverage combine . */; coverage report; coverage xml
+        codecov
+
+  test-fpga:
+    runs-on: [self-hosted, linux, intel-fpga, xilinx-fpga]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: |
+        rm -rf .dacecache tests/.dacecache
+        . /opt/setupenv
+        python -m pip install --upgrade pip
+        pip install flake8 pytest-xdist coverage codecov
+        pip install mpi4py
+        pip uninstall -y dace
+        pip install -e ".[testing]"
 
     - name: Run Intel FPGA tests
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -186,10 +186,3 @@ jobs:
         . /opt/setupenv
         python tests/fpga/xilinx_test.py
         codecov
-
-    - name: Report overall coverage
-      run: |
-        export COVERAGE_RCFILE=`pwd`/.coveragerc
-        . /opt/setupenv
-        coverage combine . */; coverage report; coverage xml
-        codecov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export NOSTATUSBAR=1
         export DACE_testing_serialization=1
-        export DACE_testing_single_cache=0
+        export DACE_cache=unique
         export DACE_optimizer_interface=" "
         if [ "${{ matrix.strict-xforms }}" = "autoopt" ]; then
             export DACE_optimizer_automatic_strict_transformations=1
@@ -58,7 +58,7 @@ jobs:
       run: |
         export NOSTATUSBAR=1
         export DACE_testing_serialization=1
-        export DACE_testing_single_cache=1
+        export DACE_cache=single
         export DACE_optimizer_automatic_strict_transformations=${{ matrix.strict-xforms }}
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         ./tests/polybench_test.sh
@@ -88,7 +88,7 @@ jobs:
 
     - name: Run parallel pytest 
       run: |
-        export DACE_testing_single_cache=0
+        export DACE_cache=unique
         export DACE_optimizer_interface=" "
         . /opt/setupenv
         pytest -n auto --cov-report=xml --cov=dace --tb=short -m "verilator or mkl or papi"
@@ -97,7 +97,7 @@ jobs:
     - name: Run MPI tests
       run: |
         export NOSTATUSBAR=1
-        export DACE_testing_single_cache=1
+        export DACE_cache=single
         export COVERAGE_RCFILE=`pwd`/.coveragerc
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv
@@ -132,7 +132,7 @@ jobs:
 
     - name: Run pytest GPU
       run: |
-        export DACE_testing_single_cache=1
+        export DACE_cache=single
         export DACE_optimizer_interface=" "
         . /opt/setupenv
         pytest --cov-report=xml --cov=dace --tb=short -m "gpu"
@@ -141,7 +141,7 @@ jobs:
     - name: Run extra GPU tests
       run: |
         export NOSTATUSBAR=1
-        export DACE_testing_single_cache=1
+        export DACE_cache=single
         export COVERAGE_RCFILE=`pwd`/.coveragerc
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv
@@ -172,7 +172,6 @@ jobs:
     - name: Run Intel FPGA tests
       run: |
         export NOSTATUSBAR=1
-        export DACE_testing_single_cache=0
         export COVERAGE_RCFILE=`pwd`/.coveragerc
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv
@@ -182,7 +181,6 @@ jobs:
     - name: Run Xilinx tests
       run: |
         export NOSTATUSBAR=1
-        export DACE_testing_single_cache=0
         export COVERAGE_RCFILE=`pwd`/.coveragerc
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -165,8 +165,7 @@ jobs:
         rm -rf .dacecache tests/.dacecache
         . /opt/setupenv
         python -m pip install --upgrade pip
-        pip install flake8 pytest-xdist coverage codecov
-        pip install mpi4py
+        pip install flake8 coverage codecov
         pip uninstall -y dace
         pip install -e ".[testing]"
 
@@ -178,6 +177,7 @@ jobs:
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv
         python tests/fpga/intel_fpga_test.py
+        codecov
 
     - name: Run Xilinx tests
       run: |
@@ -187,6 +187,7 @@ jobs:
         export PYTHON_BINARY="coverage run --source=dace --parallel-mode"
         . /opt/setupenv
         python tests/fpga/xilinx_test.py
+        codecov
 
     - name: Report overall coverage
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
         sudo apt-get install -y libpapi-dev papi-tools  # Instrumentation dependencies
         sudo apt-get install -y verilator # RTL simulation dependencies
         python -m pip install --upgrade pip
-        pip install flake8 pytest coverage codecov
+        pip install flake8 pytest-xdist coverage codecov
         pip install -e ".[testing]"
 
     - name: Test dependencies
@@ -52,7 +52,7 @@ jobs:
         else
             export DACE_optimizer_automatic_strict_transformations=${{ matrix.strict-xforms }}
         fi
-        pytest --cov-report=xml --cov=dace --tb=short -m "not gpu and not verilator and not tensorflow and not mkl"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "not gpu and not verilator and not tensorflow and not mkl"
         codecov
     - name: Run other tests
       run: |
@@ -77,7 +77,7 @@ jobs:
         rm -rf .dacecache tests/.dacecache
         . /opt/setupenv
         python -m pip install --upgrade pip
-        pip install flake8 pytest coverage codecov
+        pip install flake8 pytest-xdist coverage codecov
         pip install mpi4py
         pip uninstall -y dace
         pip install -e ".[testing]"
@@ -92,7 +92,7 @@ jobs:
         export DACE_testing_single_cache=1
         export DACE_optimizer_interface=" "
         . /opt/setupenv
-        pytest --cov-report=xml --cov=dace --tb=short -m "gpu or verilator or mkl"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "gpu or verilator or mkl"
         codecov
 
     - name: Run PAPI tests
@@ -100,7 +100,7 @@ jobs:
         export DACE_testing_single_cache=1
         export DACE_optimizer_interface=" "
         . /opt/setupenv
-        pytest --cov-report=xml --cov=dace --tb=short -m "papi"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "papi"
         codecov
 
     - name: Run extra GPU tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export NOSTATUSBAR=1
         export DACE_testing_serialization=1
-        export DACE_testing_single_cache=1
+        export DACE_testing_single_cache=0
         export DACE_optimizer_interface=" "
         if [ "${{ matrix.strict-xforms }}" = "autoopt" ]; then
             export DACE_optimizer_automatic_strict_transformations=1
@@ -89,7 +89,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        export DACE_testing_single_cache=1
+        export DACE_testing_single_cache=0
         export DACE_optimizer_interface=" "
         . /opt/setupenv
         pytest -n auto --cov-report=xml --cov=dace --tb=short -m "gpu or verilator or mkl"
@@ -97,7 +97,7 @@ jobs:
 
     - name: Run PAPI tests
       run: |
-        export DACE_testing_single_cache=1
+        export DACE_testing_single_cache=0
         export DACE_optimizer_interface=" "
         . /opt/setupenv
         pytest -n auto --cov-report=xml --cov=dace --tb=short -m "papi"

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -740,10 +740,10 @@ required:
         title: Naming of cache entry 
         description: >
             Determine the name of the generated dacecache folder.
-            "name" uses the name of the SDFG, causing it to be overridden by
-            other programs using a similar SDFG name.
-            "hash" uses a mangled name using the hash of the SDFG, such that any
-            change to the SDFG will generate a different cache folder.
+            "name" uses the name of the SDFG directly, causing it to be
+            overridden by other programs using the same SDFG name.
+            "hash" uses a mangled name based on the hash of the SDFG, such that
+            any change to the SDFG will generate a different cache folder.
             "unique" uses a name based on the currently running Pythion process 
             at code generation time, such that no caching or clashes can happen
             between different processes or subsequent invokations of Python.

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -744,9 +744,9 @@ required:
             other programs using a similar SDFG name.
             "hash" uses a mangled name using the hash of the SDFG, such that any
             change to the SDFG will generate a different cache folder.
-            "unique" uses a name based on the SDFGs current location in memory
+            "unique" uses a name based on the currently running Pythion process 
             at code generation time, such that no caching or clashes can happen
-            between different processes or subsequent invokations of Python..
+            between different processes or subsequent invokations of Python.
             "single" uses a single cache folder for all SDFGs, saving space and
             potentially build time, but disallows executing SDFGs in parallel
             and caching of more than one simultaneous SDFG.

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -734,6 +734,23 @@ required:
         title: Debug printing
         description: Enable verbose printouts.
 
+    cache:
+        type: str 
+        default: name 
+        title: Naming of cache entry 
+        description: >
+            Determine the name of the generated dacecache folder.
+            "name" uses the name of the SDFG, causing it to be overridden by
+            other programs using a similar SDFG name.
+            "hash" uses a mangled name using the hash of the SDFG, such that any
+            change to the SDFG will generate a different cache folder.
+            "unique" uses a name based on the SDFGs current location in memory
+            at code generation time, such that no caching or clashes can happen
+            between different processes or subsequent invokations of Python..
+            "single" uses a single cache folder for all SDFGs, saving space and
+            potentially build time, but disallows executing SDFGs in parallel
+            and caching of more than one simultaneous SDFG.
+
     profiling:
         type: bool
         default: false
@@ -785,14 +802,6 @@ required:
                 description: >
                     Before generating code, verify that a serialization/deserialization loop
                     generates the same SDFG.
-
-            single_cache:
-                type: bool
-                default: false
-                title: Use one build folder
-                description: >
-                    When generating code, use a single build folder as cache.
-                    Speeds up build time but disallows concurrent invocations.
 
     #############################################
     # DaCe library settings

--- a/dace/frontend/octave/ast_node.py
+++ b/dace/frontend/octave/ast_node.py
@@ -28,10 +28,10 @@ class AST_Node():
             str(type(self)) + " does not implement replace_child()")
 
     def specialize(self):
-        """ Some nodes can be simplified after parsing the complete AST and 
-            before actually generating code, i.e., AST_FunCall nodes could be 
+        """ Some nodes can be simplified after parsing the complete AST and
+            before actually generating code, i.e., AST_FunCall nodes could be
             function calls or array accesses, and we don't really know unless
-            we know the context of the call. 
+            we know the context of the call.
 
             This function traverses the AST
             and tries to specialize nodes after completing the AST. It should
@@ -126,7 +126,7 @@ class AST_Node():
             sdfg_state = sdfg.nodes()[state]
             for node in sdfg_state.nodes():
                 if isinstance(node, dace.sdfg.nodes.AccessNode):
-                    m = re.match(TEMPVARS_PREFIX + "(\d+)", node.label)
+                    m = re.match(TEMPVARS_PREFIX + r"(\d+)", node.label)
                     if m is not None:
                         if maxvar < int(m.group(1)):
                             maxvar = int(m.group(1))
@@ -136,7 +136,7 @@ class AST_Node():
 
     def get_name_in_sdfg(self, sdfg):
         """ If this node has no name assigned yet, create a new one of the form
-            `__tmp_X` where `X` is an integer, such that this node does not yet 
+            `__tmp_X` where `X` is an integer, such that this node does not yet
             exist in the given SDFG.
             @note: We assume that we create exactly one SDFG from each AST,
                    otherwise we need to store the hash of the SDFG the name was

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -7,7 +7,7 @@ import errno
 import itertools
 import os
 import pickle, json
-from hashlib import sha256
+from hashlib import md5, sha256
 from pydoc import locate
 import random
 import re
@@ -684,10 +684,27 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         """ Returns a relative path to the build cache folder for this SDFG. """
         if hasattr(self, '_build_folder'):
             return self._build_folder
-        elif Config.get_bool('testing', 'single_cache'):
-            return os.path.join('.dacecache', 'test')
-        else:
+        cache_config = Config.get('cache')
+        if cache_config == 'single':
+            # Always use the same directory, overwriting any other program,
+            # preventing parallelism and caching of multiple programs, but
+            # saving space and potentially build time
+            return os.path.join('.dacecache', 'single_cache')
+        elif cache_config == 'hash':
+            # Any change to the SDFG will result in a new cache folder
+            md5_hash = md5(str(self.to_json()).encode('utf-8')).hexdigest()
+            return os.path.join('.dacecache', f'{self.name}_{md5_hash}')
+        elif cache_config == 'unique':
+            # Base name on location in memory, so no caching is possible between
+            # processes or subsequent invokations
+            md5_hash = md5(str(id(self)).encode('utf-8')).hexdigest()
+            return os.path.join('.dacecache', f'{self.name}_{md5_hash}')
+        elif cache_config == 'name':
+            # Overwrites previous invocations, and can clash with other programs
+            # if executed in parallel in the same working directory
             return os.path.join('.dacecache', self.name)
+        else:
+            raise ValueError(f'Unknown cache configuration: {cache_config}')
 
     @build_folder.setter
     def build_folder(self, newfolder: str):

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -697,7 +697,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         elif cache_config == 'unique':
             # Base name on location in memory, so no caching is possible between
             # processes or subsequent invokations
-            md5_hash = md5(str(id(self)).encode('utf-8')).hexdigest()
+            md5_hash = md5(str(os.getpid()).encode('utf-8')).hexdigest()
             return os.path.join('.dacecache', f'{self.name}_{md5_hash}')
         elif cache_config == 'name':
             # Overwrites previous invocations, and can clash with other programs

--- a/test_all.sh
+++ b/test_all.sh
@@ -8,7 +8,7 @@ PYTHONPATH=$SCRIPTPATH
 
 DACE_debugprint="${DACE_debugprint:-0}"
 DACE_testing_serialization="${DACE_testing_serialization:-1}"
-DACE_testing_single_cache="${DACE_testing_single_cache:-1}"
+DACE_cache="${DACE_cache:-single}"
 DACE_optimizer_interface="${DACE_optimizer_interface:-dace.transformation.optimizer.SDFGOptimizer}"
 DACE_optimizer_transform_on_call="${DACE_optimizer_transform_on_call:-1}"
 NOSTATUSBAR="${NOSTATUSBAR:-0}"

--- a/tests/buffer_tiling_test.py
+++ b/tests/buffer_tiling_test.py
@@ -78,6 +78,7 @@ def _semantic_eq(tile_sizes, program):
     B2 = np.zeros((16, 16), dtype=np.float32)
 
     sdfg = program.to_sdfg()
+    sdfg._name = f"{sdfg._name}_{'_'.join(map(str, tile_sizes))}"
     sdfg.apply_strict_transformations()
     sdfg(w3=w3, w5=w5, A=A, B=B1, I=A.shape[0], J=A.shape[1])
 

--- a/tests/buffer_tiling_test.py
+++ b/tests/buffer_tiling_test.py
@@ -78,7 +78,7 @@ def _semantic_eq(tile_sizes, program):
     B2 = np.zeros((16, 16), dtype=np.float32)
 
     sdfg = program.to_sdfg()
-    sdfg._name = f"{sdfg._name}_{'_'.join(map(str, tile_sizes))}"
+    sdfg.name = f"{sdfg.name}_{'_'.join(map(str, tile_sizes))}"
     sdfg.apply_strict_transformations()
     sdfg(w3=w3, w5=w5, A=A, B=B1, I=A.shape[0], J=A.shape[1])
 

--- a/tests/chained_nested_tasklet_test.py
+++ b/tests/chained_nested_tasklet_test.py
@@ -19,7 +19,7 @@ def test_nested_map():
     output[:] = dp.int32(0)
 
     # Construct SDFG
-    mysdfg = SDFG('ctasklet')
+    mysdfg = SDFG('ctasklet_nested_map')
     state = mysdfg.add_state()
     A_ = state.add_array('A', [N], dp.int32)
     B_ = state.add_array('B', [N], dp.int32)
@@ -62,13 +62,13 @@ def test_nested_sdfg():
     output[:] = dp.int32(0)
 
     # Construct outer SDFG
-    mysdfg = SDFG('ctasklet')
+    mysdfg = SDFG('ctasklet_nested_sdfg')
     state = mysdfg.add_state()
     A_ = state.add_array('A', [N], dp.int32)
     B_ = state.add_array('B', [N], dp.int32)
 
     # Construct inner SDFG
-    nsdfg = dp.SDFG('ctasklet_inner')
+    nsdfg = dp.SDFG('ctasklet_nested_sdfg_inner')
     nstate = nsdfg.add_state()
     a = nstate.add_array('a', [N], dp.int32)
     b = nstate.add_array('b', [N], dp.int32)

--- a/tests/control_flow_test.py
+++ b/tests/control_flow_test.py
@@ -146,7 +146,7 @@ def test_2d_assignment():
 
 def test_while_symbol():
     @dace.program
-    def whiletest(A: dace.int32[1]):
+    def whiletest_symbol(A: dace.int32[1]):
         i = 6
         while i > 0:
             A[0] -= 1
@@ -155,19 +155,19 @@ def test_while_symbol():
     A = dace.ndarray([1], dace.int32)
     A[0] = 5
 
-    whiletest(A)
+    whiletest_symbol(A)
 
     assert A[0] == 4
 
     if dace.Config.get_bool('optimizer', 'detect_control_flow'):
-        code = whiletest.to_sdfg().generate_code()[0].clean_code
+        code = whiletest_symbol.to_sdfg().generate_code()[0].clean_code
         assert 'while ' in code
         assert 'goto ' not in code
 
 
 def test_while_data():
     @dace.program
-    def whiletest(A: dace.int32[1]):
+    def whiletest_data(A: dace.int32[1]):
         while A[0] > 0:
             with dace.tasklet:
                 a << A[0]
@@ -177,13 +177,13 @@ def test_while_data():
     A = dace.ndarray([1], dace.int32)
     A[0] = 5
 
-    whiletest(A)
+    whiletest_data(A)
 
     assert A[0] == 0
 
     # Disable check due to CFG generation in Python frontend
     # if dace.Config.get_bool('optimizer', 'detect_control_flow'):
-    #     code = whiletest.to_sdfg().generate_code()[0].clean_code
+    #     code = whiletest_data.to_sdfg().generate_code()[0].clean_code
     #     assert 'while ' in code
 
 
@@ -219,7 +219,7 @@ def test_dowhile():
 
 def test_ifchain():
     @dace.program
-    def casetest(A: dace.int32[2]):
+    def ifchain_program(A: dace.int32[2]):
         if A[0] == 0:
             A[1] = 5
         elif A[0] == 1:
@@ -229,7 +229,7 @@ def test_ifchain():
         elif A[0] == 5:
             A[1] = 0
 
-    sdfg: dace.SDFG = casetest.to_sdfg()
+    sdfg: dace.SDFG = ifchain_program.to_sdfg()
     A = np.array([3, 0], dtype=np.int32)
     sdfg(A=A)
     assert A[1] == 1
@@ -240,7 +240,7 @@ def test_ifchain():
 
 
 def test_ifchain_manual():
-    sdfg = dace.SDFG('casetest')
+    sdfg = dace.SDFG('ifchain')
     sdfg.add_array('A', [2], dace.int32)
     init = sdfg.add_state()
     case0 = sdfg.add_state()
@@ -268,7 +268,7 @@ def test_ifchain_manual():
 
 
 def test_switchcase():
-    sdfg = dace.SDFG('casetest')
+    sdfg = dace.SDFG('switchcase')
     sdfg.add_array('A', [2], dace.int32)
     init = sdfg.add_state()
     case0 = sdfg.add_state()

--- a/tests/cr_complex_test.py
+++ b/tests/cr_complex_test.py
@@ -8,7 +8,7 @@ N = 12
 
 
 @dace.program
-def program(input, output):
+def cr_complex(input, output):
     @dace.map(_[0:N])
     def tasklet(i):
         a << input[i]
@@ -24,7 +24,7 @@ def test_cr_complex():
     B = np.ndarray([1], dtype=A.dtype)
     B[0] = 0
 
-    program(A, B)
+    cr_complex(A, B)
 
     diff = abs(np.sum(A) - B[0])
     print("Difference:", diff)

--- a/tests/cuda_grid_test.py
+++ b/tests/cuda_grid_test.py
@@ -22,7 +22,7 @@ def was_vectorized(sdfg: dace.SDFG) -> bool:
 
 
 @dace.program(dace.float32[N], dace.float32[N])
-def cudahello(V, Vout):
+def cuda_grid(V, Vout):
     # Transient variable
     @dace.map(_[0:N])
     def multiplication(i):
@@ -49,12 +49,15 @@ def _test(sdfg):
 
 
 def test_cpu():
-    _test(cudahello.to_sdfg())
+    sdfg = cudahello.to_sdfg()
+    sdfg._name = "cuda_grid_cpu"
+    _test(sdfg)
 
 
 @pytest.mark.gpu
 def test_gpu():
     sdfg = cudahello.to_sdfg()
+    sdfg._name = "cuda_grid_gpu"
     assert sdfg.apply_transformations(GPUTransformMap) == 1
     _test(sdfg)
 
@@ -62,6 +65,7 @@ def test_gpu():
 @pytest.mark.gpu
 def test_gpu_vec():
     sdfg: dace.SDFG = cudahello.to_sdfg()
+    sdfg._name = "cuda_grid_gpu_vec"
     assert sdfg.apply_transformations([GPUTransformMap, Vectorization]) == 2
     _test(sdfg)
 

--- a/tests/cuda_grid_test.py
+++ b/tests/cuda_grid_test.py
@@ -22,7 +22,7 @@ def was_vectorized(sdfg: dace.SDFG) -> bool:
 
 
 @dace.program(dace.float32[N], dace.float32[N])
-def cuda_grid(V, Vout):
+def cudahello(V, Vout):
     # Transient variable
     @dace.map(_[0:N])
     def multiplication(i):

--- a/tests/cuda_grid_test.py
+++ b/tests/cuda_grid_test.py
@@ -50,14 +50,14 @@ def _test(sdfg):
 
 def test_cpu():
     sdfg = cudahello.to_sdfg()
-    sdfg._name = "cuda_grid_cpu"
+    sdfg.name = "cuda_grid_cpu"
     _test(sdfg)
 
 
 @pytest.mark.gpu
 def test_gpu():
     sdfg = cudahello.to_sdfg()
-    sdfg._name = "cuda_grid_gpu"
+    sdfg.name = "cuda_grid_gpu"
     assert sdfg.apply_transformations(GPUTransformMap) == 1
     _test(sdfg)
 
@@ -65,7 +65,7 @@ def test_gpu():
 @pytest.mark.gpu
 def test_gpu_vec():
     sdfg: dace.SDFG = cudahello.to_sdfg()
-    sdfg._name = "cuda_grid_gpu_vec"
+    sdfg.name = "cuda_grid_gpu_vec"
     assert sdfg.apply_transformations([GPUTransformMap, Vectorization]) == 2
     _test(sdfg)
 

--- a/tests/cuda_smem2d_test.py
+++ b/tests/cuda_smem2d_test.py
@@ -39,21 +39,21 @@ def _test(sdfg):
 
 def test_cpu():
     sdfg = cudahello.to_sdfg()
-    sdfg._name = "cuda_smem2d_cpu"
+    sdfg.name = "cuda_smem2d_cpu"
     _test(sdfg)
 
 
 @pytest.mark.gpu
 def test_gpu():
     sdfg = cudahello.to_sdfg()
-    sdfg._name = "cuda_smem2d_gpu"
+    sdfg.name = "cuda_smem2d_gpu"
     _test(sdfg)
 
 
 @pytest.mark.gpu
 def test_gpu_localstorage():
     sdfg = cudahello.to_sdfg()
-    sdfg._name = "cuda_smem2d_gpu_localstorage"
+    sdfg.name = "cuda_smem2d_gpu_localstorage"
     assert sdfg.apply_transformations([GPUTransformMap, InLocalStorage],
                                       options=[{}, {
                                           'array': 'gpu_V'

--- a/tests/cuda_smem2d_test.py
+++ b/tests/cuda_smem2d_test.py
@@ -38,19 +38,22 @@ def _test(sdfg):
 
 
 def test_cpu():
-    _test(cudahello.to_sdfg())
+    sdfg = cudahello.to_sdfg()
+    sdfg._name = "cuda_smem2d_cpu"
+    _test(sdfg)
 
 
 @pytest.mark.gpu
 def test_gpu():
     sdfg = cudahello.to_sdfg()
-    assert sdfg.apply_transformations(GPUTransformMap) == 1
+    sdfg._name = "cuda_smem2d_gpu"
     _test(sdfg)
 
 
 @pytest.mark.gpu
 def test_gpu_localstorage():
     sdfg = cudahello.to_sdfg()
+    sdfg._name = "cuda_smem2d_gpu_localstorage"
     assert sdfg.apply_transformations([GPUTransformMap, InLocalStorage],
                                       options=[{}, {
                                           'array': 'gpu_V'

--- a/tests/duplicate_naming_test.py
+++ b/tests/duplicate_naming_test.py
@@ -8,7 +8,7 @@ number = 42
 
 
 @dace.program
-def f(A, number):
+def duplicate_naming_inner(A, number):
     @dace.map(_[0:W])
     def bla(i):
         inp << A[i]
@@ -17,11 +17,11 @@ def f(A, number):
 
 
 @dace.program
-def prog(A, B):
+def duplicate_naming(A, B):
     no = dace.define_local([number], dace.float32)
     number = dace.define_local([W], dace.float32)
 
-    f(A, number)
+    duplicate_naming_inner(A, number)
 
     @dace.map(_[0:W])
     def bla2(i):
@@ -39,7 +39,7 @@ def test():
     A[:] = np.mgrid[0:W.get()]
     B[:] = dace.float32(0.0)
 
-    prog(A, B, W=W)
+    duplicate_naming(A, B, W=W)
 
     diff = np.linalg.norm(4 * A - B) / W.get()
     print("Difference:", diff)

--- a/tests/fpga/intel_fpga_test.py
+++ b/tests/fpga/intel_fpga_test.py
@@ -93,7 +93,9 @@ def run(path: Path, sdfg_names: Union[str, Iterable[str]], args: Iterable[Any]):
     os.environ["DACE_compiler_fpga_vendor"] = "intel_fpga"
     os.environ["DACE_compiler_use_cache"] = "0"
     os.environ["DACE_compiler_default_data_types"] = "C"
-    os.environ["DACE_testing_single_cache"] = "0"
+    # We would like to use DACE_cache=hash, but we want to have access to the
+    # program's build folder
+    os.environ["DACE_cache"] = "name"
     os.environ["DACE_compiler_intel_fpga_mode"] = "emulator"
     os.environ["DACE_optimizer_transform_on_call"] = "0"
     os.environ["DACE_optimizer_interface"] = ""

--- a/tests/fpga/xilinx_test.py
+++ b/tests/fpga/xilinx_test.py
@@ -81,7 +81,9 @@ def run(path: Path, sdfg_names: Union[str, Iterable[str]], run_synthesis: bool,
     env = os.environ.copy()
     env["DACE_compiler_fpga_vendor"] = "xilinx"
     env["DACE_compiler_use_cache"] = "0"
-    env["DACE_testing_single_cache"] = "0"
+    # We would like to use DACE_cache=hash, but we need to know which folder to
+    # run synthesis in.
+    env["DACE_cache"] = "name"
     env["DACE_compiler_xilinx_mode"] = "simulation"
     os.environ["DACE_optimizer_transform_on_call"] = "0"
     os.environ["DACE_optimizer_interface"] = ""

--- a/tests/instrumentation_test.py
+++ b/tests/instrumentation_test.py
@@ -32,6 +32,7 @@ def onetest(instrumentation: dace.InstrumentationType, size=128):
     C = np.zeros([size, size], dtype=np.float64)
 
     sdfg: dace.SDFG = slowmm.to_sdfg()
+    sdfg._name = f"instrumentation_test_{instrumentation.name}"
     sdfg.apply_strict_transformations()
 
     # Set instrumentation both on the state and the map

--- a/tests/instrumentation_test.py
+++ b/tests/instrumentation_test.py
@@ -32,7 +32,7 @@ def onetest(instrumentation: dace.InstrumentationType, size=128):
     C = np.zeros([size, size], dtype=np.float64)
 
     sdfg: dace.SDFG = slowmm.to_sdfg()
-    sdfg._name = f"instrumentation_test_{instrumentation.name}"
+    sdfg.name = f"instrumentation_test_{instrumentation.name}"
     sdfg.apply_strict_transformations()
 
     # Set instrumentation both on the state and the map

--- a/tests/intarg_test.py
+++ b/tests/intarg_test.py
@@ -6,7 +6,7 @@ W = dp.symbol('W')
 
 
 @dp.program
-def prog(A, B, integer):
+def intarg(A, B, integer):
     @dp.map(_[0:W])
     def compute(i):
         a << A[i]
@@ -23,7 +23,7 @@ def test():
     A[:] = np.mgrid[0:W.get()]
     B[:] = dp.float32(0.0)
 
-    prog(A, B, 5, W=W)
+    intarg(A, B, 5, W=W)
 
     diff = np.linalg.norm(5 * A - B) / W.get()
     print("Difference:", diff)

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -12,14 +12,14 @@ def program_generator(size, factor):
                   dace.float64[size],
                   size=size,
                   factor=factor)
-    def program(input, output):
+    def lib_reuse(input, output):
         @dace.map(_[0:size])
         def tasklet(i):
             a << input[i]
             b >> output[i]
             b = a * factor
 
-    return program
+    return lib_reuse
 
 
 def test_reload():

--- a/tests/library/einsum_blas_test.py
+++ b/tests/library/einsum_blas_test.py
@@ -99,7 +99,7 @@ def test_3x2(impl):
         C = np.zeros(C_desc.shape).astype(np.float32)
 
         sdfg: dace.SDFG = test_3x2.to_sdfg()
-        sdfg.name = impl + "_einsum_simple"
+        sdfg.name = impl + "_einsum_3x2"
         if impl == "cuBLAS":
             sdfg.apply_gpu_transformations()
         sdfg.expand_library_nodes()
@@ -126,7 +126,7 @@ def test_4x4(impl):
         C = np.zeros(C_desc.shape).astype(np.float32)
 
         sdfg: dace.SDFG = test_4x4.to_sdfg()
-        sdfg.name = impl + "_einsum_simple"
+        sdfg.name = impl + "_einsum_4x4"
         if impl == "cuBLAS":
             sdfg.apply_gpu_transformations()
         sdfg.expand_library_nodes()

--- a/tests/local_inline_test.py
+++ b/tests/local_inline_test.py
@@ -6,7 +6,7 @@ W = dace.symbol('W')
 
 
 @dace.program
-def bla(AA, BB):
+def local_inline_inner(AA, BB):
     tmp = dace.define_local([W], AA.dtype)
 
     @dace.map(_[0:W])
@@ -23,9 +23,9 @@ def bla(AA, BB):
 
 
 @dace.program
-def prog(A: dace.float64[W], B: dace.float64[W], C: dace.float64[W]):
-    bla(A, B)
-    bla(B, C)
+def local_inline(A: dace.float64[W], B: dace.float64[W], C: dace.float64[W]):
+    local_inline_inner(A, B)
+    local_inline_inner(B, C)
 
 
 def test():
@@ -39,7 +39,7 @@ def test():
     B[:] = 0.0
     C[:] = 0.0
 
-    prog(A, B, C)
+    local_inline(A, B, C)
 
     diff = np.linalg.norm((-(-A + 1) + 1) - C) / W.get()
     print("Difference:", diff)

--- a/tests/multi_inline_test.py
+++ b/tests/multi_inline_test.py
@@ -20,12 +20,12 @@ def bla(input, output):
 
 
 @dp.program
-def myprogram(A, B):
+def multi_inline(A, B):
     bla(A, B)
 
 
 def test():
-    myprogram.compile(dp.float32[W, H], dp.float32[H, W])
+    multi_inline.compile(dp.float32[W, H], dp.float32[H, W])
 
 
 if __name__ == "__main__":

--- a/tests/multi_output_scope_test.py
+++ b/tests/multi_output_scope_test.py
@@ -6,7 +6,7 @@ W = dace.symbol('W')
 
 
 @dace.program
-def prog(A, stats):
+def multi_output_scope(A, stats):
     @dace.map(_[0:W])
     def compute(i):
         inp << A[i]
@@ -26,7 +26,7 @@ def test():
     A[:] = np.random.normal(3.0, 5.0, W.get())
     stats[:] = 0.0
 
-    prog(A, stats, W=W)
+    multi_output_scope(A, stats, W=W)
 
     mean = stats[0] / W.get()
     variance = stats[1] / W.get() - mean * mean

--- a/tests/multistate_init_test.py
+++ b/tests/multistate_init_test.py
@@ -6,7 +6,7 @@ W = dace.symbol('W')
 
 
 @dace.program
-def prog(A):
+def multistate_init(A):
     number = dace.define_local([1], dace.float32)
 
     @dace.map(_[0:W])
@@ -35,7 +35,7 @@ def test():
     A[:] = np.mgrid[0:W.get()]
     regression[:] = A[:]
 
-    prog(A, W=W)
+    multistate_init(A, W=W)
 
     diff = np.linalg.norm(4 * regression - A) / W.get()
     print("Difference:", diff)

--- a/tests/numpy/dace_elementwise_test.py
+++ b/tests/numpy/dace_elementwise_test.py
@@ -5,12 +5,12 @@ import numpy as np
 
 def test_output():
     @dace.program
-    def prog(A: dace.float64[5, 3], B: dace.float64[5, 3]):
+    def elementwise(A: dace.float64[5, 3], B: dace.float64[5, 3]):
         dace.elementwise(lambda x: log(x), A, B)
 
     A = np.random.rand(5, 3)
     B = np.zeros((5, 3))
-    prog(A=A.copy(), B=B)
+    elementwise(A=A.copy(), B=B)
 
     diff = np.linalg.norm(np.log(A) - B)
     print('Difference:', diff)
@@ -19,12 +19,12 @@ def test_output():
 
 def test_output_none():
     @dace.program
-    def prog(A: dace.float64[5, 3], B: dace.float64[5, 3]):
+    def elementise_none(A: dace.float64[5, 3], B: dace.float64[5, 3]):
         B[:] = dace.elementwise(lambda x: log(x), A)
 
     A = np.random.rand(5, 3)
     B = np.zeros((5, 3))
-    prog(A=A.copy(), B=B)
+    elementise_none(A=A.copy(), B=B)
 
     diff = np.linalg.norm(np.log(A) - B)
     print('Difference:', diff)
@@ -33,12 +33,12 @@ def test_output_none():
 
 def test_cast():
     @dace.program
-    def prog(A: dace.float32[5, 3], B: dace.float64[5, 3]):
+    def elementwise_cast(A: dace.float32[5, 3], B: dace.float64[5, 3]):
         dace.elementwise(lambda x: x, A, B)
 
     A = np.random.rand(5, 3).astype(np.float32)
     B = np.zeros((5, 3)).astype(np.float64)
-    prog(A=A.copy(), B=B)
+    elementwise_cast(A=A.copy(), B=B)
 
     diff = np.linalg.norm(A - B)
     print('Difference:', diff)

--- a/tests/numpy/reductions_test.py
+++ b/tests/numpy/reductions_test.py
@@ -159,12 +159,12 @@ def test_mean_reduce_symbolic_shape():
     N = dace.symbol('N')
 
     @dace.program
-    def prog(A: dace.float64[10, N, 3]):
+    def mean_reduce_symbolic_shape(A: dace.float64[10, N, 3]):
         return np.mean(A, axis=(-2, 0))
 
     X = np.random.normal(scale=10, size=(10, 12, 3)).astype(np.float64)
 
-    dace_result = prog(A=X)
+    dace_result = mean_reduce_symbolic_shape(A=X)
     numpy_result = np.mean(X, axis=(-2, 0))
 
     assert np.allclose(dace_result, numpy_result)

--- a/tests/parallel_sections_test.py
+++ b/tests/parallel_sections_test.py
@@ -14,9 +14,6 @@ def test():
 
     sdfg.add_stream("fifo_in_a", dace.dtypes.int32, 1, transient=True)
     sdfg.add_stream("fifo_in_b", dace.dtypes.int32, 1, transient=True)
-    sdfg.add_stream("fifo_in_a", dace.dtypes.int32, 1, transient=True)
-    sdfg.add_stream("fifo_in_b", dace.dtypes.int32, 1, transient=True)
-    sdfg.add_stream("fifo_out", dace.dtypes.int32, 1, transient=True)
     sdfg.add_stream("fifo_out", dace.dtypes.int32, 1, transient=True)
 
     state = sdfg.add_state("sections")

--- a/tests/parallel_sections_test.py
+++ b/tests/parallel_sections_test.py
@@ -9,35 +9,27 @@ def test():
 
     sdfg = dace.SDFG("parallel_sections")
 
+    sdfg.add_array("array_in", (2 * N, ), dace.dtypes.int32)
+    sdfg.add_array("array_out", (N, ), dace.dtypes.int32)
+
+    sdfg.add_stream("fifo_in_a", dace.dtypes.int32, 1, transient=True)
+    sdfg.add_stream("fifo_in_b", dace.dtypes.int32, 1, transient=True)
+    sdfg.add_stream("fifo_in_a", dace.dtypes.int32, 1, transient=True)
+    sdfg.add_stream("fifo_in_b", dace.dtypes.int32, 1, transient=True)
+    sdfg.add_stream("fifo_out", dace.dtypes.int32, 1, transient=True)
+    sdfg.add_stream("fifo_out", dace.dtypes.int32, 1, transient=True)
+
     state = sdfg.add_state("sections")
 
-    array_in = state.add_array("array_in", (2 * N, ), dace.dtypes.int32)
-    array_out = state.add_array("array_out", (N, ), dace.dtypes.int32)
+    array_in = state.add_access("array_in")
+    array_out = state.add_access("array_out")
 
-    fifo_in_a_0 = state.add_stream("fifo_in_a",
-                                   dace.dtypes.int32,
-                                   1,
-                                   transient=True)
-    fifo_in_b_0 = state.add_stream("fifo_in_b",
-                                   dace.dtypes.int32,
-                                   1,
-                                   transient=True)
-    fifo_in_a_1 = state.add_stream("fifo_in_a",
-                                   dace.dtypes.int32,
-                                   1,
-                                   transient=True)
-    fifo_in_b_1 = state.add_stream("fifo_in_b",
-                                   dace.dtypes.int32,
-                                   1,
-                                   transient=True)
-    fifo_out_0 = state.add_stream("fifo_out",
-                                  dace.dtypes.int32,
-                                  1,
-                                  transient=True)
-    fifo_out_1 = state.add_stream("fifo_out",
-                                  dace.dtypes.int32,
-                                  1,
-                                  transient=True)
+    fifo_in_a_0 = state.add_access("fifo_in_a")
+    fifo_in_b_0 = state.add_access("fifo_in_b")
+    fifo_in_a_1 = state.add_access("fifo_in_a")
+    fifo_in_b_1 = state.add_access("fifo_in_b")
+    fifo_out_0 = state.add_access("fifo_out")
+    fifo_out_1 = state.add_access("fifo_out")
 
     ###########################################################################
     # First processing element: reads from memory into a stream

--- a/tests/python_frontend/multiple_nested_sdfgs_test.py
+++ b/tests/python_frontend/multiple_nested_sdfgs_test.py
@@ -82,7 +82,8 @@ def test_call_multiple_sdfgs():
     ##################
     # put everything together as a program
     @dace.program
-    def prog(input: dace.float32[2, 2], output: dace.float32[2, 2]):
+    def multiple_nested_sdfgs(input: dace.float32[2, 2],
+                              output: dace.float32[2, 2]):
         tmp_max = np.max(input, axis=axis)
 
         out_tmp = dace.define_local(out_tmp_shape, out_tmp_dtype)
@@ -92,7 +93,7 @@ def test_call_multiple_sdfgs():
 
         out_tmp_div_sum(out_tmp=out_tmp, tmp_sum=tmp_sum, output=output)
 
-    sdfg = prog.to_sdfg(strict=False)
+    sdfg = multiple_nested_sdfgs.to_sdfg(strict=False)
     state = sdfg.nodes()[-1]
     for n in state.nodes():
         if isinstance(n, dace.sdfg.nodes.AccessNode):

--- a/tests/python_frontend/test_propagate_strict.py
+++ b/tests/python_frontend/test_propagate_strict.py
@@ -15,15 +15,15 @@ def nested_prog2(X: dace.int32[2, 2]):
 
 
 @dace
-def prog(X: dace.int32[2, 2]):
+def propagate_strict(X: dace.int32[2, 2]):
     return nested_prog2(X + 1)
 
 
 def test_propagate_strict():
-    strict_sdfg = prog.to_sdfg(strict=True)
+    strict_sdfg = propagate_strict.to_sdfg(strict=True)
     assert len(list(strict_sdfg.all_sdfgs_recursive())) == 1
 
-    non_strict_sdfg = prog.to_sdfg(strict=False)
+    non_strict_sdfg = propagate_strict.to_sdfg(strict=False)
     assert len(list(non_strict_sdfg.all_sdfgs_recursive())) > 1
 
 

--- a/tests/reloadable_lib_test.py
+++ b/tests/reloadable_lib_test.py
@@ -11,14 +11,14 @@ def program_generator(size, factor):
                   dace.float64[size],
                   size=size,
                   factor=factor)
-    def program(input, output):
+    def reloadable_lib(input, output):
         @dace.map(_[0:size])
         def tasklet(i):
             a << input[i]
             b >> output[i]
             b = a * factor
 
-    return program
+    return reloadable_lib
 
 
 def test():

--- a/tests/short_decorator_test.py
+++ b/tests/short_decorator_test.py
@@ -4,13 +4,13 @@ import numpy as np
 
 
 @dace
-def program(A: dace.float64[20]):
+def short_decorator(A: dace.float64[20]):
     return A + A
 
 
 def test_short_decorator():
     A = np.random.rand(20)
-    assert np.allclose(program(A), A + A)
+    assert np.allclose(short_decorator(A), A + A)
 
 
 if __name__ == '__main__':

--- a/tests/transformations/loop_to_map_test.py
+++ b/tests/transformations/loop_to_map_test.py
@@ -65,11 +65,11 @@ def make_sdfg(with_wcr, map_in_guard, reverse_loop, use_variable, assign_after,
                                 "d = sqrt(a**2 + b**2)")
 
     tasklet2 = body.add_tasklet("tasklet2", {}, {},
-                                """\
+                                f"""\
 static std::mutex mutex;
 std::unique_lock<std::mutex> lock(mutex);
-std::ofstream of("{}", std::ofstream::app);
-of << i << "\\n";""".format(log_path),
+std::ofstream of("{log_path}", std::ofstream::app);
+of << i << "\\n";""",
                                 language=dace.Language.CPP)
 
     body.add_memlet_path(a, tasklet0, dst_conn="a", memlet=dace.Memlet("A[i]"))

--- a/tests/transformations/loop_to_map_test.py
+++ b/tests/transformations/loop_to_map_test.py
@@ -3,10 +3,12 @@ import argparse
 import dace
 import numpy as np
 import os
+import tempfile
 from dace.transformation.interstate import LoopToMap
 
 
-def make_sdfg(with_wcr, map_in_guard, reverse_loop, use_variable, assign_after):
+def make_sdfg(with_wcr, map_in_guard, reverse_loop, use_variable, assign_after,
+              log_path):
 
     sdfg = dace.SDFG(f"loop_to_map_test_{with_wcr}_{map_in_guard}_"
                      f"{reverse_loop}_{use_variable}_{assign_after}")
@@ -66,8 +68,8 @@ def make_sdfg(with_wcr, map_in_guard, reverse_loop, use_variable, assign_after):
                                 """\
 static std::mutex mutex;
 std::unique_lock<std::mutex> lock(mutex);
-std::ofstream of("loop_to_map_test.txt", std::ofstream::app);
-of << i << "\\n";""",
+std::ofstream of("{}", std::ofstream::app);
+of << i << "\\n";""".format(log_path),
                                 language=dace.Language.CPP)
 
     body.add_memlet_path(a, tasklet0, dst_conn="a", memlet=dace.Memlet("A[i]"))
@@ -98,7 +100,13 @@ of << i << "\\n";""",
     return sdfg
 
 
-def apply_and_verify(sdfg, n):
+def run_loop_to_map(n, *args):
+
+    # Use mangled temporary file to avoid name clashes when run in parallel
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_path = temp_file.name
+
+    sdfg = make_sdfg(*args, temp_path)
 
     if n is None:
         n = dace.int32(16)
@@ -111,11 +119,6 @@ def apply_and_verify(sdfg, n):
 
     num_transformations = sdfg.apply_transformations(LoopToMap)
 
-    try:
-        os.remove("loop_to_map_test.txt")
-    except FileNotFoundError:
-        pass
-
     sdfg(A=a, B=b, C=c, D=d, E=e, N=n)
 
     if not all(c[:] == 0.25) or not all(d[:] == 5):
@@ -125,51 +128,51 @@ def apply_and_verify(sdfg, n):
         raise ValueError("Validation failed.")
 
     numbers_written = []
-    with open("loop_to_map_test.txt", "r") as f:
+    with open(temp_path, "r") as f:
         for line in f:
             numbers_written.append(int(line.strip()))
     if not all(sorted(numbers_written) == np.arange(n)):
         raise ValueError("Validation failed.")
 
-    os.remove("loop_to_map_test.txt")
+    os.remove(temp_path)  # Clean up
 
     return num_transformations
 
 
 def test_loop_to_map(n=None):
     # Case 0: no wcr, no dataflow in guard. Transformation should apply
-    if apply_and_verify(make_sdfg(False, False, False, False, False), n) != 1:
+    if run_loop_to_map(n, False, False, False, False, False) != 1:
         raise RuntimeError("LoopToMap was not applied.")
 
 
 def test_loop_to_map_wcr(n=None):
     # Case 1: WCR on the edge. Transformation should apply
-    if apply_and_verify(make_sdfg(True, False, False, False, False), n) != 1:
+    if run_loop_to_map(n, True, False, False, False, False) != 1:
         raise RuntimeError("LoopToMap was not applied.")
 
 
 def test_loop_to_map_dataflow_on_guard(n=None):
     # Case 2: there is dataflow on the guard state. Should not apply
-    if apply_and_verify(make_sdfg(False, True, False, False, False), n) != 0:
+    if run_loop_to_map(n, False, True, False, False, False) != 0:
         raise RuntimeError("LoopToMap should not have been applied.")
 
 
 def test_loop_to_map_negative_step(n=None):
     # Case 3: loop order reversed. Transformation should still apply
-    if apply_and_verify(make_sdfg(False, False, True, False, False), n) != 1:
+    if run_loop_to_map(n, False, False, True, False, False) != 1:
         raise RuntimeError("LoopToMap was not applied.")
 
 
 def test_loop_to_map_variable_used(n=None):
     # Case 4: the loop variable is used in a later state: should not apply
-    if apply_and_verify(make_sdfg(False, False, False, True, False), n) != 0:
+    if run_loop_to_map(n, False, False, False, True, False) != 0:
         raise RuntimeError("LoopToMap should not have been applied.")
 
 
 def test_loop_to_map_variable_reassigned(n=None):
     # Case 5: the loop variable is used in a later state, but reassigned first:
     # should apply
-    if apply_and_verify(make_sdfg(False, False, False, True, True), n) != 1:
+    if run_loop_to_map(n, False, False, False, True, True) != 1:
         raise RuntimeError("LoopToMap was not applied.")
 
 
@@ -184,7 +187,7 @@ def test_output_copy():
     for i in range(1, 20):
         regression[i, :] = regression[i - 1] + 5
 
-    sdfg = l2mtest.to_sdfg()
+    sdfg = l2mtest_copy.to_sdfg()
 
     assert sdfg.apply_transformations(LoopToMap) == 0
     sdfg(A=A)
@@ -203,7 +206,7 @@ def test_output_accumulate():
     for i in range(1, 20):
         regression[i, :] += regression[i - 1] + 5
 
-    sdfg = l2mtest.to_sdfg()
+    sdfg = l2mtest_accumulate.to_sdfg()
 
     assert sdfg.apply_transformations(LoopToMap) == 0
     sdfg(A=A)

--- a/tests/transformations/loop_to_map_test.py
+++ b/tests/transformations/loop_to_map_test.py
@@ -175,7 +175,7 @@ def test_loop_to_map_variable_reassigned(n=None):
 
 def test_output_copy():
     @dace.program
-    def l2mtest(A: dace.float64[20, 20]):
+    def l2mtest_copy(A: dace.float64[20, 20]):
         for i in range(1, 20):
             A[i, :] = A[i - 1] + 5
 
@@ -194,7 +194,7 @@ def test_output_copy():
 
 def test_output_accumulate():
     @dace.program
-    def l2mtest(A: dace.float64[20, 20]):
+    def l2mtest_accumulate(A: dace.float64[20, 20]):
         for i in range(1, 20):
             A[i, :] += A[i - 1] + 5
 

--- a/tests/transformations/subgraph_fusion/complex_test.py
+++ b/tests/transformations/subgraph_fusion/complex_test.py
@@ -25,8 +25,9 @@ out3 = np.ndarray((N.get(), M.get(), O.get()), np.float64)
 
 
 @dace.program
-def program(A: dace.float64[N], B: dace.float64[M], C: dace.float64[O], \
-         out1: dace.float64[N,M], out2: dace.float64[1], out3: dace.float64[N,M,O]):
+def subgraph_fusion_complex(A: dace.float64[N], B: dace.float64[M], C: dace.float64[O],
+                 out1: dace.float64[N, M], out2: dace.float64[1],
+                 out3: dace.float64[N, M, O]):
 
     tmp1 = np.ndarray([N, M, O], dtype=dace.float64)
     tmp2 = np.ndarray([N, M, O], dtype=dace.float64)
@@ -136,7 +137,7 @@ def _test_quantitatively(sdfg, graph):
 
 
 def test_complex():
-    sdfg = program.to_sdfg()
+    sdfg = subgraph_fusion_complex.to_sdfg()
     sdfg.apply_strict_transformations()
     _test_quantitatively(sdfg, sdfg.nodes()[0])
 

--- a/tests/transformations/subgraph_fusion/intermediate_mimo_test.py
+++ b/tests/transformations/subgraph_fusion/intermediate_mimo_test.py
@@ -19,7 +19,7 @@ N.set(1000)
 
 
 @dace.program
-def program(A: dace.float64[N], B: dace.float64[N], C: dace.float64[N],
+def mimo(A: dace.float64[N], B: dace.float64[N], C: dace.float64[N],
             D: dace.float64[N]):
 
     for i in dace.map[0:N // 2]:
@@ -74,7 +74,7 @@ def _test_quantitatively(sdfg):
 
 
 def test_mimo():
-    sdfg = program.to_sdfg()
+    sdfg = mimo.to_sdfg()
     from dace.transformation.interstate.state_fusion import StateFusion
     sdfg.apply_transformations_repeated(StateFusion)
     # merge the C array

--- a/tests/transformations/subgraph_fusion/invariant_dimension_test.py
+++ b/tests/transformations/subgraph_fusion/invariant_dimension_test.py
@@ -27,8 +27,8 @@ out1 = np.ndarray((N.get(), M.get(), O.get()), np.float64)
 
 
 @dace.program
-def program(A: dace.float64[N, M, O], B: dace.float64[N, M, O],
-            C: dace.float64[N, M, O]):
+def invariant_dimension(A: dace.float64[N, M, O], B: dace.float64[N, M, O],
+                        C: dace.float64[N, M, O]):
     for i, j in dace.map[0:N, 0:M]:
         with dace.tasklet:
             in1 << A[i, j, 0]
@@ -123,7 +123,7 @@ def _test_quantitatively(sdfg, graph):
 
 
 def test_invariant_dim():
-    sdfg = program.to_sdfg()
+    sdfg = invariant_dimension.to_sdfg()
     sdfg.apply_strict_transformations()
     graph = sdfg.nodes()[0]
     fix_sdfg(sdfg, graph)

--- a/tests/transformations/subgraph_fusion/parallel_test.py
+++ b/tests/transformations/subgraph_fusion/parallel_test.py
@@ -11,11 +11,13 @@ N, M, O, P, Q, R = [dace.symbol(s) for s in ['N', 'M', 'O', 'P', 'Q', 'R']]
 
 
 @dace.program
-def program(A: dace.float64[N], B: dace.float64[M], C: dace.float64[O],
-            D: dace.float64[M], E: dace.float64[N], F: dace.float64[P],
-            G: dace.float64[M], H: dace.float64[P], I: dace.float64[N],
-            J: dace.float64[R], X: dace.float64[N], Y: dace.float64[M],
-            Z: dace.float64[P]):
+def subgraph_fusion_parallel(A: dace.float64[N], B: dace.float64[M],
+                             C: dace.float64[O], D: dace.float64[M],
+                             E: dace.float64[N], F: dace.float64[P],
+                             G: dace.float64[M], H: dace.float64[P],
+                             I: dace.float64[N], J: dace.float64[R],
+                             X: dace.float64[N], Y: dace.float64[M],
+                             Z: dace.float64[P]):
 
     tmp1 = np.ndarray([N, M, O], dtype=dace.float64)
     for i, j, k in dace.map[0:N, 0:M, 0:O]:
@@ -67,7 +69,7 @@ def test_p1():
     Q.set(42)
     R.set(25)
 
-    sdfg = program.to_sdfg()
+    sdfg = subgraph_fusion_parallel.to_sdfg()
     sdfg.apply_strict_transformations()
     state = sdfg.nodes()[0]
 

--- a/tests/transformations/subgraph_fusion/reduction_test.py
+++ b/tests/transformations/subgraph_fusion/reduction_test.py
@@ -17,7 +17,8 @@ M.set(30)
 
 
 @dace.program
-def program(A: dace.float64[M, N], B: dace.float64[M, N], C: dace.float64[N]):
+def reduction_test_1(A: dace.float64[M, N], B: dace.float64[M, N],
+                     C: dace.float64[N]):
 
     tmp = np.ndarray(shape=[M, N], dtype=np.float64)
     tmp[:] = 2 * A[:] + B[:]
@@ -25,7 +26,8 @@ def program(A: dace.float64[M, N], B: dace.float64[M, N], C: dace.float64[N]):
 
 
 @dace.program
-def program2(A: dace.float64[M, N], B: dace.float64[M, N], C: dace.float64[N]):
+def reduction_test_2(A: dace.float64[M, N], B: dace.float64[M, N],
+                     C: dace.float64[N]):
 
     tmp = np.ndarray(shape=[M, N], dtype=np.float64)
     C[:] = dace.reduce(lambda a, b: max(a, b), B, axis=0)
@@ -39,7 +41,7 @@ def program2(A: dace.float64[M, N], B: dace.float64[M, N], C: dace.float64[N]):
 
 
 def test_p1():
-    sdfg = program.to_sdfg()
+    sdfg = reduction_test_1.to_sdfg()
     sdfg.apply_strict_transformations()
     state = sdfg.nodes()[0]
     for node in state.nodes():
@@ -72,7 +74,7 @@ def test_p1():
 
 
 def test_p2():
-    sdfg = program2.to_sdfg()
+    sdfg = reduction_test_2.to_sdfg()
     sdfg.apply_strict_transformations()
     state = sdfg.nodes()[0]
     A = np.random.rand(M.get(), N.get()).astype(np.float64)

--- a/tests/transformations/subgraph_fusion/sequential1_test.py
+++ b/tests/transformations/subgraph_fusion/sequential1_test.py
@@ -12,7 +12,8 @@ N = dace.symbol('N')
 
 
 @dace.program
-def program(A: dace.float64[N], B: dace.float64[N], C: dace.float64[N]):
+def subgraph_fusion_sequential(A: dace.float64[N], B: dace.float64[N],
+                               C: dace.float64[N]):
 
     for i in dace.map[0:N]:
         with dace.tasklet:
@@ -30,7 +31,7 @@ def program(A: dace.float64[N], B: dace.float64[N], C: dace.float64[N]):
 def test_sequential():
     N.set(1000)
 
-    sdfg = program.to_sdfg()
+    sdfg = subgraph_fusion_sequential.to_sdfg()
     state = sdfg.nodes()[0]
 
     A = np.random.rand(N.get()).astype(np.float64)

--- a/tests/transformations/subgraph_fusion/sequential2_test.py
+++ b/tests/transformations/subgraph_fusion/sequential2_test.py
@@ -12,7 +12,7 @@ N = dace.symbol('N')
 
 
 @dace.program
-def program(A: dace.float64[N], C: dace.float64[N]):
+def sequential2(A: dace.float64[N], C: dace.float64[N]):
     B = np.ndarray(shape=[N], dtype=np.float64)
     for i in dace.map[0:N]:
         with dace.tasklet:
@@ -30,7 +30,7 @@ def program(A: dace.float64[N], C: dace.float64[N]):
 def test_sequential():
     N.set(1000)
 
-    sdfg = program.to_sdfg()
+    sdfg = sequential2.to_sdfg()
     state = sdfg.nodes()[0]
 
     A = np.random.rand(N.get()).astype(np.float64)

--- a/tests/transformations/subgraph_fusion/smax_test.py
+++ b/tests/transformations/subgraph_fusion/smax_test.py
@@ -75,7 +75,7 @@ def get_partition(sdfg, graph):
 
 def test_2fuse():
     sdfg = softmax.to_sdfg()
-    sdfg._name = 'softmax_2part'
+    sdfg.name = 'softmax_2part'
     sdfg.apply_strict_transformations()
     X_in = np.random.rand(H.get(), B.get(), SN.get(),
                           SM.get()).astype(np.float32)
@@ -100,7 +100,7 @@ def test_2fuse():
 
 def test_1fuse():
     sdfg = softmax.to_sdfg()
-    sdfg._name = 'softmax_fused'
+    sdfg.name = 'softmax_fused'
     sdfg.apply_strict_transformations()
     X_in = np.random.rand(H.get(), B.get(), SN.get(),
                           SM.get()).astype(np.float32)
@@ -123,9 +123,10 @@ def test_1fuse():
     print("PASS")
     return
 
+
 def test_1fuse():
     sdfg = softmax.to_sdfg()
-    sdfg._name = 'softmax_fused'
+    sdfg.name = 'softmax_fused'
     sdfg.apply_strict_transformations()
     X_in = np.random.rand(H.get(), B.get(), SN.get(),
                           SM.get()).astype(np.float32)
@@ -147,6 +148,7 @@ def test_1fuse():
     print(np.linalg.norm(res2))
     assert np.allclose(res1, res2)
     print("PASS")
+
 
 if __name__ == "__main__":
     test_2fuse()

--- a/tests/transformations/subgraph_fusion/tiling_pool_test.py
+++ b/tests/transformations/subgraph_fusion/tiling_pool_test.py
@@ -69,7 +69,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     graph = sdfg.nodes()[0]
 
     # baseline
-    sdfg._name = 'baseline'
+    sdfg._name = f'baseline_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
     csdfg(A=A, B=B1, N=N)
     del csdfg
@@ -83,7 +83,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     st.schedule = dace.dtypes.ScheduleType.Sequential
     st.apply(sdfg)
 
-    sdfg._name = 'tiled'
+    sdfg._name = f'tiled_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
     csdfg(A=A, B=B2, N=N)
     del csdfg
@@ -93,7 +93,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     sf = SubgraphFusion(subgraph)
     sf.apply(sdfg)
 
-    sdfg._name = 'fused'
+    sdfg._name = f'fused_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
     csdfg(A=A, B=B3, N=N)
     del csdfg

--- a/tests/transformations/subgraph_fusion/tiling_pool_test.py
+++ b/tests/transformations/subgraph_fusion/tiling_pool_test.py
@@ -69,7 +69,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     graph = sdfg.nodes()[0]
 
     # baseline
-    sdfg._name = f'baseline_{tile_size}_{offset}_{unroll}'
+    sdfg.name = f'baseline_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
     csdfg(A=A, B=B1, N=N)
     del csdfg
@@ -83,7 +83,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     st.schedule = dace.dtypes.ScheduleType.Sequential
     st.apply(sdfg)
 
-    sdfg._name = f'tiled_{tile_size}_{offset}_{unroll}'
+    sdfg.name = f'tiled_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
     csdfg(A=A, B=B2, N=N)
     del csdfg
@@ -93,7 +93,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     sf = SubgraphFusion(subgraph)
     sf.apply(sdfg)
 
-    sdfg._name = f'fused_{tile_size}_{offset}_{unroll}'
+    sdfg.name = f'fused_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
     csdfg(A=A, B=B3, N=N)
     del csdfg

--- a/tests/transformations/subgraph_fusion/tiling_stencil_test.py
+++ b/tests/transformations/subgraph_fusion/tiling_stencil_test.py
@@ -111,7 +111,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     if view:
         sdfg.view()
     # baseline
-    sdfg._name = 'baseline'
+    sdfg.name = 'baseline'
     sdfg.save('baseline.sdfg')
     csdfg = sdfg.compile()
     csdfg(A=A, B=B1, N=N)
@@ -127,7 +127,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     st.apply(sdfg)
     if view:
         sdfg.view()
-    sdfg._name = 'tiled'
+    sdfg.name = 'tiled'
     sdfg.validate()
     sdfg.save('tiled.sdfg')
     csdfg = sdfg.compile()
@@ -141,7 +141,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     # also test consolidation
     sf.consolidate = True
     sf.apply(sdfg)
-    sdfg._name = 'fused'
+    sdfg.name = 'fused'
     sdfg.save('fused.sdfg')
     csdfg = sdfg.compile()
     csdfg(A=A, B=B3, N=N)
@@ -153,11 +153,14 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     assert np.allclose(B1, B3)
     print("PASS")
 
+
 test_settings = list(itertools.product([1, 8], [False, True], [False, True]))
+
 
 @pytest.mark.parametrize(["tile", "offset", "unroll"], test_settings)
 def test_all(tile, offset, unroll):
     invoke_stencil(tile, offset, unroll)
+
 
 if __name__ == '__main__':
     for (t, o, u) in itertools.product([1, 8], [False, True], [False, True]):

--- a/tests/vector_min_test.py
+++ b/tests/vector_min_test.py
@@ -19,10 +19,13 @@ def test():
 
     # Construct SDFG
     mysdfg = SDFG('myvmin')
+    mysdfg.add_array('A', [N], dp.float32)
+    mysdfg.add_array('B', [N], dp.float32)
+    mysdfg.add_array('C', [N], dp.float32)
     state = mysdfg.add_state()
-    A = state.add_array('A', [N], dp.float32)
-    B = state.add_array('B', [N], dp.float32)
-    C = state.add_array('C', [N], dp.float32)
+    A = state.add_access('A')
+    B = state.add_access('B')
+    C = state.add_access('C')
 
     tasklet, map_entry, map_exit = state.add_mapped_tasklet(
         'mytasklet', dict(i='0:N:2'),


### PR DESCRIPTION
- Use pytesdt-xdist to test in parallel.
- Introduce a new flag for generating the SDFG cache name with more options, allowing a random name based on the process ID to be used, avoiding clashes between parallel tests.
- Reorganize heterogeneous tests so they can potentially be run in parallel (if we add more runners).
- Rename a bunch of SDFGs to avoid name clashes even without using the unique cache name.