### PR TITLE
Bugfix for map unroller

### DIFF
--- a/dace/transformation/dataflow/map_unroll.py
+++ b/dace/transformation/dataflow/map_unroll.py
@@ -68,7 +68,7 @@ class MapUnroll(transformation.Transformation):
         # Check for local memories that need to be replicated
         local_memories = [
             name for name in sdutil.local_transients(
-                sdfg, subgraph, entry_node=None, include_nested=True)
+                sdfg, subgraph, entry_node=map_entry, include_nested=True)
             if not isinstance(sdfg.arrays[name], dt.Stream)
             and not isinstance(sdfg.arrays[name], dt.View)
         ]


### PR DESCRIPTION
At the moment all local transients will be returned, which leads to problems if there are any outside of the map which is unrolled.