### PR TITLE
Unroll PEs in FPGA Codegen

### DIFF
--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -24,14 +24,15 @@ from dace.codegen.targets.target import make_absolute
 T = TypeVar('T')
 
 
-def generate_program_folder(sdfg,
+def generate_program_folder(sdfg_json,
                             code_objects: List[CodeObject],
                             out_path: str,
                             config=None):
     """ Writes all files required to configure and compile the DaCe program
         into the specified folder.
 
-        :param sdfg: The SDFG to generate the program folder for.
+        :param sdfg_json: The previously serialized JSON of the SDFG to generate
+                          the program folder for.
         :param code_objects: List of generated code objects.
         :param out_path: The folder in which the build files should be written.
         :return: Path to the program folder.
@@ -88,13 +89,16 @@ def generate_program_folder(sdfg,
     else:
         Config.save(os.path.join(out_path, "dace.conf"))
 
-    if sdfg is not None:
+    if sdfg_json is not None:
         # Save the SDFG itself and its hash
-        hash = sdfg.save(os.path.join(out_path, "program.sdfg"), hash=True)
-        filepath = os.path.join(out_path, 'include', 'hash.h')
-        contents = f'#define __HASH_{sdfg.name} "{hash}"\n'
+        with open(os.path.join(out_path, "program.sdfg"), "w") as fp:
+            fp.write(dace.serialize.dumps(sdfg_json))
+        hash = sdfg_json["attributes"]["hash"]
+        filepath = os.path.join(out_path, "include", "hash.h")
+        contents = (
+            f'#define __HASH_{sdfg_json["attributes"]["name"]} "{hash}"\n')
         if not identical_file_exists(filepath, contents):
-            with open(filepath, 'w') as hfile:
+            with open(filepath, "w") as hfile:
                 hfile.write(contents)
 
     return out_path

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -24,15 +24,14 @@ from dace.codegen.targets.target import make_absolute
 T = TypeVar('T')
 
 
-def generate_program_folder(sdfg_json,
+def generate_program_folder(sdfg,
                             code_objects: List[CodeObject],
                             out_path: str,
                             config=None):
     """ Writes all files required to configure and compile the DaCe program
         into the specified folder.
 
-        :param sdfg_json: The previously serialized JSON of the SDFG to generate
-                          the program folder for.
+        :param sdfg: The SDFG to generate the program folder for.
         :param code_objects: List of generated code objects.
         :param out_path: The folder in which the build files should be written.
         :return: Path to the program folder.
@@ -89,16 +88,13 @@ def generate_program_folder(sdfg_json,
     else:
         Config.save(os.path.join(out_path, "dace.conf"))
 
-    if sdfg_json is not None:
+    if sdfg is not None:
         # Save the SDFG itself and its hash
-        with open(os.path.join(out_path, "program.sdfg"), "w") as fp:
-            fp.write(dace.serialize.dumps(sdfg_json))
-        hash = sdfg_json["attributes"]["hash"]
-        filepath = os.path.join(out_path, "include", "hash.h")
-        contents = (
-            f'#define __HASH_{sdfg_json["attributes"]["name"]} "{hash}"\n')
+        hash = sdfg.save(os.path.join(out_path, "program.sdfg"), hash=True)
+        filepath = os.path.join(out_path, 'include', 'hash.h')
+        contents = f'#define __HASH_{sdfg.name} "{hash}"\n'
         if not identical_file_exists(filepath, contents):
-            with open(filepath, "w") as hfile:
+            with open(filepath, 'w') as hfile:
                 hfile.write(contents)
 
     return out_path

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -26,6 +26,7 @@ from dace.codegen.targets.target import (TargetCodeGenerator, IllegalCopy,
 from dace.codegen import cppunparse
 from dace.properties import Property, make_properties, indirect_properties
 from dace.symbolic import evaluate
+from dace.transformation.dataflow import MapUnroll
 from collections import defaultdict
 
 _CPU_STORAGE_TYPES = {
@@ -248,6 +249,17 @@ class FPGACodeGen(TargetCodeGenerator):
         state_id = sdfg.node_id(state)
 
         if not self._in_device_code:
+
+            # Unroll maps directly in the SDFG so the subgraphs can be
+            # recognized as independent processing elements
+            top_level_unrolled = [
+                n for n in state.scope_children()[None]
+                if isinstance(n, dace.sdfg.nodes.MapEntry)
+                and n.schedule == dtypes.ScheduleType.Unrolled
+            ]
+            for map_entry in top_level_unrolled:
+                MapUnroll.apply_to(sdfg, _map_entry=map_entry)
+
             kernels = []  # List of tuples (subgraph, kernel_id)
 
             # Start a new state code generation: reset previous dependencies if any

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1769,16 +1769,12 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # Fill in scope entry/exit connectors
         sdfg.fill_scope_connectors()
 
-        # Serialize SDFG before generating code, since the codegen is allowed
-        # to mutate the SDFG internally
-        sdfg_json = sdfg.to_json(hash=True)
-
         # Generate code for the program by traversing the SDFG state by state
         program_objects = codegen.generate_code(sdfg)
 
         # Generate the program folder and write the source files
         program_folder = compiler.generate_program_folder(
-            sdfg_json, program_objects, sdfg.build_folder)
+            sdfg, program_objects, sdfg.build_folder)
 
         # Compile the code and get the shared library path
         shared_library = compiler.configure_and_compile(program_folder,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1744,10 +1744,12 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # Importing these outside creates an import loop
         from dace.codegen import codegen, compiler
 
+        # Compute build folder path before running codegen
+        build_folder = self.build_folder
+
         if Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists
-            binary_filename = compiler.get_binary_name(self.build_folder,
-                                                       self.name)
+            binary_filename = compiler.get_binary_name(build_folder, self.name)
             if os.path.isfile(binary_filename):
                 return compiler.load_from_file(self, binary_filename)
 
@@ -1774,7 +1776,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         # Generate the program folder and write the source files
         program_folder = compiler.generate_program_folder(
-            sdfg, program_objects, sdfg.build_folder)
+            sdfg, program_objects, build_folder)
 
         # Compile the code and get the shared library path
         shared_library = compiler.configure_and_compile(program_folder,
@@ -1791,8 +1793,8 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # it to the generating code and storing command line arguments that
         # were provided.
         if sys.argv is not None and len(sys.argv) > 0:
-            os.makedirs(sdfg.build_folder, exist_ok=True)
-            with open(os.path.join(sdfg.build_folder, 'program.sdfgl'),
+            os.makedirs(build_folder, exist_ok=True)
+            with open(os.path.join(build_folder, 'program.sdfgl'),
                       'w') as launchfiles_file:
                 launchfiles_file.write(
                     'name,SDFG_intermediate,SDFG,source,' +
@@ -1800,7 +1802,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                               for i in range(len(sys.argv))]) + '\n')
                 launchfiles_file.write(
                     sdfg.name + ',' + os.path.abspath(
-                        os.path.join(sdfg.build_folder, 'program.sdfg')) + ',' +
+                        os.path.join(build_folder, 'program.sdfg')) + ',' +
                     os.path.abspath(os.path.join('_dacegraphs', 'program.sdfg'))
                     + ',' + os.path.abspath(sys.argv[0]) + ',' +
                     ','.join([str(el) for el in sys.argv]))

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1758,6 +1758,9 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         # Clone SDFG as the other modules may modify its contents
         sdfg = copy.deepcopy(self)
+        # Fix the build folder name on the copied SDFG to avoid it changing
+        # if the codegen modifies the SDFG (thereby changing its hash)
+        sdfg.build_folder = build_folder
 
         # Rename SDFG to avoid runtime issues with clashing names
         index = 0

--- a/dace/transformation/dataflow/map_unroll.py
+++ b/dace/transformation/dataflow/map_unroll.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 
-from dace import dtypes, registry, symbolic, SDFG
+from dace import data as dt, dtypes, registry, symbolic, SDFG
 from dace.sdfg import nodes, utils as sdutil
 from dace.sdfg.state import StateSubgraphView
 from dace.transformation import transformation
@@ -68,10 +68,12 @@ class MapUnroll(transformation.Transformation):
                 nested_sdfgs[node.sdfg] = node.sdfg.to_json()
 
         # Check for local memories that need to be replicated
-        local_memories = sdutil.local_transients(sdfg,
-                                                 subgraph,
-                                                 entry_node=None,
-                                                 include_nested=True)
+        local_memories = [
+            name for name in sdutil.local_transients(
+                sdfg, subgraph, entry_node=None, include_nested=True)
+            if isinstance(sdfg.arrays[name], dt.Array)
+            and not isinstance(sdfg.arrays[name], dt.View)
+        ]
 
         params = map_entry.map.params
         ranges = map_entry.map.range.ranges

--- a/dace/transformation/dataflow/map_unroll.py
+++ b/dace/transformation/dataflow/map_unroll.py
@@ -1,8 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-
 from dace import data as dt, dtypes, registry, symbolic, SDFG
 from dace.sdfg import nodes, utils as sdutil
-from dace.sdfg.state import StateSubgraphView
 from dace.transformation import transformation
 from dace.properties import make_properties
 import copy

--- a/dace/transformation/dataflow/map_unroll.py
+++ b/dace/transformation/dataflow/map_unroll.py
@@ -71,7 +71,7 @@ class MapUnroll(transformation.Transformation):
         local_memories = [
             name for name in sdutil.local_transients(
                 sdfg, subgraph, entry_node=None, include_nested=True)
-            if isinstance(sdfg.arrays[name], dt.Array)
+            if not isinstance(sdfg.arrays[name], dt.Stream)
             and not isinstance(sdfg.arrays[name], dt.View)
         ]
 

--- a/tests/fpga/intel_fpga_test.py
+++ b/tests/fpga/intel_fpga_test.py
@@ -95,6 +95,8 @@ TESTS = [
         "kernels_inside_component_2_1", "kernels_inside_components_0_1",
         "kernels_lns_inside_component_1", "multiple_kernels_multiple_states"
     ], []),
+    ("tests/fpga/map_unroll_processing_elements.py",
+     "map_unroll_processing_elements", []),
 ]
 
 

--- a/tests/fpga/map_unroll_processing_elements.py
+++ b/tests/fpga/map_unroll_processing_elements.py
@@ -1,0 +1,40 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import dace.sdfg.nodes as nodes
+import importlib.util
+import numpy as np
+from pathlib import Path
+
+if __name__ == "__main__":
+
+    # Grab the systolic GEMM implementation the samples directory
+    spec = importlib.util.spec_from_file_location(
+        "gemm",
+        Path(__file__).parent.parent.parent / "samples" / "fpga" /
+        "gemm_systolic_vectorized.py")
+    gemm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gemm)
+
+    # Create an SDFG with multiple processing elements
+    sdfg = gemm.make_sdfg("map_unroll_processing_elements", 4)
+    sdfg.specialize({"P": 4, "M": 32})
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, nodes.MapEntry) and node.params == ["p"]:
+                node.unroll = False
+                node.schedule = dace.ScheduleType.Unrolled
+
+    # Initialize arrays: Randomize A and B, zero C
+    A = np.ndarray([32, 32], dtype=dace.float32.type)
+    B = np.ndarray([32, 32], dtype=dace.float32.type)
+    C = np.ndarray([32, 32], dtype=dace.float32.type)
+    A[:] = np.random.rand(32, 32).astype(dace.float32.type)
+    B[:] = np.random.rand(32, 32).astype(dace.float32.type)
+    C[:] = np.random.rand(32, 32).astype(dace.float32.type)
+
+    C_regression = np.ndarray([32, 32], dtype=np.float32)
+    C_regression = A @ B + C
+
+    sdfg(A=A, B=B, C=C, N=32, K=32)
+    diff = np.linalg.norm(C_regression - C) / float(32 * 32)
+    assert diff < 1e-6

--- a/tests/fpga/xilinx_test.py
+++ b/tests/fpga/xilinx_test.py
@@ -72,24 +72,31 @@ TESTS = [
     ("tests/rtl/hardware_test.py", "floating_point_vector_plus_scalar", True,
      False, [1]),
     # Auto-opt for FPGA
-    ("tests/fpga/auto_opt_fpga.py", ["global_to_local_1", "rr_interleave_1"], True, False, []),
+    ("tests/fpga/auto_opt_fpga.py", ["global_to_local_1",
+                                     "rr_interleave_1"], True, False, []),
     # Over approx Shapes
-    ("tests/fpga/overapprox_transient_shapes.py", ["overapprox_1"], True, False, []),
+    ("tests/fpga/overapprox_transient_shapes.py", ["overapprox_1"], True, False,
+     []),
     # Kernel_detection
     ("tests/fpga/kernels_detection.py", [
         "kernels_inside_component_0_1", "kernels_inside_component_1_1",
         "kernels_inside_component_2_1", "kernels_inside_components_0_1",
         "kernels_lns_inside_component_1", "multiple_kernels_multiple_states"
     ], True, False, []),
-    ("tests/fpga/hbm_vadd_fpga.py", ["vadd_2b1d_1", "vadd_2b2d_1",
-     "vadd_2b3d_1", "vadd_8b1d_1"], True, False, []),
-      # For hbm_reduction not all sdfgs are added, since relatively redundant
-     ("tests/fpga/hbm_reduce_fpga.py", ["red_2x3_2b_1", "red_1x40_8b_1", 
-     "red_1x50_1b_1"], True, False, []),
+    ("tests/fpga/hbm_vadd_fpga.py",
+     ["vadd_2b1d_1", "vadd_2b2d_1", "vadd_2b3d_1",
+      "vadd_8b1d_1"], True, False, []),
+    # For hbm_reduction not all sdfgs are added, since relatively redundant
+    ("tests/fpga/hbm_reduce_fpga.py",
+     ["red_2x3_2b_1", "red_1x40_8b_1", "red_1x50_1b_1"], True, False, []),
     ("tests/fpga/hbm_dynamic_memlets.py", ["dyn_memlet_1"], True, False, []),
-    ("tests/fpga/hbm_deeply_nested_fpga.py", ["deepnest_test_1"], True, False, []),
+    ("tests/fpga/hbm_deeply_nested_fpga.py", ["deepnest_test_1"], True, False,
+     []),
     ("tests/fpga/hbm_copy_fpga.py", ["hbm2hbm1", "hbm2ddr1"], True, False, []),
+    ("tests/fpga/map_unroll_processing_elements.py",
+     ["map_unroll_processing_elements"], True, True, []),
 ]
+
 
 def run(path: Path, sdfg_names: Union[str, Iterable[str]], run_synthesis: bool,
         assert_ii_1: bool, args: Iterable[Any]):


### PR DESCRIPTION
Unroll maps with schedule `Unrolled` as part of the FPGA codegen in order to detect them as processing elements.

This is potentially fishy, since we are applying a transformation during code generation (!!) that modifies the SDFG. It is, however, a neat way of avoiding manually handling this in the FPGA codegen when detecting and generating modules.