### PR TITLE
Nested access offset fix

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -717,7 +717,11 @@ class TaskletTransformer(ExtNodeTransformer):
                         # NOTE: The code takes into account the case where an
                         # index is dependent on multiple symbols. See also
                         # tests/python_frontend/nested_name_accesses_test.py.
-                        repl_dict[s] = sr[0][0]
+                        step = sr[0][2]
+                        if (step < 0) == True:
+                            repl_dict[s] = sr[0][1]
+                        else:
+                            repl_dict[s] = sr[0][0]
                 offset.append(r[0].subs(repl_dict))
 
             if ignore_indices:
@@ -738,6 +742,8 @@ class TaskletTransformer(ExtNodeTransformer):
             shape = squeezed_rng.size()
             for i, sr in zip(ignore_indices, sym_rng):
                 iMin, iMax, step = sr.ranges[0]
+                if (step < 0) == True:
+                    iMin, iMax, step = iMax, iMin, -step
                 ts = to_squeeze_rng.tile_sizes[i]
                 sqz_idx = squeezed_rng.ranges.index(to_squeeze_rng.ranges[i])
                 shape[sqz_idx] = ts * sympy.ceiling(
@@ -2972,8 +2978,15 @@ class ProgramVisitor(ExtNodeVisitor):
                         # NOTE: The code takes into account the case where an
                         # index is dependent on multiple symbols. See also
                         # tests/python_frontend/nested_name_accesses_test.py.
-                        repl_dict[s] = sr[0][0]
-                offset.append(r[0].subs(repl_dict))
+                        step = sr[0][2]
+                        if (step < 0) == True:
+                            repl_dict[s] = sr[0][1]
+                        else:
+                            repl_dict[s] = sr[0][0]
+                if repl_dict:
+                    offset.append(r[0].subs(repl_dict))
+                else:
+                    offset.append(0)
 
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)
@@ -2992,6 +3005,8 @@ class ProgramVisitor(ExtNodeVisitor):
             shape = squeezed_rng.size()
             for i, sr in zip(ignore_indices, sym_rng):
                 iMin, iMax, step = sr.ranges[0]
+                if (step < 0) == True:
+                    iMin, iMax, step = iMax, iMin, -step
                 ts = to_squeeze_rng.tile_sizes[i]
                 sqz_idx = squeezed_rng.ranges.index(to_squeeze_rng.ranges[i])
                 shape[sqz_idx] = ts * sympy.ceiling(

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -694,11 +694,30 @@ class TaskletTransformer(ExtNodeTransformer):
         else:
             ignore_indices = []
             sym_rng = []
+            offset = []
             for i, r in enumerate(rng):
                 for s, sr in self.symbols.items():
                     if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
                         sym_rng.append(sr)
+                        # NOTE: Assume that the i-th index of the range is
+                        # dependent on a local symbol s, i.e, rng[i] = f(s).
+                        # Therefore, the i-th index will not be squeezed
+                        # even if it has length equal to 1. However, it must
+                        # still be offsetted by f(min(sr)), so that the indices
+                        # for the squeezed connector start from 0.
+                        # Example:
+                        # Memlet range: [i+1, j, k+1]
+                        # k: local symbol with range(1, 4)
+                        # i,j: global symbols
+                        # Squeezed range: [f(k)] = [k+1]
+                        # Offset squeezed range: [f(k)-f(min(range(1, 4)))] =
+                        #                        [f(k)-f(1)] = [k-1]
+                        # See also
+                        # tests/python_frontend/nested_name_accesses_test.py.
+                        offset.append(r[0].subs({s:sr[0][0]}))
+                    else:
+                        offset.append(0)
 
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)
@@ -709,14 +728,17 @@ class TaskletTransformer(ExtNodeTransformer):
                                                   r,
                                                   use_dst=use_dst)
 
-            squeezed_rng = copy.deepcopy(rng)
+            to_squeeze_rng = rng
+            if ignore_indices:
+                to_squeeze_rng = rng.offset_new(offset, True)
+            squeezed_rng = copy.deepcopy(to_squeeze_rng)
             non_squeezed = squeezed_rng.squeeze(ignore_indices)
             # TODO: Need custom shape computation here
             shape = squeezed_rng.size()
             for i, sr in zip(ignore_indices, sym_rng):
                 iMin, iMax, step = sr.ranges[0]
-                ts = rng.tile_sizes[i]
-                sqz_idx = squeezed_rng.ranges.index(rng.ranges[i])
+                ts = to_squeeze_rng.tile_sizes[i]
+                sqz_idx = squeezed_rng.ranges.index(to_squeeze_rng.ranges[i])
                 shape[sqz_idx] = ts * sympy.ceiling(
                     ((iMax.approx
                       if isinstance(iMax, symbolic.SymExpr) else iMax) + 1 -
@@ -2926,11 +2948,30 @@ class ProgramVisitor(ExtNodeVisitor):
         else:
             ignore_indices = []
             sym_rng = []
+            offset = []
             for i, r in enumerate(rng):
                 for s, sr in self.symbols.items():
                     if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
                         sym_rng.append(sr)
+                        # NOTE: Assume that the i-th index of the range is
+                        # dependent on a local symbol s, i.e, rng[i] = f(s).
+                        # Therefore, the i-th index will not be squeezed
+                        # even if it has length equal to 1. However, it must
+                        # still be offsetted by f(min(sr)), so that the indices
+                        # for the squeezed connector start from 0.
+                        # Example:
+                        # Memlet range: [i+1, j, k+1]
+                        # k: local symbol with range(1, 4)
+                        # i,j: global symbols
+                        # Squeezed range: [f(k)] = [k+1]
+                        # Offset squeezed range: [f(k)-f(min(range(1, 4)))] =
+                        #                        [f(k)-f(1)] = [k-1]
+                        # See also
+                        # tests/python_frontend/nested_name_accesses_test.py.
+                        offset.append(r[0].subs({s:sr[0][0]}))
+                    else:
+                        offset.append(0)
 
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)
@@ -2940,15 +2981,17 @@ class ProgramVisitor(ExtNodeVisitor):
                                                   parent_array, [s],
                                                   r,
                                                   use_dst=use_dst)
-
-            squeezed_rng = copy.deepcopy(rng)
+            to_squeeze_rng = rng
+            if ignore_indices:
+                to_squeeze_rng = rng.offset_new(offset, True)
+            squeezed_rng = copy.deepcopy(to_squeeze_rng)
             non_squeezed = squeezed_rng.squeeze(ignore_indices)
             # TODO: Need custom shape computation here
             shape = squeezed_rng.size()
             for i, sr in zip(ignore_indices, sym_rng):
                 iMin, iMax, step = sr.ranges[0]
-                ts = rng.tile_sizes[i]
-                sqz_idx = squeezed_rng.ranges.index(rng.ranges[i])
+                ts = to_squeeze_rng.tile_sizes[i]
+                sqz_idx = squeezed_rng.ranges.index(to_squeeze_rng.ranges[i])
                 shape[sqz_idx] = ts * sympy.ceiling(
                     ((iMax.approx
                       if isinstance(iMax, symbolic.SymExpr) else iMax) + 1 -

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -696,6 +696,7 @@ class TaskletTransformer(ExtNodeTransformer):
             sym_rng = []
             offset = []
             for i, r in enumerate(rng):
+                repl_dict = {}
                 for s, sr in self.symbols.items():
                     if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
@@ -713,11 +714,11 @@ class TaskletTransformer(ExtNodeTransformer):
                         # Squeezed range: [f(k)] = [k+1]
                         # Offset squeezed range: [f(k)-f(min(range(1, 4)))] =
                         #                        [f(k)-f(1)] = [k-1]
-                        # See also
+                        # NOTE: The code takes into account the case where an
+                        # index is dependent on multiple symbols. See also
                         # tests/python_frontend/nested_name_accesses_test.py.
-                        offset.append(r[0].subs({s:sr[0][0]}))
-                    else:
-                        offset.append(0)
+                        repl_dict[s] = sr[0][0]
+                offset.append(r[0].subs(repl_dict))
 
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)
@@ -2950,6 +2951,7 @@ class ProgramVisitor(ExtNodeVisitor):
             sym_rng = []
             offset = []
             for i, r in enumerate(rng):
+                repl_dict = {}
                 for s, sr in self.symbols.items():
                     if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
@@ -2967,11 +2969,11 @@ class ProgramVisitor(ExtNodeVisitor):
                         # Squeezed range: [f(k)] = [k+1]
                         # Offset squeezed range: [f(k)-f(min(range(1, 4)))] =
                         #                        [f(k)-f(1)] = [k-1]
-                        # See also
+                        # NOTE: The code takes into account the case where an
+                        # index is dependent on multiple symbols. See also
                         # tests/python_frontend/nested_name_accesses_test.py.
-                        offset.append(r[0].subs({s:sr[0][0]}))
-                    else:
-                        offset.append(0)
+                        repl_dict[s] = sr[0][0]
+                offset.append(r[0].subs(repl_dict))
 
             if ignore_indices:
                 tmp_memlet = Memlet.simple(parent_name, rng)

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -109,9 +109,49 @@ def test_nested_multi_offset_access_dappy():
     assert(np.allclose(out, ref))
 
 
+def test_nested_dec_offset_access():
+
+    @dc.program
+    def nested_offset_access(inp: dc.float64[6, 5, 5]):
+        out = np.zeros((5, 5, 5), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i+1, j, 1] + inp[i, j, 1])
+            for k in range(3, 0, -1):
+                out[i, j, k] = 0.25 * (inp[i+1, j, k+1] + inp[i, j, k+1])
+        return out
+
+    inp = np.reshape(np.arange(6*5*5, dtype=np.float64), (6, 5, 5)).copy()
+    out = nested_offset_access(inp)
+    ref = nested_offset_access.f(inp)
+    assert(np.allclose(out, ref))
+
+
+def test_nested_dec_offset_access_dappy():
+
+    @dc.program
+    def nested_offset_access(inp: dc.float64[6, 5, 5]):
+        out = np.zeros((5, 5, 5), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i+1, j, 1] + inp[i, j, 1])
+            for k in range(3, 0, -1):
+                with dc.tasklet():
+                    in1 << inp[i+1, j, k+1]
+                    in2 << inp[i, j, k+1]
+                    out1 >> out[i, j, k]
+                    out1 = 0.25 * (in1 + in2)
+        return out
+
+    inp = np.reshape(np.arange(6*5*5, dtype=np.float64), (6, 5, 5)).copy()
+    out = nested_offset_access(inp)
+    ref = nested_offset_access.f(inp)
+    assert(np.allclose(out, ref))
+
+
 if __name__ == "__main__":
     test_nested_name_accesses()
     test_nested_offset_access()
     test_nested_offset_access_dappy()
     test_nested_multi_offset_access()
     test_nested_multi_offset_access_dappy()
+    test_nested_dec_offset_access()
+    test_nested_dec_offset_access_dappy()

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -31,5 +31,45 @@ def test_nested_name_accesses():
     assert(rel_err < 1e-7)
 
 
+def test_nested_offset_access():
+
+    @dc.program
+    def nested_offset_access(inp: dc.float64[6, 5, 5]):
+        out = np.zeros((5, 5, 5), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i+1, j, 1] + inp[i, j, 1])
+            for k in range(1, 4):
+                out[i, j, k] = 0.25 * (inp[i+1, j, k+1] + inp[i, j, k+1])
+        return out
+
+    inp = np.reshape(np.arange(6*5*5, dtype=np.float64), (6, 5, 5)).copy()
+    out = nested_offset_access(inp)
+    ref = nested_offset_access.f(inp)
+    assert(np.allclose(out, ref))
+
+
+def test_nested_offset_access_dappy():
+
+    @dc.program
+    def nested_offset_access(inp: dc.float64[6, 5, 5]):
+        out = np.zeros((5, 5, 5), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i+1, j, 1] + inp[i, j, 1])
+            for k in range(1, 4):
+                with dc.tasklet():
+                    in1 << inp[i+1, j, k+1]
+                    in2 << inp[i, j, k+1]
+                    out1 >> out[i, j, k]
+                    out1 = 0.25 * (in1 + in2)
+        return out
+
+    inp = np.reshape(np.arange(6*5*5, dtype=np.float64), (6, 5, 5)).copy()
+    out = nested_offset_access(inp)
+    ref = nested_offset_access.f(inp)
+    assert(np.allclose(out, ref))
+
+
 if __name__ == "__main__":
     test_nested_name_accesses()
+    test_nested_offset_access()
+    test_nested_offset_access_dappy()

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -69,7 +69,49 @@ def test_nested_offset_access_dappy():
     assert(np.allclose(out, ref))
 
 
+def test_nested_multi_offset_access():
+
+    @dc.program
+    def nested_offset_access(inp: dc.float64[6, 5, 10]):
+        out = np.zeros((5, 5, 10), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i+1, j, 1] + inp[i, j, 1])
+            for k in range(1, 5):
+                for l in range(4):
+                    out[i, j, k+l] = 0.25 * (inp[i+1, j, k+l+1] + inp[i, j, k+l+1])
+        return out
+
+    inp = np.reshape(np.arange(6*5*10, dtype=np.float64), (6, 5, 10)).copy()
+    out = nested_offset_access(inp)
+    ref = nested_offset_access.f(inp)
+    assert(np.allclose(out, ref))
+
+
+def test_nested_multi_offset_access_dappy():
+
+    @dc.program
+    def nested_offset_access(inp: dc.float64[6, 5, 10]):
+        out = np.zeros((5, 5, 10), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i+1, j, 1] + inp[i, j, 1])
+            for k in range(1, 5):
+                for l in range(4):
+                    with dc.tasklet():
+                        in1 << inp[i+1, j, k+l+1]
+                        in2 << inp[i, j, k+l+1]
+                        out1 >> out[i, j, k+l]
+                        out1 = 0.25 * (in1 + in2)
+        return out
+
+    inp = np.reshape(np.arange(6*5*10, dtype=np.float64), (6, 5, 10)).copy()
+    out = nested_offset_access(inp)
+    ref = nested_offset_access.f(inp)
+    assert(np.allclose(out, ref))
+
+
 if __name__ == "__main__":
     test_nested_name_accesses()
     test_nested_offset_access()
     test_nested_offset_access_dappy()
+    test_nested_multi_offset_access()
+    test_nested_multi_offset_access_dappy()


### PR DESCRIPTION
When accessing an outer-scope array in a nested context, we must squeeze its shape and access ranges to the smallest values that we can infer. To that end, we check whether the access ranges are dependent on symbols defined locally in the nested context. We use the ranges of the local symbols to infer the "squeezed" shape of the array's connector to the local context. However, we must also offset the access indices that are dependent on those local symbols, such as that accesses to the connector start from 0. This PR introduces such offsetting in the ProgramVisitor's `_add_access` methods.