### PR TITLE
Add schedules to the labels of map nodes

### DIFF
--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -859,7 +859,7 @@ class Map(object):
         return self.label + "[" + ", ".join([
             "{}={}".format(i, r) for i, r in zip(
                 self._params, [sbs.Range.dim_to_string(d) for d in self._range])
-        ]) + "]"
+        ]) + "] (" + str(self.schedule) + ")"
 
     def validate(self, sdfg, state, node):
         if not dtypes.validate_name(self.label):


### PR DESCRIPTION
Without this, SDFV needs to re-calculate the node label on each draw call