### PR TITLE
Refine nested access after loop2map

### DIFF
--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -14,7 +14,7 @@ import warnings
 
 # Transformations
 from dace.transformation.dataflow import MapCollapse, TrivialMapElimination, MapFusion
-from dace.transformation.interstate import LoopToMap
+from dace.transformation.interstate import LoopToMap, RefineNestedAccess
 from dace.transformation.subgraph.composite import CompositeFusion
 from dace.transformation.subgraph import ReduceExpansion
 from dace.transformation.subgraph import helpers as xfsh
@@ -110,7 +110,8 @@ def greedy_fuse(graph_or_subgraph: GraphViewType,
             if expand_reductions:
                 for graph in sdfg.nodes():
                     for node in graph.nodes():
-                        if isinstance(node, dace.libraries.standard.nodes.Reduce):
+                        if isinstance(node,
+                                      dace.libraries.standard.nodes.Reduce):
                             try:
                                 ReduceExpansion.apply_to(sdfg, _reduce=node)
                             except ValueError as e:
@@ -119,7 +120,7 @@ def greedy_fuse(graph_or_subgraph: GraphViewType,
             fusion_condition.expansion_split = not permutations_only
 
         condition_function = lambda sdfg, subgraph: fusion_condition.can_be_applied(
-                                                    sdfg, subgraph)
+            sdfg, subgraph)
         enumerator = GreedyEnumerator(sdfg,
                                       graph,
                                       subgraph,
@@ -428,7 +429,9 @@ def set_fast_implementations(sdfg: SDFG,
         if isinstance(node, nodes.LibraryNode):
             for impl in implementation_prio:
                 if impl in node.implementations:
-                    if isinstance(node, dace.libraries.standard.nodes.reduce.Reduce) and node.implementation == 'CUDA (block)':
+                    if isinstance(node,
+                                  dace.libraries.standard.nodes.reduce.Reduce
+                                  ) and node.implementation == 'CUDA (block)':
                         continue
                     node.implementation = impl
                     break
@@ -513,10 +516,11 @@ def auto_optimize(sdfg: SDFG,
                                           validate_all=validate_all)
         for s in sdfg.sdfg_list:
             xfh.split_interstate_edges(s)
-        l2ms = sdfg.apply_transformations_repeated(LoopToMap,
-                                                   strict=True,
-                                                   validate=False,
-                                                   validate_all=validate_all)
+        l2ms = sdfg.apply_transformations_repeated(
+            (LoopToMap, RefineNestedAccess),
+            strict=True,
+            validate=False,
+            validate_all=validate_all)
         transformed = l2ms > 0
 
     # Collapse maps and eliminate trivial dimensions
@@ -604,7 +608,6 @@ def auto_optimize(sdfg: SDFG,
 
     # Set all Default storage types that are constant sized to registers
     move_small_arrays_to_stack(sdfg)
-
     '''
     # Fix storage and allocation properties, e.g., for benchmarking purposes
     # FORNOW: Leave out

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -1115,6 +1115,9 @@ class RefineNestedAccess(transformation.Transformation):
         _offset_refine(torefine_in, state.in_edges_by_connector)
         _offset_refine(torefine_out, state.out_edges_by_connector)
 
+        # Propagate State Memlets
+        propagation.propagate_memlets_state(sdfg, state)
+
 
 @registry.autoregister
 @make_properties

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -1115,7 +1115,7 @@ class RefineNestedAccess(transformation.Transformation):
         _offset_refine(torefine_in, state.in_edges_by_connector)
         _offset_refine(torefine_out, state.out_edges_by_connector)
 
-        # Propagate State Memlets
+        # Propagate the State Memlets
         propagation.propagate_memlets_state(sdfg, state)
 
 


### PR DESCRIPTION
The LoopToMap transformation may create a nested SDFG for the loop-body that has input and output the whole range of each read or written array. Using the entire range of an array may prohibit further optimizations. This PR overcomes this issue by having the auto-optimizer use LoopToMap in conjunction with RefinedNestedAccess.