### PR TITLE
Copy on self-assignment with partial overlap

### DIFF
--- a/tests/numpy/copies_and_views_test.py
+++ b/tests/numpy/copies_and_views_test.py
@@ -127,8 +127,8 @@ def test_needs_view():
     sdfg = selfcopy.to_sdfg()
     for s in sdfg.all_sdfgs_recursive():
         assert not any(
-            isinstance(d, data.Array) and d.transient and d.shape == (3,)
-            for d in s.arrays.values())
+            isinstance(d, data.Array) and not isinstance(d, data.View)
+            and d.transient and d.shape == (3,) for d in s.arrays.values())
 
 
 def test_needs_copy():
@@ -146,8 +146,8 @@ def test_needs_copy():
     found_copy = False
     for s in sdfg.all_sdfgs_recursive():
         found_copy |= any(
-            isinstance(d, data.Array) and d.transient and d.shape == (3,)
-            for d in s.arrays.values())
+            isinstance(d, data.Array)  and not isinstance(d, data.View)
+            and d.transient and d.shape == (3,) for d in s.arrays.values())
     assert found_copy
 
 


### PR DESCRIPTION
This PR generates data copies on self-assignments with partial overlap of the read and write subsets. Examples:
- `q[3 + j, 4 + i, 0:3] = q[3 - i + 1, 4 + j, 0:3]` will result in Array q -> View q_0 -> Array q
- `q[3 + j, 4 + i, 0:3] = q[3 - i + 1, 4 + j, 1:4]` will result in Array q -> View q_0 -> Transient q_0_0 -> Array q
