### PR TITLE
Install networkx>=2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='dace',
       },
       include_package_data=True,
       install_requires=[
-          'numpy', 'networkx >= 2.2', 'astunparse', 'sympy', 'pyyaml', 'ply',
+          'numpy', 'networkx >= 2.5', 'astunparse', 'sympy', 'pyyaml', 'ply',
           'websockets', 'requests', 'flask', 'scikit-build', 'cmake', 'aenum',
           'dataclasses; python_version < "3.7"', 'dill', 'pyreadline;platform_system=="Windows"'
       ],


### PR DESCRIPTION
Networkx 2.5 is required for `transitive_closure_dag`