### PR TITLE
Fix for StateFusion rendering the start state of the SDFG invalid

### DIFF
--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -447,6 +447,8 @@ class StateFusion(transformation.Transformation):
         if first_state.is_empty():
             sdutil.change_edge_dest(sdfg, first_state, second_state)
             sdfg.remove_node(first_state)
+            if sdfg.start_state == first_state:
+                sdfg.start_state = sdfg.node_id(second_state)
             return
 
         # Special case 2: second state is empty
@@ -454,6 +456,8 @@ class StateFusion(transformation.Transformation):
             sdutil.change_edge_src(sdfg, second_state, first_state)
             sdutil.change_edge_dest(sdfg, second_state, first_state)
             sdfg.remove_node(second_state)
+            if sdfg.start_state == second_state:
+                sdfg.start_state = sdfg.node_id(first_state)
             return
 
         # Normal case: both states are not empty
@@ -532,3 +536,5 @@ class StateFusion(transformation.Transformation):
         # Redirect edges and remove second state
         sdutil.change_edge_src(sdfg, second_state, first_state)
         sdfg.remove_node(second_state)
+        if sdfg.start_state == second_state:
+            sdfg.start_state = sdfg.node_id(first_state)


### PR DESCRIPTION
When fusing state, it is possible that the effectively removed state is the SDFG's start state. This is normally OK since the start state is automatically re-computed in the next call to the property. However, the property considers the case where there are multiple candidate start states. In those cases, it keeps the old start state, which may have been removed. The apply method of StateFusion now checks for this case and manually sets the SDFG's start state to be the state that was not removed by the transformation.