### PR TITLE
Container compatibility for config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The priority order for configuration files is as follows:
  3. A `.dace.conf` located in the current working directory
  4. The `.dace.conf` located in the user's home directory or the path pointed to by the `DACE_CONFIG` environment variable
 
+If no configuration file can be created in any of the above paths, default settings will be used.
+
 Useful environment variable configurations include:
 
  * `DACE_CONFIG` (default: `~/.dace.conf`): Override DaCe configuration file choice.

--- a/dace/config.py
+++ b/dace/config.py
@@ -4,6 +4,7 @@ import os
 import platform
 import tempfile
 import yaml
+import warnings
 
 
 @contextlib.contextmanager
@@ -96,10 +97,10 @@ class Config(object):
 
     @staticmethod
     def initialize():
-        """ Initializes configuration.
+        """
+        Initializes configuration.
 
-            B{Note:} This function runs automatically when the module
-                     is loaded.
+        :note: This function runs automatically when the module is loaded.
         """
 
         # If already initialized, skip
@@ -107,13 +108,12 @@ class Config(object):
             return
 
         # Override default configuration file path
+        default_filename = '.dace.conf'
         if 'DACE_CONFIG' in os.environ:
-            cfg_filename = os.environ['DACE_CONFIG']
+            default_cfg_filename = os.environ['DACE_CONFIG']
         else:
             home = os.path.expanduser("~")
-            cfg_filename = os.path.join(home, ".dace.conf")
-
-        Config._cfg_filename = cfg_filename
+            default_cfg_filename = os.path.join(home, default_filename)
 
         dace_path = os.path.dirname(os.path.abspath(__file__))
         Config._metadata_filename = os.path.join(dace_path, 'config_schema.yml')
@@ -121,13 +121,34 @@ class Config(object):
         # Load configuration schema (for validation and defaults)
         Config.load_schema()
 
-        if os.path.isfile(cfg_filename):
-            Config.load()
+        # Priority order: current working directory, default configuration file (DACE_CONFIG), then ~/.dace.conf
+        for filename in [default_filename, default_cfg_filename]:
+            Config._cfg_filename = filename
+            try:
+                if os.path.isfile(filename):
+                    Config.load()
+                    break
+            except (FileNotFoundError, PermissionError, OSError):
+                # If any filesystem-related error happened during file load, move on to next candidate
+                continue
         else:
-            # Load the defaults from metadata and save new conf file
+            # None of the files were found
+
+            # Load the defaults from metadata
             Config._config = {}
             _add_defaults(Config._config, Config._config_metadata['required'])
-            Config.save()
+
+            # Try to create a new config file in reversed priority order, and if all else fails keep config in memory
+            for filename in [default_cfg_filename, default_filename, None]:
+                Config._cfg_filename = filename
+                try:
+                    Config.save()
+                    break
+                except (FileNotFoundError, PermissionError, OSError):
+                    # If any filesystem-related error happened during file save, move on to next candidate
+                    continue
+            else:
+                warnings.warn('No DaCe configuration file was able to be saved')
 
     @staticmethod
     def load(filename=None):
@@ -169,9 +190,10 @@ class Config(object):
         """
         if path is None:
             path = Config._cfg_filename
-        # Write configuration file
-        with open(path, 'w') as f:
-            yaml.dump(Config._config, f, default_flow_style=False)
+        if path is not None:
+            # Write configuration file
+            with open(path, 'w') as f:
+                yaml.dump(Config._config, f, default_flow_style=False)
 
     @staticmethod
     def get_metadata(*key_hierarchy):


### PR DESCRIPTION
Respect reversed priority order when trying to save a file: home directory first, then cwd, then operate with in-memory config using the default settings.