### PR TITLE
Replace connector names

### DIFF
--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -58,6 +58,10 @@ def replace(subgraph: 'dace.sdfg.state.StateGraphView', name: str,
             edge.data.other_subset = _replsym(edge.data.other_subset, symrepl)
         if symname in edge.data.volume.free_symbols:
             edge.data.volume = _replsym(edge.data.volume, symrepl)
+        if edge.src_conn == name:
+            edge.src_conn = new_name
+        if edge.dst_conn == name:
+            edge.dst_conn = new_name
 
 
 def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
@@ -98,13 +102,12 @@ def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
             if pname == 'symbol_mapping':
                 # Symbol mappings for nested SDFGs
                 for symname, sym_mapping in propval.items():
-                    propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
-                        symrepl)
+                    propval[symname] = symbolic.pystr_to_symbolic(
+                        sym_mapping).subs(symrepl)
             elif pname in ('in_connectors', 'out_connectors'):
                 for key in list(propval.keys()):
-                    updated = str(symbolic.pystr_to_symbolic(key).subs(symrepl))
-                    if key != updated:
-                        propval[updated] = propval.pop(key)
+                    if key == name:
+                        propval[new_name] = propval.pop(key)
 
 
 def replace_properties_dict(node: Any, symrepl: Dict[symbolic.SymbolicType,

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -94,12 +94,17 @@ def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
             elif propval.code is not None:
                 for stmt in propval.code:
                     ASTFindReplace({name: new_name}).visit(stmt)
-        elif (isinstance(propclass, properties.DictProperty)
-              and pname == 'symbol_mapping'):
-            # Symbol mappings for nested SDFGs
-            for symname, sym_mapping in propval.items():
-                propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
-                    symrepl)
+        elif isinstance(propclass, properties.DictProperty):
+            if pname == 'symbol_mapping':
+                # Symbol mappings for nested SDFGs
+                for symname, sym_mapping in propval.items():
+                    propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
+                        symrepl)
+            elif pname in ('in_connectors', 'out_connectors'):
+                for key in list(propval.keys()):
+                    updated = str(symbolic.pystr_to_symbolic(key).subs(symrepl))
+                    if key != updated:
+                        propval[updated] = propval.pop(key)
 
 
 def replace_properties_dict(node: Any, symrepl: Dict[symbolic.SymbolicType,


### PR DESCRIPTION
Variables inside tasklets were being replaced, but not the connectors on the node, which can cause a mismatch between connector names and variables references in the code after a replacement.

This was one of the most frustrating bugs I've ever debugged 🤠 