### PR TITLE
Split interstate edges of all SDFGs before LoopToMap

### DIFF
--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -509,7 +509,8 @@ def auto_optimize(sdfg: SDFG,
     while transformed:
         sdfg.apply_strict_transformations(validate=False,
                                           validate_all=validate_all)
-        xfh.split_interstate_edges(sdfg)
+        for s in sdfg.sdfg_list:
+            xfh.split_interstate_edges(s)
         l2ms = sdfg.apply_transformations_repeated(LoopToMap,
                                                    strict=True,
                                                    validate=False,

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -120,16 +120,16 @@ class LoopToMap(DetectLoop):
                 return False
 
         # Find all loop-body states
-        states = set([body_end])
+        states = set()
         to_visit = [begin]
         while to_visit:
             state = to_visit.pop(0)
-            if state is body_end:
-                continue
-            for _, dst, _ in graph.out_edges(state):
-                if dst not in states:
+            for _, dst, _ in sdfg.out_edges(state):
+                if dst not in states and dst is not guard:
                     to_visit.append(dst)
             states.add(state)
+
+        assert(body_end in states)
 
         write_set = set()
         for state in states:
@@ -276,14 +276,12 @@ class LoopToMap(DetectLoop):
                                                        itervar=self.itervar)
 
         # Find all loop-body states
-        states = set([body_end])
+        states = set()
         to_visit = [body]
         while to_visit:
             state = to_visit.pop(0)
-            if state is body_end:
-                continue
             for _, dst, _ in sdfg.out_edges(state):
-                if dst not in states:
+                if dst not in states and dst is not guard:
                     to_visit.append(dst)
             states.add(state)
 

--- a/dace/transformation/interstate/multistate_inline.py
+++ b/dace/transformation/interstate/multistate_inline.py
@@ -21,7 +21,7 @@ from dace.properties import make_properties, Property
 from dace import data
 
 
-@registry.autoregister_params(singlestate=True, strict=True)
+@registry.autoregister_params(singlestate=True, strict=False)
 @make_properties
 class InlineMultistateSDFG(transformation.Transformation):
     """

--- a/tests/inlining_test.py
+++ b/tests/inlining_test.py
@@ -131,6 +131,8 @@ def test_multistate_inline():
         nested(A)
 
     sdfg = outerprog.to_sdfg(strict=True)
+    from dace.transformation.interstate import InlineMultistateSDFG
+    sdfg.apply_transformations(InlineMultistateSDFG)
     assert sdfg.number_of_nodes() in (4, 5)
 
     A = np.random.rand(20)
@@ -153,6 +155,8 @@ def test_multistate_inline_samename():
             nested(A)
 
     sdfg = outerprog.to_sdfg(strict=True)
+    from dace.transformation.interstate import InlineMultistateSDFG
+    sdfg.apply_transformations(InlineMultistateSDFG)
     assert sdfg.number_of_nodes() in (7, 8)
 
     A = np.random.rand(20)


### PR DESCRIPTION
In the auto-optimizer, before applying LoopToMap to all levels of the SDFGs, we must split the interstate edges to all levels of the SDFG as well (not only the top-level SDFG). This PR also updates LoopToMap slightly to work with multi-state loop bodies that contain double-linked chains of nested loops. Furthermore, the PR changes the multi-state inline transformation to non-strict.