### PR TITLE
Support lambda expressions and callbacks as arguments

### DIFF
--- a/.github/workflows/general-ci.yml
+++ b/.github/workflows/general-ci.yml
@@ -37,23 +37,6 @@ jobs:
     - name: Test dependencies
       run: |
         papi_avail
-    
-    - name: Test MPI with pytest
-      run: |
-        export NOSTATUSBAR=1
-        export DACE_testing_serialization=1
-        export DACE_cache=unique
-        export DACE_optimizer_interface=" "
-        if [ "${{ matrix.strict-xforms }}" = "autoopt" ]; then
-            export DACE_optimizer_automatic_strict_transformations=1
-            export DACE_optimizer_autooptimize=1
-            echo "Auto-optimization heuristics"
-        else
-            export DACE_optimizer_automatic_strict_transformations=${{ matrix.strict-xforms }}
-        fi
-        mpirun -n 2 coverage run --source=dace --parallel-mode -m pytest --with-mpi --tb=short -m "mpi"
-        coverage combine .; coverage report; coverage xml
-        codecov
 
     - name: Test with pytest
       run: |
@@ -84,6 +67,22 @@ jobs:
             export DACE_optimizer_automatic_strict_transformations=${{ matrix.strict-xforms }}
         fi
         pytest -n 1 --cov-report=xml --cov=dace --tb=short -m "lapack"
+        codecov
+    - name: Test MPI with pytest
+      run: |
+        export NOSTATUSBAR=1
+        export DACE_testing_serialization=1
+        export DACE_cache=unique
+        export DACE_optimizer_interface=" "
+        if [ "${{ matrix.strict-xforms }}" = "autoopt" ]; then
+            export DACE_optimizer_automatic_strict_transformations=1
+            export DACE_optimizer_autooptimize=1
+            echo "Auto-optimization heuristics"
+        else
+            export DACE_optimizer_automatic_strict_transformations=${{ matrix.strict-xforms }}
+        fi
+        mpirun -n 2 coverage run --source=dace --parallel-mode -m pytest --with-mpi --tb=short -m "mpi"
+        coverage combine .; coverage report; coverage xml
         codecov
     - name: Run other tests
       run: |

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1261,7 +1261,10 @@ class DaCeKeywordRemover(ExtNodeTransformer):
              and isinstance(self.sdfg.arrays[funcname].dtype, dtypes.callback))
                 or
             (funcname in self.sdfg.symbols
-             and isinstance(self.sdfg.symbols[funcname], dtypes.callback))):
+             and isinstance(self.sdfg.symbols[funcname], dtypes.callback))
+                or
+            (funcname in self.memlets
+             and isinstance(self.memlets[funcname][3], dtypes.callback))):
             # Visit arguments without changing their types
             self.allow_casts = False
             result = self.generic_visit(node)

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -371,6 +371,9 @@ def emit_memlet_reference(dispatcher,
                                 typedef,
                                 allow_shadowing=True)
 
+    if isinstance(typedef, dtypes.typeclass):
+        return (typedef, pointer_name, expr)
+
     return (typedef + ref, pointer_name, expr)
 
 
@@ -1254,8 +1257,11 @@ class DaCeKeywordRemover(ExtNodeTransformer):
 
     def visit_Call(self, node: ast.Call):
         funcname = rname(node.func)
-        if (funcname in self.sdfg.symbols
-                and isinstance(self.sdfg.symbols[funcname], dtypes.callback)):
+        if ((funcname in self.sdfg.arrays
+             and isinstance(self.sdfg.arrays[funcname].dtype, dtypes.callback))
+                or
+            (funcname in self.sdfg.symbols
+             and isinstance(self.sdfg.symbols[funcname], dtypes.callback))):
             # Visit arguments without changing their types
             self.allow_casts = False
             result = self.generic_visit(node)

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -855,8 +855,11 @@ class callback(typeclass):
     def __init__(self, return_types, *variadic_args):
         self.uid = next(_atomic_counter_generator())
         from dace import data
+        self.is_empty = False
         if return_types is None:
             return_types = []
+            if not variadic_args:
+                self.is_empty = True
         elif not isinstance(return_types, (list, tuple, set)):
             return_types = [return_types]
         self.dtype = self

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -97,24 +97,13 @@ def rname(node):
     if isinstance(node, ast.Call):  # form @dace.attr(...)
         if isinstance(node.func, ast.Name):
             return node.func.id
-        # Assuming isinstance(node.func, ast.Attribute) == True
-        name = node.func.attr
-        # Handle calls with submodules and methods, e.g. numpy.add.reduce
-        value = node.func.value
-        while isinstance(value, ast.Attribute):
-            name = value.attr + '.' + name
-            value = value.value
-        if isinstance(value, ast.Name):
-            name = value.id + '.' + name
-        else:
-            raise NotImplementedError("Unsupported AST {n} node nested inside "
-                                      "AST call node: {s}".format(
-                                          n=type(value), s=unparse(value)))
-        return name
+        return unparse(node.func)
     if isinstance(node, ast.FunctionDef):  # form def func(...)
         return node.name
     if isinstance(node, ast.keyword):
         return node.arg
+    if isinstance(node, ast.Lambda):
+        return unparse(node)
     try:
         if isinstance(node, ast.arg):  # form func(..., arg, ...)
             return node.arg

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -4979,7 +4979,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     rng = subsets.Range.from_indices(rng)
                 if inference:
                     rng.offset(rng, True)
-                    return self.sdfg.arrays[true_name].dtype, rng.size()
+                    return self.defined[true_name].dtype, rng.size()
                 new_name, new_rng = self._add_read_access(name, rng, node)
                 new_arr = self.sdfg.arrays[new_name]
                 full_rng = subsets.Range.from_array(new_arr)

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -58,7 +58,10 @@ class StructTransformer(ast.NodeTransformer):
 
     def visit_Call(self, node: ast.Call):
         # Struct initializer
-        name = astutils.rname(node.func)
+        try:
+            name = astutils.rname(node.func)
+        except TypeError:
+            name = None
         if name not in self._structs:
             return self.generic_visit(node)
 
@@ -981,7 +984,8 @@ def preprocess_dace_program(
 
     # Filter out callbacks that were removed after dead code elimination
     closure_resolver.closure.callbacks = {
-        k: v for k, v in closure_resolver.closure.callbacks.items()
+        k: v
+        for k, v in closure_resolver.closure.callbacks.items()
         if k in ctr.seen_calls
     }
 

--- a/tests/python_frontend/lambda_test.py
+++ b/tests/python_frontend/lambda_test.py
@@ -23,6 +23,23 @@ def test_inline_lambda_tasklet():
     assert np.allclose(A, B + C)
 
 
+def test_inline_lambda_tasklet_2():
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        for i in dace.map[0:20]:
+            with dace.tasklet:
+                a >> A[i]
+                b << B[i]
+                c << C[i]
+                a = (lambda a, b: a + b)(b, c)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(A, B + C)
+
+
 @pytest.mark.skip
 def test_inline_lambda_scalar():
     @dace.program
@@ -30,6 +47,20 @@ def test_inline_lambda_scalar():
         f = lambda a, b: a + b
         for i in dace.map[0:20]:
             A[i] = f(B[i], C[i])
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+@pytest.mark.skip
+def test_inline_lambda_scalar_2():
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        for i in dace.map[0:20]:
+            A[i] = (lambda a, b: a + b)(B[i], C[i])
 
     A = np.random.rand(20)
     B = np.random.rand(20)
@@ -52,7 +83,6 @@ def test_inline_lambda_array():
     assert np.allclose(A, B + C)
 
 
-@pytest.mark.skip
 def test_lambda_global():
     f = lambda a, b: a + b
 
@@ -67,7 +97,6 @@ def test_lambda_global():
     assert np.allclose(A, B + C)
 
 
-@pytest.mark.skip
 def test_lambda_call_jit():
     @dace.program
     def lamb(A, B, C, f):
@@ -99,10 +128,62 @@ def test_lambda_nested_call():
     assert np.allclose(A, B + C)
 
 
+@pytest.mark.skip
+def test_lambda_nested_call_inline():
+    @dace.program
+    def lamb2(A, B, C, f):
+        A[:] = f(B, C)
+
+    @dace.program
+    def lamb1(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        lamb2(A, B, C, lambda a, b: a + b)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb1(A, B, C)
+    assert np.allclose(A, B + C)
+
+
+def test_lambda_with_closure():
+    c = 4
+    f = lambda a, b: a + b * c
+
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20]):
+        C[:] = f(A, B)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C)
+    assert np.allclose(C, A + c * B)
+
+
+def test_lambda_not_parsable():
+    @dace.program
+    def lamb(A: dace.float64[20], B: dace.float64[20], C: dace.float64[20], f1,
+             f2):
+        B[:] = f1(A)
+        C[:] = f2(A)
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    C = np.random.rand(20)
+    lamb(A, B, C, lambda a: 2 * a, lambda a: 4 * a)
+    assert np.allclose(B, 2 * A)
+    assert np.allclose(C, 4 * A)
+
+
 if __name__ == '__main__':
     test_inline_lambda_tasklet()
+    test_inline_lambda_tasklet_2()
     # test_inline_lambda_scalar()
+    # test_inline_lambda_scalar_2()
     # test_inline_lambda_array()
-    # test_lambda_global()
-    # test_lambda_call_jit()
+    test_lambda_global()
+    test_lambda_call_jit()
     # test_lambda_nested_call()
+    # test_lambda_nested_call_inline()
+    test_lambda_with_closure()
+    test_lambda_not_parsable()


### PR DESCRIPTION
- [ ] When parsable, Lambda expressions should be treated as a function (inlineable)
- [x] When not parsable, Lambda expressions should be treated as callbacks
- [x] Support callbacks as arguments to `@dace.program`s