### PR TITLE
Intel FPGA Stencil Node Expansion

### DIFF
--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -2419,6 +2419,9 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
                                    after_memlets_stream):
         # Inject dependency pragmas on memlets
         for edge in dfg.out_edges(node):
+            dataname = edge.data.data
+            if not dataname:
+                continue  # Empty memlet
             datadesc = sdfg.arrays[edge.data.data]
             if (isinstance(datadesc, dt.Array)
                     and (datadesc.storage == dace.StorageType.FPGA_Local

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -2422,7 +2422,7 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
             dataname = edge.data.data
             if not dataname:
                 continue  # Empty memlet
-            datadesc = sdfg.arrays[edge.data.data]
+            datadesc = sdfg.arrays[dataname]
             if (isinstance(datadesc, dt.Array)
                     and (datadesc.storage == dace.StorageType.FPGA_Local
                          or datadesc.storage == dace.StorageType.FPGA_Registers)

--- a/dace/libraries/stencil/_common.py
+++ b/dace/libraries/stencil/_common.py
@@ -1,14 +1,23 @@
 import collections
 import copy
 import functools
+import numpy as np
 import operator
-from typing import Tuple
+from typing import Dict, Tuple
 
 import dace
 
 
-def dim_to_abs_val(input, dimensions):
+def dim_to_abs_val(input, _dimensions, sdfg):
     """Compute scalar number from independent dimension unit."""
+    input = [dace.symbolic.resolve_symbol_to_constant(x, sdfg) for x in input]
+    dimensions = [
+        dace.symbolic.resolve_symbol_to_constant(x, sdfg) for x in _dimensions
+    ]
+    for i, dim in enumerate(dimensions[1:]):
+        if dim is None:
+            raise ValueError(f"Shape size \"{_dimensions[i + 1]}\" must "
+                             f"evaluate to a constant.")
     vec = [
         functools.reduce(operator.mul, dimensions[i + 1:], 1)
         for i in range(len(dimensions))
@@ -16,7 +25,10 @@ def dim_to_abs_val(input, dimensions):
     return functools.reduce(operator.add, map(operator.mul, input, vec), 0)
 
 
-def make_iterators(dimensions, halo_sizes=None, parameters=None):
+def make_iterators(dimensions,
+                   halo_sizes=None,
+                   parameters=None,
+                   vector_length=1):
     def add_halo(i):
         if i == len(dimensions) - 1 and halo_sizes is not None:
             return " + " + str(-halo_sizes[0] + halo_sizes[1])
@@ -24,16 +36,19 @@ def make_iterators(dimensions, halo_sizes=None, parameters=None):
             return ""
 
     if parameters is None:
-        return collections.OrderedDict([("i" + str(i),
-                                         "0:" + str(d) + add_halo(i))
-                                        for i, d in enumerate(dimensions)])
+        iterators = collections.OrderedDict([("i" + str(i),
+                                              "0:" + str(d) + add_halo(i))
+                                             for i, d in enumerate(dimensions)])
     else:
-        return collections.OrderedDict([(parameters[i],
-                                         "0:" + str(d) + add_halo(i))
-                                        for i, d in enumerate(dimensions)])
+        iterators = collections.OrderedDict([(parameters[i],
+                                              "0:" + str(d) + add_halo(i))
+                                             for i, d in enumerate(dimensions)])
+    if vector_length > 1:
+        iterators[parameters[-1]] += "/{}".format(vector_length)
+    return iterators
 
 
-def _check_stencil_shape(shape: Tuple, other: Tuple):
+def check_stencil_shape(shape: Tuple, other: Tuple):
     """
     Compares the existing shape with a proposed shape, setting it to the new
     shape if the new shape has higher dimensionality. If the dimensionality is
@@ -51,26 +66,139 @@ def _check_stencil_shape(shape: Tuple, other: Tuple):
     return shape
 
 
-def _parse_connectors(node, state, sdfg):
+def parse_connectors(node, state, sdfg):
     """
     Collects the inputs and outputs, infers the shape of the iteration space,
-    and creates a dictionary mapping each data name to its descriptor in the
-    parent SDFG.
+    creates dictionaries mapping each connector to the data name in the
+    parent SDFG and to the incoming/outgoing edge in the parent state, and
+    collects vectorization widths.
     """
     inputs: List[str] = []
     outputs: List[str] = []
     shape: Tuple[int] = []
+    field_to_data: Dict[str, str] = {}
     field_to_desc: Dict[str, dace.Data] = {}
+    field_to_edge = {}
+    memlets: Dict[str, dace.Memlet] = {}
+    vector_lengths = {}
     for e in state.in_edges(node):
         field = e.dst_conn
         inputs.append(field)
-        desc = sdfg.data(dace.sdfg.find_input_arraynode(state, e).data)
+        data_name = dace.sdfg.find_input_arraynode(state, e).data
+        desc = sdfg.data(data_name)
+        field_to_data[field] = data_name
         field_to_desc[field] = desc
-        shape = _check_stencil_shape(shape, desc.shape)
+        field_to_edge[field] = e
+        vector_lengths[field] = desc.veclen
+        shape = check_stencil_shape(shape, desc.shape)
     for e in state.out_edges(node):
         field = e.src_conn
         outputs.append(field)
-        desc = sdfg.data(dace.sdfg.find_output_arraynode(state, e).data)
+        data_name = dace.sdfg.find_output_arraynode(state, e).data
+        desc = sdfg.data(data_name)
+        field_to_data[field] = data_name
         field_to_desc[field] = desc
-        shape = _check_stencil_shape(shape, desc.shape)
-    return inputs, outputs, shape, field_to_desc
+        field_to_edge[field] = e
+        vector_lengths[field] = desc.veclen
+        shape = check_stencil_shape(shape, desc.shape)
+    return (inputs, outputs, shape, field_to_data, field_to_desc, field_to_edge,
+            vector_lengths)
+
+
+def make_iterator_mapping(node, field_accesses, shape) -> Dict[str, Tuple[int]]:
+    """
+    Builds a complete iterator mapping dictionary for all data, including both
+    explicitly specified mappings and implicit ones (that access all
+    dimensions).
+    """
+    iterator_mapping: Dict[str, Tuple[int]] = {}
+    for field_name, accesses in field_accesses.items():
+        if field_name in node.iterator_mapping:
+            iterators = node.iterator_mapping[field_name]
+        else:
+            iterators = tuple(True for _ in range(len(shape)))
+        iterator_mapping[field_name] = iterators
+        num_dims = sum(iterators, 0)
+        if num_dims == 0:
+            continue  # Scalar input
+        if len(iterators) != len(shape):
+            raise ValueError(
+                f"Invalid iterator mapping for {field_name}: {iterators}")
+    return iterator_mapping
+
+
+def generate_boundary_conditions(node, shape, field_accesses, field_to_desc,
+                                 iterator_mapping):
+    boundary_code = ""
+    # Conditions where the output should not be written
+    oob_cond = set()
+    # Loop over each input
+    for field_name in node.in_connectors:
+        accesses = field_accesses[field_name]
+        dtype = field_to_desc[field_name].dtype.type
+        iterators = iterator_mapping[field_name]
+        num_dims = sum(iterators, 0)
+        # Loop over each access to this data
+        for indices, memlet_name in accesses.items():
+            if len(indices) != num_dims:
+                raise ValueError(f"Access {field_name}[{indices}] inconsistent "
+                                 f"with iterator mapping {iterators}.")
+            cond = set()
+            # Loop over each index of this access
+            for i, offset in enumerate(indices):
+                if offset < 0:
+                    term = f"_i{i} < {str(-offset)}"
+                elif offset > 0:
+                    term = f"_i{i} >= {str(shape[i] - offset)}"
+                cond.add(term)
+            if len(cond) == 0:
+                boundary_code += "{} = _{}\n".format(memlet_name, memlet_name)
+            else:
+                if field_name in node.boundary_conditions:
+                    bc = node.boundary_conditions[field_name]
+                else:
+                    bc = {"btype": "shrink"}
+                btype = bc["btype"]
+                if btype == "copy":
+                    center_memlet = accesses[center]
+                    boundary_val = "_{}".format(center_memlet)
+                elif btype == "constant":
+                    boundary_val = bc["value"]
+                elif btype == "shrink":
+                    # We don't need to do anything here, it's up to the
+                    # user to not use the junk output
+                    if np.issubdtype(dtype, np.floating):
+                        boundary_val = np.finfo(dtype).min
+                    else:
+                        # If not a float, assume it's some kind of integer
+                        boundary_val = np.iinfo(dtype).min
+                    # Add this to the output condition
+                    oob_cond |= cond
+                else:
+                    raise ValueError(
+                        f"Unsupported boundary condition type: {btype}")
+                boundary_code += ("{} = {} if {} else _{}\n".format(
+                    memlet_name, boundary_val, " or ".join(sorted(cond)),
+                    memlet_name))
+    return boundary_code, oob_cond
+
+
+def validate_vector_lengths(vector_lengths, iterator_mapping):
+    """
+    Assert that vector lengths are valid and consistent.
+    """
+    # All fields must be vectorized if they access the innermost dimension,
+    # and cannot be vectorized if they don't
+    expected = max(vector_lengths.values())
+    for field_name, vector_length in vector_lengths.items():
+        dim_mask = iterator_mapping[field_name]
+        if dim_mask[-1] == True:
+            if vector_length != expected:
+                raise ValueError(f"Field {field_name} has vectorization width "
+                                 f"{vector_length}, expected {expected}.")
+        else:
+            if vector_length != 1:
+                raise ValueError(
+                    f"Field {field_name} cannot be vectorized, "
+                    "because it doesn't read the innermost dimension.")
+    return expected

--- a/dace/libraries/stencil/_common.py
+++ b/dace/libraries/stencil/_common.py
@@ -1,0 +1,76 @@
+import collections
+import copy
+import functools
+import operator
+from typing import Tuple
+
+import dace
+
+
+def dim_to_abs_val(input, dimensions):
+    """Compute scalar number from independent dimension unit."""
+    vec = [
+        functools.reduce(operator.mul, dimensions[i + 1:], 1)
+        for i in range(len(dimensions))
+    ]
+    return functools.reduce(operator.add, map(operator.mul, input, vec), 0)
+
+
+def make_iterators(dimensions, halo_sizes=None, parameters=None):
+    def add_halo(i):
+        if i == len(dimensions) - 1 and halo_sizes is not None:
+            return " + " + str(-halo_sizes[0] + halo_sizes[1])
+        else:
+            return ""
+
+    if parameters is None:
+        return collections.OrderedDict([("i" + str(i),
+                                         "0:" + str(d) + add_halo(i))
+                                        for i, d in enumerate(dimensions)])
+    else:
+        return collections.OrderedDict([(parameters[i],
+                                         "0:" + str(d) + add_halo(i))
+                                        for i, d in enumerate(dimensions)])
+
+
+def _check_stencil_shape(shape: Tuple, other: Tuple):
+    """
+    Compares the existing shape with a proposed shape, setting it to the new
+    shape if the new shape has higher dimensionality. If the dimensionality is
+    the same, they must be identical.
+    """
+    if len(other) > len(shape):
+        shape = copy.copy(other)
+    elif len(other) == len(shape):
+        if shape != other:
+            raise ValueError(f"Inconsistent input sizes: {shape} "
+                             f"vs. {other}")
+    else:
+        # Allow lower-dimensional accesses
+        pass
+    return shape
+
+
+def _parse_connectors(node, state, sdfg):
+    """
+    Collects the inputs and outputs, infers the shape of the iteration space,
+    and creates a dictionary mapping each data name to its descriptor in the
+    parent SDFG.
+    """
+    inputs: List[str] = []
+    outputs: List[str] = []
+    shape: Tuple[int] = []
+    field_to_desc: Dict[str, dace.Data] = {}
+    for e in state.in_edges(node):
+        field = e.dst_conn
+        inputs.append(field)
+        desc = sdfg.data(dace.sdfg.find_input_arraynode(state, e).data)
+        field_to_desc[field] = desc
+        shape = _check_stencil_shape(shape, desc.shape)
+    for e in state.out_edges(node):
+        field = e.src_conn
+        outputs.append(field)
+        desc = sdfg.data(dace.sdfg.find_output_arraynode(state, e).data)
+        field_to_desc[field] = desc
+        shape = _check_stencil_shape(shape, desc.shape)
+    return inputs, outputs, shape, field_to_desc

--- a/dace/libraries/stencil/cpu.py
+++ b/dace/libraries/stencil/cpu.py
@@ -54,7 +54,7 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
         write_code = ""
         if len(oob_cond) > 1:
             write_code += "if not (" + " or ".join(sorted(oob_cond)) + "):\n"
-        write_code += "\n".join("{}{}_out = {}".format(
+        write_code += "\n".join("{}_{} = {}".format(
             "\t" if len(oob_cond) > 0 else "", field_accesses[output][tuple(
                 0 for _ in range(len(shape)))], field_accesses[output][tuple(
                     0 for _ in range(len(shape)))], output)

--- a/dace/libraries/stencil/cpu.py
+++ b/dace/libraries/stencil/cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2020-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
 import astunparse
 import collections
@@ -9,7 +9,7 @@ from typing import Dict, List, Tuple
 import dace
 
 from .subscript_converter import SubscriptConverter
-from ._common import _parse_connectors
+from ._common import *
 
 
 @dace.library.expansion
@@ -23,11 +23,8 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
         sdfg = dace.SDFG(node.label + "_outer")
         state = sdfg.add_state(node.label + "_outer")
 
-        # Find outer data descriptor
-        (inputs, outputs, shape,
-         field_to_desc) = _parse_connectors(node, parent_state, parent_sdfg)
-
-        parameters = [f"_i{i}" for i in range(len(shape))]
+        (inputs, outputs, shape, field_to_data, field_to_desc,
+         _, vector_lengths) = parse_connectors(node, parent_state, parent_sdfg)
 
         #######################################################################
         # Tasklet code generation
@@ -40,72 +37,15 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
         new_ast = converter.visit(ast.parse(code))
         code = astunparse.unparse(new_ast)
         field_accesses: Dict[str, List[Tuple[int]]] = converter.mapping
+        iterator_mapping = make_iterator_mapping(node, field_accesses, shape)
+        validate_vector_lengths(vector_lengths, iterator_mapping)
 
         #######################################################################
-        # Implement boundary conditions
+        # Boundary condition generation
         #######################################################################
 
-        boundary_code = ""
-        iterator_mapping: Dict[str, Tuple[int]] = {}
-        oob_cond = set()
-        # Loop over each input
-        for field_name in inputs:
-            accesses = field_accesses[field_name]
-            if field_name in node.iterator_mapping:
-                iterators = node.iterator_mapping[field_name]
-            else:
-                iterators = tuple(True for _ in range(len(shape)))
-            iterator_mapping[field_name] = iterators
-            num_dims = sum(iterators, 0)
-            if num_dims == 0:
-                continue  # Scalar input
-            if len(iterators) != len(shape):
-                raise ValueError(
-                    f"Invalid iterator mapping for {field_name}: {iterators}")
-            dtype = field_to_desc[field_name].dtype.type
-            # Loop over each access to this data
-            for indices, memlet_name in accesses.items():
-                if len(indices) != num_dims:
-                    raise ValueError(f"Access {indices} inconsistent with "
-                                     f"iterator mapping {iterators}.")
-                cond = set()
-                # Loop over each index of this access
-                for i, offset in enumerate(indices):
-                    if offset < 0:
-                        term = parameters[i] + " < " + str(-offset)
-                    elif offset > 0:
-                        term = parameters[i] + " >= " + str(shape[i] - offset)
-                    cond.add(term)
-                if len(cond) == 0:
-                    boundary_code += "{} = {}_in\n".format(
-                        memlet_name, memlet_name)
-                else:
-                    if field_name in node.boundary_conditions:
-                        bc = node.boundary_conditions[field_name]
-                    else:
-                        bc = {"btype": "shrink"}
-                    btype = bc["btype"]
-                    if btype == "copy":
-                        center_memlet = accesses[center]
-                        boundary_val = "_{}".format(center_memlet)
-                    elif btype == "constant":
-                        boundary_val = bc["value"]
-                    elif btype == "shrink":
-                        # We don't need to do anything here, it's up to the
-                        # user to not use the junk output
-                        if np.issubdtype(dtype, np.floating):
-                            boundary_val = np.nan
-                        else:
-                            # If not a float, assume it's some kind of integer
-                            boundary_val = np.iinfo(dtype).min
-                        # Add this to the output condition
-                        oob_cond |= cond
-                    else:
-                        raise ValueError(
-                            f"Unsupported boundary condition type: {btype}")
-                    boundary_code += ("{} = {} if {} else {}_in\n".format(
-                        memlet_name, boundary_val, " or ".join(sorted(cond)),
-                        memlet_name))
+        boundary_code, oob_cond = generate_boundary_conditions(
+            node, shape, field_accesses, field_to_desc, iterator_mapping)
 
         #######################################################################
         # Write all output memlets
@@ -124,13 +64,13 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
 
         input_connectors = sum(
             [
-                [f"{c}_in" for c in field_accesses[k].values()] for k in inputs
+                [f"_{c}" for c in field_accesses[k].values()] for k in inputs
                 # Don't include scalar variables
                 if sum(iterator_mapping[k], 0) > 0
             ],
             [])
         output_connectors = sum(
-            [[f"{c}_out" for c in field_accesses[k].values()] for k in outputs],
+            [[f"_{c}" for c in field_accesses[k].values()] for k in outputs],
             [])
 
         #######################################################################
@@ -146,6 +86,8 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
         #######################################################################
         # Build dataflow state
         #######################################################################
+
+        parameters = [f"_i{i}" for i in range(len(shape))]
 
         entry, exit = state.add_map(
             node.name + "_map",
@@ -170,7 +112,7 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
                 state.add_memlet_path(read_node,
                                       entry,
                                       tasklet,
-                                      dst_conn=connector + "_in",
+                                      dst_conn=f"_{connector}",
                                       memlet=memlet)
 
         index_tuple = ", ".join(parameters)
@@ -184,7 +126,7 @@ class ExpandStencilCPU(dace.library.ExpandTransformation):
                 state.add_memlet_path(tasklet,
                                       exit,
                                       write_node,
-                                      src_conn=connector + "_out",
+                                      src_conn=f"_{connector}",
                                       memlet=dace.Memlet(
                                           f"{field}[{index_tuple}]",
                                           dynamic=len(oob_cond) > 0))

--- a/dace/libraries/stencil/cpu.py
+++ b/dace/libraries/stencil/cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
 import astunparse
 import collections

--- a/dace/libraries/stencil/intel_fpga.py
+++ b/dace/libraries/stencil/intel_fpga.py
@@ -1,0 +1,458 @@
+import ast
+import astunparse
+import collections
+import functools
+import itertools
+import operator
+import re
+
+import dace
+from dace import data as dt, subsets as sbs
+import numpy as np
+from .subscript_converter import SubscriptConverter
+from ._common import *
+
+
+@dace.library.expansion
+class ExpandStencilIntelFPGA(dace.library.ExpandTransformation):
+
+    environments = []
+
+    @staticmethod
+    def expansion(node, parent_state, parent_sdfg):
+
+        sdfg = dace.SDFG(node.label + "_outer")
+        state = sdfg.add_state(node.label + "_outer")
+
+        (inputs, outputs, shape, field_to_data, field_to_desc, field_to_edge,
+         vector_lengths) = parse_connectors(node, parent_state, parent_sdfg)
+
+        #######################################################################
+        # Parse the tasklet code
+        #######################################################################
+
+        # Replace relative indices with memlet names
+        converter = SubscriptConverter()
+
+        # Add copy boundary conditions
+        for field in node.boundary_conditions:
+            if node.boundary_conditions[field]["btype"] == "copy":
+                center_index = tuple(0 for _ in range(
+                    len(parent_sdfg.arrays[field_to_data[field]].shape)))
+                # This will register the renaming
+                converter.convert(field, center_index)
+
+        # Replace accesses in the code
+        code = node.code.as_string
+        new_ast = converter.visit(ast.parse(code))
+        code = astunparse.unparse(new_ast)
+        field_accesses = converter.mapping
+
+        iterator_mapping = make_iterator_mapping(node, field_accesses, shape)
+        vector_length = validate_vector_lengths(vector_lengths,
+                                                iterator_mapping)
+
+        # Extract which fields to read from streams and what to buffer
+        buffer_sizes = collections.OrderedDict()
+        buffer_accesses = collections.OrderedDict()
+        scalars = {}  # {name: type}
+        for field_name in inputs:
+            relative = field_accesses[field_name]
+            dim_mask = iterator_mapping[field_name]
+            if not any(dim_mask):
+                # This is a scalar, no buffer needed. Instead, the SDFG must
+                # take this as a symbol
+                scalars[field_name] = parent_sdfg.symbols[field_name]
+                sdfg.add_symbol(field_name, parent_sdfg.symbols[field_name])
+                continue
+            abs_indices = ([
+                dim_to_abs_val(i, tuple(s for s, m in zip(shape, dim_mask)
+                                        if m), parent_sdfg) for i in relative
+            ] + ([0] if field_name in node.boundary_conditions
+                 and node.boundary_conditions[field_name]["btype"] == "copy"
+                 else []))
+            max_access = max(abs_indices)
+            min_access = min(abs_indices)
+            buffer_size = max_access - min_access + vector_lengths[field_name]
+            buffer_sizes[field_name] = buffer_size
+            # (indices relative to center, buffer indices, buffer center index)
+            buffer_accesses[field_name] = ([tuple(r) for r in relative], [
+                i - min_access for i in abs_indices
+            ], -min_access)
+
+        # Create a initialization phase corresponding to the highest distance
+        # to the center
+        init_sizes = [
+            (buffer_sizes[key] - vector_lengths[key] - val[2]) // vector_length
+            for key, val in buffer_accesses.items()
+        ]
+        init_size_max = int(np.max(init_sizes))
+
+        parameters = [f"_i{i}" for i in range(len(shape))]
+
+        # Dimensions we need to iterate over
+        iterator_mask = np.array([s != 0 and s != 1 for s in shape], dtype=bool)
+        iterators = make_iterators(
+            tuple(s for s, m in zip(shape, iterator_mask) if m),
+            parameters=tuple(s for s, m in zip(parameters, iterator_mask) if m),
+            vector_length=vector_length)
+
+        # Manually add pipeline entry and exit nodes
+        pipeline_range = dace.properties.SubsetProperty.from_string(', '.join(
+            iterators.values()))
+        pipeline = dace.sdfg.nodes.Pipeline(
+            "compute_" + node.label,
+            list(iterators.keys()),
+            pipeline_range,
+            dace.dtypes.ScheduleType.FPGA_Device,
+            False,
+            init_size=init_size_max,
+            init_overlap=False,
+            drain_size=init_size_max,
+            drain_overlap=True)
+        entry = dace.sdfg.nodes.PipelineEntry(pipeline)
+        exit = dace.sdfg.nodes.PipelineExit(pipeline)
+        state.add_nodes_from([entry, exit])
+
+        # Add nested SDFG to do 1) shift buffers 2) read from input 3) compute
+        nested_sdfg = dace.SDFG(node.label + "_inner", parent=state)
+        nested_sdfg_tasklet = state.add_nested_sdfg(
+            nested_sdfg,
+            sdfg,
+            # Input connectors
+            [k + "_in" for k in field_accesses if any(iterator_mapping[k])] +
+            [name + "_buffer_in" for name, _ in buffer_sizes.items()],
+            # Output connectors
+            [k + "_out" for k in outputs] +
+            [name + "_buffer_out" for name, _ in buffer_sizes.items()],
+            schedule=dace.ScheduleType.FPGA_Device)
+        # Propagate symbols
+        for sym_name, sym_type in parent_sdfg.symbols.items():
+            nested_sdfg.add_symbol(sym_name, sym_type)
+            nested_sdfg_tasklet.symbol_mapping[sym_name] = sym_name
+        # Map iterators
+        for p in parameters:
+            nested_sdfg.add_symbol(p, dace.int64)
+            nested_sdfg_tasklet.symbol_mapping[p] = p
+
+        # Shift state, which shifts all buffers by one
+        shift_state = nested_sdfg.add_state(node.label + "_shift")
+
+        # Update state, which reads new values from memory
+        update_state = nested_sdfg.add_state(node.label + "_update")
+
+        #######################################################################
+        # Implement boundary conditions
+        #######################################################################
+
+        boundary_code, oob_cond = generate_boundary_conditions(
+            node, shape, field_accesses, field_to_desc, iterator_mapping)
+
+        #######################################################################
+        # Only write if we're in bounds
+        #######################################################################
+
+        write_code = ("\n".join([
+            "{}_inner_out = {}\n".format(
+                output,
+                field_accesses[output][tuple(0 for _ in range(len(shape)))])
+            for output in outputs
+        ]))
+        if init_size_max > 0 or len(oob_cond) > 0:
+            write_cond = []
+            if init_size_max > 0:
+                init_cond = pipeline.init_condition()
+                write_cond.append("not " + init_cond)
+                nested_sdfg_tasklet.symbol_mapping[init_cond] = init_cond
+                nested_sdfg.add_symbol(init_cond, dace.bool)
+            if len(oob_cond) > 0:
+                oob_cond = " or ".join(sorted(oob_cond))
+                oob_cond = f"not ({oob_cond})"
+                write_cond.append(oob_cond)
+            write_cond = " and ".join(write_cond)
+            write_cond = f"if {write_cond}:\n\t"
+        else:
+            write_cond = ""
+
+        code = boundary_code + "\n" + code + "\n" + write_code
+
+        #######################################################################
+        # Create DaCe compute state
+        #######################################################################
+
+        # Compute state, which reads from input channels, performs the compute,
+        # and writes to the output channel(s)
+        compute_state = nested_sdfg.add_state(node.label + "_compute")
+        compute_inputs = list(
+            itertools.chain.from_iterable(
+                [["_" + v for v in field_accesses[f].values()] for f in inputs
+                 if any(iterator_mapping[f])]))
+        compute_tasklet = compute_state.add_tasklet(
+            node.label + "_compute",
+            compute_inputs, {name + "_inner_out"
+                             for name in outputs},
+            code,
+            language=dace.dtypes.Language.Python)
+        if vector_length > 1:
+            compute_unroll_entry, compute_unroll_exit = compute_state.add_map(
+                compute_state.label + "_unroll",
+                {"i_unroll": f"0:{vector_length}"},
+                schedule=dace.ScheduleType.FPGA_Device,
+                unroll=True)
+
+        # Connect the three nested states
+        nested_sdfg.add_edge(shift_state, update_state,
+                             dace.sdfg.InterstateEdge())
+        nested_sdfg.add_edge(update_state, compute_state,
+                             dace.sdfg.InterstateEdge())
+
+        # First, grab scalar variables
+        for scalar, scalar_type in scalars.items():
+            nested_sdfg.add_symbol(scalar, scalar_type)
+
+        for (field_name, size), init_size in zip(buffer_sizes.items(),
+                                                 init_sizes):
+
+            data_name = field_to_data[field_name]
+            connector = field_to_edge[field_name].dst_conn
+            array_index = ", ".join(
+                s for s, p in zip(parameters, iterator_mapping[field_name])
+                if p)
+
+            # Outer memory read
+            data_name_outer = connector
+            data_name_inner = field_name + "_in"
+            desc_outer = parent_sdfg.arrays[data_name].clone()
+            desc_outer.transient = False
+            sdfg.add_datadesc(data_name_outer, desc_outer)
+            read_node_outer = state.add_read(data_name_outer)
+            if isinstance(desc_outer, dt.Stream):
+                subset = "0"
+            else:
+                subset = str(sbs.Range.from_array(desc_outer))
+            state.add_memlet_path(
+                read_node_outer,
+                entry,
+                nested_sdfg_tasklet,
+                dst_conn=data_name_inner,
+                memlet=dace.Memlet(f"{data_name_outer}[{subset}]"))
+
+            # Create inner memory pipe
+            desc_inner = desc_outer.clone()
+            nested_sdfg.add_datadesc(data_name_inner, desc_inner)
+
+            buffer_name_outer = f"{node.label}_{field_name}_buffer"
+            buffer_name_inner_read = f"{field_name}_buffer_in"
+            buffer_name_inner_write = f"{field_name}_buffer_out"
+
+            # Create buffer transient in outer SDFG
+            field_dtype = parent_sdfg.data(data_name).dtype
+            _, desc_outer = sdfg.add_array(
+                buffer_name_outer, (size, ),
+                field_dtype.base_type,
+                storage=dace.dtypes.StorageType.FPGA_Local,
+                transient=True)
+
+            # Create read and write nodes
+            read_node_outer = state.add_read(buffer_name_outer)
+            write_node_outer = state.add_write(buffer_name_outer)
+
+            # Outer buffer read
+            state.add_memlet_path(read_node_outer,
+                                  entry,
+                                  nested_sdfg_tasklet,
+                                  dst_conn=buffer_name_inner_read,
+                                  memlet=dace.Memlet(
+                                      f"{buffer_name_outer}[0:{size}]",
+                                      dynamic=True))
+
+            # Outer buffer write
+            state.add_memlet_path(nested_sdfg_tasklet,
+                                  exit,
+                                  write_node_outer,
+                                  src_conn=buffer_name_inner_write,
+                                  memlet=dace.Memlet(
+                                      f"{write_node_outer.data}[0:{size}]",
+                                      dynamic=True))
+
+            # Inner copy
+            desc_inner_read = desc_outer.clone()
+            desc_inner_read.transient = False
+            desc_inner_read.name = buffer_name_inner_read
+            desc_inner_write = desc_inner_read.clone()
+            desc_inner_write.name = buffer_name_inner_write
+            nested_sdfg.add_datadesc(buffer_name_inner_read, desc_inner_read)
+            nested_sdfg.add_datadesc(buffer_name_inner_write, desc_inner_write)
+
+            # Make shift state if necessary
+            if size > 1:
+                shift_read = shift_state.add_read(buffer_name_inner_read)
+                shift_write = shift_state.add_write(buffer_name_inner_write)
+                shift_entry, shift_exit = shift_state.add_map(
+                    f"shift_{field_name}",
+                    {"i_shift": f"0:{size} - {vector_lengths[field_name]}"},
+                    schedule=dace.dtypes.ScheduleType.FPGA_Device,
+                    unroll=True)
+                shift_tasklet = shift_state.add_tasklet(
+                    f"shift_{field_name}", {f"{field_name}_shift_in"},
+                    {f"{field_name}_shift_out"},
+                    f"{field_name}_shift_out = {field_name}_shift_in")
+                shift_state.add_memlet_path(
+                    shift_read,
+                    shift_entry,
+                    shift_tasklet,
+                    dst_conn=field_name + "_shift_in",
+                    memlet=dace.Memlet(
+                        f"{shift_read.data}"
+                        f"[i_shift + {vector_lengths[field_name]}]"))
+                shift_state.add_memlet_path(
+                    shift_tasklet,
+                    shift_exit,
+                    shift_write,
+                    src_conn=field_name + "_shift_out",
+                    memlet=dace.Memlet(f"{shift_write.data}[i_shift]"))
+
+            # Begin reading according to this field's own buffer size, which is
+            # translated to an index by subtracting it from the maximum buffer
+            # size
+            begin_reading = (init_size_max - init_size)
+            end_reading = (
+                functools.reduce(operator.mul, shape, 1) / vector_length +
+                init_size_max - init_size)
+
+            update_read = update_state.add_read(data_name_inner)
+            update_write = update_state.add_write(buffer_name_inner_write)
+            update_tasklet = update_state.add_tasklet(
+                "read_wavefront", {"wavefront_in"}, {"buffer_out"},
+                "if {it} >= {begin} and {it} < {end}:\n"
+                "\tbuffer_out = wavefront_in\n".format(
+                    it=pipeline.iterator_str(),
+                    begin=begin_reading,
+                    end=end_reading),
+                language=dace.dtypes.Language.Python)
+            nested_sdfg_tasklet.symbol_mapping[pipeline.iterator_str()] = (
+                pipeline.iterator_str())
+            iterator_str = pipeline.iterator_str()
+            if iterator_str not in nested_sdfg.symbols:
+                nested_sdfg.add_symbol(iterator_str, dace.int64)
+            if isinstance(desc_inner, dt.Stream):
+                subset = "0"
+            else:
+                subset = array_index
+            update_state.add_memlet_path(update_read,
+                                         update_tasklet,
+                                         memlet=dace.Memlet(
+                                             f"{update_read.data}[{subset}]",
+                                             dynamic=True),
+                                         dst_conn="wavefront_in")
+            subset = f"{size} - {vector_length}:{size}" if size > 1 else "0"
+            update_state.add_memlet_path(
+                update_tasklet,
+                update_write,
+                memlet=dace.Memlet(f"{update_write.data}[{subset}]"),
+                src_conn="buffer_out")
+
+            # Make compute state
+            compute_read = compute_state.add_read(buffer_name_inner_read)
+            for relative, offset in zip(buffer_accesses[field_name][0],
+                                        buffer_accesses[field_name][1]):
+                memlet_name = field_accesses[field_name][tuple(relative)]
+                if vector_length > 1:
+                    if vector_lengths[field_name] > 1:
+                        offset = f"{offset} + i_unroll"
+                    else:
+                        offset = str(offset)
+                    path = [compute_read, compute_unroll_entry, compute_tasklet]
+                else:
+                    offset = str(offset)
+                    path = [compute_read, compute_tasklet]
+                compute_state.add_memlet_path(
+                    *path,
+                    dst_conn="_" + memlet_name,
+                    memlet=dace.Memlet(f"{compute_read.data}[{offset}]"))
+
+        for field_name in outputs:
+
+            for offset in field_accesses[field_name]:
+                if offset is not None and list(offset) != [0] * len(offset):
+                    raise NotImplementedError("Output offsets not implemented")
+
+            data_name = field_to_data[field_name]
+
+            # Outer write
+            data_name_outer = field_name
+            data_name_inner = field_name + "_out"
+            desc_outer = parent_sdfg.arrays[data_name].clone()
+            desc_outer.transient = False
+            array_index = ", ".join(map(str, parameters))
+            try:
+                sdfg.add_datadesc(data_name_outer, desc_outer)
+            except NameError:  # Already an input
+                parent_sdfg.arrays[data_name].access = (
+                    dace.AccessType.ReadWrite)
+            write_node_outer = state.add_write(data_name_outer)
+            if isinstance(desc_outer, dt.Stream):
+                subset = "0"
+            else:
+                subset = str(sbs.Range.from_array(desc_outer))
+            state.add_memlet_path(
+                nested_sdfg_tasklet,
+                exit,
+                write_node_outer,
+                src_conn=data_name_inner,
+                memlet=dace.Memlet(f"{data_name_outer}[{subset}]"))
+
+            # Create inner stream
+            desc_inner = desc_outer.clone()
+            nested_sdfg.add_datadesc(data_name_inner, desc_inner)
+
+            # Inner write
+            write_node_inner = compute_state.add_write(data_name_inner)
+
+            # Intermediate buffer, mostly relevant for vectorization
+            output_buffer_name = field_name + "_output_buffer"
+            nested_sdfg.add_array(output_buffer_name, (vector_length, ),
+                                  desc_inner.dtype.base_type,
+                                  storage=dace.StorageType.FPGA_Registers,
+                                  transient=True)
+            output_buffer = compute_state.add_access(output_buffer_name)
+
+            # Condition write tasklet
+            output_tasklet = compute_state.add_tasklet(
+                field_name + "_conditional_write", {f"_{output_buffer_name}"},
+                {f"_{data_name_inner}"},
+                (write_cond + f"_{data_name_inner} = _{output_buffer_name}"))
+
+            # If vectorized, we need to pass through the unrolled scope
+            if vector_length > 1:
+                compute_state.add_memlet_path(
+                    compute_tasklet,
+                    compute_unroll_exit,
+                    output_buffer,
+                    src_conn=field_name + "_inner_out",
+                    memlet=dace.Memlet(f"{output_buffer_name}[i_unroll]"))
+            else:
+                compute_state.add_memlet_path(
+                    compute_tasklet,
+                    output_buffer,
+                    src_conn=field_name + "_inner_out",
+                    memlet=dace.Memlet(f"{output_buffer_name}[0]")),
+
+            # Final memlet to the output
+            compute_state.add_memlet_path(
+                output_buffer,
+                output_tasklet,
+                dst_conn=f"_{output_buffer_name}",
+                memlet=dace.Memlet(f"{output_buffer.data}[0:{vector_length}]")),
+            if isinstance(desc_inner, dt.Stream):
+                subset = "0"
+            else:
+                subset = array_index
+            compute_state.add_memlet_path(
+                output_tasklet,
+                write_node_inner,
+                src_conn=f"_{data_name_inner}",
+                memlet=dace.Memlet(f"{write_node_inner.data}[{subset}]",
+                                   dynamic=True)),
+
+        return sdfg

--- a/dace/libraries/stencil/stencil.py
+++ b/dace/libraries/stencil/stencil.py
@@ -6,7 +6,7 @@ import dace
 import dace.library
 
 from .cpu import ExpandStencilCPU
-# from .intel_fpga import ExpandStencilIntelFPGA
+from .intel_fpga import ExpandStencilIntelFPGA
 # from .xilinx import ExpandStencilXilinx
 
 
@@ -48,7 +48,7 @@ class Stencil(dace.library.LibraryNode):
 
     implementations = {
         "pure": ExpandStencilCPU,
-        # "intel_fpga": ExpandStencilIntelFPGA,
+        "intel_fpga": ExpandStencilIntelFPGA,
         # "xilinx": ExpandStencilXilinx
     }
     default_implementation = "pure"

--- a/dace/libraries/stencil/stencil.py
+++ b/dace/libraries/stencil/stencil.py
@@ -1,11 +1,13 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import collections
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import dace
 import dace.library
 
 from .cpu import ExpandStencilCPU
+# from .intel_fpga import ExpandStencilIntelFPGA
+# from .xilinx import ExpandStencilXilinx
 
 
 @dace.library.node
@@ -44,7 +46,11 @@ class Stencil(dace.library.LibraryNode):
     This will use iterators _i0 and _i2 for accessing b.
     """
 
-    implementations = {"pure": ExpandStencilCPU}
+    implementations = {
+        "pure": ExpandStencilCPU,
+        # "intel_fpga": ExpandStencilIntelFPGA,
+        # "xilinx": ExpandStencilXilinx
+    }
     default_implementation = "pure"
 
     code = dace.properties.CodeProperty(

--- a/dace/libraries/stencil/subscript_converter.py
+++ b/dace/libraries/stencil/subscript_converter.py
@@ -70,7 +70,7 @@ class SubscriptConverter(ast.NodeTransformer):
         index_tuple = node.slice
         if isinstance(index_tuple, (ast.Subscript, ast.Index)):
             index_tuple = index_tuple.value
-        if isinstance(index_tuple, ast.Constant):
+        if isinstance(index_tuple, (ast.Constant, ast.Num)):
             index_tuple = (index_tuple, )
         if isinstance(index_tuple, ast.Tuple):
             index_tuple = index_tuple.elts

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -58,6 +58,10 @@ def replace(subgraph: 'dace.sdfg.state.StateGraphView', name: str,
             edge.data.other_subset = _replsym(edge.data.other_subset, symrepl)
         if symname in edge.data.volume.free_symbols:
             edge.data.volume = _replsym(edge.data.volume, symrepl)
+        if edge.src_conn == name:
+            edge.src_conn = new_name
+        if edge.dst_conn == name:
+            edge.dst_conn = new_name
 
 
 def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
@@ -98,13 +102,12 @@ def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
             if pname == 'symbol_mapping':
                 # Symbol mappings for nested SDFGs
                 for symname, sym_mapping in propval.items():
-                    propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
-                        symrepl)
+                    propval[symname] = symbolic.pystr_to_symbolic(
+                        sym_mapping).subs(symrepl)
             elif pname in ('in_connectors', 'out_connectors'):
                 for key in list(propval.keys()):
-                    updated = str(symbolic.pystr_to_symbolic(key).subs(symrepl))
-                    if key != updated:
-                        propval[updated] = propval.pop(key)
+                    if key == name:
+                        propval[new_name] = propval.pop(key)
 
 
 def replace_properties_dict(node: Any, symrepl: Dict[symbolic.SymbolicType,

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -94,12 +94,17 @@ def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
             elif propval.code is not None:
                 for stmt in propval.code:
                     ASTFindReplace({name: new_name}).visit(stmt)
-        elif (isinstance(propclass, properties.DictProperty)
-              and pname == 'symbol_mapping'):
-            # Symbol mappings for nested SDFGs
-            for symname, sym_mapping in propval.items():
-                propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
-                    symrepl)
+        elif isinstance(propclass, properties.DictProperty):
+            if pname == 'symbol_mapping':
+                # Symbol mappings for nested SDFGs
+                for symname, sym_mapping in propval.items():
+                    propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
+                        symrepl)
+            elif pname in ('in_connectors', 'out_connectors'):
+                for key in list(propval.keys()):
+                    updated = str(symbolic.pystr_to_symbolic(key).subs(symrepl))
+                    if key != updated:
+                        propval[updated] = propval.pop(key)
 
 
 def replace_properties_dict(node: Any, symrepl: Dict[symbolic.SymbolicType,

--- a/tests/library/stencil/stencil_node_test.py
+++ b/tests/library/stencil/stencil_node_test.py
@@ -4,14 +4,13 @@ from dace.fpga_testing import intel_fpga_test
 from dace.libraries.stencil import Stencil
 import numpy as np
 from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG
-from dace.transformation.dataflow import StreamingMemory
 
 ROWS = dace.symbol("rows")
 COLS = dace.symbol("cols")
 DTYPE = np.float32
 
 
-def make_sdfg(implementation="pure"):
+def make_sdfg(implementation: str):
 
     sdfg = dace.SDFG("stencil_node_test")
     _, a_desc = sdfg.add_array("a", (ROWS, COLS), dtype=DTYPE)
@@ -72,7 +71,7 @@ def run_stencil(sdfg, rows, cols, specialize: bool):
 
 
 def test_stencil_node():
-    run_stencil(make_sdfg(), 16, 32, False)
+    run_stencil(make_sdfg("pure"), 16, 32, False)
 
 
 @intel_fpga_test()

--- a/tests/library/stencil/stencil_node_test.py
+++ b/tests/library/stencil/stencil_node_test.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
-from dace.fpga_testing import fpga_test
+from dace.fpga_testing import intel_fpga_test
 from dace.libraries.stencil import Stencil
 import numpy as np
 from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG
@@ -27,7 +27,7 @@ def make_sdfg(implementation="pure"):
 
     stencil_node = Stencil(
         "stencil_test",
-        "res[0, 0] = c * b[0] * (a[-1, 0] + a[1, 0] + a[0, -1] + a[0, 1]) + d[0, 0]",
+        "res[0, 0] = c * b[0] * (a[-1, 0] + a[1, 0] + a[0, -1] + a[0, 1]) + d[0, -1] + d[0, 1]",
         iterator_mapping={"b": (True, False)})
     stencil_node.implementation = implementation
     state.add_node(stencil_node)
@@ -53,25 +53,25 @@ def make_sdfg(implementation="pure"):
 
 
 def run_stencil(sdfg, specialize: bool):
-    rows = 8
-    cols = 4
-    a = np.ones((rows, cols), dtype=DTYPE)
-    a[1:-1, 1:-1] = 0
+    rows = 16
+    cols = 32
+    a = np.zeros((rows, cols), dtype=DTYPE)
+    a[1:-1, 1:-1] = np.arange(1, (rows - 2) * (cols - 2) + 1,
+                              dtype=DTYPE).reshape((rows - 2, cols - 2))
     b = np.empty((rows, ), dtype=DTYPE)
     b[:] = 1
     c = DTYPE(0.25)
-    d = np.ones((rows, cols), dtype=DTYPE)
+    d = 0.5 * np.ones((rows, cols), dtype=DTYPE)
     res = np.zeros((rows, cols), dtype=DTYPE)
+    print("RUNNING SDFG")
     if specialize:
         sdfg.specialize({"cols": cols})
         sdfg(a=a, b=b, c=c, d=d, res=res, rows=rows)
     else:
         sdfg(a=a, b=b, c=c, d=d, res=res, rows=rows, cols=cols)
+    print("FINISHED RUNNING SDFG")
     expected = (0.25 *
-                (a[2:, 1:-1] + a[:-2, 1:-1] + a[1:-1, 2:] + a[1:-1, :-2]) +
-                d[1:-1, 1:-1])
-    print(expected)
-    print(res)
+                (a[2:, 1:-1] + a[:-2, 1:-1] + a[1:-1, 2:] + a[1:-1, :-2]) + 1)
     assert np.allclose(expected, res[1:-1, 1:-1])
 
 
@@ -79,6 +79,7 @@ def test_stencil_node():
     run_stencil(make_sdfg(), False)
 
 
+@intel_fpga_test()
 def test_stencil_node_fpga():
     sdfg = make_sdfg(dace.Config.get("compiler", "fpga_vendor"))
     assert sdfg.apply_transformations(FPGATransformSDFG) == 1
@@ -88,5 +89,5 @@ def test_stencil_node_fpga():
 
 
 if __name__ == "__main__":
-    # test_stencil_node()
-    test_stencil_node_fpga()
+    test_stencil_node()
+    test_stencil_node_fpga(None)


### PR DESCRIPTION
Ported the Intel FPGA stencil node expansion from StencilFlow, adapted to be able to read from arrays instead of streams.

The streaming implementation is not yet verified to work, since the `StreamingMemory` transformation does not work with this expansion, due to the read happening in the nested SDFG.