### PR TITLE
Inline sdfg improvements

### DIFF
--- a/dace/transformation/dataflow/prune_connectors.py
+++ b/dace/transformation/dataflow/prune_connectors.py
@@ -42,13 +42,13 @@ class PruneConnectors(pm.Transformation):
                             iter(graph.in_edges_by_connector(
                                 nsdfg, e.src_conn))).src) > 0):
                     prune_in.remove(e.src_conn)
-        has_before = any(
-            graph.in_degree(graph.memlet_path(e)[0].src) > 0 for e in graph.in_edges(nsdfg)
-            if e.dst_conn in prune_in)
-        has_after = any(
+        has_before = all(
+            graph.in_degree(graph.memlet_path(e)[0].src) > 0
+            for e in graph.in_edges(nsdfg) if e.dst_conn in prune_in)
+        has_after = all(
             graph.out_degree(graph.memlet_path(e)[-1].dst) > 0
             for e in graph.out_edges(nsdfg) if e.src_conn in prune_out)
-        if has_before or has_after:
+        if has_before and has_after:
             return False
         if len(prune_in) > 0 or len(prune_out) > 0:
             return True
@@ -78,6 +78,10 @@ class PruneConnectors(pm.Transformation):
                     prune_in.remove(e.src_conn)
 
         for conn in prune_in:
+            if any(
+                    state.in_degree(state.memlet_path(e)[0].src) > 0
+                    for e in state.in_edges(nsdfg) if e.dst_conn == conn):
+                continue
             for e in state.in_edges_by_connector(nsdfg, conn):
                 state.remove_memlet_path(e, remove_orphans=True)
                 if conn in nsdfg.sdfg.arrays and conn not in all_data_used:
@@ -85,6 +89,10 @@ class PruneConnectors(pm.Transformation):
                     nsdfg.sdfg.remove_data(conn)
 
         for conn in prune_out:
+            if any(
+                    state.out_degree(state.memlet_path(e)[-1].dst) > 0
+                    for e in state.out_edges(nsdfg) if e.src_conn == conn):
+                continue
             for e in state.out_edges_by_connector(nsdfg, conn):
                 state.remove_memlet_path(e, remove_orphans=True)
                 if conn in nsdfg.sdfg.arrays and conn not in all_data_used:


### PR DESCRIPTION
Improvements to InlineSDFG:
- InlineSDFG should not match when the nested SDFG has "unused" connectors, i.e., connectors without a corresponding access node inside the nested SDFG. If the transformation matches, then StopIteration will be raised when applying.
- PruneConnectors should match whenever it is possible to remove at least one connector.