### PR TITLE
Support non-zero offset on output of stencil library node

### DIFF
--- a/dace/libraries/stencil/_common.py
+++ b/dace/libraries/stencil/_common.py
@@ -1,11 +1,15 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import ast
+import astunparse
 import collections
 import copy
 import functools
 import numpy as np
 import operator
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import dace
+from .subscript_converter import SubscriptConverter
 
 
 def dim_to_abs_val(input, _dimensions, sdfg):
@@ -103,6 +107,43 @@ def parse_connectors(node, state, sdfg):
         shape = check_stencil_shape(shape, desc.shape)
     return (inputs, outputs, shape, field_to_data, field_to_desc, field_to_edge,
             vector_lengths)
+
+
+def parse_accesses(code, outputs: List[str]):
+    """
+    Runs the subscript converter to extract accesses of the format a[0, -1] into
+    their accesses tuple (0, -1) and a generated memlet name a_0_m1.
+    If an offset is found on the output, all indices are adjusted accordingly,
+    such that the output is written at the central index.
+    """
+
+    # Run subscript converter
+    converter = SubscriptConverter()
+    new_ast = converter.visit(ast.parse(code))
+    field_accesses: Dict[str, List[Tuple[int]]] = converter.mapping
+
+    # Check that there's only one write to the output
+    offset = None
+    for output in outputs:
+        if len(field_accesses[output]) > 1:
+            raise ValueError(
+                f"Stencil {node.label} can only write {output} once.")
+        _offset = next(iter(field_accesses[output].keys()))
+        if offset is None:
+            offset = _offset
+        else:
+            if _offset != offset:
+                raise ValueError(f"Inconsistent output offset for "
+                                 f"{node.label}: {offset} and {_offset}")
+
+    # If the offset is non-zero, rerun the converter to adjust
+    if offset is not None and any(o != 0 for o in offset):
+        converter = SubscriptConverter(offset=tuple(-o for o in offset))
+        new_ast = converter.visit(ast.parse(code))
+        field_accesses = converter.mapping
+    new_code = astunparse.unparse(new_ast)
+
+    return new_code, field_accesses
 
 
 def make_iterator_mapping(node, field_accesses, shape) -> Dict[str, Tuple[int]]:

--- a/dace/libraries/stencil/_common.py
+++ b/dace/libraries/stencil/_common.py
@@ -150,6 +150,8 @@ def generate_boundary_conditions(node, shape, field_accesses, field_to_desc,
                     term = f"_i{i} < {str(-offset)}"
                 elif offset > 0:
                     term = f"_i{i} >= {str(shape[i] - offset)}"
+                else:
+                    continue
                 cond.add(term)
             if len(cond) == 0:
                 boundary_code += "{} = _{}\n".format(memlet_name, memlet_name)

--- a/tests/library/stencil/stencil_node_test.py
+++ b/tests/library/stencil/stencil_node_test.py
@@ -5,21 +5,52 @@ from dace.libraries.stencil import Stencil
 import numpy as np
 from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG
 
+SIZE = dace.symbol("size")
 ROWS = dace.symbol("rows")
 COLS = dace.symbol("cols")
 DTYPE = np.float32
 
 
-def make_sdfg(implementation: str):
+def make_sdfg_1d(implementation: str):
 
-    sdfg = dace.SDFG("stencil_node_test")
+    sdfg = dace.SDFG("stencil_node_test_1d")
+    _, a_desc = sdfg.add_array("a", (SIZE, ), dtype=DTYPE)
+    _, res_desc = sdfg.add_array("res", (SIZE, ), dtype=DTYPE)
+
+    state = sdfg.add_state("stencil_node_test_1d")
+    a = state.add_read("a")
+    res = state.add_write("res")
+
+    stencil_node = Stencil(
+        "stencil_test", """\
+tmp0 = (a[0] + a[1])
+tmp1 = (tmp0 + a[2])
+res[1] = (dace.float32(0.3333) * tmp1)""")
+    stencil_node.implementation = implementation
+    state.add_node(stencil_node)
+
+    state.add_memlet_path(a,
+                          stencil_node,
+                          dst_conn="a",
+                          memlet=dace.Memlet.from_array("a", a_desc))
+    state.add_memlet_path(stencil_node,
+                          res,
+                          src_conn="res",
+                          memlet=dace.Memlet.from_array("res", res_desc))
+
+    return sdfg
+
+
+def make_sdfg_2d(implementation: str):
+
+    sdfg = dace.SDFG("stencil_node_test_2d")
     _, a_desc = sdfg.add_array("a", (ROWS, COLS), dtype=DTYPE)
     _, b_desc = sdfg.add_array("b", (ROWS, ), dtype=DTYPE)
     sdfg.add_symbol("c", DTYPE)
     _, d_desc = sdfg.add_array("d", (ROWS, COLS), dtype=DTYPE)
     _, res_desc = sdfg.add_array("res", (ROWS, COLS), dtype=DTYPE)
 
-    state = sdfg.add_state("stencil_node_test")
+    state = sdfg.add_state("stencil_node_test_2d")
     a = state.add_read("a")
     b = state.add_read("b")
     d = state.add_read("d")
@@ -52,7 +83,29 @@ def make_sdfg(implementation: str):
     return sdfg
 
 
-def run_stencil(sdfg, rows, cols, specialize: bool):
+def run_stencil_1d(sdfg, size):
+    a = np.zeros((size, ), dtype=DTYPE)
+    a[1:-1] = np.arange(1, size - 1, dtype=DTYPE).reshape((size - 2))
+    res = np.zeros((size, ), dtype=DTYPE)
+    sdfg(a=a, res=res, size=size)
+    expected = 0.3333 * (a[:-2] + a[1:-1] + a[2:])
+    assert np.allclose(expected, res[1:-1])
+
+
+def test_stencil_node_1d():
+    run_stencil_1d(make_sdfg_1d("pure"), 32)
+
+
+@intel_fpga_test()
+def test_stencil_node_1d_fpga_array():
+    sdfg = make_sdfg_1d(dace.Config.get("compiler", "fpga_vendor"))
+    assert sdfg.apply_transformations(FPGATransformSDFG) == 1
+    assert sdfg.apply_transformations(InlineSDFG) == 1
+    run_stencil_1d(sdfg, 32)
+    return sdfg
+
+
+def run_stencil_2d(sdfg, rows, cols, specialize: bool):
     a = np.zeros((rows, cols), dtype=DTYPE)
     a[1:-1, 1:-1] = np.arange(1, (rows - 2) * (cols - 2) + 1,
                               dtype=DTYPE).reshape((rows - 2, cols - 2))
@@ -70,20 +123,22 @@ def run_stencil(sdfg, rows, cols, specialize: bool):
     assert np.allclose(expected, res[1:-1, 1:-1])
 
 
-def test_stencil_node():
-    run_stencil(make_sdfg("pure"), 16, 32, False)
+def test_stencil_node_2d():
+    run_stencil_2d(make_sdfg_2d("pure"), 16, 32, False)
 
 
 @intel_fpga_test()
-def test_stencil_node_fpga_array():
-    sdfg = make_sdfg(dace.Config.get("compiler", "fpga_vendor"))
+def test_stencil_node_2d_fpga_array():
+    sdfg = make_sdfg_2d(dace.Config.get("compiler", "fpga_vendor"))
     sdfg.specialize({"cols": 32})
     assert sdfg.apply_transformations(FPGATransformSDFG) == 1
     assert sdfg.apply_transformations(InlineSDFG) == 1
-    run_stencil(sdfg, 16, 32, True)
+    run_stencil_2d(sdfg, 16, 32, True)
     return sdfg
 
 
 if __name__ == "__main__":
-    test_stencil_node()
-    test_stencil_node_fpga_array(None)
+    test_stencil_node_1d()
+    test_stencil_node_1d_fpga_array(None)
+    test_stencil_node_2d()
+    test_stencil_node_2d_fpga_array(None)


### PR DESCRIPTION
When this is detected, the subscript converter is re-run with the offset to adjust all indices accordingly.