### PR TITLE
Symbol Mapping Replacement Fix

### DIFF
--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -106,8 +106,8 @@ def replace_properties(node: Any, symrepl: Dict[symbolic.symbol,
               and pname == 'symbol_mapping'):
             # Symbol mappings for nested SDFGs
             for symname, sym_mapping in propval.items():
-                propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(
-                    symrepl)
+                propval[symname] = symbolic.pystr_to_symbolic(
+                    str(sym_mapping)).subs(symrepl)
 
 
 def replace_properties_dict(node: Any, symrepl: Dict[symbolic.SymbolicType,

--- a/tests/symbol_mapping_replace_test.py
+++ b/tests/symbol_mapping_replace_test.py
@@ -1,0 +1,43 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import numpy as np
+
+symsym = dace.symbol('symsym', dace.float64)
+value1 = dace.symbol('value1', dace.float64)
+value2 = dace.symbol('value2', dace.float64)
+
+
+@dace.program
+def inner(A: dace.float64[10, 10, 10]):
+    A[...] = symsym
+
+
+@dace.program
+def mid(A):
+    tmp = value1 + value2
+    inner(A=A, symsym=tmp)
+    A[...] += 1
+
+
+@dace.program
+def outer(A, inp1: float, inp2: float):
+    tmp = inp1 + inp2
+    mid(A, value1=tmp, value2=1.0)
+
+
+def test_symbol_mapping_replace():
+
+    with dace.config.set_temporary('optimizer',
+                                   'automatic_strict_transformations',
+                                   value=True):
+        A = np.ones((10, 10, 10))
+        ref = A.copy()
+        b = 2.0
+        c = 2.0
+        outer(A, inp1=b, inp2=c)
+        outer.f(ref, inp1=b, inp2=c)
+        assert (np.allclose(A, ref))
+
+
+if __name__ == '__main__':
+    test_symbol_mapping_replace()


### PR DESCRIPTION
When replacing a symbol in a nested SDFG, the symbol mapping is updated with the following code:
```python
            # Symbol mappings for nested SDFGs
            for symname, sym_mapping in propval.items():
                propval[symname] = symbolic.pystr_to_symbolic(sym_mapping).subs(symrepl)
```
`sym_mapping` is the original symbol from the nested SDFG's parent. This symbol may have been defined by the user, e.g., `sym = dace.symbol('sym', dtype=dace.float64)`. On the other hand, `symrepl` is a symbolic dictionary created with `pystr_to_symbolic`, which returns symbols with the default (integer) datatype. Please note, that `pystr_to_symbolic` will return the unmodified input if it is already a symbol. Therefore, any symbols that have been defined by with a non-default datatype will not be replaced by the above code. This PR fixes the issue in the following manner:
```python
            # Symbol mappings for nested SDFGs
            for symname, sym_mapping in propval.items():
                propval[symname] = symbolic.pystr_to_symbolic(
                    str(sym_mapping)).subs(symrepl)
```