### PR TITLE
Redundant Read/Write Slices

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -102,6 +102,12 @@ def _method(sdfg: SDFG, sample_data: data.Array, dtype):
     return name, new_data
 
 
+@specifies_datatype(datatype=data.View)
+def _method(sdfg: SDFG, sample_data: data.View, dtype):
+    name, new_data = sdfg.add_temp_transient(sample_data.shape, dtype)
+    return name, new_data
+
+
 @specifies_datatype(datatype=data.Stream)
 def _method(sdfg: SDFG, sample_data: data.Stream, dtype):
     name = sdfg.temp_data_name()

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1970,10 +1970,17 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         """
         # These are imported in order to update the transformation registry
         from dace.transformation import dataflow, interstate
+        from dace.transformation.dataflow import (RedundantReadSlice,
+                                                  RedundantWriteSlice)
         # This is imported here to avoid an import loop
         from dace.transformation.transformation import (Transformation,
                                                         strict_transformations)
 
+        self.apply_transformations_repeated([RedundantReadSlice,
+                                             RedundantWriteSlice],
+                                            validate=validate,
+                                            strict=True,
+                                            validate_all=validate_all)
         self.apply_transformations_repeated(strict_transformations(),
                                             validate=validate,
                                             strict=True,

--- a/dace/transformation/dataflow/__init__.py
+++ b/dace/transformation/dataflow/__init__.py
@@ -30,7 +30,9 @@ from .streaming_memory import StreamingMemory, StreamingComposition
 # Complexity reduction
 from .dedup_access import DeduplicateAccess
 from .redundant_array import (RedundantArray, RedundantSecondArray,
-                              SqueezeViewRemove, UnsqueezeViewRemove)
+                              SqueezeViewRemove, UnsqueezeViewRemove,
+                              RedundantReadSlice,
+                              RedundantWriteSlice)
 from .redundant_array_copying import (RedundantArrayCopyingIn,
                                       RedundantArrayCopying,
                                       RedundantArrayCopying2,

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -1169,6 +1169,10 @@ class UnsqueezeViewRemove(pm.Transformation):
 
 def _is_slice(adesc: data.Array, vdesc: data.View) -> bool:
     """ Checks whether a View of an Array is a slice or not. """
+    # Explicitly fail in case of Views with more dimensions than the Array.
+    # NOTE: We want to avoid matching slices produced with np.newaxis
+    if len(vdesc.shape) > len(adesc.shape):
+        return False
     try:
         # Iterate over the View's strides.
         for vi, s in enumerate(vdesc.strides):

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -766,7 +766,11 @@ class RedundantSecondArray(pm.Transformation):
                             return False
                         # If there is a forward path then a must not be a direct
                         # successor of the (true) out_array.
-                        if has_fward_path and a in G.successors(true_out_array):
+                        try:
+                            if has_fward_path and a in G.successors(
+                                    true_out_array):
+                                return False
+                        except NetworkXError:
                             return False
 
         # Make sure that both arrays are using the same storage location

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -1161,3 +1161,320 @@ class UnsqueezeViewRemove(pm.Transformation):
             sdfg.remove_data(in_array.data)
         except ValueError:  # Already in use (e.g., with Views)
             pass
+
+
+def _is_slice(adesc: data.Array, vdesc: data.View) -> bool:
+    """ Checks whether a View of an Array is a slice or not. """
+    try:
+        # Iterate over the View's strides.
+        for vi, s in enumerate(vdesc.strides):
+            # All of the View's strides must exist in the Array's strides.
+            # Otherwise, it is not a slice but a reintepretation.
+            ai = adesc.strides.index(s)
+            # If the View's length is not clearly less or equal than
+            # the Array's corresponding length, then we cannot confirm that
+            # the View is a slice.
+            if (vdesc.shape[vi] <= adesc.shape[ai]) == True:
+                continue
+            else:
+                return False
+    except ValueError:  # list.index throws ValueError if a stride is not found
+        return False
+    
+    return True
+
+
+def _sliced_dims(adesc: data.Array, vdesc: data.View) -> typing.List[int]:
+    """ Returns the Array dimensions viewed by a slice-View.
+        NOTE: This method assumes that `_is_slice(adesc, vdesc) == True`.
+    """
+    return [adesc.strides.index(s) for s in vdesc.strides]
+
+
+@registry.autoregister_params(singlestate=True, strict=True)
+class RedundantReadSlice(pm.Transformation):
+    """ Detects patterns of the form Array -> View(Array) and removes
+    the View if it is a slice. """
+
+    in_array = pm.PatternNode(nodes.AccessNode)
+    out_array = pm.PatternNode(nodes.AccessNode)
+
+    @staticmethod
+    def expressions():
+        return [
+            sdutil.node_path_graph(RedundantReadSlice.in_array,
+                                   RedundantReadSlice.out_array)
+        ]
+
+    @staticmethod
+    def can_be_applied(graph, candidate, expr_index, sdfg, strict=False):
+        in_array = graph.nodes()[candidate[RedundantReadSlice.in_array]]
+        out_array = graph.nodes()[candidate[RedundantReadSlice.out_array]]
+
+        in_desc = in_array.desc(sdfg)
+        out_desc = out_array.desc(sdfg)
+
+        # Make sure that both arrays are using the same storage location.
+        if in_desc.storage != out_desc.storage:
+            return False
+
+        # The match must be Array -> View
+        if not(isinstance(in_desc, data.Array) and not
+               isinstance(in_desc, data.View)):
+            return False
+        if not isinstance(out_desc, data.View):
+            return False
+
+        # Ensure in degree is one (only one source, which is in_array)
+        if graph.in_degree(out_array) != 1:
+            return False
+
+        # The match must be Array -> View(Array), i.e.,
+        # the View must point to the Array. Find the true out_desc.
+        true_out_array = sdutil.get_last_view_node(graph, out_array)
+        if not true_out_array:
+            return False
+        if true_out_array is not in_array:
+            return False
+
+        # Ensure that the View is a slice of the Array.
+        if not _is_slice(in_desc, out_desc):
+            return False
+
+        # Get edge e1 and extract subsets for the Array and View
+        e = graph.edges_between(in_array, out_array)[0]
+        a_subset = e.data.get_src_subset(e, graph)
+        v_subset = e.data.get_dst_subset(e, graph)
+
+        # Make sure the memlet covers the removed View.
+        # NOTE: Since we assume that the View is a slice of the Array, the
+        # following must hold:
+        # a_subset.size() == v_subset.size() == out_desc.shape
+        if not (a_subset and v_subset):
+            return False
+        for subset in (a_subset, v_subset):
+            if len(subset) != len(out_desc.shape):
+                return False
+            if any(m != a for m, a in zip(subset.size(), out_desc.shape)):
+                return False
+
+        return True
+
+    @staticmethod
+    def match_to_str(graph, candidate):
+        out_array = graph.nodes()[candidate[RedundantReadSlice.out_array]]
+
+        return "Remove " + str(out_array)
+
+    def apply(self, sdfg):
+        def gnode(nname):
+            return graph.nodes()[self.subgraph[nname]]
+
+        graph = sdfg.nodes()[self.state_id]
+        in_array = gnode(RedundantReadSlice.in_array)
+        out_array = gnode(RedundantReadSlice.out_array)
+        in_desc = sdfg.arrays[in_array.data]
+        out_desc = sdfg.arrays[out_array.data]
+
+        # We assume the following pattern: A -- e1 --> V(A) -- e2 --> others
+
+        # Get edge e1 and extract subsets for the Array and View
+        e1 = graph.edges_between(in_array, out_array)[0]
+        # a_subset, v1_subset = _validate_subsets(e1, sdfg.arrays)
+        a_subset = e1.data.get_src_subset(e1, graph)
+        v1_subset = e1.data.get_dst_subset(e1, graph)
+
+        # Split the dimensions of A to sliced and non-viewed
+        sliced_dims = _sliced_dims(in_desc, out_desc)
+        nviewed_dims = [i for i in range(len(in_desc.shape))
+                        if i not in sliced_dims]
+        aset, popped = pop_dims(a_subset, nviewed_dims)
+
+        # Iterate over the e2 edges and traverse the memlet tree
+        for e2 in graph.out_edges(out_array):
+            path = graph.memlet_tree(e2)
+            wcr = e1.data.wcr
+            wcr_nonatomic = e1.data.wcr_nonatomic
+            for e3 in path:
+                # Extract subsets for view V and others
+                v3_subset, other_subset = _validate_subsets(
+                    e3, sdfg.arrays, src_name=out_array.data)
+                # Modify memlet to match array A. Example:
+                # A -- (0, a:b)/(c:c+b) --> V -- (c+d)/None --> others
+                # A -- (0, a+d)/None --> others
+                e3.data.data = in_array.data
+                # (c+d) - (c:c+b) = (d)
+                v3_subset.offset(v1_subset, negative=True)
+                # (0, a:b)(d) = (0, a+d) (or offset for indices)
+
+                vset = v3_subset
+
+                e3.data.subset = compose_and_push_back(aset, vset,
+                                                       nviewed_dims, popped)
+                # NOTE: This fixes the following case:
+                # A ----> A[subset] ----> ... -----> Tasklet
+                # Tasklet is not data, so it doesn't have an other subset.
+                if isinstance(e3.dst, nodes.AccessNode):
+                    e3.data.other_subset = other_subset
+                else:
+                    e3.data.other_subset = None
+                wcr = wcr or e3.data.wcr
+                wcr_nonatomic = wcr_nonatomic or e3.data.wcr_nonatomic
+                e3.data.wcr = wcr
+                e3.data.wcr_nonatomic = wcr_nonatomic
+
+            # Remove edge and add new one
+            graph.remove_edge(e2)
+            e2.data.wcr = wcr
+            e2.data.wcr_nonatomic = wcr_nonatomic
+            graph.add_edge(in_array, e2.src_conn, e2.dst, e2.dst_conn, e2.data)
+
+        # Finally, remove out_array node
+        graph.remove_node(out_array)
+        if out_array.data in sdfg.arrays:
+            try:
+                sdfg.remove_data(out_array.data)
+            except ValueError:  # Already in use (e.g., with Views)
+                pass
+
+
+@registry.autoregister_params(singlestate=True, strict=True)
+class RedundantWriteSlice(pm.Transformation):
+    """ Detects patterns of the form View(Array) -> Array and removes
+    the View if it is a slice. """
+
+    in_array = pm.PatternNode(nodes.AccessNode)
+    out_array = pm.PatternNode(nodes.AccessNode)
+
+    @staticmethod
+    def expressions():
+        return [
+            sdutil.node_path_graph(RedundantWriteSlice.in_array,
+                                   RedundantWriteSlice.out_array)
+        ]
+
+    @staticmethod
+    def can_be_applied(graph, candidate, expr_index, sdfg, strict=False):
+        in_array = graph.nodes()[candidate[RedundantWriteSlice.in_array]]
+        out_array = graph.nodes()[candidate[RedundantWriteSlice.out_array]]
+
+        in_desc = in_array.desc(sdfg)
+        out_desc = out_array.desc(sdfg)
+
+        # Make sure that both arrays are using the same storage location.
+        if in_desc.storage != out_desc.storage:
+            return False
+
+        # The match must be View -> Array
+        if not(isinstance(out_desc, data.Array) and not
+               isinstance(out_desc, data.View)):
+            return False
+        if not isinstance(in_desc, data.View):
+            return False
+
+        # Ensure out degree is one (only one target, which is out_array)
+        if graph.out_degree(in_array) != 1:
+            return False
+
+        # The match must be View(Array) -> Array , i.e.,
+        # the View must point to the Array. Find the true in_desc.
+        true_in_array = sdutil.get_last_view_node(graph, in_array)
+        if not true_in_array:
+            return False
+        if true_in_array is not out_array:
+            return False
+
+        # Ensure that the View is a slice of the Array.
+        if not _is_slice(out_desc, in_desc):
+            return False
+
+        # Get edge e1 and extract subsets for the Array and View
+        e = graph.edges_between(in_array, out_array)[0]
+        v_subset = e.data.get_src_subset(e, graph)
+        a_subset = e.data.get_dst_subset(e, graph)
+
+        # Make sure the memlet covers the removed View.
+        # NOTE: Since we assume that the View is a slice of the Array, the
+        # following must hold:
+        # a_subset.size() == v_subset.size() == in_desc.shape
+        if not (a_subset and v_subset):
+            return False
+        for subset in (a_subset, v_subset):
+            if len(subset) != len(in_desc.shape):
+                return False
+            if any(m != a for m, a in zip(subset.size(), in_desc.shape)):
+                return False
+
+        return True
+
+    @staticmethod
+    def match_to_str(graph, candidate):
+        in_array = graph.nodes()[candidate[RedundantWriteSlice.in_array]]
+
+        return "Remove " + str(in_array)
+
+    def apply(self, sdfg):
+        def gnode(nname):
+            return graph.nodes()[self.subgraph[nname]]
+
+        graph = sdfg.nodes()[self.state_id]
+        in_array = gnode(RedundantWriteSlice.in_array)
+        out_array = gnode(RedundantWriteSlice.out_array)
+        in_desc = sdfg.arrays[in_array.data]
+        out_desc = sdfg.arrays[out_array.data]
+
+        # We assume the following pattern: others -- e2 --> V(A) -- e1 --> A
+
+        # Get edge e1 and extract subsets for the Array and View
+        e1 = graph.edges_between(in_array, out_array)[0]
+        v1_subset = e1.data.get_src_subset(e1, graph)
+        a_subset = e1.data.get_dst_subset(e1, graph)
+
+        # Split the dimensions of A to sliced and non-viewed
+        sliced_dims = _sliced_dims(out_desc, in_desc)
+        nviewed_dims = [i for i in range(len(out_desc.shape))
+                        if i not in sliced_dims]
+        aset, popped = pop_dims(a_subset, nviewed_dims)
+
+        # Iterate over the e2 edges and traverse the memlet tree
+        for e2 in graph.in_edges(in_array):
+            path = graph.memlet_tree(e2)
+            wcr = e1.data.wcr
+            wcr_nonatomic = e1.data.wcr_nonatomic
+            for e3 in path:
+                # Extract subsets for view V and others
+                other_subset, v3_subset = _validate_subsets(
+                    e3, sdfg.arrays, dst_name=in_array.data)
+                # Modify memlet to match array A.
+                e3.data.data = out_array.data
+                v3_subset.offset(v1_subset, negative=True)
+
+                vset = v3_subset
+
+                e3.data.subset = compose_and_push_back(aset, vset,
+                                                       nviewed_dims, popped)
+                # NOTE: This fixes the following case:
+                # Tasklet ----> A[subset] ----> ... -----> A
+                # Tasklet is not data, so it doesn't have an other subset.
+                if isinstance(e3.src, nodes.AccessNode):
+                    e3.data.other_subset = other_subset
+                else:
+                    e3.data.other_subset = None
+                wcr = wcr or e3.data.wcr
+                wcr_nonatomic = wcr_nonatomic or e3.data.wcr_nonatomic
+                e3.data.wcr = wcr
+                e3.data.wcr_nonatomic = wcr_nonatomic
+
+            # Remove edge and add new one
+            graph.remove_edge(e2)
+            e2.data.wcr = wcr
+            e2.data.wcr_nonatomic = wcr_nonatomic
+            graph.add_edge(e2.src, e2.src_conn, out_array, e2.dst_conn, e2.data)
+
+        # Finally, remove in_array node
+        graph.remove_node(in_array)
+        if in_array.data in sdfg.arrays:
+            try:
+                sdfg.remove_data(in_array.data)
+            except ValueError:  # Already in use (e.g., with Views)
+                pass

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -170,8 +170,8 @@ class LoopToMap(DetectLoop):
                         # variable. The iteration variable must be used.
                         if e.data.wcr is None:
                             dst_subset = e.data.get_dst_subset(e, state)
-                            if not _check_range(dst_subset, a, itersym, b,
-                                                step):
+                            if not (dst_subset and _check_range(
+                                        dst_subset, a, itersym, b, step)):
                                 return False
                         # End of check
 

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -363,6 +363,8 @@ class StateFusion(transformation.Transformation):
                                     nodes_first = [
                                         n for n in first_input if n.data == d
                                     ]
+                                else:
+                                    nodes_first = []
                                 for n2 in nodes_second:
                                     for e in second_state.in_edges(n2):
                                         path = second_state.memlet_path(e)

--- a/tests/transformations/redundant_slices_test.py
+++ b/tests/transformations/redundant_slices_test.py
@@ -10,8 +10,8 @@ from dace.transformation.dataflow import RedundantReadSlice, RedundantWriteSlice
 def _count_views(sdfg: dace.SDFG) -> int:
     num = 0
     for n, _ in sdfg.all_nodes_recursive():
-        if (isinstance(n, nodes.AccessNode) and
-                isinstance(sdfg.arrays[n.data], data.View)):
+        if (isinstance(n, nodes.AccessNode)
+                and isinstance(sdfg.arrays[n.data], data.View)):
             num += 1
     return num
 
@@ -34,6 +34,24 @@ def test_read_slice():
 
 
 @dace.program
+def jacobi1d_half2(TMAX: dace.int32, A: dace.float32[12, 12, 12],
+                   B: dace.float32[12]):
+    for _ in range(TMAX):
+        B[1:-1] = 0.3333 * (A[:-2, 3, 4] + A[5, 1:-1, 6] + A[7, 8, 2:])
+
+
+def test_read_slice2():
+    sdfg = jacobi1d_half2.to_sdfg(strict=False)
+    num_views_before = _count_views(sdfg)
+    if num_views_before != 3:
+        warnings.Warn("Incorrect number of Views detected. Please ensure that "
+                      "the test is compatible with this DaCe version.")
+    sdfg.apply_transformations_repeated(RedundantReadSlice)
+    num_views_after = _count_views(sdfg)
+    assert (num_views_after == 0)
+
+
+@dace.program
 def write_slice(A: dace.float32[10]):
     B = A[2:8]
     B[:] = np.pi
@@ -41,18 +59,38 @@ def write_slice(A: dace.float32[10]):
 
 def test_write_slice():
     sdfg = write_slice.to_sdfg(strict=False)
-    sdfg.save('test_before.sdfg')
     num_views_before = _count_views(sdfg)
     if num_views_before == 0:
         warnings.Warn("Incorrect number of Views detected. Please ensure that "
                       "the test is compatible with this DaCe version.")
-    print(num_views_before)
     sdfg.apply_transformations_repeated(RedundantWriteSlice)
-    sdfg.save('test_after.sdfg')
+    num_views_after = _count_views(sdfg)
+    assert (num_views_after == 0)
+
+
+@dace.program
+def write_slice2(A: dace.float32[10, 10, 10]):
+    B1 = A[2:8, 3, 4]
+    B2 = A[5, 2:8, 6]
+    B3 = A[7, 8, 2:8]
+    B1[:] = np.pi
+    B2[:] = np.pi
+    B3[:] = np.pi
+
+
+def test_write_slice2():
+    sdfg = write_slice2.to_sdfg(strict=False)
+    num_views_before = _count_views(sdfg)
+    if num_views_before == 0:
+        warnings.Warn("Incorrect number of Views detected. Please ensure that "
+                      "the test is compatible with this DaCe version.")
+    sdfg.apply_transformations_repeated(RedundantWriteSlice)
     num_views_after = _count_views(sdfg)
     assert (num_views_after == 0)
 
 
 if __name__ == '__main__':
     test_read_slice()
+    test_read_slice2()
     test_write_slice()
+    test_write_slice2()

--- a/tests/transformations/redundant_slices_test.py
+++ b/tests/transformations/redundant_slices_test.py
@@ -1,0 +1,58 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import numpy as np
+import warnings
+
+import dace
+from dace import data, nodes
+from dace.transformation.dataflow import RedundantReadSlice, RedundantWriteSlice
+
+
+def _count_views(sdfg: dace.SDFG) -> int:
+    num = 0
+    for n, _ in sdfg.all_nodes_recursive():
+        if (isinstance(n, nodes.AccessNode) and
+                isinstance(sdfg.arrays[n.data], data.View)):
+            num += 1
+    return num
+
+
+@dace.program
+def jacobi1d_half(TMAX: dace.int32, A: dace.float32[12], B: dace.float32[12]):
+    for _ in range(TMAX):
+        B[1:-1] = 0.3333 * (A[:-2] + A[1:-1] + A[2:])
+
+
+def test_read_slice():
+    sdfg = jacobi1d_half.to_sdfg(strict=False)
+    num_views_before = _count_views(sdfg)
+    if num_views_before != 3:
+        warnings.Warn("Incorrect number of Views detected. Please ensure that "
+                      "the test is compatible with this DaCe version.")
+    sdfg.apply_transformations_repeated(RedundantReadSlice)
+    num_views_after = _count_views(sdfg)
+    assert (num_views_after == 0)
+
+
+@dace.program
+def write_slice(A: dace.float32[10]):
+    B = A[2:8]
+    B[:] = np.pi
+
+
+def test_write_slice():
+    sdfg = write_slice.to_sdfg(strict=False)
+    sdfg.save('test_before.sdfg')
+    num_views_before = _count_views(sdfg)
+    if num_views_before == 0:
+        warnings.Warn("Incorrect number of Views detected. Please ensure that "
+                      "the test is compatible with this DaCe version.")
+    print(num_views_before)
+    sdfg.apply_transformations_repeated(RedundantWriteSlice)
+    sdfg.save('test_after.sdfg')
+    num_views_after = _count_views(sdfg)
+    assert (num_views_after == 0)
+
+
+if __name__ == '__main__':
+    test_read_slice()
+    test_write_slice()


### PR DESCRIPTION
This PR introduces the RedundantReadSlice and RedundantWriteSlice transformations. We define slices as DaCe Views of DaCe Arrays following the same semantics as NumPy Views generated by slicing NumPy Arrays with basic indexing. The new transformations are essentially simplified versions of RedundantArray and RedundantSecondArray with much stricter constraints. Furthermore, `SDFG.apply_strict_transformations` makes a first pass over the new transformations (only) in order to simplify the graph as much as possible before continuing with the other strict transformations.