### PR TITLE
Python frontend: Better support for arguments

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -342,6 +342,9 @@ class CompiledSDFG(object):
             if not dtypes.is_array(arg) and isinstance(atype, dt.Array):
                 if isinstance(arg, list):
                     print('WARNING: Casting list argument "%s" to ndarray' % a)
+                elif arg is None:
+                    # None values are passed as null pointers
+                    pass
                 else:
                     raise TypeError(
                         'Passing an object (type %s) to an array in argument "%s"'
@@ -389,6 +392,9 @@ class CompiledSDFG(object):
             # List to array
             elif isinstance(arg, list) and isinstance(argtype, dt.Array):
                 arglist[index] = np.array(arg, dtype=argtype.dtype.type)
+            # Null pointer
+            elif arg is None and isinstance(argtype, dt.Array):
+                arglist[index] = ctypes.c_void_p(0)
 
         # Retain only the element datatype for upcoming checks and casts
         arg_ctypes = [t.dtype.as_ctypes() for t in argtypes]

--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -1092,7 +1092,10 @@ def cppunparse(node, expr_semicolon=True, locals=None, defined_symbols=None):
 # Code can either be a string or a function
 def py2cpp(code, expr_semicolon=True, defined_symbols=None):
     if isinstance(code, str):
-        return cppunparse(ast.parse(code), expr_semicolon, defined_symbols=defined_symbols)
+        try:
+            return cppunparse(ast.parse(code), expr_semicolon, defined_symbols=defined_symbols)
+        except SyntaxError:
+            return code
     elif isinstance(code, ast.AST):
         return cppunparse(code, expr_semicolon, defined_symbols=defined_symbols)
     elif isinstance(code, list):

--- a/dace/codegen/targets/common.py
+++ b/dace/codegen/targets/common.py
@@ -39,8 +39,8 @@ def sym2cpp(s, arrayexprs: Optional[Set[str]] = None) -> Union[str, List[str]]:
     :return: C++-compilable expression or list thereof.
     """
     if not isinstance(s, list):
-        return symbolic.symstr(s, arrayexprs)
-    return [symbolic.symstr(d, arrayexprs) for d in s]
+        return cppunparse.pyexpr2cpp(symbolic.symstr(s, arrayexprs))
+    return [cppunparse.pyexpr2cpp(symbolic.symstr(d, arrayexprs)) for d in s]
 
 
 def codeblock_to_cpp(cb: CodeBlock):

--- a/dace/data.py
+++ b/dace/data.py
@@ -46,7 +46,7 @@ def create_datadescriptor(obj):
         return Scalar(symbolic.symtype(obj))
     elif isinstance(obj, dtypes.typeclass):
         return Scalar(obj)
-    elif obj in {int, float, complex, bool}:
+    elif obj in {int, float, complex, bool, None}:
         return Scalar(dtypes.typeclass(obj))
     elif callable(obj):
         # Cannot determine return value/argument types from function object

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -765,6 +765,30 @@ class struct(typeclass):
         )
 
 
+class constant:
+    """ 
+    Data descriptor type hint signalling that argument evaluation is 
+    deferred to call time.
+
+    Example usage::
+
+        @dace.program
+        def example(A: dace.float64[20], constant: dace.constant):
+            if constant == 0:
+                return A + 1
+            else:
+                return A + 2
+
+    
+    In the above code, ``constant`` will be replaced with its value at call time
+    during parsing.
+    """
+    @staticmethod
+    def __descriptor__():
+        raise ValueError('All constant arguments must be provided in order '
+                         'to compile the SDFG ahead-of-time.')
+
+
 ####### Utility function ##############
 def ptrtonumpy(ptr, inner_ctype, shape):
     import ctypes

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -282,6 +282,7 @@ class ConditionalCodeResolver(ast.NodeTransformer):
         self.globals = globals
 
     def visit_If(self, node: ast.If) -> Any:
+        node = self.generic_visit(node)
         try:
             test = RewriteSympyEquality(self.globals).visit(node.test)
             result = astutils.evalnode(test, self.globals)
@@ -299,7 +300,7 @@ class ConditionalCodeResolver(ast.NodeTransformer):
             # Cannot evaluate if condition at compile time
             pass
 
-        return self.generic_visit(node)
+        return node
 
     def visit_IfExp(self, node: ast.IfExp) -> Any:
         return self.visit_If(node)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3729,6 +3729,8 @@ class ProgramVisitor(ExtNodeVisitor):
                 fcopy.global_vars = {**func.global_vars, **self.globals}
                 fargs = (self._eval_arg(arg) for _, arg in args)
                 sdfg = fcopy.to_sdfg(*fargs, strict=self.strict, save=False)
+                args = [(k, v) for k, v in args if k in sdfg.arg_names]
+                required_args = [k for k, _ in args]
             elif self._has_sdfg(func):
                 fargs = tuple(
                     self._eval_arg(self._parse_function_arg(arg))

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -802,6 +802,9 @@ class GlobalResolver(ast.NodeTransformer):
                 return newnode
         return self.generic_visit(node)
 
+    def visit_Subscript(self, node: ast.Subscript) -> Any:
+        return self.visit_Attribute(node)
+
     def visit_Call(self, node: ast.Call) -> Any:
         try:
             global_func = astutils.evalnode(node.func, self.globals)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3729,8 +3729,9 @@ class ProgramVisitor(ExtNodeVisitor):
                 fcopy.global_vars = {**func.global_vars, **self.globals}
                 fargs = (self._eval_arg(arg) for _, arg in args)
                 sdfg = fcopy.to_sdfg(*fargs, strict=self.strict, save=False)
-                args = [(k, v) for k, v in args if k in sdfg.arg_names]
-                required_args = [k for k, _ in args]
+                required_args = [k for k, _ in args if k in sdfg.arg_names]
+                # Filter out constant arguments
+                args = [(k, v) for k, v in args if k not in fcopy.constant_args]
             elif self._has_sdfg(func):
                 fargs = tuple(
                     self._eval_arg(self._parse_function_arg(arg))

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -355,6 +355,10 @@ class DaceProgram:
         nargs = len(given_args)
         arg_ind = 0
         for i, (aname, sig_arg) in enumerate(self.signature.parameters.items()):
+            if self.objname is not None and aname == self.objname:
+                # Skip "self" argument
+                continue
+
             ann = sig_arg.annotation
 
             # Variable-length arguments: obtain from the remainder of given_*

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -225,7 +225,7 @@ class DaceProgram:
         result.update(
             infer_symbols_from_datadescriptor(
                 sdfg, {k: create_datadescriptor(v)
-                       for k, v in kwargs.items()}))
+                       for k, v in result.items()}))
         return result
 
     def __call__(self, *args, **kwargs):

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -380,7 +380,7 @@ class DaceProgram:
                     if ann is dtypes.constant:
                         curtype = None
                     else:
-                        curtype = ann
+                        curtype = create_datadescriptor(ann)
 
                 # If no annotation is provided, use given arguments
                 if curtype is None and sig_arg.kind is sig_arg.POSITIONAL_ONLY:
@@ -428,9 +428,9 @@ class DaceProgram:
         if not _is_empty(rettype):
             if isinstance(rettype, tuple):
                 for i, subrettype in enumerate(rettype):
-                    types[f'__return_{i}'] = subrettype
+                    types[f'__return_{i}'] = create_datadescriptor(subrettype)
             else:
-                types['__return'] = rettype
+                types['__return'] = create_datadescriptor(rettype)
 
         return types
 

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -7,6 +7,7 @@ import copy
 import os
 import sympy
 from typing import Any, Dict, List, Optional, Set, Tuple
+import warnings
 
 from dace import symbolic, dtypes
 from dace.config import Config
@@ -148,6 +149,15 @@ class DaceProgram:
         }
         self.symbols = set(k for k, v in self.global_vars.items()
                            if isinstance(v, symbolic.symbol))
+
+        # Add type annotations from decorator arguments (DEPRECATED)
+        if self.dec_args:
+            warnings.warn(
+                'Using decorator arguments for types is deprecated. '
+                'Please use type hints on function arguments instead.')
+            for arg, pval in zip(self.dec_args,
+                                 self.signature.parameters.values()):
+                pval._annotation = arg
 
         if self.argnames is None:
             self.argnames = []

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -423,6 +423,16 @@ class DaceProgram:
         # (for inferring types and values in the DaCe program)
         global_vars = copy.copy(self.global_vars)
 
+        # Remove constant and None arguments, make globals that can be folded
+        for k, v in argtypes.items():
+            if v.dtype.type is None:
+                global_vars[k] = None
+        argtypes = {
+            k: v
+            for k, v in argtypes.items() if v.dtype.type is not None
+        }
+
+        # Set module aliases to point to their actual names
         modules = {
             k: v.__name__
             for k, v in global_vars.items() if dtypes.ismodule(v)

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -159,6 +159,11 @@ class DaceProgram:
                                  self.signature.parameters.values()):
                 pval._annotation = arg
 
+        # Keep a set of constant arguments to ignore
+        self.constant_args = set(
+            pname for pname, pval in self.signature.parameters.items()
+            if pval.annotation is dtypes.constant)
+
         if self.argnames is None:
             self.argnames = []
 
@@ -229,8 +234,10 @@ class DaceProgram:
         # Update arguments with symbols in data shapes
         result.update(
             infer_symbols_from_datadescriptor(
-                sdfg, {k: create_datadescriptor(v)
-                       for k, v in result.items()}))
+                sdfg, {
+                    k: create_datadescriptor(v)
+                    for k, v in result.items() if k not in self.constant_args
+                }))
         return result
 
     def __call__(self, *args, **kwargs):

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -4563,7 +4563,7 @@ def dot(pv: 'ProgramVisitor',
     arr_a = sdfg.arrays[op_a]
     arr_b = sdfg.arrays[op_b]
 
-    if len(arr_a.shape) == 2 and len(arr_b.shape == 2):
+    if len(arr_a.shape) == 2 and len(arr_b.shape) == 2:
         # Matrix multiplication
         # TODO: `If op_out`, then this is not correct. We need np.matmult,
         # but it is not implemented yet

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -831,7 +831,7 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
 
     def _print_Symbol(self, expr):
         if expr.name == 'NoneSymbol':
-            return 'None'
+            return 'nullptr'
         return super()._print_Symbol(expr)
 
     def _print_Pow(self, expr):

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -731,6 +731,15 @@ class SympyBooleanConverter(ast.NodeTransformer):
                             keywords=[])
         return ast.copy_location(new_node, node)
 
+    def visit_Constant(self, node):
+        if node.value is None:
+            return ast.copy_location(ast.Name(id='NoneSymbol', ctx=ast.Load()),
+                                     node)
+        return self.generic_visit(node)
+
+    def visit_NameConstant(self, node):
+        return self.visit_Constant(node)
+
 
 @lru_cache(2048)
 def pystr_to_symbolic(expr, symbol_map=None, simplify=None):
@@ -758,7 +767,7 @@ def pystr_to_symbolic(expr, symbol_map=None, simplify=None):
 
     # Sympy processes "not/and/or" as direct evaluation. Replace with
     # And/Or(x, y), Not(x)
-    if isinstance(expr, str) and re.search(r'\bnot\b|\band\b|\bor\b|==|!=',
+    if isinstance(expr, str) and re.search(r'\bnot\b|\band\b|\bor\b|\bNone\b|==|!=',
                                            expr):
         expr = unparse(SympyBooleanConverter().visit(ast.parse(expr).body[0]))
 
@@ -819,6 +828,11 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
 
     def _print_NegativeInfinity(self, expr):
         return '-INFINITY'
+
+    def _print_Symbol(self, expr):
+        if expr.name == 'NoneSymbol':
+            return 'None'
+        return super()._print_Symbol(expr)
 
     def _print_Pow(self, expr):
         base = self._print(expr.args[0])

--- a/tests/codegen/sve/map_test.py
+++ b/tests/codegen/sve/map_test.py
@@ -37,10 +37,15 @@ def test_map_advanced():
     assert '__pg_j' not in code
 
     # Check for stride of N * 2
-    assert '__pg_k) * (2*N)' in code
+    assert '__pg_k) * (2 * N)' in code
 
     # Offset initial
     assert 'k = 1' in code
 
     # Upper bound (minus 1)
-    assert '(8*N))' in code
+    assert '(8 * N))' in code
+
+
+if __name__ == '__main__':
+    test_map_simple()
+    test_map_advanced()

--- a/tests/python_frontend/constant_and_keyword_args_test.py
+++ b/tests/python_frontend/constant_and_keyword_args_test.py
@@ -17,6 +17,17 @@ def test_kwargs():
     assert np.allclose(A, kw + 1)
 
 
+def test_kwargs_jit():
+    @dace.program
+    def kwarg(A, kw):
+        A[:] = kw + 1
+
+    A = np.random.rand(20)
+    kw = np.random.rand(20)
+    kwarg(A, kw=kw)
+    assert np.allclose(A, kw + 1)
+
+
 def test_kwargs_with_default():
     @dace.program
     def kwarg(A: dace.float64[20], kw: dace.float64[20] = np.ones([20])):
@@ -35,4 +46,5 @@ def test_kwargs_with_default():
 
 if __name__ == '__main__':
     test_kwargs()
+    test_kwargs_jit()
     test_kwargs_with_default()

--- a/tests/python_frontend/constant_and_keyword_args_test.py
+++ b/tests/python_frontend/constant_and_keyword_args_test.py
@@ -44,7 +44,116 @@ def test_kwargs_with_default():
     assert np.allclose(A, kw + 1)
 
 
+
+
+def test_none_arrays():
+    @dace.program
+    def myprog(A: dace.float64[20], B: dace.float64[20]):
+        result = np.zeros([20], dtype=dace.float64)
+        if B is None:
+            if A is not None:
+                result[:] = A
+            else:
+                result[:] = 1
+        else:
+            result[:] = B
+        return result
+
+    # Tests
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    assert np.allclose(myprog(A, B), B)
+    assert np.allclose(myprog(A, None), A)
+    assert np.allclose(myprog(None, None), 1)
+
+
+def test_none_arrays_jit():
+    @dace.program
+    def myprog_jit(A, B):
+        if B is None:
+            if A is not None:
+                return A
+            else:
+                return np.ones([20], np.float64)
+        else:
+            return B
+
+    # Tests
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    assert np.allclose(myprog_jit(A, B), B)
+    assert np.allclose(myprog_jit(A, None), A)
+    assert np.allclose(myprog_jit(None, None), 1)
+
+
+def test_optional_argument_jit():
+    @dace.program
+    def linear(x, w, bias):
+        """ Linear layer with weights w applied to x, and optional bias. """
+        if bias is not None:
+            return x @ w.T + bias
+        else:
+            return x @ w.T
+
+    x = np.random.rand(13, 14)
+    w = np.random.rand(10, 14)
+    b = np.random.rand(10)
+
+    # Try without bias
+    assert np.allclose(linear.f(x, w, None), linear(x, w, None))
+
+    # Try with bias
+    assert np.allclose(linear.f(x, w, b), linear(x, w, b))
+
+
+def test_optional_argument_jit_kwarg():
+    @dace.program
+    def linear(x, w, bias=None):
+        """ Linear layer with weights w applied to x, and optional bias. """
+        if bias is not None:
+            return np.dot(x, w.T) + bias
+        else:
+            return np.dot(x, w.T)
+
+    x = np.random.rand(13, 14)
+    w = np.random.rand(10, 14)
+    b = np.random.rand(10)
+
+    # Try without bias
+    assert np.allclose(linear.f(x, w), linear(x, w))
+
+    # Try with bias
+    assert np.allclose(linear.f(x, w, b), linear(x, w, b))
+
+
+def test_optional_argument():
+    @dace.program
+    def linear(x: dace.float64[13, 14],
+               w: dace.float64[10, 14],
+               bias: dace.float64[10] = None):
+        """ Linear layer with weights w applied to x, and optional bias. """
+        if bias is not None:
+            return np.dot(x, w.T) + bias
+        else:
+            return np.dot(x, w.T)
+
+    x = np.random.rand(13, 14)
+    w = np.random.rand(10, 14)
+    b = np.random.rand(10)
+
+    # Try without bias
+    assert np.allclose(linear.f(x, w), linear(x, w))
+
+    # Try with bias
+    assert np.allclose(linear.f(x, w, b), linear(x, w, b))
+
+
 if __name__ == '__main__':
     test_kwargs()
     test_kwargs_jit()
     test_kwargs_with_default()
+    test_none_arrays()
+    test_none_arrays_jit()
+    test_optional_argument_jit()
+    test_optional_argument_jit_kwarg()
+    test_optional_argument()

--- a/tests/python_frontend/constant_and_keyword_args_test.py
+++ b/tests/python_frontend/constant_and_keyword_args_test.py
@@ -1,0 +1,38 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests constants, optional, and keyword arguments. """
+import dace
+import numpy as np
+import pytest
+from dace.frontend.python.common import DaceSyntaxError
+
+
+def test_kwargs():
+    @dace.program
+    def kwarg(A: dace.float64[20], kw: dace.float64[20]):
+        A[:] = kw + 1
+
+    A = np.random.rand(20)
+    kw = np.random.rand(20)
+    kwarg(A, kw=kw)
+    assert np.allclose(A, kw + 1)
+
+
+def test_kwargs_with_default():
+    @dace.program
+    def kwarg(A: dace.float64[20], kw: dace.float64[20] = np.ones([20])):
+        A[:] = kw + 1
+
+    # Call without argument
+    A = np.random.rand(20)
+    kwarg(A)
+    assert np.allclose(A, 2.0)
+
+    # Call with argument
+    kw = np.random.rand(20)
+    kwarg(A, kw)
+    assert np.allclose(A, kw + 1)
+
+
+if __name__ == '__main__':
+    test_kwargs()
+    test_kwargs_with_default()

--- a/tests/python_frontend/constant_and_keyword_args_test.py
+++ b/tests/python_frontend/constant_and_keyword_args_test.py
@@ -216,6 +216,29 @@ def test_constant_argument_simple():
     assert 'cst' not in code
 
 
+def test_constant_argument_default():
+    @dace.program
+    def const_prog(B: dace.float64[20], cst: dace.constant = 7):
+        B[:] = cst
+
+    # Test program
+    A = np.random.rand(20)
+    const_prog(A)
+    assert np.allclose(A, 7)
+
+    # Forcefully clear cache to recompile
+    const_prog.clear_cache()
+
+    # Test program
+    A = np.random.rand(20)
+    const_prog(A, cst=4)
+    assert np.allclose(A, 4)
+
+    # Test code for folding
+    code = const_prog.to_sdfg().generate_code()[0].clean_code
+    assert 'cst' not in code
+
+
 if __name__ == '__main__':
     test_kwargs()
     test_kwargs_jit()
@@ -231,3 +254,4 @@ if __name__ == '__main__':
     test_optional_argument_jit_kwarg()
     test_optional_argument()
     test_constant_argument_simple()
+    test_constant_argument_default()

--- a/tests/python_frontend/constant_and_keyword_args_test.py
+++ b/tests/python_frontend/constant_and_keyword_args_test.py
@@ -3,7 +3,6 @@
 import dace
 import numpy as np
 import pytest
-from dace.frontend.python.common import DaceSyntaxError
 
 
 def test_kwargs():
@@ -44,6 +43,37 @@ def test_kwargs_with_default():
     assert np.allclose(A, kw + 1)
 
 
+def test_var_args_aot():
+    # This test is supposed to be unsupported
+    with pytest.raises(SyntaxError):
+
+        @dace.program
+        def arg_aot(*args: dace.float64[20]):
+            return args[0] + args[1]
+
+        arg_aot.compile()
+
+
+def test_var_args_empty():
+    # This test is supposed to be unsupported
+    with pytest.raises(SyntaxError):
+
+        @dace.program
+        def arg_aot(*args):
+            return np.zeros([20])
+
+        arg_aot.compile()
+
+
+def test_var_kwargs_aot():
+    # This test is supposed to be unsupported
+    with pytest.raises(SyntaxError):
+
+        @dace.program
+        def kwarg_aot(**kwargs: dace.float64[20]):
+            return kwargs['A'] + kwargs['B']
+
+        kwarg_aot.compile()
 
 
 def test_none_arrays():
@@ -152,6 +182,9 @@ if __name__ == '__main__':
     test_kwargs()
     test_kwargs_jit()
     test_kwargs_with_default()
+    test_var_args_aot()
+    test_var_args_empty()
+    test_var_kwargs_aot()
     test_none_arrays()
     test_none_arrays_jit()
     test_optional_argument_jit()

--- a/tests/python_frontend/global_folding_test.py
+++ b/tests/python_frontend/global_folding_test.py
@@ -158,34 +158,6 @@ def test_dead_code_elimination_unreachable():
     assert '3' in parsed_code and '2' in parsed_code  # Reachable code
 
 
-# TODO: dace.constant should signal that argument evaluation is deferred to
-#       (nested) call time
-# dace.constant = lambda x: None
-# def test_constant_parameter():
-#     """
-#     Tests nested functions with constant parameters passed in as arguments.
-#     """
-#     @dace.program
-#     def nested_func(cfg: dace.constant(MyConfiguration), A: dace.float64[20]):
-#         return A[cfg.p]
-
-#     @dace.program
-#     def constant_parameter(
-#             cfg: dace.constant(MyConfiguration),
-#             cfg2: dace.constant(MyConfiguration), A: dace.float64[20]):
-#         A[cfg.q] = nested_func(cfg, A)
-#         A[MyConfiguration.get_random_number()] = nested_func(cfg2, A)
-
-#     cfg1 = MyConfiguration(3)
-#     cfg2 = MyConfiguration(4)
-#     A = np.random.rand(20)
-#     reg_A = np.copy(A)
-#     reg_A[12] = reg_A[6]
-#     reg_A[4] = reg_A[8]
-
-#     constant_parameter(cfg1, cfg2, A)
-#     assert np.allclose(A, reg_A)
-
 if __name__ == '__main__':
     test_instantiated_global()
     test_nested_globals()
@@ -193,4 +165,3 @@ if __name__ == '__main__':
     test_dead_code_elimination_ifexp()
     test_dead_code_elimination_noelse()
     test_dead_code_elimination_unreachable()
-    # test_constant_parameter()

--- a/tests/python_frontend/lambda_test.py
+++ b/tests/python_frontend/lambda_test.py
@@ -1,0 +1,108 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests lambda functions. """
+import dace
+import numpy as np
+import pytest
+
+
+def test_inline_lambda_tasklet():
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        for i in dace.map[0:20]:
+            with dace.tasklet:
+                a >> A[i]
+                b << B[i]
+                c << C[i]
+                f = lambda a, b: a + b
+                a = f(b, c)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+@pytest.mark.skip
+def test_inline_lambda_scalar():
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        f = lambda a, b: a + b
+        for i in dace.map[0:20]:
+            A[i] = f(B[i], C[i])
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+@pytest.mark.skip
+def test_inline_lambda_array():
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        f = lambda a, b: a + b
+        A[:] = f(B, C)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+@pytest.mark.skip
+def test_lambda_global():
+    f = lambda a, b: a + b
+
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        A[:] = f(B, C)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+@pytest.mark.skip
+def test_lambda_call_jit():
+    @dace.program
+    def lamb(A, B, C, f):
+        A[:] = f(B, C)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    f = lambda a, b: a + b
+    lamb(A, B, C, f)
+    assert np.allclose(A, B + C)
+
+
+@pytest.mark.skip
+def test_lambda_nested_call():
+    @dace.program
+    def lamb2(A, B, C, f):
+        A[:] = f(B, C)
+
+    @dace.program
+    def lamb1(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        f = lambda a, b: a + b
+        lamb2(A, B, C, f)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb1(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+if __name__ == '__main__':
+    test_inline_lambda_tasklet()
+    # test_inline_lambda_scalar()
+    # test_inline_lambda_array()
+    # test_lambda_global()
+    # test_lambda_call_jit()
+    # test_lambda_nested_call()


### PR DESCRIPTION
- [x] Default/keyword arguments
- [x] Variable-length arguments (`*args`, `**kwargs`, only in JIT mode)
- [x] Optional arguments (None inputs) for arrays
- [x] Arbitrary constant arguments that get evaluated at call time (JIT mode only)