### PR TITLE
Work around bug introduced by using sympy 1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='dace',
       },
       include_package_data=True,
       install_requires=[
-          'numpy', 'networkx >= 2.5', 'astunparse', 'sympy', 'pyyaml', 'ply',
+          'numpy', 'networkx >= 2.5', 'astunparse', 'sympy<1.9', 'pyyaml', 'ply',
           'websockets', 'requests', 'flask', 'scikit-build', 'cmake', 'aenum',
           'dataclasses; python_version < "3.7"', 'dill', 'pyreadline;platform_system=="Windows"'
       ],


### PR DESCRIPTION
It appears that dace uses some internals of `sympy`, so the introduction of version 1.9 breaks `dace`. This issue was unfortunately uncovered via the `gt4py` continuous integration tests. If `dace` is using/abusing internals of sympy it should really pin a major version so as to not fall victim to these issues.

Specifically, it appears that `__getstate__()` now returns `None` instead of an empty iterator.

```
    def __getstate__(self):
>       return dict(
            super().__getstate__(), **{
                'value': self.value,
                'dtype': self.dtype,
                '_constraints': self._constraints
            })
E       TypeError: 'NoneType' object is not iterable
```
