### PR TITLE
Fix for InlineSDFG and empty input memlets

### DIFF
--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -120,7 +120,9 @@ class InlineSDFG(transformation.Transformation):
             if (edge.data.is_empty()
                     and not isinstance(edge.src, nodes.EntryNode)):
                 return False
-            in_connectors.add(edge.dst_conn)
+            # NOTE: Empty memlets do not attach to connectors
+            if edge.dst_conn or not edge.data.is_empty():
+                in_connectors.add(edge.dst_conn)
         for edge in graph.out_edges(nested_sdfg):
             if edge.src_conn in out_connectors:
                 return False

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -129,7 +129,9 @@ class InlineSDFG(transformation.Transformation):
             if (edge.data.is_empty()
                     and not isinstance(edge.dst, nodes.ExitNode)):
                 return False
-            out_connectors.add(edge.src_conn)
+            # NOTE: Empty memlets do not attach to connectors
+            if edge.src_conn or not edge.data.is_empty():
+                out_connectors.add(edge.src_conn)
 
         # Ensure output connectors have no additional outputs (if in a scope),
         # and ensure no two connectors are directly connected to each other


### PR DESCRIPTION
Input edges with empty memlets inside a Map scope do not attach to connectors. This PR fixes an issue where Inline SDFG fails to apply due to trying to match a `None` connector to those edges.