### PR TITLE
Add support for Reference data descriptors

### DIFF
--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -1044,6 +1044,9 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
 
         if isinstance(nodedesc, dt.View):
             return self.allocate_view(sdfg, dfg, state_id, node, function_stream, declaration_stream, allocation_stream)
+        elif isinstance(nodedesc, dt.Reference):
+            return self.allocate_reference(sdfg, dfg, state_id, node, function_stream, declaration_stream,
+                                           allocation_stream)
         elif isinstance(nodedesc, dt.Stream):
 
             if not self._in_device_code:

--- a/dace/data.py
+++ b/dace/data.py
@@ -800,7 +800,29 @@ class View(Array):
         # We ensure that allocation lifetime is always set to Scope, since the
         # view is generated upon "allocation"
         if self.lifetime != dtypes.AllocationLifetime.Scope:
-            raise ValueError('Only Scope allocation lifetime is supported for ' 'Views')
+            raise ValueError('Only Scope allocation lifetime is supported for Views')
+
+    def as_array(self):
+        copy = cp.deepcopy(self)
+        copy.__class__ = Array
+        return copy
+
+
+@make_properties
+class Reference(Array):
+    """ 
+    Data descriptor that acts as a dynamic reference of another array. It can be used just like a regular array,
+    except that it could be set to an arbitrary array or sub-array at runtime. To set a reference, connect another
+    access node to it and use the "set" connector.
+    In order to enable data-centric analysis and optimizations, avoid using References as much as possible.
+    """
+    def validate(self):
+        super().validate()
+
+        # We ensure that allocation lifetime is always set to Scope, since the
+        # view is generated upon "allocation"
+        if self.lifetime != dtypes.AllocationLifetime.Scope:
+            raise ValueError('Only Scope allocation lifetime is supported for References')
 
     def as_array(self):
         copy = cp.deepcopy(self)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1574,6 +1574,48 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
 
+    def add_reference(self,
+                      name: str,
+                      shape,
+                      dtype,
+                      storage=dtypes.StorageType.Default,
+                      strides=None,
+                      offset=None,
+                      debuginfo=None,
+                      allow_conflicts=False,
+                      total_size=None,
+                      find_new_name=False,
+                      alignment=0,
+                      may_alias=False) -> Tuple[str, dt.Reference]:
+        """ Adds a reference to the SDFG data descriptor store. """
+
+        # convert strings to int if possible
+        newshape = []
+        for s in shape:
+            try:
+                newshape.append(int(s))
+            except:
+                newshape.append(dace.symbolic.pystr_to_symbolic(s))
+        shape = newshape
+
+        if isinstance(dtype, type) and dtype in dtypes._CONSTANT_TYPES[:-1]:
+            dtype = dtypes.typeclass(dtype)
+
+        desc = dt.Reference(dtype,
+                            shape,
+                            storage=storage,
+                            allow_conflicts=allow_conflicts,
+                            transient=True,
+                            strides=strides,
+                            offset=offset,
+                            lifetime=dtypes.AllocationLifetime.Scope,
+                            alignment=alignment,
+                            debuginfo=debuginfo,
+                            total_size=total_size,
+                            may_alias=may_alias)
+
+        return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
+
     def add_stream(self,
                    name: str,
                    dtype,

--- a/tests/sdfg/reference_test.py
+++ b/tests/sdfg/reference_test.py
@@ -1,0 +1,45 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests the use of Reference data descriptors. """
+import dace
+import numpy as np
+
+
+def test_reference_branch():
+    sdfg = dace.SDFG('refbranch')
+    sdfg.add_array('A', [20], dace.float64)
+    sdfg.add_array('B', [20], dace.float64)
+    sdfg.add_symbol('i', dace.int64)
+    sdfg.add_reference('ref', [20], dace.float64)
+    sdfg.add_array('out', [20], dace.float64)
+
+    # Branch to a or b depending on i
+    start = sdfg.add_state()
+    a = sdfg.add_state()
+    b = sdfg.add_state()
+    finish = sdfg.add_state()
+    sdfg.add_edge(start, a, dace.InterstateEdge('i < 5'))
+    sdfg.add_edge(start, b, dace.InterstateEdge('i >= 5'))
+    sdfg.add_edge(a, finish, dace.InterstateEdge())
+    sdfg.add_edge(b, finish, dace.InterstateEdge())
+
+    # Copy from reference to output
+    a.add_edge(a.add_read('A'), None, a.add_write('ref'), 'set', dace.Memlet('A'))
+    b.add_edge(b.add_read('B'), None, b.add_write('ref'), 'set', dace.Memlet('B'))
+
+    r = finish.add_read('ref')
+    w = finish.add_write('out')
+    finish.add_nedge(r, w, dace.Memlet('ref'))
+
+    A = np.random.rand(20)
+    B = np.random.rand(20)
+    out = np.random.rand(20)
+
+    sdfg(A=A, B=B, out=out, i=10)
+    assert np.allclose(out, B)
+
+    sdfg(A=A, B=B, out=out, i=1)
+    assert np.allclose(out, A)
+
+
+if __name__ == '__main__':
+    test_reference_branch()


### PR DESCRIPTION
Typed/shaped pointers that can be set at runtime. Necessary for supporting several challenging programs, while skirting around optimizing _some parts_ of them.

As opposed to Views, there are no special graph rules (e.g. edge node) for references, as once they are set, they can be used as normal access nodes. Aliasing rules do apply though and transformations (e.g., redundant array) can be amended at a later PR. Future PRs may eliminate trivial References via passes/transformations too.

It is not accessible from frontends at this point on purpose, as those constructs are highly discouraged.