### PR TITLE
Ignore external submodules when running pytest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -208,6 +208,7 @@ jobs:
 
     - name: Run FPGA Tests
       run: |
+        export COVERAGE_RCFILE=`pwd`/.coveragerc
         pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
         coverage report
         coverage xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,4 @@ markers =
 python_files =
     *_test.py
     *_cudatest.py
+addopts = --ignore=dace/external


### PR DESCRIPTION
To make sure we don't pick up any tests in other repositories.