### PR TITLE
Bugfixes: StripMining, sdfg.free_symbols

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -721,7 +721,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         if validate:
             for state in self.nodes():
                 for node in state.nodes():
-                    if isinstance(node, nd.AccessNode) and nd.data == name:
+                    if isinstance(node, nd.AccessNode) and node.data == name:
                         raise ValueError("Data descriptor %s is already used"
                                          "in node %s, state %s" %
                                          (name, node, state))

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1563,6 +1563,11 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                                 "in SDFG" % name)
         self._arrays[name] = datadesc
 
+        # Add free symbols to the SDFG global symbol storage
+        for sym in datadesc.free_symbols:
+            if sym.name not in self.symbols:
+                self.add_symbol(sym.name, sym.dtype)
+
         return name
 
     def add_loop(

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -949,9 +949,8 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # Start with the set of SDFG free symbols
         free_syms |= set(self.symbols.keys())
 
-        # Add free data symbols and exclude data descriptor names
+        # Exclude data descriptor names
         for name, desc in self.arrays.items():
-            free_syms |= set(map(str, desc.free_symbols))
             defined_syms.add(name)
 
         # Add free state symbols
@@ -1563,11 +1562,6 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                 raise NameError('Array or Stream with name "%s" already exists '
                                 "in SDFG" % name)
         self._arrays[name] = datadesc
-
-        # Add free symbols to the SDFG global symbol storage
-        for sym in datadesc.free_symbols:
-            if sym.name not in self.symbols:
-                self.add_symbol(sym.name, sym.dtype)
 
         return name
 

--- a/dace/transformation/dataflow/local_storage.py
+++ b/dace/transformation/dataflow/local_storage.py
@@ -90,14 +90,14 @@ class LocalStorage(xf.Transformation, ABC):
             raise NameError('Array %s not found!' % array)
         if self.create_array:
             # Add transient array
-            new_data, _ = sdfg.add_array(
-                prefix + invariant_memlet.data, [
-                    symbolic.overapproximate(r).simplify()
-                    for r in invariant_memlet.bounding_box_size()
-                ],
-                sdfg.arrays[invariant_memlet.data].dtype,
-                transient=True,
-                find_new_name=True)
+            new_data, _ = sdfg.add_transient(
+                            name = prefix + invariant_memlet.data,
+                            shape = [
+                                symbolic.overapproximate(r).simplify()
+                                for r in invariant_memlet.bounding_box_size()
+                                    ],
+                            dtype = sdfg.arrays[invariant_memlet.data].dtype,
+                            find_new_name=True)
 
         else:
             new_data = prefix + invariant_memlet.data

--- a/dace/transformation/dataflow/mapreduce.py
+++ b/dace/transformation/dataflow/mapreduce.py
@@ -126,6 +126,11 @@ class MapReduceFusion(pm.Transformation):
         # Delete relevant edges and nodes
         graph.remove_nodes_from(nodes_to_remove)
 
+        # Delete relevant data descriptors
+        for node in set(nodes_to_remove):
+            if isinstance(node, nodes.AccessNode):
+                sdfg.remove_data(node.data, True)
+
         # Filter out reduced dimensions from subset
         filtered_subset = [
             dim for i, dim in enumerate(memlet_edge.data.subset)

--- a/dace/transformation/dataflow/mapreduce.py
+++ b/dace/transformation/dataflow/mapreduce.py
@@ -129,7 +129,12 @@ class MapReduceFusion(pm.Transformation):
         # Delete relevant data descriptors
         for node in set(nodes_to_remove):
             if isinstance(node, nodes.AccessNode):
-                sdfg.remove_data(node.data, True)
+                # try to delete it
+                try:
+                    sdfg.remove_data(node.data)
+                # will raise ValueError if the datadesc is used somewhere else
+                except ValueError:
+                    pass
 
         # Filter out reduced dimensions from subset
         filtered_subset = [


### PR DESCRIPTION
StripMining:
- for tiling_type: number_of_tiles, now creates the correct tile size.

SDFG.free_symbols:
- now correctly computes the free_symbols.
- the free_symbols of data descriptors are not needed as they are covered in the free_symbols of each state.

SDFG.add_datadesc:
- add free symbols to the SDFG global symbol storage not needed

MapReduceFusion: 
- delete data descriptors that are not used anymore

LocalStorage:
- sdfg.add_array -> sdfg.add_transient