### PR TITLE
SDFV: Add web serving capability

### DIFF
--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -6,49 +6,77 @@ import tempfile
 import sys
 import os
 import platform
+from typing import Optional, Union
+import functools
 
 import dace
 import tempfile
 import jinja2
 
 
-def view(sdfg, filename=None):
+def partialclass(cls, *args, **kwds):
+    class NewCls(cls):
+        __init__ = functools.partialmethod(cls.__init__, *args, **kwds)
+
+    return NewCls
+
+
+def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
     """View an sdfg in the system's HTML viewer
        :param sdfg: the sdfg to view, either as `dace.SDFG` object or a json string
-       :param filename: the filename to write the HTML to. If `None`, a temporary file will be created.
+       :param filename: the filename to write the HTML to. If `None`, a
+                        temporary file will be created. If an integer,
+                        the generated HTML and related sources will be
+                        served using a basic web server on that port,
+                        blocking the current thread.
     """
     if type(sdfg) is dace.SDFG:
         sdfg = dace.serialize.dumps(sdfg.to_json())
+
+    if filename is None:
+        fd, html_filename = tempfile.mkstemp(suffix=".sdfg.html")
+    elif isinstance(filename, int):
+        dirname = tempfile.mkdtemp()
+        html_filename = os.path.join(dirname, "sdfg.html")
+        fd = None
+    else:
+        fd = None
+        html_filename = filename + ".html"
 
     basepath = os.path.join(os.path.dirname(os.path.realpath(dace.__file__)), 'viewer')
     template_loader = jinja2.FileSystemLoader(searchpath=os.path.join(basepath, 'templates'))
     template_env = jinja2.Environment(loader=template_loader)
     template = template_env.get_template('sdfv.html')
 
-    html = template.render(sdfg=json.dumps(sdfg), dir=basepath + '/')
-
-    if filename is None:
-        fd, html_filename = tempfile.mkstemp(suffix=".sdfg.html")
-    else:
-        fd = None
-        html_filename = filename + ".html"
+    # if we are serving, the base path should just be root
+    html = template.render(sdfg=json.dumps(sdfg), dir="/" if isinstance(filename, int) else (basepath + '/'))
 
     with open(html_filename, "w") as f:
         f.write(html)
 
     print("File saved at %s" % html_filename)
 
-    system = platform.system()
-
-    if system == 'Windows':
-        os.system(html_filename)
-    elif system == 'Darwin':
-        os.system('open %s' % html_filename)
-    else:
-        os.system('xdg-open %s' % html_filename)
-
     if fd is not None:
         os.close(fd)
+
+    if isinstance(filename, int):
+        # link in the web resources
+        os.symlink(os.path.join(basepath, 'webclient'), os.path.join(dirname, 'webclient'))
+
+        # start the web server
+        import http.server
+        handler = partialclass(http.server.SimpleHTTPRequestHandler, directory=dirname)
+        httpd = http.server.HTTPServer(('localhost', 8000), handler)
+        httpd.serve_forever()
+    else:
+        system = platform.system()
+
+        if system == 'Windows':
+            os.system(html_filename)
+        elif system == 'Darwin':
+            os.system('open %s' % html_filename)
+        else:
+            os.system('xdg-open %s' % html_filename)
 
 
 def main():


### PR DESCRIPTION
When `filename` argument of SDFV is an int, start a `http.server` to serve the generated HTML and the dependencies.

This is really useful when interactively debugging sdfgs on a remote machine; you can just do `sdfg.view(8000)` (e.g. from within PDB), local-forward that port via SSH and then view the sdfg.