### PR TITLE
Reallocation of non-free SDFG symbol-dependent transients.

### DIFF
--- a/tests/nested_symbol_test.py
+++ b/tests/nested_symbol_test.py
@@ -33,10 +33,6 @@ def test_nested_symbol():
 
 
 def test_nested_symbol_dynamic():
-    if not dace.Config.get_bool('optimizer',
-                                'automatic_strict_transformations'):
-        warnings.warn("Test disabled (missing allocation lifetime support)")
-        return
 
     A = np.random.rand(5)
     expected = A.copy()


### PR DESCRIPTION
When the shape of a transient depends on a non-free SDFG symbol, for example, a for-loop variable, the code generator declares the transient as a pointer at the beginning of the SDFG, allocates it at the beginning of the `first` SDFGState used, and de-allocates it at the end of the `last` SDFGState used. The `first` and `last` SDFGStates are defined based on their topological order (see `SDFG.topological_sort`). However, it may not be possible to find a (correct) topological order for various reasons, or there might be other issues. The purpose of this PR is to investigate such issues and further refine code generation to support these cases, potentially employing `realloc` instead of `new`.