### PR TITLE
Give the Data class' property 'dtype' the correct enum choices

### DIFF
--- a/dace/data.py
+++ b/dace/data.py
@@ -45,7 +45,7 @@ class Data(object):
         Examples: Arrays, Streams, custom arrays (e.g., sparse matrices).
     """
 
-    dtype = TypeClassProperty(default=dtypes.int32)
+    dtype = TypeClassProperty(default=dtypes.int32, choices=dtypes.Typeclasses)
     shape = ShapeProperty(default=[])
     transient = Property(dtype=bool, default=False)
     storage = Property(dtype=dtypes.StorageType,

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -930,6 +930,24 @@ float64 = typeclass(numpy.float64)
 complex64 = typeclass(numpy.complex64)
 complex128 = typeclass(numpy.complex128)
 
+@extensible_enum
+class Typeclasses(aenum.AutoNumberEnum):
+    bool = bool
+    bool_ = bool_
+    int8 = int8
+    int16 = int16
+    int32 = int32
+    int64 = int64
+    uint8 = uint8
+    uint16 = uint16
+    uint32 = uint32
+    uint64 = uint64
+    float16 = float16
+    float32 = float32
+    float64 = float64
+    complex64 = complex64
+    complex128 = complex128
+
 DTYPE_TO_TYPECLASS = {
     int: typeclass(int),
     float: typeclass(float),


### PR DESCRIPTION
The property `dtype` of the class `Data` and its subclasses is a `typeclass` property. The class `typeclass` seems to be constrained to a set of predefined types which are listed in `dace.dtypes`. These predefined values are also used for reconstructing the `dtype` property from JSON. This creates a proper enum for these options and provides them to the `dtype` property as choices.

Benefit: This allows for easier editing of a data container's data type since it removes the chance of typos and the need for additional string parsing after user input.