### PR TITLE
Improve handling of unregistered objects and custom/external extensions like transformations and library nodes

### DIFF
--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -1214,8 +1214,7 @@ class LibraryNode(CodeNode):
         if cls == LibraryNode:
             clazz = pydoc.locate(json_obj['classpath'])
             if clazz is None:
-                raise TypeError('Unrecognized library node type "%s"' %
-                                json_obj['classpath'])
+                return UnregisteredLibraryNode.from_json(json_obj, context)
             return clazz.from_json(json_obj, context)
         else:  # Subclasses are actual library nodes
             ret = cls(json_obj['attributes']['name'])
@@ -1290,3 +1289,21 @@ class LibraryNode(CodeNode):
         """Register an implementation to belong to this library node type."""
         cls.implementations[name] = transformation_type
         transformation_type._match_node = cls
+
+
+class UnregisteredLibraryNode(LibraryNode):
+
+    original_json = {}
+
+    def __init__(self, json_obj={}, label=None):
+        self.original_json = json_obj
+        super().__init__(label)
+
+    def to_json(self):
+        return self.original_json
+
+    @staticmethod
+    def from_json(json_obj, context=None):
+        return UnregisteredLibraryNode(
+            json_obj=json_obj, label=json_obj['attributes']['name']
+        )

--- a/dace/serialize.py
+++ b/dace/serialize.py
@@ -139,8 +139,11 @@ def from_json(obj, context=None, known_type=None):
                         known_type.__name__)
 
     if t:
-        deserialized = _DACE_SERIALIZE_TYPES[t].from_json(obj, context=context)
-        if deserialized is None:
+        try:
+            deserialized = _DACE_SERIALIZE_TYPES[t].from_json(
+                obj, context=context
+            )
+        except Exception:
             deserialized = SerializableObject.from_json(
                 obj, context=context, typename=t
             )

--- a/dace/serialize.py
+++ b/dace/serialize.py
@@ -7,6 +7,25 @@ import dace.dtypes
 JSON_STORE_METADATA = True
 
 
+class SerializableObject(object):
+
+    json_obj = {}
+    typename = None
+
+    def __init__(self, json_obj={}, typename=None):
+        self.json_obj = json_obj
+        self.typename = typename
+
+    def to_json(self):
+        retval = self.json_obj
+        retval['dace_unregistered'] = True
+        return retval
+
+    @staticmethod
+    def from_json(json_obj, context=None, typename=None):
+        return SerializableObject(json_obj, typename)
+
+
 class NumpySerializer:
     """ Helper class to load/store numpy arrays from JSON. """
     @staticmethod
@@ -120,7 +139,12 @@ def from_json(obj, context=None, known_type=None):
                         known_type.__name__)
 
     if t:
-        return _DACE_SERIALIZE_TYPES[t].from_json(obj, context=context)
+        deserialized = _DACE_SERIALIZE_TYPES[t].from_json(obj, context=context)
+        if deserialized is None:
+            deserialized = SerializableObject.from_json(
+                obj, context=context, typename=t
+            )
+        return deserialized
 
     # No type was found, so treat this as a regular dictionary
     return {

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -393,23 +393,6 @@ class Transformation(TransformationBase):
             xform = next(ext for ext in Transformation.extensions().keys()
                          if ext.__name__ == json_obj['transformation'])
         except StopIteration:
-            # This json object indicates that it is a transformation, but the
-            # corresponding serializable class cannot be found (i.e. the
-            # transformation is not known to DaCe). Handle this by creating a
-            # dummy transformation to keep serialization intact.
-            if all(attr in json_obj for attr in [
-                'sdfg_id', 'state_id', '_subgraph', 'expr_index',
-                'transformation'
-            ]):
-                xform = Transformation(
-                    sdfg_id=json_obj['sdfg_id'],
-                    state_id=json_obj['state_id'],
-                    subgraph=json_obj['_subgraph'],
-                    expr_index=json_obj['expr_index'],
-                    override=True
-                )
-                xform.dummy_for = json_obj['transformation']
-                return xform
             return None
 
         # Recreate subgraph
@@ -743,20 +726,6 @@ class SubgraphTransformation(TransformationBase):
             xform = next(ext for ext in SubgraphTransformation.extensions().keys()
                          if ext.__name__ == json_obj['transformation'])
         except StopIteration:
-            # This json object indicates that it is a transformation, but the
-            # corresponding serializable class cannot be found (i.e. the
-            # transformation is not known to DaCe). Handle this by creating a
-            # dummy transformation to keep serialization intact.
-            if all(attr in json_obj for attr in [
-                'sdfg_id', 'state_id', '_subgraph', 'transformation'
-            ]):
-                xform = SubgraphTransformation(
-                    sdfg_id=json_obj['sdfg_id'],
-                    state_id=json_obj['state_id'],
-                    subgraph=json_obj['_subgraph']
-                )
-                xform.dummy_for = json_obj['transformation']
-                return xform
             return None
 
         # Reconstruct transformation

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -372,19 +372,11 @@ class Transformation(TransformationBase):
 
     def to_json(self, parent=None) -> Dict[str, Any]:
         props = serialize.all_properties_to_json(self)
-        if hasattr(self, 'dummy_for'):
-            return {
-                'type': 'Transformation',
-                'transformation': self.dummy_for,
-                'dummy_transformation': True,
-                **props
-            }
-        else:
-            return {
-                'type': 'Transformation',
-                'transformation': type(self).__name__,
-                **props
-            }
+        return {
+            'type': 'Transformation',
+            'transformation': type(self).__name__,
+            **props
+        }
 
     @staticmethod
     def from_json(json_obj: Dict[str, Any],
@@ -705,19 +697,11 @@ class SubgraphTransformation(TransformationBase):
 
     def to_json(self, parent=None):
         props = serialize.all_properties_to_json(self)
-        if hasattr(self, 'dummy_for'):
-            return {
-                'type': 'SubgraphTransformation',
-                'transformation': self.dummy_for,
-                'dummy_transformation': True,
-                **props
-            }
-        else:
-            return {
-                'type': 'SubgraphTransformation',
-                'transformation': type(self).__name__,
-                **props
-            }
+        return {
+            'type': 'SubgraphTransformation',
+            'transformation': type(self).__name__,
+            **props
+        }
 
     @staticmethod
     def from_json(json_obj: Dict[str, Any],

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -376,6 +376,7 @@ class Transformation(TransformationBase):
             return {
                 'type': 'Transformation',
                 'transformation': self.dummy_for,
+                'dummy_transformation': True,
                 **props
             }
         else:
@@ -725,6 +726,7 @@ class SubgraphTransformation(TransformationBase):
             return {
                 'type': 'SubgraphTransformation',
                 'transformation': self.dummy_for,
+                'dummy_transformation': True,
                 **props
             }
         else:

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -381,11 +381,8 @@ class Transformation(TransformationBase):
     @staticmethod
     def from_json(json_obj: Dict[str, Any],
                   context: Dict[str, Any] = None) -> 'Transformation':
-        try:
-            xform = next(ext for ext in Transformation.extensions().keys()
-                         if ext.__name__ == json_obj['transformation'])
-        except StopIteration:
-            return None
+        xform = next(ext for ext in Transformation.extensions().keys()
+                     if ext.__name__ == json_obj['transformation'])
 
         # Recreate subgraph
         expr = xform.expressions()[json_obj['expr_index']]
@@ -706,11 +703,8 @@ class SubgraphTransformation(TransformationBase):
     @staticmethod
     def from_json(json_obj: Dict[str, Any],
                   context: Dict[str, Any] = None) -> 'SubgraphTransformation':
-        try:
-            xform = next(ext for ext in SubgraphTransformation.extensions().keys()
-                         if ext.__name__ == json_obj['transformation'])
-        except StopIteration:
-            return None
+        xform = next(ext for ext in SubgraphTransformation.extensions().keys()
+                     if ext.__name__ == json_obj['transformation'])
 
         # Reconstruct transformation
         ret = xform(json_obj['subgraph'], json_obj['sdfg_id'],


### PR DESCRIPTION
Provide a general deserialized representation for unregistered objects such that they can be re-serialized without any loss of information and handled without causing exceptions.
In particular: keep transformation histories intact when they contain unregistered transformations, and don't fail on deserializing SDFGs with unregistered LibraryNodes.