### PR TITLE
Xilinx preprocess interstate edges

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -516,9 +516,7 @@ def cpp_array_expr(sdfg,
 
     if with_brackets:
         if fpga.is_fpga_array(desc):
-            is_array_interface = desc.storage ==  dace.StorageType.FPGA_Global
-            is_output = False
-            ptrname = fpga.fpga_ptr(memlet.data, desc, sdfg, subset, is_write=is_output, is_array_interface=is_array_interface)
+            ptrname = fpga.fpga_ptr(memlet.data, desc, sdfg, subset)
         else:
             ptrname = ptr(memlet.data, desc, sdfg)
         return "%s[%s]" % (ptrname, offset_cppstr)

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -936,7 +936,14 @@ class InterstateEdgeUnparser(cppunparse.CPPUnparser):
             raise SyntaxError('Range subscripts disallowed in interstate edges')
 
         memlet = mmlt.Memlet(data=target, subset=rng)
-        self.write(cpp_array_expr(self.sdfg, memlet))
+
+        if target not in self.sdfg.arrays:
+            # This could be an FPGA array whose name has been mangled
+            unmangled = fpga.unmangle_fpga_array_name(self.sdfg, target)
+            desc = self.sdfg.arrays[unmangled]
+            self.write(cpp_array_expr(self.sdfg, memlet, referenced_array=desc))
+        else:
+            self.write(cpp_array_expr(self.sdfg, memlet))
 
 
 def unparse_interstate_edge(code_ast: Union[ast.AST, str], sdfg: SDFG, symbols=None) -> str:

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -510,12 +510,15 @@ def cpp_array_expr(sdfg,
     subset = memlet.subset if not use_other_subset else memlet.other_subset
     s = subset if relative_offset else subsets.Indices(offset)
     o = offset if relative_offset else None
+
     desc = (sdfg.arrays[memlet.data] if referenced_array is None else referenced_array)
     offset_cppstr = cpp_offset_expr(desc, s, o, packed_veclen, indices=indices)
 
     if with_brackets:
         if fpga.is_fpga_array(desc):
-            ptrname = fpga.fpga_ptr(memlet.data, desc, sdfg, subset)
+            is_array_interface = desc.storage ==  dace.StorageType.FPGA_Global
+            is_output = False
+            ptrname = fpga.fpga_ptr(memlet.data, desc, sdfg, subset, is_write=is_output, is_array_interface=is_array_interface)
         else:
             ptrname = ptr(memlet.data, desc, sdfg)
         return "%s[%s]" % (ptrname, offset_cppstr)

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -258,26 +258,26 @@ def fpga_ptr(name: str,
 
             subset_info = low  #used for arrayinterface name where it must be int
     if is_array_interface:
-        if is_write is None:
-            raise ValueError("is_write must be set for ArrayInterface.")
-        ptr_in = f"__{name}_in"
-        ptr_out = f"__{name}_out"
-        if dispatcher is not None:
-            # DaCe allows reading from an output connector, even though it
-            # is not an input connector. If this occurs, panic and read
-            # from the output interface instead
-            if is_write or not dispatcher.defined_vars.has(ptr_in, ancestor):
-                # Throw a KeyError if this pointer also doesn't exist
-                dispatcher.defined_vars.get(ptr_out, ancestor)
-                # Otherwise use it
-                name = ptr_out
-            else:
-                name = ptr_in
-        else:
-            # We might call this before the variable is even defined (e.g., because
-            # we are about to define it), so if the dispatcher is not passed, just
-            # return the appropriate string
-            name = ptr_out if is_write else ptr_in
+        # if is_write is None:
+        #     raise ValueError("is_write must be set for ArrayInterface.")
+        # ptr_in = f"__{name}_in"
+        # ptr_out = f"__{name}_out"
+        # if dispatcher is not None:
+        #     # DaCe allows reading from an output connector, even though it
+        #     # is not an input connector. If this occurs, panic and read
+        #     # from the output interface instead
+        #     if is_write or not dispatcher.defined_vars.has(ptr_in, ancestor):
+        #         # Throw a KeyError if this pointer also doesn't exist
+        #         dispatcher.defined_vars.get(ptr_out, ancestor)
+        #         # Otherwise use it
+        #         name = ptr_out
+        #     else:
+        #         name = ptr_in
+        # else:
+        #     # We might call this before the variable is even defined (e.g., because
+        #     # we are about to define it), so if the dispatcher is not passed, just
+        #     # return the appropriate string
+        #     name = ptr_out if is_write else ptr_in
         # Append the interface id, if provided
         if interface_id is not None:
             name = f"{name}_{interface_id}"

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -377,6 +377,9 @@ class FPGACodeGen(TargetCodeGenerator):
         # Right before finalizing code, write FPGA context to state structure
         self._frame.statestruct.append('dace_fpga_context *fpga_context;')
 
+        # Call vendor-specific preprocessing
+        self._internal_preprocess(sdfg)
+
     def _kernels_subgraphs(self, graph: Union[dace.sdfg.SDFGState, ScopeSubgraphView], dependencies: dict):
         '''
             Finds subgraphs of an SDFGState or ScopeSubgraphView that correspond to kernels.

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -284,6 +284,22 @@ def fpga_ptr(name: str,
     return name
 
 
+def unmangle_fpga_array_name(sdfg: dace.SDFG, arr_name: str):
+    '''
+    Returns the unmangled array name if it refers to an array interface.
+    Otherwise return it as it is.
+    :param name: array name to unmangle
+    '''
+
+    unmangled = re.sub('_in$|_out$', '', arr_name)
+    unmangled = re.sub('^__', '', unmangled)
+
+    if unmangled not in sdfg.arrays:
+        return arr_name
+    else:
+        return unmangled
+
+
 class FPGACodeGen(TargetCodeGenerator):
     # Set by deriving class
     target_name = None

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -179,6 +179,13 @@ DACE_EXPORTED void __dace_exit_intel_fpga({sdfg.name}_t *__state) {{
 
         return [host_code_obj] + kernel_code_objs + other_code_objs
 
+
+    def _internal_preprocess(self, sdfg: dace.SDFG):
+        '''
+        Vendor-specific SDFG Preprocessing
+        '''
+        pass
+
     def create_mangled_channel_name(self, var_name, kernel_id, external_stream):
         '''
         Memorize and returns the mangled name of a global channel

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -224,8 +224,7 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                         # Perform replacement
                         for k, v in replace_dict.items():
                             e.data.replace(k, v)
-                            # Copy array description: it will be needed by cpp.cpp_array_expr (called by cotnrol flow)
-                            graph.arrays[v] = graph.arrays[k]
+
 
     def define_stream(self, dtype, buffer_size, var_name, array_size, function_stream, kernel_stream, sdfg):
         """

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -568,8 +568,6 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
                         host_stream, instrumentation_stream):
         """Generates a module that will run as a dataflow function in the FPGA
            kernel."""
-        import pdb
-        pdb.set_trace()
         state_id = sdfg.node_id(state)
         dfg = sdfg.nodes()[state_id]
 

--- a/tests/npbench/nussinov_test.py
+++ b/tests/npbench/nussinov_test.py
@@ -23,7 +23,7 @@ def match(b1: dc.int32, b2: dc.int32):
 
 
 @dc.program
-def kernel(seq: dc.int32[N]):
+def nussinov_kernel(seq: dc.int32[N]):
 
     table = np.zeros((N, N), np.int32)
 
@@ -94,13 +94,13 @@ def run_nussinov(device_type: dace.dtypes.DeviceType):
 
     if device_type in {dace.dtypes.DeviceType.CPU, dace.dtypes.DeviceType.GPU}:
         # Parse the SDFG and apply autopot
-        sdfg = kernel.to_sdfg()
+        sdfg = nussinov_kernel.to_sdfg()
         sdfg.simplify()
         dace_res = sdfg(seq=seq, N=N)
 
     elif device_type == dace.dtypes.DeviceType.FPGA:
         # Parse SDFG and apply FPGA friendly optimization
-        sdfg = kernel.to_sdfg(simplify=True)
+        sdfg = nussinov_kernel.to_sdfg(simplify=True)
         applied = sdfg.apply_transformations([FPGATransformSDFG])
         assert applied == 1
 
@@ -126,7 +126,7 @@ def test_gpu():
     run_nussinov(dace.dtypes.DeviceType.GPU)
 
 
-@fpga_test(assert_ii_1=False, xilinx=False)
+@fpga_test(assert_ii_1=False)
 def test_fpga():
     return run_nussinov(dace.dtypes.DeviceType.FPGA)
 


### PR DESCRIPTION
Preprocessing pass for Xilinx: it goes over interstate edges and replaces names of the accessed arrays with their mangled ones (if any).

The nussinov polybench test trigger this behavior.
Partially solves #902 