### PR TITLE
FIx for #864

### DIFF
--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -1736,7 +1736,7 @@ def _array_const_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_type = dtypes.DTYPE_TO_TYPECLASS[type(right_operand)]
         right_shape = [1]
         arguments = [left_arr, right_operand]
-        tasklet_args = ['__in1', str(right_operand)]
+        tasklet_args = ['__in1', f'({str(right_operand)})']
     else:
         left_arr = None
         left_type = dtypes.DTYPE_TO_TYPECLASS[type(left_operand)]
@@ -1746,7 +1746,7 @@ def _array_const_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_shape = right_arr.shape
         storage = right_arr.storage
         arguments = [left_operand, right_arr]
-        tasklet_args = [str(left_operand), '__in2']
+        tasklet_args = [f'({str(left_operand)})', '__in2']
 
     result_type, casting = _result_type(arguments, operator)
     left_cast = casting[0]
@@ -1819,7 +1819,7 @@ def _array_sym_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_type = _sym_type(right_operand)
         right_shape = [1]
         arguments = [left_arr, right_operand]
-        tasklet_args = ['__in1', astutils.unparse(right_operand)]
+        tasklet_args = ['__in1', f'({astutils.unparse(right_operand)})']
     else:
         left_arr = None
         left_type = _sym_type(left_operand)
@@ -1829,7 +1829,7 @@ def _array_sym_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_shape = right_arr.shape
         storage = right_arr.storage
         arguments = [left_operand, right_arr]
-        tasklet_args = [astutils.unparse(left_operand), '__in2']
+        tasklet_args = [f'({astutils.unparse(left_operand)})', '__in2']
 
     result_type, casting = _result_type(arguments, operator)
     left_cast = casting[0]
@@ -1947,7 +1947,7 @@ def _scalar_const_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_scal = None
         right_type = dtypes.DTYPE_TO_TYPECLASS[type(right_operand)]
         arguments = [left_scal, right_operand]
-        tasklet_args = ['__in1', str(right_operand)]
+        tasklet_args = ['__in1', f'({str(right_operand)})']
     else:
         left_scal = None
         left_type = dtypes.DTYPE_TO_TYPECLASS[type(left_operand)]
@@ -1955,7 +1955,7 @@ def _scalar_const_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_type = right_scal.dtype
         storage = right_scal.storage
         arguments = [left_operand, right_scal]
-        tasklet_args = [str(left_operand), '__in2']
+        tasklet_args = [f'({str(left_operand)})', '__in2']
 
     result_type, casting = _result_type(arguments, operator)
     left_cast = casting[0]
@@ -2011,7 +2011,7 @@ def _scalar_sym_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_scal = None
         right_type = _sym_type(right_operand)
         arguments = [left_scal, right_operand]
-        tasklet_args = ['__in1', astutils.unparse(right_operand)]
+        tasklet_args = ['__in1', f'({astutils.unparse(right_operand)})']
     else:
         left_scal = None
         left_type = _sym_type(left_operand)
@@ -2019,7 +2019,7 @@ def _scalar_sym_binop(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState,
         right_type = right_scal.dtype
         storage = right_scal.storage
         arguments = [left_operand, right_scal]
-        tasklet_args = [astutils.unparse(left_operand), '__in2']
+        tasklet_args = [f'({astutils.unparse(left_operand)})', '__in2']
 
     result_type, casting = _result_type(arguments, operator)
     left_cast = casting[0]


### PR DESCRIPTION
Adds missing parentheses to the tasklet code of binary operations with symbols or constants. Fixes #864.