### PR TITLE
Add enum properties and enums which are safe from custom values

### DIFF
--- a/dace/data.py
+++ b/dace/data.py
@@ -9,7 +9,7 @@ from typing import Set
 import dace.dtypes as dtypes
 from dace.codegen import cppunparse
 from dace import symbolic, serialize
-from dace.properties import (Property, make_properties, DictProperty,
+from dace.properties import (EnumProperty, Property, make_properties, DictProperty,
                              ReferenceProperty, ShapeProperty, SubsetProperty,
                              SymbolicProperty, TypeClassProperty,
                              DebugInfoProperty, CodeProperty, ListProperty)
@@ -48,16 +48,12 @@ class Data(object):
     dtype = TypeClassProperty(default=dtypes.int32, choices=dtypes.Typeclasses)
     shape = ShapeProperty(default=[])
     transient = Property(dtype=bool, default=False)
-    storage = Property(dtype=dtypes.StorageType,
-                       desc="Storage location",
-                       choices=dtypes.StorageType,
-                       default=dtypes.StorageType.Default,
-                       from_string=lambda x: dtypes.StorageType[x])
-    lifetime = Property(dtype=dtypes.AllocationLifetime,
-                        desc='Data allocation span',
-                        choices=dtypes.AllocationLifetime,
-                        default=dtypes.AllocationLifetime.Scope,
-                        from_string=lambda x: dtypes.AllocationLifetime[x])
+    storage = EnumProperty(dtype=dtypes.StorageType,
+                           desc="Storage location",
+                           default=dtypes.StorageType.Default)
+    lifetime = EnumProperty(dtype=dtypes.AllocationLifetime,
+                            desc='Data allocation span',
+                            default=dtypes.AllocationLifetime.Scope)
     location = DictProperty(
         key_type=str,
         value_type=symbolic.pystr_to_symbolic,

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -9,9 +9,10 @@ import re
 from functools import wraps
 from typing import Any
 from dace.config import Config
-from dace.registry import extensible_enum
+from dace.registry import extensible_enum, undefined_safe_enum
 
 
+@undefined_safe_enum
 @extensible_enum
 class DeviceType(aenum.AutoNumberEnum):
     CPU = ()  #: Multi-core CPU
@@ -19,6 +20,7 @@ class DeviceType(aenum.AutoNumberEnum):
     FPGA = ()  #: FPGA (Intel or Xilinx)
 
 
+@undefined_safe_enum
 @extensible_enum
 class StorageType(aenum.AutoNumberEnum):
     """ Available data storage types in the SDFG. """
@@ -36,6 +38,7 @@ class StorageType(aenum.AutoNumberEnum):
     FPGA_ShiftRegister = ()  #: Only accessible at constant indices
 
 
+@undefined_safe_enum
 @extensible_enum
 class ScheduleType(aenum.AutoNumberEnum):
     """ Available map schedule types in the SDFG. """
@@ -67,6 +70,7 @@ GPU_SCHEDULES = [
 ]
 
 
+@undefined_safe_enum
 class ReductionType(aenum.AutoNumberEnum):
     """ Reduction types natively supported by the SDFG compiler. """
 
@@ -90,6 +94,7 @@ class ReductionType(aenum.AutoNumberEnum):
     Div = ()  #: Division (only supported in OpenMP)
 
 
+@undefined_safe_enum
 @extensible_enum
 class AllocationLifetime(aenum.AutoNumberEnum):
     """ Options for allocation span (when to allocate/deallocate) of data. """
@@ -101,6 +106,7 @@ class AllocationLifetime(aenum.AutoNumberEnum):
     Persistent = ()  #: Allocated throughout multiple invocations (init/exit)
 
 
+@undefined_safe_enum
 @extensible_enum
 class Language(aenum.AutoNumberEnum):
     """ Available programming languages for SDFG tasklets. """
@@ -111,6 +117,7 @@ class Language(aenum.AutoNumberEnum):
     SystemVerilog = ()
 
 
+@undefined_safe_enum
 class AccessType(aenum.AutoNumberEnum):
     """ Types of access to an `AccessNode`. """
 
@@ -119,6 +126,7 @@ class AccessType(aenum.AutoNumberEnum):
     ReadWrite = ()
 
 
+@undefined_safe_enum
 @extensible_enum
 class InstrumentationType(aenum.AutoNumberEnum):
     """ Types of instrumentation providers.
@@ -131,6 +139,7 @@ class InstrumentationType(aenum.AutoNumberEnum):
     GPU_Events = ()
 
 
+@undefined_safe_enum
 @extensible_enum
 class TilingType(aenum.AutoNumberEnum):
     """ Available tiling types in a `StripMining` transformation. """
@@ -955,6 +964,7 @@ complex64 = typeclass(numpy.complex64)
 complex128 = typeclass(numpy.complex128)
 
 
+@undefined_safe_enum
 @extensible_enum
 class Typeclasses(aenum.AutoNumberEnum):
     bool = bool

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -701,6 +701,38 @@ class DictProperty(Property):
 ###############################################################################
 
 
+class EnumProperty(Property):
+
+    def __init__(self, dtype, *args, **kwargs):
+        kwargs['dtype'] = dtype
+        super().__init__(*args, **kwargs)
+
+        def f(s, *args, **kwargs):
+            if s is None:
+                return None
+            try:
+                self._undefined_val = None
+                return dtype[s]
+            except KeyError:
+                self._undefined_val = s
+                return dtype['Undefined']
+
+        self._choices = dtype
+        self._from_json = f
+        self._from_string = f
+
+        self._undefined_val = None
+
+        def g(obj):
+            if self._undefined_val is None:
+                return obj._name_
+            else:
+                return self._undefined_val
+
+        self._to_json = g
+        self._to_string = g
+
+
 class SDFGReferenceProperty(Property):
     def to_json(self, obj):
         if obj is None:

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -725,7 +725,7 @@ class EnumProperty(Property):
 
         def g(obj):
             if self._undefined_val is None:
-                return obj._name_
+                return dace.serialize.to_json(obj)
             else:
                 return self._undefined_val
 

--- a/dace/registry.py
+++ b/dace/registry.py
@@ -56,6 +56,18 @@ def autoregister_params(**params):
     return lambda cls: autoregister(cls, **params)
 
 
+def undefined_safe_enum(cls: Type):
+    """
+    Decorator that adds a value ``Undefined`` to an enumeration.
+    """
+    if not issubclass(cls, Enum):
+        raise TypeError(
+            "Only aenum.Enum subclasses may be used with undefined values"
+        )
+    extend_enum(cls, 'Undefined')
+    return cls
+
+
 def extensible_enum(cls: Type):
     """
     Decorator that adds a function called ``register`` to an enumeration,

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Set, Union
 from dace.config import Config
 from dace.sdfg import graph
 from dace.frontend.python.astutils import unparse
-from dace.properties import (Property, CodeProperty, LambdaProperty,
+from dace.properties import (EnumProperty, Property, CodeProperty, LambdaProperty,
                              RangeProperty, DebugInfoProperty, SetProperty,
                              make_properties, indirect_properties, DataProperty,
                              SymbolicProperty, ListProperty,
@@ -222,9 +222,11 @@ class Node(object):
 class AccessNode(Node):
     """ A node that accesses data in the SDFG. Denoted by a circular shape. """
 
-    access = Property(choices=dtypes.AccessType,
-                      desc="Type of access to this array",
-                      default=dtypes.AccessType.ReadWrite)
+    access = EnumProperty(
+        dtype=dtypes.AccessType,
+        desc="Type of access to this array",
+        default=dtypes.AccessType.ReadWrite
+    )
     setzero = Property(dtype=bool, desc="Initialize to zero", default=False)
     debuginfo = DebugInfoProperty()
     data = DataProperty(desc="Data (array, stream, scalar) to access")
@@ -340,9 +342,11 @@ class Tasklet(CodeNode):
         default=CodeBlock("", dtypes.Language.CPP))
     debuginfo = DebugInfoProperty()
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = EnumProperty(
+        dtype=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation
+    )
 
     def __init__(self,
                  label,
@@ -472,12 +476,10 @@ class NestedSDFG(CodeNode):
 
     # NOTE: We cannot use SDFG as the type because of an import loop
     sdfg = SDFGReferenceProperty(desc="The SDFG", allow_none=True)
-    schedule = Property(dtype=dtypes.ScheduleType,
-                        desc="SDFG schedule",
-                        allow_none=True,
-                        choices=dtypes.ScheduleType,
-                        from_string=lambda x: dtypes.ScheduleType[x],
-                        default=dtypes.ScheduleType.Default)
+    schedule = EnumProperty(dtype=dtypes.ScheduleType,
+                            desc="SDFG schedule",
+                            allow_none=True,
+                            default=dtypes.ScheduleType.Default)
     symbol_mapping = DictProperty(
         key_type=str,
         value_type=dace.symbolic.pystr_to_symbolic,
@@ -488,9 +490,11 @@ class NestedSDFG(CodeNode):
                             desc="Show this node/scope/state as collapsed",
                             default=False)
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = EnumProperty(
+        dtype=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation
+    )
 
     no_inline = Property(
         dtype=bool,
@@ -772,11 +776,9 @@ class Map(object):
     params = ListProperty(element_type=str, desc="Mapped parameters")
     range = RangeProperty(desc="Ranges of map parameters",
                           default=sbs.Range([]))
-    schedule = Property(dtype=dtypes.ScheduleType,
-                        desc="Map schedule",
-                        choices=dtypes.ScheduleType,
-                        from_string=lambda x: dtypes.ScheduleType[x],
-                        default=dtypes.ScheduleType.Default)
+    schedule = EnumProperty(dtype=dtypes.ScheduleType,
+                            desc="Map schedule",
+                            default=dtypes.ScheduleType.Default)
     unroll = Property(dtype=bool, desc="Map unrolling")
     collapse = Property(dtype=int,
                         default=1,
@@ -787,9 +789,11 @@ class Map(object):
                             desc="Show this node/scope/state as collapsed",
                             default=False)
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = EnumProperty(
+        dtype=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation
+    )
 
     def __init__(self,
                  label,
@@ -979,11 +983,9 @@ class Consume(object):
     pe_index = Property(dtype=str, desc="Processing element identifier")
     num_pes = SymbolicProperty(desc="Number of processing elements", default=1)
     condition = CodeProperty(desc="Quiescence condition", allow_none=True)
-    schedule = Property(dtype=dtypes.ScheduleType,
-                        desc="Consume schedule",
-                        choices=dtypes.ScheduleType,
-                        from_string=lambda x: dtypes.ScheduleType[x],
-                        default=dtypes.ScheduleType.Default)
+    schedule = EnumProperty(dtype=dtypes.ScheduleType,
+                            desc="Consume schedule",
+                            default=dtypes.ScheduleType.Default)
     chunksize = Property(dtype=int,
                          desc="Maximal size of elements to consume at a time",
                          default=1)
@@ -992,9 +994,11 @@ class Consume(object):
                             desc="Show this node/scope/state as collapsed",
                             default=False)
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = EnumProperty(
+        dtype=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation
+    )
 
     def as_map(self):
         """ Compatibility function that allows to view the consume as a map,
@@ -1185,13 +1189,12 @@ class LibraryNode(CodeNode):
         allow_none=True,
         desc=("Which implementation this library node will expand into."
               "Must match a key in the list of possible implementations."))
-    schedule = Property(
+    schedule = EnumProperty(
         dtype=dtypes.ScheduleType,
         desc="If set, determines the default device mapping of "
         "the node upon expansion, if expanded to a nested SDFG.",
-        choices=dtypes.ScheduleType,
-        from_string=lambda x: dtypes.ScheduleType[x],
-        default=dtypes.ScheduleType.Default)
+        default=dtypes.ScheduleType.Default
+    )
     debuginfo = DebugInfoProperty()
 
     def __init__(self, name, *args, **kwargs):

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -33,7 +33,7 @@ from dace.sdfg.graph import OrderedDiGraph, Edge, SubgraphView
 from dace.sdfg.state import SDFGState
 from dace.sdfg.propagation import propagate_memlets_sdfg
 from dace.dtypes import validate_name
-from dace.properties import (ListProperty, make_properties, Property,
+from dace.properties import (EnumProperty, ListProperty, make_properties, Property,
                              CodeProperty, TransformationHistProperty,
                              SDFGReferenceProperty, DictProperty,
                              OrderedDictProperty, CodeBlock)
@@ -240,9 +240,11 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                            dtypes.typeclass,
                            desc="Global symbols for this SDFG")
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = EnumProperty(
+        dtype=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation
+    )
 
     global_code = DictProperty(
         str,

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -11,7 +11,7 @@ from dace.sdfg.graph import (OrderedMultiDiConnectorGraph, MultiConnectorEdge,
                              SubgraphView)
 from dace.sdfg.propagation import propagate_memlet
 from dace.sdfg.validation import validate_state
-from dace.properties import (Property, DictProperty, SubsetProperty,
+from dace.properties import (EnumProperty, Property, DictProperty, SubsetProperty,
                              SymbolicProperty, CodeBlock, make_properties)
 from inspect import getframeinfo, stack
 import itertools
@@ -709,9 +709,11 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet],
                       default=False,
                       desc="Do not synchronize at the end of the state")
 
-    instrument = Property(choices=dtypes.InstrumentationType,
-                          desc="Measure execution statistics with given method",
-                          default=dtypes.InstrumentationType.No_Instrumentation)
+    instrument = EnumProperty(
+        dtype=dtypes.InstrumentationType,
+        desc="Measure execution statistics with given method",
+        default=dtypes.InstrumentationType.No_Instrumentation
+    )
 
     executions = SymbolicProperty(default=0,
                                   desc="The number of times this state gets "

--- a/dace/transformation/dataflow/copy_to_device.py
+++ b/dace/transformation/dataflow/copy_to_device.py
@@ -31,11 +31,9 @@ class CopyToDevice(transformation.Transformation):
 
     _nested_sdfg = nodes.NestedSDFG("", graph.OrderedDiGraph(), {}, {})
 
-    storage = properties.Property(dtype=dtypes.StorageType,
-                                  desc="Nested SDFG storage",
-                                  choices=dtypes.StorageType,
-                                  from_string=lambda x: dtypes.StorageType[x],
-                                  default=dtypes.StorageType.Default)
+    storage = properties.EnumProperty(dtype=dtypes.StorageType,
+                                      desc="Nested SDFG storage",
+                                      default=dtypes.StorageType.Default)
 
     @staticmethod
     def annotates_memlets():

--- a/dace/transformation/dataflow/streaming_memory.py
+++ b/dace/transformation/dataflow/streaming_memory.py
@@ -117,12 +117,11 @@ class StreamingMemory(xf.Transformation):
         default=1,
         desc='Set buffer size for the newly-created stream')
 
-    storage = properties.Property(
+    storage = properties.EnumProperty(
         dtype=dtypes.StorageType,
         desc='Set storage type for the newly-created stream',
-        choices=dtypes.StorageType,
-        default=dtypes.StorageType.Default,
-        from_string=lambda x: dtypes.StorageType[x])
+        default=dtypes.StorageType.Default
+    )
 
     @staticmethod
     def expressions() -> List[gr.SubgraphView]:
@@ -392,12 +391,11 @@ class StreamingComposition(xf.Transformation):
         default=1,
         desc='Set buffer size for the newly-created stream')
 
-    storage = properties.Property(
+    storage = properties.EnumProperty(
         dtype=dtypes.StorageType,
         desc='Set storage type for the newly-created stream',
-        choices=dtypes.StorageType,
-        default=dtypes.StorageType.Default,
-        from_string=lambda x: dtypes.StorageType[x])
+        default=dtypes.StorageType.Default
+    )
 
     @staticmethod
     def expressions() -> List[gr.SubgraphView]:

--- a/dace/transformation/dataflow/strip_mining.py
+++ b/dace/transformation/dataflow/strip_mining.py
@@ -6,7 +6,7 @@ import dace
 from copy import deepcopy as dcpy
 from dace import dtypes, registry, subsets, symbolic
 from dace.sdfg import SDFG, SDFGState
-from dace.properties import make_properties, Property, SymbolicProperty
+from dace.properties import EnumProperty, make_properties, Property, SymbolicProperty
 from dace.sdfg import nodes
 from dace.sdfg import utils as sdutil
 from dace.symbolic import issymbolic, overapproximate, SymExpr
@@ -155,9 +155,9 @@ class StripMining(transformation.Transformation):
         default=False,
         desc="Continuous (false) or strided (true) elements in tile")
 
-    tiling_type = Property(
+    tiling_type = EnumProperty(
+        dtype=dtypes.TilingType,
         default=dtypes.TilingType.Normal,
-        choices=dtypes.TilingType,
         allow_none=True,
         desc="normal: the outerloop increments with tile_size, "
         "ceilrange: uses ceiling(N/tile_size) in outer range, "

--- a/dace/transformation/subgraph/composite.py
+++ b/dace/transformation/subgraph/composite.py
@@ -13,7 +13,7 @@ from dace.transformation.subgraph.stencil_tiling import StencilTiling
 import dace.transformation.subgraph.helpers as helpers
 
 from dace import dtypes, registry, symbolic, subsets, data
-from dace.properties import make_properties, Property, ShapeProperty
+from dace.properties import EnumProperty, make_properties, Property, ShapeProperty
 from dace.sdfg import SDFG, SDFGState
 from dace.sdfg.graph import SubgraphView
 
@@ -37,12 +37,10 @@ class CompositeFusion(transformation.SubgraphTransformation):
                             dtype = bool,
                             default = False)
 
-    transient_allocation = Property(
+    transient_allocation = EnumProperty(
         desc="Storage Location to push transients to that are "
              "fully contained within the subgraph.",
         dtype=dtypes.StorageType,
-        choices=dtypes.StorageType, 
-        from_string=lambda x: dtypes.StorageType[x],
         default=dtypes.StorageType.Default)
 
     schedule_innermaps = Property(desc="Schedule of inner fused maps",

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -9,7 +9,7 @@ from dace.sdfg.graph import SubgraphView
 from dace.sdfg.scope import ScopeTree
 from dace.memlet import Memlet
 from dace.transformation import transformation
-from dace.properties import ListProperty, make_properties, Property
+from dace.properties import EnumProperty, ListProperty, make_properties, Property
 from dace.symbolic import symstr, overapproximate
 from dace.sdfg.propagation import propagate_memlets_sdfg, propagate_memlet, propagate_memlets_scope, _propagate_node
 from dace.transformation.subgraph import helpers
@@ -45,12 +45,10 @@ class SubgraphFusion(transformation.SubgraphTransformation):
 
     debug = Property(desc="Show debug info", dtype=bool, default=False)
 
-    transient_allocation = Property(
+    transient_allocation = EnumProperty(
         dtype=dtypes.StorageType,
         desc="Storage Location to push transients to that are "
         "fully contained within the subgraph.",
-        choices=dtypes.StorageType,
-        from_string=lambda x: dtypes.StorageType[x],
         default=dtypes.StorageType.Default)
 
     schedule_innermaps = Property(desc="Schedule of inner maps. If none, "


### PR DESCRIPTION
If a value not registered in an `EnumProperty`'s choices is deserialized, it is deserialized as `Undefined` in the corresponding enum property's data type. The original value is remembered, such that it can be restored upon subsequent re-serialization. This means that custom/unregistered values can be used for enum properties without causing errors, while remaining intact through de-/re-serialization of the SDFG.