### PR TITLE
Include event names in `sdprof` reports

### DIFF
--- a/dace/codegen/instrumentation/report.py
+++ b/dace/codegen/instrumentation/report.py
@@ -59,7 +59,8 @@ class InstrumentationReport(object):
         return 'InstrumentationReport(name=%s)' % self.name
 
     def _get_runtimes_string(
-        self, label, runtimes, element, sdfg, state, string, row_format, colw
+        self, label, runtimes, element, sdfg, state, string, row_format, colw,
+        with_element_heading=True
     ):
         indent = ''
         if len(runtimes) > 0:
@@ -112,12 +113,13 @@ class InstrumentationReport(object):
             else:
                 element_label = 'N/A'
 
-            string += row_format.format(element_label,
-                                        '',
-                                        '',
-                                        '',
-                                        '',
-                                        width=colw)
+            if with_element_heading:
+                string += row_format.format(element_label,
+                                            '',
+                                            '',
+                                            '',
+                                            '',
+                                            width=colw)
 
             string += row_format.format(indent + label + ':',
                                         '', '', '', '', width=colw)
@@ -161,12 +163,15 @@ class InstrumentationReport(object):
             for element in element_list:
                 events = self.durations[element]
                 if len(events) > 0:
+                    with_element_heading = True
                     for event in events.keys():
                         runtimes = events[event]
                         string, sdfg, state = self._get_runtimes_string(
                             event, runtimes, element, sdfg, state, string,
-                            row_format, COLW
+                            row_format, COLW, with_element_heading
                         )
+                        with_element_heading = False
+
             string += ('-' * (COLW * 5)) + '\n'
 
         if len(self.counters) > 0:

--- a/dace/codegen/instrumentation/report.py
+++ b/dace/codegen/instrumentation/report.py
@@ -42,19 +42,93 @@ class InstrumentationReport(object):
             for event in events:
                 if 'ph' in event:
                     phase = event['ph']
+                    name = event['name']
                     if phase == 'X':
                         uuid = self.get_event_uuid(event)
                         if uuid not in self.durations:
-                            self.durations[uuid] = []
-                        self.durations[uuid].append(event['dur'] / 1000)
+                            self.durations[uuid] = {}
+                        if name not in self.durations[uuid]:
+                            self.durations[uuid][name] = []
+                        self.durations[uuid][name].append(event['dur'] / 1000)
                     if phase == 'C':
-                        name = event['name']
                         if name not in self.counters:
                             self.counters[name] = 0
                         self.counters[name] += event['args'][name]
 
     def __repr__(self):
         return 'InstrumentationReport(name=%s)' % self.name
+
+    def _get_runtimes_string(
+        self, label, runtimes, element, sdfg, state, string, row_format, colw
+    ):
+        indent = ''
+        if len(runtimes) > 0:
+            element_label = ''
+            if element[0] > -1 and element[1] > -1 and element[2] > -1:
+                # This element is a node.
+                if sdfg != element[0]:
+                    # No parent SDFG row present yet, print it.
+                    string += row_format.format('SDFG (' +
+                                                str(element[0]) + ')',
+                                                '',
+                                                '',
+                                                '',
+                                                '',
+                                                width=colw)
+                sdfg = element[0]
+                if state != element[1]:
+                    # No parent state row present yet, print it.
+                    string += row_format.format('|-State (' +
+                                                str(element[1]) + ')',
+                                                '',
+                                                '',
+                                                '',
+                                                '',
+                                                width=colw)
+                state = element[1]
+                element_label = '| |-Node (' + str(element[2]) + ')'
+                indent = '| | |'
+            elif element[0] > -1 and element[1] > -1:
+                # This element is a state.
+                if sdfg != element[0]:
+                    # No parent SDFG row present yet, print it.
+                    string += row_format.format('SDFG (' +
+                                                str(element[0]) + ')',
+                                                '',
+                                                '',
+                                                '',
+                                                '',
+                                                width=colw)
+                sdfg = element[0]
+                state = element[1]
+                element_label = '|-State (' + str(element[1]) + ')'
+                indent = '| |'
+            elif element[0] > -1:
+                # This element is an SDFG.
+                sdfg = element[0]
+                state = -1
+                element_label = 'SDFG (' + str(element[0]) + ')'
+                indent = '|'
+            else:
+                element_label = 'N/A'
+
+            string += row_format.format(element_label,
+                                        '',
+                                        '',
+                                        '',
+                                        '',
+                                        width=colw)
+
+            string += row_format.format(indent + label + ':',
+                                        '', '', '', '', width=colw)
+            string += row_format.format(indent,
+                                        '%.3f' % np.min(runtimes),
+                                        '%.3f' % np.mean(runtimes),
+                                        '%.3f' % np.median(runtimes),
+                                        '%.3f' % np.max(runtimes),
+                                        width=colw)
+
+        return string, sdfg, state
 
     def __str__(self):
         COLW = 15
@@ -85,60 +159,14 @@ class InstrumentationReport(object):
             state = -1
 
             for element in element_list:
-                runtimes = self.durations[element]
-                if len(runtimes) > 0:
-                    element_label = ''
-                    if element[0] > -1 and element[1] > -1 and element[2] > -1:
-                        # This element is a node.
-                        if sdfg != element[0]:
-                            # No parent SDFG row present yet, print it.
-                            string += row_format.format('SDFG (' +
-                                                        str(element[0]) + ')',
-                                                        '',
-                                                        '',
-                                                        '',
-                                                        '',
-                                                        width=COLW)
-                        sdfg = element[0]
-                        if state != element[1]:
-                            # No parent state row present yet, print it.
-                            string += row_format.format('| State (' +
-                                                        str(element[1]) + ')',
-                                                        '',
-                                                        '',
-                                                        '',
-                                                        '',
-                                                        width=COLW)
-                        state = element[1]
-                        element_label = '| | Node (' + str(element[2]) + ')'
-                    elif element[0] > -1 and element[1] > -1:
-                        # This element is a state.
-                        if sdfg != element[0]:
-                            # No parent SDFG row present yet, print it.
-                            string += row_format.format('SDFG (' +
-                                                        str(element[0]) + ')',
-                                                        '',
-                                                        '',
-                                                        '',
-                                                        '',
-                                                        width=COLW)
-                        sdfg = element[0]
-                        state = element[1]
-                        element_label = '| State (' + str(element[1]) + ')'
-                    elif element[0] > -1:
-                        # This element is an SDFG.
-                        sdfg = element[0]
-                        state = -1
-                        element_label = 'SDFG (' + str(element[0]) + ')'
-                    else:
-                        element_label = 'N/A'
-
-                    string += row_format.format(element_label,
-                                                '%.3f' % np.min(runtimes),
-                                                '%.3f' % np.mean(runtimes),
-                                                '%.3f' % np.median(runtimes),
-                                                '%.3f' % np.max(runtimes),
-                                                width=COLW)
+                events = self.durations[element]
+                if len(events) > 0:
+                    for event in events.keys():
+                        runtimes = events[event]
+                        string, sdfg, state = self._get_runtimes_string(
+                            event, runtimes, element, sdfg, state, string,
+                            row_format, COLW
+                        )
             string += ('-' * (COLW * 5)) + '\n'
 
         if len(self.counters) > 0:

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -365,7 +365,7 @@ DACE_EXPORTED void {host_function_name}({', '.join(kernel_args_opencl)}) {{""")
 
             if state.instrument == dtypes.InstrumentationType.FPGA:
                 kernel_host_stream.write("""\
-const unsigned long int _dace_fpga_begin_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+const unsigned long int _dace_fpga_begin_ms = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
 """)
 
             kernel_host_stream.write(f"""\
@@ -412,16 +412,16 @@ std::cout << "FPGA OpenCL kernel \\"{module_name}\\" executed in " << elapsed <<
     if (event_end > last_end) {{
         last_end = event_end;
     }}
-    __state->report.add_completion("{module_name} [ns]", "FPGA", event_start, event_end, {sdfg.sdfg_id}, {state_id}, {state.node_id(sg.nodes()[0])});{print_str}
+    __state->report.add_completion("{module_name}", "FPGA", event_start, event_end, {sdfg.sdfg_id}, {state_id}, -1);{print_str}
 }}""")
                 kernel_host_stream.write(f"""\
-const unsigned long int _dace_fpga_end_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
-__state->report.add_completion("Full FPGA kernel runtime for {state.label} [ns]", "FPGA", first_start, last_end, {sdfg.sdfg_id}, {state_id}, -1);
-__state->report.add_completion("Full FPGA state runtime for {state.label} [ns]", "FPGA", _dace_fpga_begin_ns, _dace_fpga_end_ns, {sdfg.sdfg_id}, {state_id}, -1);
+const unsigned long int _dace_fpga_end_ms = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+__state->report.add_completion("Full FPGA kernel runtime for {state.label}", "FPGA", first_start, last_end, {sdfg.sdfg_id}, {state_id}, -1);
+__state->report.add_completion("Full FPGA state runtime for {state.label}", "FPGA", _dace_fpga_begin_ms, _dace_fpga_end_ms, {sdfg.sdfg_id}, {state_id}, -1);
 """)
                 if Config.get_bool("instrumentation", "print_fpga_runtime"):
                     kernel_host_stream.write(f"""
-const double elapsed = 1e-9 * (_dace_fpga_end_ns - _dace_fpga_begin_ns);
+const double elapsed = 1e-9 * (_dace_fpga_end_ms - _dace_fpga_begin_ms);
 std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " seconds.\\n";\
 """)
 

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -365,7 +365,7 @@ DACE_EXPORTED void {host_function_name}({', '.join(kernel_args_opencl)}) {{""")
 
             if state.instrument == dtypes.InstrumentationType.FPGA:
                 kernel_host_stream.write("""\
-const unsigned long int _dace_fpga_begin_ms = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+const unsigned long int _dace_fpga_begin_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
 """)
 
             kernel_host_stream.write(f"""\
@@ -415,13 +415,13 @@ std::cout << "FPGA OpenCL kernel \\"{module_name}\\" executed in " << elapsed <<
     __state->report.add_completion("{module_name}", "FPGA", event_start, event_end, {sdfg.sdfg_id}, {state_id}, -1);{print_str}
 }}""")
                 kernel_host_stream.write(f"""\
-const unsigned long int _dace_fpga_end_ms = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+const unsigned long int _dace_fpga_end_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
 __state->report.add_completion("Full FPGA kernel runtime for {state.label}", "FPGA", first_start, last_end, {sdfg.sdfg_id}, {state_id}, -1);
-__state->report.add_completion("Full FPGA state runtime for {state.label}", "FPGA", _dace_fpga_begin_ms, _dace_fpga_end_ms, {sdfg.sdfg_id}, {state_id}, -1);
+__state->report.add_completion("Full FPGA state runtime for {state.label}", "FPGA", _dace_fpga_begin_us, _dace_fpga_end_us, {sdfg.sdfg_id}, {state_id}, -1);
 """)
                 if Config.get_bool("instrumentation", "print_fpga_runtime"):
                     kernel_host_stream.write(f"""
-const double elapsed = 1e-9 * (_dace_fpga_end_ms - _dace_fpga_begin_ms);
+const double elapsed = 1e-9 * (_dace_fpga_end_us - _dace_fpga_begin_us);
 std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " seconds.\\n";\
 """)
 

--- a/tests/fpga/kernels_detection.py
+++ b/tests/fpga/kernels_detection.py
@@ -71,10 +71,7 @@ def test_kernels_inside_component_0():
     res = program(x=x, y=y, v=v, w=w, z=z)
     assert np.allclose(res, x + y + v + w + z)
     report = sdfg.get_latest_report()
-    assert (len(
-        re.findall(
-            r"Node \([0-9]+\)\s+[0-9\.]+\s+[0-9\.]+\s+[0-9\.]+\s+[0-9\.]+",
-            str(report))) == 3)
+    assert (len(re.findall(r"Node \([0-9]+\):", str(report))) == 3)
 
 
 def test_kernels_inside_component_1():

--- a/tests/fpga/kernels_detection.py
+++ b/tests/fpga/kernels_detection.py
@@ -71,7 +71,7 @@ def test_kernels_inside_component_0():
     res = program(x=x, y=y, v=v, w=w, z=z)
     assert np.allclose(res, x + y + v + w + z)
     report = sdfg.get_latest_report()
-    assert (len(re.findall(r"Node \([0-9]+\):", str(report))) == 3)
+    assert len(re.findall(r"_Add__[0-9]+(:|__Add__[0-9]+:)", str(report))) == 3
 
 
 def test_kernels_inside_component_1():


### PR DESCRIPTION
Example report:

```
Instrumentation report
SDFG Hash: 26b82bdad82332901ca002d8ec19e6da72d40c49754655422032705ba2e2bf3f
---------------------------------------------------------------------------
Element        Runtime (ms)
               Min            Mean           Median         Max
---------------------------------------------------------------------------
SDFG (0)
|SDFG gemm:
|              3572.881       3572.881       3572.881       3572.881
|-State (0)
| |State MapState:
| |            3572.867       3572.867       3572.867       3572.867
| |-Node (0)
| | |Map gemm_16:
| | |          3567.709       3567.709       3567.709       3567.709
| |-Node (7)
| | |Tasklet 0_0_7:
| | |          0.000          0.000          0.000          0.030
| |-Node (9)
| | |Tasklet 0_0_9:
| | |          0.000          0.000          0.000          0.091
---------------------------------------------------------------------------
```