### PR TITLE
Fix for issues with Tasklet-syntax and indirection

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1846,7 +1846,7 @@ class ProgramVisitor(ExtNodeVisitor):
                             inner_indices.add(n)
                     # Avoid the case where all indices are outer,
                     # i.e., the whole array is carried through the nested SDFG levels.
-                    if len(outer_indices) < len(irng):
+                    if len(outer_indices) < len(irng) or irng.num_elements() == 1:
                         irng.pop(outer_indices)
                         orng.pop(outer_indices)
                         irng.offset(orng, True)
@@ -1935,7 +1935,7 @@ class ProgramVisitor(ExtNodeVisitor):
                             inner_indices.add(n)
                     # Avoid the case where all indices are outer,
                     # i.e., the whole array is carried through the nested SDFG levels.
-                    if len(outer_indices) < len(irng):
+                    if len(outer_indices) < len(irng) or irng.num_elements() == 1:
                         irng.pop(outer_indices)
                         orng.pop(outer_indices)
                         irng.offset(orng, True)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1844,9 +1844,12 @@ class ProgramVisitor(ExtNodeVisitor):
                             outer_indices.append(n)
                         elif n not in inner_indices:
                             inner_indices.add(n)
-                    irng.pop(outer_indices)
-                    orng.pop(outer_indices)
-                    irng.offset(orng, True)
+                    # Avoid the case where all indices are outer,
+                    # i.e., the whole array is carried through the nested SDFG levels.
+                    if len(outer_indices) < len(irng):
+                        irng.pop(outer_indices)
+                        orng.pop(outer_indices)
+                        irng.offset(orng, True)
                     if (memlet.data, scope_memlet.subset, 'w') in self.accesses:
                         vname = self.accesses[(memlet.data, scope_memlet.subset, 'w')][0]
                         memlet = Memlet.simple(vname, str(irng))
@@ -1930,9 +1933,12 @@ class ProgramVisitor(ExtNodeVisitor):
                             outer_indices.append(n)
                         elif n not in inner_indices:
                             inner_indices.add(n)
-                    irng.pop(outer_indices)
-                    orng.pop(outer_indices)
-                    irng.offset(orng, True)
+                    # Avoid the case where all indices are outer,
+                    # i.e., the whole array is carried through the nested SDFG levels.
+                    if len(outer_indices) < len(irng):
+                        irng.pop(outer_indices)
+                        orng.pop(outer_indices)
+                        irng.offset(orng, True)
                     if self._find_access(memlet.data, scope_memlet.subset, 'w'):
                         vname = self.accesses[(memlet.data, scope_memlet.subset, 'w')][0]
                         inner_memlet = Memlet.simple(vname, str(irng))

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -400,8 +400,6 @@ def add_indirection_subgraph(sdfg: SDFG,
     for arrname, arr_accesses in accesses.items():
         arr_name = arrname
         for i, access in enumerate(arr_accesses):
-            if isinstance(access, (list, tuple)):
-                access = access[0]
             if isinstance(access, sympy.Tuple):
                 access = list(access)
             if not isinstance(access, (list, tuple)):

--- a/tests/indirection_test.py
+++ b/tests/indirection_test.py
@@ -3,6 +3,7 @@ import dace as dp
 import numpy as np
 
 W = dp.symbol('W')
+H = dp.symbol('H')
 
 
 @dp.program
@@ -34,5 +35,74 @@ def test():
     assert diff == 0
 
 
+def test_two_nested_levels_indirection():
+
+    @dp.program
+    def indirection(A, x, B):
+        for j in dp.map[0:H]:
+            @dp.map(_[0:W])
+            def ind(i):
+                bla << A[x[i]]
+                out >> B[i]
+                out = bla
+    
+
+    W.set(5)
+    H.set(5)
+
+    A = dp.ndarray([W * W])
+    B = dp.ndarray([W])
+    x = dp.ndarray([W], dtype=dp.uint32)
+
+    A[:] = np.arange(10, 10 + W.get() * W.get())
+    B[:] = dp.float32(0)
+    x[:] = np.random.randint(0, W.get() * W.get(), W.get())
+
+    indirection(A, x, B, W=W, H=H)
+
+    print(x)
+    print(B)
+    B_ref = np.array([A[x[i]] for i in range(W.get())], dtype=B.dtype)
+    diff = np.linalg.norm(B - B_ref)
+    assert diff == 0
+
+
+def test_multi_dimensional_indirection():
+
+    @dp.program
+    def indirection(A, x, B):
+        for j in dp.map[0:H]:
+            @dp.map(_[0:W])
+            def ind(i):
+                bla << A[x[i, j]]
+                out >> B[i, j]
+                out = bla
+    
+
+    W.set(5)
+    H.set(5)
+
+    A = dp.ndarray([W * W])
+    B = dp.ndarray([W, H])
+    x = dp.ndarray([W, H], dtype=dp.uint32)
+
+    A[:] = np.arange(10, 10 + W.get() * W.get())
+    B[:] = dp.float32(0)
+    x[:] = np.random.randint(0, W.get() * W.get(), size=(W.get(), H.get()))
+
+    indirection(A, x, B, W=W, H=H)
+
+    print(x)
+    print(B)
+    B_ref = np.ndarray((W.get(), H.get()), dtype=B.dtype)
+    for i in range(W.get()):
+        for j in range(H.get()):
+            B_ref[i, j] = A[x[i, j]]
+    diff = np.linalg.norm(B - B_ref)
+    assert diff == 0
+
+
 if __name__ == "__main__":
     test()
+    test_two_nested_levels_indirection()
+    test_multi_dimensional_indirection()


### PR DESCRIPTION
Fixes the following issues:
- [x] Multi-dimensional indirection truncates the index and keeps only the first dimension.
- [x] Indirected arrays are not properly propagated tthrough all nested SDFG levels.
