### PR TITLE
Change DRAM bank assignment syntax to work with Vitis 2021.1

### DIFF
--- a/dace/codegen/CMakeLists.txt
+++ b/dace/codegen/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(DACE_FILE ${DACE_FILES})
       set(DACE_XILINX_HOST_FILES ${DACE_XILINX_HOST_FILES} ${DACE_FILE})
     elseif(DACE_FILE_EXT MATCHES ".cpp")
       set(DACE_XILINX_KERNEL_FILES ${DACE_XILINX_KERNEL_FILES} ${DACE_FILE})
-    elseif(DACE_FILE_EXT MATCHES ".ini")
+    elseif(DACE_FILE_EXT MATCHES ".cfg")
       set(DACE_XILINX_CONFIG_FILE ${DACE_FILE})
     endif()
   elseif(${DACE_FILE_TARGET} STREQUAL "intel_fpga")
@@ -479,21 +479,6 @@ if(DACE_ENABLE_XILINX)
           --advanced.prop kernel.${DACE_KERNEL_NAME}.kernel_flags="${DACE_XILINX_SYNTHESIS_FLAGS}")
     endif()
 
-    # Load kernel memory interface assignments, if they exist
-    if (EXISTS ${DACE_KERNEL_DIRECTORY}/${DACE_KERNEL_NAME}_memory_interfaces.csv)
-      file(STRINGS
-          ${DACE_KERNEL_DIRECTORY}/${DACE_KERNEL_NAME}_memory_interfaces.csv
-          _ASSIGNMENTS)
-      foreach(_ASSIGNMENT ${_ASSIGNMENTS})
-        string(REPLACE "," ";" _ASSIGNMENT ${_ASSIGNMENT})
-        list(GET _ASSIGNMENT 0 _INTERFACE_NAME)
-        list(GET _ASSIGNMENT 1 _INTERFACE_TYPE)
-        list(GET _ASSIGNMENT 2 _INTERFACE_INDEX)
-        set(VITIS_BUILD_FLAGS ${VITIS_BUILD_FLAGS}
-            --sp "${DACE_KERNEL_NAME}_1.m_axi_${_INTERFACE_NAME}:${_INTERFACE_TYPE}[${_INTERFACE_INDEX}]")
-      endforeach()
-    endif()
-
   endforeach()
 
   add_custom_target(xilinx_synthesis DEPENDS ${DACE_SYNTHESIS_TARGETS})
@@ -626,27 +611,23 @@ if(DACE_ENABLE_XILINX)
       OUTPUT ${DACE_PROGRAM_NAME}_sw_emu.xclbin
       COMMAND XILINX_PATH=${CMAKE_BINARY_DIR} ${Vitis_COMPILER}
       ${VITIS_BUILD_FLAGS}
+      --config "${DACE_XILINX_CONFIG_FILE}"
       -l
       -t sw_emu
       ${DACE_VITIS_KERNELS_SW_EMU}
       -o ${DACE_PROGRAM_NAME}_sw_emu.xclbin
-      DEPENDS ${DACE_PROGRAM_NAME}_sw_emu.xo)
-
-    unset (VITIS_CONFIG_LINK)
-    if (EXISTS ${DACE_XILINX_CONFIG_FILE})
-        set (VITIS_CONFIG_LINK --config "${DACE_XILINX_CONFIG_FILE}")
-    endif()
+      DEPENDS ${DACE_PROGRAM_NAME}_sw_emu.xo ${DACE_XILINX_CONFIG_FILE})
 
     add_custom_command(
       OUTPUT ${DACE_PROGRAM_NAME}_hw_emu.xclbin
       COMMAND XILINX_PATH=${CMAKE_BINARY_DIR} ${Vitis_COMPILER}
       ${VITIS_BUILD_FLAGS}
-      ${VITIS_CONFIG_LINK}
+      --config "${DACE_XILINX_CONFIG_FILE}"
       -l
       -t hw_emu
       ${DACE_VITIS_KERNELS_HW_EMU}
       -o ${DACE_PROGRAM_NAME}_hw_emu.xclbin
-      DEPENDS ${DACE_VITIS_KERNELS_HW_EMU})
+      DEPENDS ${DACE_VITIS_KERNELS_HW_EMU} ${DACE_XILINX_CONFIG_FILE})
 
     add_custom_command(
       OUTPUT emconfig.json
@@ -657,12 +638,12 @@ if(DACE_ENABLE_XILINX)
       OUTPUT ${DACE_PROGRAM_NAME}_hw.xclbin
       COMMAND XILINX_PATH=${CMAKE_BINARY_DIR} ${Vitis_COMPILER}
       ${VITIS_BUILD_FLAGS}
-      ${VITIS_CONFIG_LINK}
+      --config "${DACE_XILINX_CONFIG_FILE}"
       -l
       -t hw
       ${DACE_VITIS_KERNELS_HW}
       -o ${DACE_PROGRAM_NAME}_hw.xclbin
-      DEPENDS ${DACE_VITIS_KERNELS_HW})
+      DEPENDS ${DACE_VITIS_KERNELS_HW} ${DACE_XILINX_CONFIG_FILE})
 
   endif()
 

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -330,15 +330,6 @@ class FPGACodeGen(TargetCodeGenerator):
                                      state_host_body_stream, state_parameters,
                                      kern_id)
 
-                # Emit the connections ini file
-                if len(self._stream_connections) > 0:
-                    ini_stream = CodeIOStream()
-                    ini_stream.write('[connectivity]')
-                    for _, (src, dst) in self._stream_connections.items():
-                        ini_stream.write('stream_connect={}:{}'.format(
-                            src, dst))
-                    self._other_codes['link.ini'] = ini_stream
-
             kernel_args_call_host = []
             kernel_args_opencl = []
 

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -189,9 +189,8 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                 # TODO: Support HBM
                 link_cfg.write(f"sp={kernel_name}_1.m_axi_{interface_name}:DDR[{memory_bank}]")
         # Emit mapping between inter-kernel streaming interfaces
-        if len(self._stream_connections) > 0:
-            for _, (src, dst) in self._stream_connections.items():
-                link_cfg.write(f"stream_connect={src}:{dst}")
+        for _, (src, dst) in self._stream_connections.items():
+            link_cfg.write(f"stream_connect={src}:{dst}")
 
         other_objs = []
         for name, code in self._other_codes.items():

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -174,48 +174,37 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
             for (kernel_name, code) in self._kernel_codes
         ]
 
-        # Configuration file with interface assignments
+        # Memory bank and streaming interfaces connectivity configuration file
+        link_cfg = CodeIOStream()
+        self._other_codes["link.cfg"] = link_cfg
+        link_cfg.write("[connectivity]")
         are_assigned = [v is not None for v in self._bank_assignments.values()]
         if any(are_assigned):
             if not all(are_assigned):
                 raise RuntimeError("Some, but not all global memory arrays "
                                    "were assigned to memory banks: {}".format(
                                        self._bank_assignments))
-            are_assigned = True
-        else:
-            are_assigned = False
-        bank_assignment_code = []
-        for name, _ in self._host_codes:
-            # Only iterate over assignments if any exist
-            if are_assigned:
-                for (kernel_name, interface_name
-                     ), memory_bank in self._bank_assignments.items():
-                    if kernel_name != name:
-                        continue
-                    # TODO: Support HBM
-                    bank_assignment_code.append(
-                        f"{interface_name},DDR,{memory_bank}")
-            # Create file even if there are no assignments
-            kernel_code_objs.append(
-                CodeObject("{}_memory_interfaces".format(name),
-                           "\n".join(bank_assignment_code),
-                           "csv",
+            # Emit mapping from kernel memory interfaces to DRAM banks
+            for (kernel_name, interface_name), memory_bank in self._bank_assignments.items():
+                # TODO: Support HBM
+                link_cfg.write(f"sp={kernel_name}_1.m_axi_{interface_name}:DDR[{memory_bank}]")
+        # Emit mapping between inter-kernel streaming interfaces
+        if len(self._stream_connections) > 0:
+            for _, (src, dst) in self._stream_connections.items():
+                link_cfg.write(f"stream_connect={src}:{dst}")
+
+        other_objs = []
+        for name, code in self._other_codes.items():
+            name = name.split(".")
+            other_objs.append(
+                CodeObject(name[0],
+                           code.getvalue(),
+                           ".".join(name[1:]),
                            XilinxCodeGen,
                            "Xilinx",
                            target_type="device"))
 
-        # Emit the .ini file
-        others = [
-            CodeObject(''.join(name.split('.')[:-1]),
-                       other_code.getvalue(),
-                       name.split('.')[-1],
-                       XilinxCodeGen,
-                       "Xilinx",
-                       target_type="device")
-            for name, other_code in self._other_codes.items()
-        ]
-
-        return [host_code_obj] + kernel_code_objs + others
+        return [host_code_obj] + kernel_code_objs + other_objs
 
     @staticmethod
     def define_stream(dtype, buffer_size, var_name, array_size, function_stream,
@@ -840,8 +829,9 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                                                      node.ctype)
             if name not in self._stream_connections:
                 self._stream_connections[name] = [None, None]
-            self._stream_connections[name][
-                0 if is_output else 1] = '{}_1.{}'.format(kernel_name, name)
+            key = 0 if is_output else 1
+            val = '{}_1.{}'.format(kernel_name, name)
+            self._stream_connections[name][key] = val
 
         self.generate_modules(sdfg, state, kernel_name, subgraphs,
                               subgraph_parameters, module_stream, entry_stream,

--- a/tests/fpga/kernels_detection.py
+++ b/tests/fpga/kernels_detection.py
@@ -22,7 +22,7 @@ def count_kernels(cachedir: str):
     with open(f".dacecache/{cachedir}/dace_files.csv") as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         for row in csv_reader:
-            if row[1] == "device" and not row[-1].endswith("csv"):
+            if row[1] == "device" and row[-1].endswith("cpp"):
                 kernels = kernels + 1
     return kernels
 

--- a/tests/fpga/kernels_detection.py
+++ b/tests/fpga/kernels_detection.py
@@ -22,7 +22,8 @@ def count_kernels(cachedir: str):
     with open(f".dacecache/{cachedir}/dace_files.csv") as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         for row in csv_reader:
-            if row[1] == "device" and row[-1].endswith("cpp"):
+            if row[1] == "device" and (row[-1].endswith("cpp")
+                                       or row[-1].endswith("cl")):
                 kernels = kernels + 1
     return kernels
 


### PR DESCRIPTION
I've consolidated the `.cfg`/`.ini` file to include both the DRAM bank assignments and the streaming interface assignments between kernels in `xilinx.py`.