### PR TITLE
Support callbacks with keyword arguments

### DIFF
--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -663,3 +663,11 @@ def create_constant(value: Any, node: Optional[ast.AST] = None) -> ast.AST:
         newnode = ast.copy_location(newnode, node)
 
     return newnode
+
+
+def escape_string(value: str):
+    """ Converts special Python characters in strings back to their parsable version (e.g., newline to ``\n``) """
+    if sys.version_info >= (3, 0):
+        return value.encode("unicode_escape").decode("utf-8")
+    # Python 2.x
+    return value.encode('string_escape')

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3837,7 +3837,7 @@ class ProgramVisitor(ExtNodeVisitor):
 
                 if isinstance(parsed_arg, str):
                     # Special case for strings
-                    parsed_arg = f'"{parsed_arg}"'
+                    parsed_arg = f'"{astutils.escape_string(parsed_arg)}"'
                 allargs.append(parsed_arg)
 
             argtypes.append(atype)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3811,13 +3811,12 @@ class ProgramVisitor(ExtNodeVisitor):
         _, func, _ = self.closure.callbacks[funcname]
 
         # Infer the type of the function arguments and return value
-        # TODO(later): Use inspect.signature and node.keywords to
-        #              work with keyword arguments
         argtypes = []
         args = []
         outargs = []
         allargs = []
-        for arg in node.args:
+        kwargs = [kw.value for kw in node.keywords]
+        for arg in itertools.chain(node.args, kwargs):
             parsed_arg = self._parse_function_arg(arg)
             if parsed_arg in self.defined:
                 atype = self.defined[parsed_arg]
@@ -3841,38 +3840,6 @@ class ProgramVisitor(ExtNodeVisitor):
                 allargs.append(parsed_arg)
 
             argtypes.append(atype)
-
-        if node.keywords:
-            sig = inspect.signature(func)
-            keys = list(sig.parameters.keys())
-            order = []
-            for kw in node.keywords:
-                order.append(keys.index(kw.arg))
-            sorted_keywords = sorted(zip(order, node.keywords))
-            for _, kw in sorted_keywords:
-                parsed_arg = self._parse_function_arg(kw.value)
-                if parsed_arg in self.defined:
-                    atype = self.defined[parsed_arg]
-                    args.append(parsed_arg)
-                    if isinstance(atype, data.Array):
-                        outargs.append(parsed_arg)
-                        allargs.append(f'__out_{parsed_arg}')
-                    elif isinstance(atype, data.Scalar):
-                        allargs.append(f'__in_{parsed_arg}')
-                    else:
-                        allargs.append(parsed_arg)
-                else:
-                    if isinstance(parsed_arg, (Number, numpy.number)):
-                        atype = data.create_datadescriptor(type(parsed_arg))
-                    else:
-                        atype = data.create_datadescriptor(parsed_arg)
-
-                    if isinstance(parsed_arg, str):
-                        # Special case for strings
-                        parsed_arg = f'"{parsed_arg}"'
-                    allargs.append(parsed_arg)
-
-                argtypes.append(atype)
 
         # Return type inference
         return_type = None

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -300,6 +300,33 @@ def has_replacement(callobj: Callable, parent_object: Optional[Any] = None, node
     return oprepo.Replacements.get(astutils.rname(node)) is not None
 
 
+def make_kwargless_callback(func: Callable, node: ast.Call):
+    """
+    Creates a version of the function that has no keyword arguments and matches the number of arguments exactly.
+    Used for creating callbacks from C to Python with keyword arguments.
+    """
+    if not node.keywords:
+        return func
+    keywords = [kw.arg for kw in node.keywords]
+    poscount = len(node.args)
+
+    # Using two levels of functions to ensure keywords are stored with the callback
+    if poscount == 0:
+        def make_cb(keywords, _):
+            def cb_func(*all_args):
+                kwargs = {kw: arg for kw, arg in zip(keywords, all_args)}
+                return func(**kwargs)
+            return cb_func
+    else:
+        def make_cb(keywords, poscount):
+            def cb_func(*all_args):
+                args = all_args[:poscount]
+                kwargs = {kw: arg for kw, arg in zip(keywords, all_args[poscount:])}
+                return func(*args, **kwargs)
+            return cb_func
+    return make_cb(keywords, poscount)
+
+
 class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
     """ Resolves global constants and lambda expressions if not
         already defined in the given scope. """
@@ -435,7 +462,15 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                 else:
                     cbqualname = astutils.rname(parent_node)
                 cbname = self._qualname_to_array_name(cbqualname, prefix='')
-                self.closure.callbacks[cbname] = (cbqualname, value, False)
+
+                # Make a version of the callback without keyword arguments
+                cb_func = make_kwargless_callback(value, parent_node)
+                
+                # If the callback already exists, and the details differ (e.g., different kwarg names), make new
+                if cbname in self.closure.callbacks and cb_func is not self.closure.callbacks[cbname][1]:
+                    cbname = data.find_new_name(cbname, self.closure.callbacks)
+
+                self.closure.callbacks[cbname] = (cbqualname, cb_func, False)
 
                 # From this point on, any failure will result in a callback
                 newnode = ast.Name(id=cbname, ctx=ast.Load())


### PR DESCRIPTION
- [x] Escape string arguments such that they generate valid code
- [x] Support kwargs, variable kwargs, and duplicate calls to same function