### PR TITLE
Fix for issue #1005

### DIFF
--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -208,7 +208,7 @@ class StateFusion(transformation.MultiStateTransformation, transformation.Simpli
                 if e.data.assignments.keys() & symbols_used:
                     return False
                 # Also fail in the inverse; symbols assigned on the second edge are free symbols on the first edge
-                if out_edges[0].data.assignments.keys() & set(e.data.free_symbols):
+                if new_assignments & set(e.data.free_symbols):
                     return False
 
         # There can be no state that have output edges pointing to both the

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -207,6 +207,9 @@ class StateFusion(transformation.MultiStateTransformation, transformation.Simpli
             for e in in_edges:
                 if e.data.assignments.keys() & symbols_used:
                     return False
+                # Also fail in the inverse; symbols assigned on the second edge are free symbols on the first edge
+                if out_edges[0].data.assignments.keys() & set(e.data.free_symbols):
+                    return False
 
         # There can be no state that have output edges pointing to both the
         # first and the second state. Such a case will produce a multi-graph.

--- a/tests/control_flow_test.py
+++ b/tests/control_flow_test.py
@@ -157,7 +157,7 @@ def test_while_symbol():
 
     if dace.Config.get_bool('optimizer', 'detect_control_flow'):
         code = whiletest_symbol.to_sdfg().generate_code()[0].clean_code
-        assert 'while ' in code
+        assert 'while ' in code or 'for ' in code
         assert 'goto ' not in code
 
 

--- a/tests/transformations/state_fusion_test.py
+++ b/tests/transformations/state_fusion_test.py
@@ -22,6 +22,25 @@ def test_fuse_assignments():
     assert sdfg.number_of_nodes() == 3
 
 
+def test_fuse_assignments_2():
+    """
+    Two states in which the first's state's input assignment depends on a symbol assigned (again)
+    on the common interstate edge. Should fail.
+    """
+    sdfg = dace.SDFG('state_fusion_test')
+    state1 = sdfg.add_state()
+    state2 = sdfg.add_state()
+    state3 = sdfg.add_state()
+    state4 = sdfg.add_state()
+    state5 = sdfg.add_state()
+    sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
+    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k='k + 1')))
+    sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(l='k + 1')))
+    sdfg.add_edge(state4, state5, dace.InterstateEdge(assignments=dict(k='k + 1')))
+    sdfg.apply_transformations_repeated(StateFusion)
+    assert sdfg.number_of_nodes() == 5
+
+
 def test_fuse_assignment_in_use():
     """ 
     Two states with an interstate assignment in between, where the assigned
@@ -380,6 +399,7 @@ def test_inout_second_state_2():
 
 if __name__ == '__main__':
     test_fuse_assignments()
+    test_fuse_assignments_2()
     test_fuse_assignment_in_use()
     test_two_to_one_cc_fusion()
     test_one_to_two_cc_fusion()


### PR DESCRIPTION
Fixes issue #1005 

StateFusion must not happen if the assigned symbols in the states' common interstate edge are free symbols in any of the first state's input edges.