### PR TITLE
Xilinx preprocess interstate edges (take care of array name)

### DIFF
--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -292,13 +292,12 @@ def unqualify_fpga_array_name(sdfg: dace.SDFG, arr_name: str):
     :param name: array name to unqualify
     '''
 
-    unqualified = re.sub('_in$|_out$', '', arr_name)
-    unqualified = re.sub('^__', '', unqualified)
-
-    if unqualified not in sdfg.arrays:
-        return arr_name
-    else:
+    if arr_name in sdfg.arrays and (arr_name.endswith('_in') or arr_name.endswith('out')) and arr_name.startswith('__'):
+        unqualified = re.sub('_in$|_out$', '', arr_name)
+        unqualified = re.sub('^__', '', unqualified)
         return unqualified
+    else:
+        return arr_name
 
 
 class FPGACodeGen(TargetCodeGenerator):

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -292,7 +292,7 @@ def unqualify_fpga_array_name(sdfg: dace.SDFG, arr_name: str):
     :param name: array name to unqualify
     '''
 
-    if arr_name in sdfg.arrays and (arr_name.endswith('_in') or arr_name.endswith('out')) and arr_name.startswith('__'):
+    if arr_name not in sdfg.arrays and (arr_name.endswith('_in') or arr_name.endswith('out')) and arr_name.startswith('__'):
         unqualified = re.sub('_in$|_out$', '', arr_name)
         unqualified = re.sub('^__', '', unqualified)
         return unqualified

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -179,6 +179,14 @@ DACE_EXPORTED void __dace_exit_intel_fpga({sdfg.name}_t *__state) {{
 
         return [host_code_obj] + kernel_code_objs + other_code_objs
 
+
+    def _internal_preprocess(self, sdfg: dace.SDFG):
+        '''
+        Vendor-specific SDFG Preprocessing
+        '''
+        pass
+
+
     def create_mangled_channel_name(self, var_name, kernel_id, external_stream):
         '''
         Memorize and returns the mangled name of a global channel

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -6,7 +6,7 @@ import itertools
 import os
 import re
 import numpy as np
-
+import ast
 import dace
 from dace import data as dt, registry, dtypes, subsets
 from dace.config import Config

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -189,6 +189,41 @@ DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
 
         return [host_code_obj] + kernel_code_objs + other_objs
 
+    def _internal_preprocess(self, sdfg: dace.SDFG):
+        '''
+        Vendor-specific SDFG Preprocessing
+        '''
+
+        # Preprocess inter state edge assignments:
+        # - look at every interstate edge
+        # - if any of them accesses an ArrayInterface (Global FPGA memory), qualify its name and replace it
+        #       in the assignment string
+
+        for graph in sdfg.all_sdfgs_recursive():
+            for state in graph.states():
+                out_edges = graph.out_edges(state)
+                for e in out_edges:
+                    if len(e.data.assignments) > 0:
+                        replace_dict = dict()
+
+                        for variable, value in e.data.assignments.items():
+                            expr = ast.parse(value)
+                            # walk in the expression, get all array names and check whether we need to qualify them
+                            for node in ast.walk(expr):
+                                if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+                                    arr_name = node.value.id
+
+                                    if arr_name not in replace_dict and arr_name in graph.arrays and graph.arrays[
+                                        arr_name].storage == dace.dtypes.StorageType.FPGA_Global:
+                                        repl = fpga.fpga_ptr(arr_name, graph.arrays[node.value.id], sdfg, None, False,
+                                                             None, None, True)
+                                        replace_dict[arr_name] = repl
+
+                        # Perform replacement
+                        for k, v in replace_dict.items():
+                            e.data.replace(k, v)
+
+
     def define_stream(self, dtype, buffer_size, var_name, array_size, function_stream, kernel_stream, sdfg):
         """
            Defines a stream

--- a/tests/npbench/nussinov_test.py
+++ b/tests/npbench/nussinov_test.py
@@ -126,7 +126,7 @@ def test_gpu():
     run_nussinov(dace.dtypes.DeviceType.GPU)
 
 
-@fpga_test(assert_ii_1=False, xilinx=False)
+@fpga_test(assert_ii_1=False)
 def test_fpga():
     return run_nussinov(dace.dtypes.DeviceType.FPGA)
 


### PR DESCRIPTION
Preprocessing pass for Xilinx: it goes over interstate edges and replaces names of the accessed arrays with their qualified ones (if any).

The nussinov polybench test trigger this behavior.
Partially solves #902