### PR TITLE
Rot90

### DIFF
--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -391,11 +391,10 @@ def _numpy_flip(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str, ax
     # anode = state.add_read(acpy)
     # state.add_edge(vnode, None, anode, None, Memlet(f'{view}[{sset}] -> {dset}'))
 
-    sbset = subsets.Range([(s-1, 0, -1) if a else (0, s-1, 1)
-                           for a, s in zip(axis, desc.shape)])
     arr_copy, _ = sdfg.add_temp_transient(desc.shape, desc.dtype, desc.storage)
     inpidx = ','.join([f'__i{i}' for i in range(ndim)])
-    outidx = ','.join([f'{s} - __i{i} - 1' for i, s in enumerate(desc.shape)])
+    outidx = ','.join([f'{s} - __i{i} - 1' if a else f'__i{i}'
+                       for i, (a, s) in enumerate(zip(axis, desc.shape))])
     state.add_mapped_tasklet(
         name="_numpy_flip_",
         map_ranges={f'__i{i}': f'0:{s}:1' for i, s in enumerate(desc.shape)},

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -359,7 +359,11 @@ def _numpy_copy(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, a: str):
 
 
 @oprepo.replaces('numpy.flip')
-def _numpy_flip(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str, axis=None):
+def _numpy_flip(pv: 'ProgramVisitor',
+                sdfg: SDFG,
+                state: SDFGState,
+                arr: str,
+                axis=None):
     """ Reverse the order of elements in an array along the given axis.
         The shape of the array is preserved, but the elements are reordered.
     """
@@ -377,9 +381,11 @@ def _numpy_flip(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str, ax
     if axis is None:
         axis = [True] * ndim
     else:
+        if not isinstance(axis, (list, tuple)):
+            axis = [axis]
         axis = [a if a >= 0 else a + ndim for a in axis]
         axis = [True if i in axis else False for i in range(ndim)]
-    
+
     # TODO: The following code assumes that code generation resolves an inverted copy.
     # sset = ','.join([f'{s}-1:-1:-1' if a else f'0:{s}:1'
     #                  for a, s in zip(axis, desc.shape)])
@@ -393,17 +399,73 @@ def _numpy_flip(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str, ax
 
     arr_copy, _ = sdfg.add_temp_transient(desc.shape, desc.dtype, desc.storage)
     inpidx = ','.join([f'__i{i}' for i in range(ndim)])
-    outidx = ','.join([f'{s} - __i{i} - 1' if a else f'__i{i}'
-                       for i, (a, s) in enumerate(zip(axis, desc.shape))])
+    outidx = ','.join([
+        f'{s} - __i{i} - 1' if a else f'__i{i}'
+        for i, (a, s) in enumerate(zip(axis, desc.shape))
+    ])
     state.add_mapped_tasklet(
         name="_numpy_flip_",
-        map_ranges={f'__i{i}': f'0:{s}:1' for i, s in enumerate(desc.shape)},
+        map_ranges={f'__i{i}': f'0:{s}:1'
+                    for i, s in enumerate(desc.shape)},
         inputs={'__inp': Memlet(f'{arr}[{inpidx}]')},
         code='__out = __inp',
         outputs={'__out': Memlet(f'{arr_copy}[{outidx}]')},
         external_edges=True)
 
     return arr_copy
+
+
+@oprepo.replaces('numpy.rot90')
+def _numpy_rot90(pv: 'ProgramVisitor',
+                 sdfg: SDFG,
+                 state: SDFGState,
+                 arr: str,
+                 k=1,
+                 axes=(0, 1)):
+    """ Rotate an array by 90 degrees in the plane specified by axes.
+        Rotation direction is from the first towards the second axis.
+    """
+
+    if arr not in sdfg.arrays.keys():
+        raise mem_parser.DaceSyntaxError(
+            pv, None, "Prototype argument {a} is not SDFG data!".format(a=arr))
+    desc = sdfg.arrays[arr]
+    if not isinstance(desc, (data.Array, data.View)):
+        raise mem_parser.DaceSyntaxError(pv, None,
+                                         "Only Arrays and Views supported!")
+
+    ndim = len(desc.shape)
+    axes = tuple(axes)
+    if len(axes) != 2:
+        raise ValueError("len(axes) must be 2.")
+
+    if axes[0] == axes[1] or abs(axes[0] - axes[1]) == ndim:
+        raise ValueError("Axes must be different.")
+
+    if (axes[0] >= ndim or axes[0] < -ndim or axes[1] >= ndim
+            or axes[1] < -ndim):
+        raise ValueError("Axes={} out of range for array of ndim={}.".format(
+            axes, ndim))
+
+    k %= 4
+
+    if k == 0:
+        return arr
+    if k == 2:
+        return _numpy_flip(pv, sdfg, state,
+                           _numpy_flip(pv, sdfg, state, arr, axes[0]), axes[1])
+
+    axes_list = list(range(ndim))
+    (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
+                                                axes_list[axes[0]])
+
+    if k == 1:
+        return _transpose(pv, sdfg, state,
+                          _numpy_flip(pv, sdfg, state, arr, axes[1]), axes_list)
+    else:
+        # k == 3
+        return _numpy_flip(pv, sdfg, state,
+                           _transpose(pv, sdfg, state, arr, axes_list), axes[1])
 
 
 @oprepo.replaces('elementwise')

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -216,32 +216,36 @@ class Range(Subset):
 
     def num_elements(self):
         return reduce(sp.Mul, self.size(), 1)
-    
+
     def num_elements_exact(self):
         return reduce(sp.Mul, self.bounding_box_size(), 1)
 
     def size(self, for_codegen=False):
         """ Returns the number of elements in each dimension. """
+        offset = [-1 if (s < 0) == True else 1 for _, _, s in self.ranges]
+
         if for_codegen == True:
             int_ceil = sp.Function('int_ceil')
             return [
                 ts * int_ceil(
                     ((iMax.approx if isinstance(iMax, symbolic.SymExpr) else
-                      iMax) + 1 - (iMin.approx if isinstance(
+                      iMax) + off - (iMin.approx if isinstance(
                           iMin, symbolic.SymExpr) else iMin)),
                     (step.approx
                      if isinstance(step, symbolic.SymExpr) else step))
-                for (iMin, iMax, step), ts in zip(self.ranges, self.tile_sizes)
+                for (iMin, iMax,
+                     step), off, ts in zip(self.ranges, offset, self.tile_sizes)
             ]
         else:
             return [
                 ts * sp.ceiling(
                     ((iMax.approx
-                      if isinstance(iMax, symbolic.SymExpr) else iMax) + 1 -
+                      if isinstance(iMax, symbolic.SymExpr) else iMax) + off -
                      (iMin.approx if isinstance(iMin, symbolic.SymExpr) else
                       iMin)) / (step.approx if isinstance(
                           step, symbolic.SymExpr) else step))
-                for (iMin, iMax, step), ts in zip(self.ranges, self.tile_sizes)
+                for (iMin, iMax,
+                     step), off, ts in zip(self.ranges, offset, self.tile_sizes)
             ]
 
     def size_exact(self):
@@ -401,7 +405,10 @@ class Range(Subset):
             dres = _simplified_str(d[0])
             if d[1] is not None:
                 if d[1] - d[0] != 0:
-                    dres += ':' + _simplified_str(d[1] + 1)
+                    off = 1
+                    if (d[2] < 0) == True:
+                        off = -1
+                    dres += ':' + _simplified_str(d[1] + off)
             if d[2] != 1:
                 if d[1] is None:
                     dres += ':'
@@ -620,9 +627,10 @@ class Range(Subset):
                              rs * other[idx][2], rt))
                     else:
                         new_subset.append(rb + rs * other[idx])
-        elif (other.data_dims() == 0 and
-                all([r == (0, 0, 1) if isinstance(other, Range) else r == 0
-                for r in other])):
+        elif (other.data_dims() == 0 and all([
+                r == (0, 0, 1) if isinstance(other, Range) else r == 0
+                for r in other
+        ])):
             # NOTE: This is a special case where the other subset is the
             # (potentially multidimensional) index zero.
             # For example, A[i, j] -> tmp[0]. The result of such a
@@ -753,7 +761,7 @@ class Range(Subset):
                     return False
             except TypeError:  # cannot determine truth value of Relational
                 type_error = True
-        
+
         if type_error:
             raise TypeError("cannot determine truth value of Relational")
 
@@ -801,7 +809,7 @@ class Indices(Subset):
 
     def num_elements(self):
         return 1
-    
+
     def num_elements_exact(self):
         return 1
 
@@ -955,7 +963,7 @@ class Indices(Subset):
             squeezed_indices = [0]
         self.indices = squeezed_indices
         return non_ones
-    
+
     def unsqueeze(self, axes: Sequence[int]) -> List[int]:
         """ Adds zeroes to the subset, in the indices contained in axes.
         

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -406,7 +406,7 @@ class Range(Subset):
             if d[1] is not None:
                 if d[1] - d[0] != 0:
                     off = 1
-                    if (d[2] < 0) == True:
+                    if d[2] is not None and (d[2] < 0) == True:
                         off = -1
                     dres += ':' + _simplified_str(d[1] + off)
             if d[2] != 1:

--- a/tests/numpy/flip_test.py
+++ b/tests/numpy/flip_test.py
@@ -10,5 +10,59 @@ def test_flip_1d(A: dace.int32[10]):
     return np.flip(A)
 
 
+@compare_numpy_output()
+def test_flip_2d(A: dace.int32[10, 5]):
+    return np.flip(A)
+
+
+@compare_numpy_output()
+def test_flip_2d_axis0(A: dace.int32[10, 5]):
+    return np.flip(A, axis=(0,))
+
+
+@compare_numpy_output()
+def test_flip_2d_axis0n(A: dace.int32[10, 5]):
+    return np.flip(A, axis=(-2,))
+
+
+@compare_numpy_output()
+def test_flip_2d_axis1(A: dace.int32[10, 5]):
+    return np.flip(A, axis=(1,))
+
+
+@compare_numpy_output()
+def test_flip_2d_axis1n(A: dace.int32[10, 5]):
+    return np.flip(A, axis=(-1,))
+
+
+@compare_numpy_output()
+def test_flip_3d(A: dace.int32[10, 5, 7]):
+    return np.flip(A)
+
+
+@compare_numpy_output()
+def test_flip_3d_axis01(A: dace.int32[10, 5, 7]):
+    return np.flip(A, axis=(0, 1))
+
+
+@compare_numpy_output()
+def test_flip_3d_axis02(A: dace.int32[10, 5, 7]):
+    return np.flip(A, axis=(0, 2))
+
+
+@compare_numpy_output()
+def test_flip_3d_axis12(A: dace.int32[10, 5, 7]):
+    return np.flip(A, axis=(1, 2))
+
+
 if __name__ == '__main__':
     test_flip_1d()
+    test_flip_2d()
+    test_flip_2d_axis0()
+    test_flip_2d_axis0n()
+    test_flip_2d_axis1()
+    test_flip_2d_axis1n()
+    test_flip_3d()
+    test_flip_3d_axis01()
+    test_flip_3d_axis02()
+    test_flip_3d_axis12()

--- a/tests/numpy/flip_test.py
+++ b/tests/numpy/flip_test.py
@@ -1,0 +1,14 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import numpy as np
+from sympy.core.numbers import comp
+import dace
+from common import compare_numpy_output
+
+
+@compare_numpy_output()
+def test_flip_1d(A: dace.int32[10]):
+    return np.flip(A)
+
+
+if __name__ == '__main__':
+    test_flip_1d()

--- a/tests/numpy/rot90_test.py
+++ b/tests/numpy/rot90_test.py
@@ -1,0 +1,32 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import numpy as np
+from sympy.core.numbers import comp
+import dace
+from common import compare_numpy_output
+
+
+@compare_numpy_output()
+def test_rot90_2d_k0(A: dace.int32[10, 10]):
+    return np.rot90(A, k=0)
+
+
+@compare_numpy_output()
+def test_rot90_2d_k1(A: dace.int32[10, 10]):
+    return np.rot90(A)
+
+
+@compare_numpy_output()
+def test_rot90_2d_k2(A: dace.int32[10, 10]):
+    return np.rot90(A, k=2)
+
+
+@compare_numpy_output()
+def test_rot90_2d_k3(A: dace.int32[10, 10]):
+    return np.rot90(A, k=3)
+
+
+if __name__ == '__main__':
+    test_rot90_2d_k0()
+    test_rot90_2d_k1()
+    test_rot90_2d_k2()
+    test_rot90_2d_k3()


### PR DESCRIPTION
This PR adds replacement methods for NumPy flip and rot90 methods.  
**NOTE**: The methods return copies of the original data.