### PR TITLE
If VSCode is open, and sdfg.view() is called, open directly in IDE

### DIFF
--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -33,11 +33,12 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
                         blocking the current thread.
     """
     # If vscode is open, try to open it inside vscode
-    if 'VSCODE_IPC_HOOK_CLI' in os.environ and filename is None:
-        filename = tempfile.mktemp(suffix='.sdfg')
-        sdfg.save(filename)
-        os.system(f'code {filename}')
-        return
+    if filename is None:
+        if 'VSCODE_IPC_HOOK_CLI' in os.environ or 'VSCODE_GIT_IPC_HANDLE' in os.environ:
+            filename = tempfile.mktemp(suffix='.sdfg')
+            sdfg.save(filename)
+            os.system(f'code {filename}')
+            return
 
     if type(sdfg) is dace.SDFG:
         sdfg = dace.serialize.dumps(sdfg.to_json())

--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -32,6 +32,13 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
                         served using a basic web server on that port,
                         blocking the current thread.
     """
+    # If vscode is open, try to open it inside vscode
+    if 'VSCODE_IPC_HOOK_CLI' in os.environ and filename is None:
+        filename = tempfile.mktemp(suffix='.sdfg')
+        sdfg.save(filename)
+        os.system(f'code {filename}')
+        return
+
     if type(sdfg) is dace.SDFG:
         sdfg = dace.serialize.dumps(sdfg.to_json())
 


### PR DESCRIPTION
fixes https://github.com/spcl/dace-vscode/issues/46