### PR TITLE
Assortment of simple fixes

### DIFF
--- a/dace/codegen/control_flow.py
+++ b/dace/codegen/control_flow.py
@@ -126,7 +126,7 @@ class SingleState(ControlFlow):
         else:
             # Dispatch empty state in any case in order to register that the
             # state was dispatched
-            self.dispatch_state(self.state)
+            expr += self.dispatch_state(self.state)
 
         # If any state has no children, it should jump to the end of the SDFG
         if not self.last_state and sdfg.out_degree(self.state) == 0:

--- a/dace/codegen/control_flow.py
+++ b/dace/codegen/control_flow.py
@@ -53,6 +53,7 @@ GeneralBlock({
 })
 """
 
+import ast
 from dataclasses import dataclass
 from typing import (Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union)
 import sympy as sp
@@ -550,12 +551,20 @@ def _cases_from_branches(
     m = cond.match(sp.Eq(a, b))
     if m:
         # Obtain original code for variable
-        astvar = edges[0].data.condition.code[0].value.left
+        call_or_compare = edges[0].data.condition.code[0].value
+        if isinstance(call_or_compare, ast.Call):
+            astvar = call_or_compare.args[0]
+        else:  # Binary comparison
+            astvar = call_or_compare.left
     else:
         # Try integer == symbol
         m = cond.match(sp.Eq(b, a))
         if m:
-            astvar = edges[0].data.condition.code[0].value.right
+            call_or_compare = edges[0].data.condition.code[0].value
+            if isinstance(call_or_compare, ast.Call):
+                astvar = call_or_compare.args[1]
+            else:  # Binary comparison
+                astvar = call_or_compare.right
         else:
             return None
 

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -240,8 +240,8 @@ def ptr(name: str, desc: data.Data, sdfg: SDFG = None, framecode=None) -> str:
             from dace.codegen.targets.cuda import CUDACodeGen  # Avoid import loop
             if not CUDACodeGen._in_device_code:  # GPU kernels cannot access state
                 return f'__state->__{sdfg.sdfg_id}_{name}'
-            # elif (sdfg, name) in framecode.where_allocated and framecode.where_allocated[(sdfg, name)] is not sdfg:
-            #     return f'__{sdfg.sdfg_id}_{name}'
+            elif (sdfg, name) in framecode.where_allocated and framecode.where_allocated[(sdfg, name)] is not sdfg:
+                return f'__{sdfg.sdfg_id}_{name}'
         elif (desc.transient and sdfg is not None and framecode is not None
               and (sdfg, name) in framecode.where_allocated and framecode.where_allocated[(sdfg, name)] is not sdfg):
             # Array allocated for another SDFG, use unambiguous name

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -240,8 +240,8 @@ def ptr(name: str, desc: data.Data, sdfg: SDFG = None, framecode=None) -> str:
             from dace.codegen.targets.cuda import CUDACodeGen  # Avoid import loop
             if not CUDACodeGen._in_device_code:  # GPU kernels cannot access state
                 return f'__state->__{sdfg.sdfg_id}_{name}'
-            elif (sdfg, name) in framecode.where_allocated and framecode.where_allocated[(sdfg, name)] is not sdfg:
-                return f'__{sdfg.sdfg_id}_{name}'
+            # elif (sdfg, name) in framecode.where_allocated and framecode.where_allocated[(sdfg, name)] is not sdfg:
+            #     return f'__{sdfg.sdfg_id}_{name}'
         elif (desc.transient and sdfg is not None and framecode is not None
               and (sdfg, name) in framecode.where_allocated and framecode.where_allocated[(sdfg, name)] is not sdfg):
             # Array allocated for another SDFG, use unambiguous name

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1003,7 +1003,11 @@ class InterstateEdgeUnparser(cppunparse.CPPUnparser):
 def unparse_interstate_edge(code_ast: Union[ast.AST, str], sdfg: SDFG, symbols=None, codegen=None) -> str:
     # Convert from code to AST as necessary
     if isinstance(code_ast, str):
+        code_ast = symbolic.symstr(symbolic.pystr_to_symbolic(code_ast))
         code_ast = ast.parse(code_ast).body[0]
+    else:
+        codestr = symbolic.symstr(symbolic.pystr_to_symbolic(unparse(code_ast)))
+        code_ast = ast.parse(codestr).body[0]
 
     strio = StringIO()
     InterstateEdgeUnparser(sdfg, code_ast, strio, symbols, codegen)

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -982,39 +982,6 @@ class InterstateEdgeUnparser(cppunparse.CPPUnparser):
         desc = self.sdfg.arrays[t.id]
         self.write(ptr(t.id, desc, self.sdfg, self.codegen))
 
-    # Replace remainder of boolean ops from SymPy
-    callcmps = {
-        "Eq": ast.Eq,
-        "NotEq": ast.NotEq,
-        "Ne": ast.NotEq,
-        "Lt": ast.Lt,
-        "Le": ast.LtE,
-        "LtE": ast.LtE,
-        "Gt": ast.Gt,
-        "Ge": ast.GtE,
-        "GtE": ast.GtE,
-    }
-    callbools = {
-        "And": ast.And,
-        "Or": ast.Or,
-    }
-
-    def _Call(self, t: ast.Call):
-        # Special cases for sympy functions
-        if isinstance(t.func, ast.Name):
-            if t.func.id in InterstateEdgeUnparser.callcmps:
-                op = InterstateEdgeUnparser.callcmps[t.func.id]()
-                self.dispatch(
-                    ast.Compare(left=t.args[0],
-                                ops=[op for _ in range(1, len(t.args))],
-                                comparators=[t.args[i] for i in range(1, len(t.args))]))
-                return
-            elif t.func.id in InterstateEdgeUnparser.callbools:
-                op = InterstateEdgeUnparser.callbools[t.func.id]()
-                self.dispatch(ast.BoolOp(op=op, values=t.args))
-                return
-        return super()._Call(t)
-
     def _Subscript(self, t: ast.Subscript):
         from dace.frontend.python.astutils import subscript_to_slice
         target, rng = subscript_to_slice(t, self.sdfg.arrays)

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -929,7 +929,10 @@ class CPUCodeGen(TargetCodeGenerator):
                         ptrname = cpp.ptr(memlet.data, desc, sdfg, self._frame)
                         is_global = desc.lifetime in (dtypes.AllocationLifetime.Global,
                                                       dtypes.AllocationLifetime.Persistent)
-                        defined_type, _ = self._dispatcher.defined_vars.get(ptrname, is_global=is_global)
+                        try:
+                            defined_type, _ = self._dispatcher.declared_arrays.get(ptrname, is_global=is_global)
+                        except KeyError:
+                            defined_type, _ = self._dispatcher.defined_vars.get(ptrname, is_global=is_global)
 
                         if defined_type == DefinedType.Scalar:
                             mname = cpp.ptr(memlet.data, desc, sdfg, self._frame)

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -1294,6 +1294,9 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                                                       defined_type,
                                                       'const %s' % ctype,
                                                       allow_shadowing=True)
+
+                    # Rename argument in kernel prototype as necessary
+                    aname = inner_ptrname
             else:
                 if aname in sdfg.arrays:
                     data_desc = sdfg.arrays[aname]

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -1283,7 +1283,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                         pass
                     ptrname = cpp.ptr(aname, data_desc, sdfg, self._frame)
                     if not defined_type:
-                        defined_type, ctype = self._dispatcher.defined_vars.get(ptrname)
+                        defined_type, ctype = self._dispatcher.defined_vars.get(ptrname, is_global=is_global)
 
                     CUDACodeGen._in_device_code = True
                     inner_ptrname = cpp.ptr(aname, data_desc, sdfg, self._frame)
@@ -1297,7 +1297,9 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                 if aname in sdfg.arrays:
                     data_desc = sdfg.arrays[aname]
                     ptrname = cpp.ptr(aname, data_desc, sdfg, self._frame)
-                    defined_type, ctype = self._dispatcher.defined_vars.get(ptrname)
+                    is_global = data_desc.lifetime in (dtypes.AllocationLifetime.Global,
+                                                       dtypes.AllocationLifetime.Persistent)
+                    defined_type, ctype = self._dispatcher.defined_vars.get(ptrname, is_global=is_global)
                     CUDACodeGen._in_device_code = True
                     inner_ptrname = cpp.ptr(aname, data_desc, sdfg, self._frame)
                     CUDACodeGen._in_device_code = False

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -612,6 +612,8 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                 if isinstance(node, nodes.NestedSDFG):
                     if node.schedule == dtypes.ScheduleType.GPU_Device:
                         continue
+                    if node.schedule not in dtypes.GPU_SCHEDULES:
+                        max_streams, max_events = self._compute_cudastreams(node.sdfg, max_streams, max_events + 1)
                 node._cuda_stream = max_streams
                 node._cs_childpath = False
                 max_streams = increment(max_streams)
@@ -1243,8 +1245,6 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
         # TODO move this into _get_const_params(dfg_scope)
         const_params |= set((str(e.src)) for e in dace.sdfg.dynamic_map_inputs(state, scope_entry))
 
-        kernel_args_typed = [('const ' if k in const_params else '') + v.as_arg(name=k) for k, v in kernel_args.items()]
-
         # Store init/exit code streams
         old_entry_stream = self.scope_entry_stream
         old_exit_stream = self.scope_exit_stream
@@ -1258,11 +1258,12 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
             outer_stream = CodeIOStream()
             instr.on_scope_exit(sdfg, state, scope_exit, outer_stream, self.scope_exit_stream, self._globalcode)
 
-        # Redefine constant arguments
+        # Redefine constant arguments and rename arguments to device counterparts
         # TODO: This (const behavior and code below) is all a hack.
         #       Refactor and fix when nested SDFGs are separate functions.
         self._dispatcher.defined_vars.enter_scope(scope_entry)
-        for aname, arg in kernel_args.items():
+        prototype_kernel_args = {}
+        for aname, arg in kernel_args.items():  # `list` wrapper is used to modify kernel_args within the loop
             if aname in const_params:
                 defined_type, ctype = None, None
                 if aname in sdfg.arrays:
@@ -1304,6 +1305,14 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                     inner_ptrname = cpp.ptr(aname, data_desc, sdfg, self._frame)
                     CUDACodeGen._in_device_code = False
                     self._dispatcher.defined_vars.add(inner_ptrname, defined_type, ctype, allow_shadowing=True)
+
+                    # Rename argument in kernel prototype as necessary
+                    aname = inner_ptrname
+
+            prototype_kernel_args[aname] = arg
+
+        kernel_args_typed = [('const ' if k in const_params else '') + v.as_arg(name=k)
+                             for k, v in prototype_kernel_args.items()]
 
         kernel_stream = CodeIOStream()
         self.generate_kernel_scope(sdfg, dfg_scope, state_id, scope_entry.map, kernel_name, grid_dims, block_dims,
@@ -1400,7 +1409,7 @@ int dace_number_blocks = ((int) ceil({fraction} * dace_number_SMs)) * {occupancy
 void  *{kname}_args[] = {{ {kargs} }};
 {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bdims}), {kname}_args, {dynsmem}, {stream});'''.format(
                 kname=kernel_name,
-                kargs=', '.join(['(void *)&' + arg for arg in kernel_args] + extra_kernel_args),
+                kargs=', '.join(['(void *)&' + arg for arg in prototype_kernel_args] + extra_kernel_args),
                 gdims='dace_number_blocks, 1, 1' if is_persistent else ', '.join(_topy(grid_dims)),
                 bdims=', '.join(_topy(block_dims)),
                 dynsmem=_topy(dynsmem_size),
@@ -2146,7 +2155,6 @@ void  *{kname}_args[] = {{ {kargs} }};
                 # Rewrite grid conditions
                 for cond in self._kernel_grid_conditions:
                     callsite_stream.write(cond, sdfg, state_id, scope_entry)
-                
 
     def generate_node(self, sdfg, dfg, state_id, node, function_stream, callsite_stream):
         if self.node_dispatch_predicate(sdfg, dfg, node):

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -1,29 +1,27 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-from dace.sdfg.nodes import EntryNode
-from typing import Optional, Set, Tuple
-
 import collections
 import copy
-import dace
 import functools
 import re
+from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple, Union
+
+import networkx as nx
+import numpy as np
+
+import dace
+from dace import config, data, dtypes
 from dace.codegen import control_flow as cflow
 from dace.codegen import dispatcher as disp
 from dace.codegen.prettycode import CodeIOStream
 from dace.codegen.targets.common import codeblock_to_cpp, sym2cpp
 from dace.codegen.targets.cpp import unparse_interstate_edge
 from dace.codegen.targets.target import TargetCodeGenerator
-from dace.sdfg import SDFG, SDFGState, ScopeSubgraphView
-from dace.sdfg import nodes, utils
-from dace.sdfg.infer_types import set_default_schedule_and_storage_types
-from dace.sdfg import scope as sdscope
-from dace import dtypes, data, config
-from typing import Any, DefaultDict, Dict, List, Tuple, Union
-
 from dace.frontend.python import wrappers
-
-import networkx as nx
-import numpy as np
+from dace.sdfg import SDFG, ScopeSubgraphView, SDFGState, nodes
+from dace.sdfg import scope as sdscope
+from dace.sdfg import utils
+from dace.sdfg.infer_types import set_default_schedule_and_storage_types
+from dace.transformation.passes.analysis import StateReachability
 
 
 def _get_or_eval_sdfg_first_arg(func, sdfg):
@@ -326,7 +324,7 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
 
         components = dace.sdfg.concurrent_subgraphs(state)
 
-        if len(components) == 1:
+        if len(components) <= 1:
             self._dispatcher.dispatch_subgraph(sdfg, state, sid, global_stream, callsite_stream, skip_entry_node=False)
         else:
             if sdfg.openmp_sections:
@@ -366,6 +364,7 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
         if config.Config.get_bool('optimizer', 'detect_control_flow'):
             # Avoid import loop
             from dace.transformation import helpers as xfh
+
             # Clean up the state machine by separating combined condition and assignment
             # edges.
             xfh.split_interstate_edges(sdfg)
@@ -427,37 +426,34 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
         :param top_sdfg: The top-level SDFG to determine for.
         """
         # Gather shared transients, free symbols, and first/last appearance
-        shared_transients = {}
         fsyms = {}
-        first_instance: Dict[int, Dict[str, Tuple[SDFGState, nodes.AccessNode]]] = {}
-        last_instance: Dict[int, Dict[str, Tuple[SDFGState, nodes.AccessNode]]] = {}
+        reachability = {}
+        access_instances: Dict[int, Dict[str, List[Tuple[SDFGState, nodes.AccessNode]]]] = {}
         for sdfg in top_sdfg.all_sdfgs_recursive():
-            shared_transients[sdfg.sdfg_id] = sdfg.shared_transients(check_toplevel=False)
             fsyms[sdfg.sdfg_id] = self.symbols_and_constants(sdfg)
+            reachability[sdfg.sdfg_id] = StateReachability().apply_pass(sdfg, {})
 
-            # Possibly confusing control flow below finds the first/last state
-            # and node of the data descriptor
-            finst: Dict[str, Tuple[SDFGState, nodes.AccessNode]] = {}
-            linst: Dict[str, Tuple[SDFGState, nodes.AccessNode]] = {}
-            array_names = set(sdfg.arrays.keys())
+            #############################################
+            # Look for all states in which a scope-allocated array is used in
+            instances: Dict[str, List[Tuple[SDFGState, nodes.AccessNode]]] = collections.defaultdict(list)
+            array_names = sdfg.arrays.keys(
+            )  #set(k for k, v in sdfg.arrays.items() if v.lifetime == dtypes.AllocationLifetime.Scope)
+            # Iterate topologically to get state-order
             for state in sdfg.topological_sort():
                 for node in state.data_nodes():
-                    if node.data not in finst:
-                        finst[node.data] = (state, node)
-                    linst[node.data] = (state, node)
+                    if node.data not in array_names:
+                        continue
+                    instances[node.data].append((state, node))
 
                 # Look in the surrounding edges for usage
                 edge_fsyms: Set[str] = set()
                 for e in sdfg.all_edges(state):
                     edge_fsyms |= e.data.free_symbols
                 for edge_array in edge_fsyms & array_names:
-                    if edge_array not in finst:
-                        finst[edge_array] = (state, nodes.AccessNode(edge_array))
-                    linst[edge_array] = (state, nodes.AccessNode(edge_array))
-                
+                    instances[edge_array].append((state, nodes.AccessNode(edge_array)))
+            #############################################
 
-            first_instance[sdfg.sdfg_id] = finst
-            last_instance[sdfg.sdfg_id] = linst
+            access_instances[sdfg.sdfg_id] = instances
 
         for sdfg, name, desc in top_sdfg.arrays_recursive():
             if not desc.transient:
@@ -479,9 +475,9 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
             # 6. True if deallocation should take place, otherwise False.
 
             first_state_instance, first_node_instance = \
-                first_instance[sdfg.sdfg_id].get(name, (None, None))
+                access_instances[sdfg.sdfg_id].get(name, [(None, None)])[0]
             last_state_instance, last_node_instance = \
-                last_instance[sdfg.sdfg_id].get(name, (None, None))
+                access_instances[sdfg.sdfg_id].get(name, [(None, None)])[-1]
 
             # Cases
             if desc.lifetime is dtypes.AllocationLifetime.Persistent:
@@ -510,8 +506,6 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
                 definition = desc.as_arg(name=f'__{sdfg.sdfg_id}_{name}') + ';'
                 self.statestruct.append(definition)
 
-                # self.to_allocate[top_sdfg].append(
-                #     (sdfg.sdfg_id, sdfg.node_id(state), node))
                 self.to_allocate[top_sdfg].append((sdfg, first_state_instance, first_node_instance, True, True, True))
                 self.where_allocated[(sdfg, name)] = top_sdfg
                 continue
@@ -522,17 +516,15 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
             # a kernel).
             alloc_scope: Union[nodes.EntryNode, SDFGState, SDFG] = None
             alloc_state: SDFGState = None
-            access_node: nodes.AccessNode = None
-            if (name in shared_transients[sdfg.sdfg_id] or desc.lifetime is dtypes.AllocationLifetime.SDFG):
-                # SDFG memory and shared transients are allocated in the
-                # beginning of their SDFG
+            if desc.lifetime == dtypes.AllocationLifetime.SDFG:
+                # SDFG descriptors are allocated in the beginning of their SDFG
                 alloc_scope = sdfg
                 if first_state_instance is not None:
                     alloc_state = first_state_instance
                 # If unused, skip
                 if first_node_instance is None:
                     continue
-            elif desc.lifetime is dtypes.AllocationLifetime.State:
+            elif desc.lifetime == dtypes.AllocationLifetime.State:
                 # State memory is either allocated in the beginning of the
                 # containing state or the SDFG (if used in more than one state)
                 curstate: SDFGState = None
@@ -548,7 +540,7 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
                 else:
                     alloc_scope = curstate
                     alloc_state = curstate
-            elif desc.lifetime is dtypes.AllocationLifetime.Scope:
+            elif desc.lifetime == dtypes.AllocationLifetime.Scope:
                 # Scope memory (default) is either allocated in the innermost
                 # scope (e.g., Map, Consume) it is used in (i.e., greatest
                 # common denominator), or in the SDFG if used in multiple states
@@ -640,12 +632,20 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
             # NOTE: Tuple is (SDFG, State, Node, declare, allocate, deallocate)
             fsymbols = fsyms[sdfg.sdfg_id]
             if (not isinstance(curscope, nodes.EntryNode)
-                    and utils.is_nonfree_sym_dependent(first_node_instance, desc, alloc_state, fsymbols)):
+                    and utils.is_nonfree_sym_dependent(first_node_instance, desc, first_state_instance, fsymbols)):
                 # Declare in current (SDFG) scope
-                self.to_allocate[curscope].append((sdfg, first_state_instance, first_node_instance, True, False, False))
-                # Allocate in first State
-                # Deallocate in last State
+                self.to_allocate[curscope].append((sdfg, None, first_node_instance, True, False, False))
+                
+                # Allocate in first State, deallocate in last State
                 if first_state_instance != last_state_instance:
+                    # If any state is not reachable from first state, find common denominators in the form of
+                    # dominator and postdominator.
+                    instances = access_instances[sdfg.sdfg_id][name]
+                    if any(inst not in reachability[sdfg.sdfg_id][first_state_instance] for inst in instances):
+                        first_state_instance, last_state_instance = _get_dominator_and_postdominator(sdfg, instances)
+                        first_node_instance = nodes.AccessNode(name)
+                        last_node_instance = nodes.AccessNode(name)
+
                     curscope = first_state_instance
                     self.to_allocate[curscope].append(
                         (sdfg, first_state_instance, first_node_instance, False, True, False))
@@ -671,7 +671,7 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
                 state_id = tsdfg.node_id(state)
             else:
                 state_id = -1
-   
+
             desc = node.desc(tsdfg)
 
             self._dispatcher.dispatch_allocate(tsdfg, state, state_id, node, desc, function_stream, callsite_stream,
@@ -687,7 +687,7 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
                 state_id = tsdfg.node_id(state)
             else:
                 state_id = -1
-            
+
             desc = node.desc(tsdfg)
 
             self._dispatcher.dispatch_deallocate(tsdfg, state, state_id, node, desc, function_stream, callsite_stream)
@@ -838,3 +838,56 @@ DACE_EXPORTED void __dace_exit_{sdfg.name}({sdfg.name}_t *__state)
 
         # Return the generated global and local code strings
         return (generated_header, clean_code, self._dispatcher.used_targets, self._dispatcher.used_environments)
+
+
+def _get_dominator_and_postdominator(sdfg: SDFG, accesses: List[Tuple[SDFGState, nodes.AccessNode]]):
+    """
+    Gets the closest common dominator and post-dominator for a list of states.
+    Used for determining allocation of data used in branched states.
+    """
+    from dace.sdfg.analysis import cfg
+
+    # Get immediate dominators
+    idom = nx.immediate_dominators(sdfg.nx, sdfg.start_state)
+    alldoms = cfg.all_dominators(sdfg, idom)
+
+    states = [a for a, _ in accesses]
+    data_name = accesses[0][1].data
+
+    # Get immediate post-dominators
+    sink_nodes = sdfg.sink_nodes()
+    if len(sink_nodes) > 1:
+        sink = sdfg.add_state()
+        for snode in sink_nodes:
+            sdfg.add_edge(snode, sink, dace.InterstateEdge())
+    else:
+        sink = sink_nodes[0]
+    ipostdom = nx.immediate_dominators(sdfg._nx.reverse(), sink)
+    allpostdoms = cfg.all_dominators(sdfg, ipostdom)
+    
+    # All dominators and postdominators include the states themselves
+    for state in states:
+        alldoms[state].add(state)
+        allpostdoms[state].add(state)
+
+
+    # If a new sink was added for post-dominator computation, remove it
+    if len(sink_nodes) > 1:
+        sdfg.remove_node(sink)
+
+    start_state = states[0]
+    while any(start_state not in alldoms[n] for n in states):
+        if idom[start_state] is start_state:
+            raise NotImplementedError(f'Could not find an appropriate dominator for allocation of "{data_name}"')
+        start_state = idom[start_state]
+
+    end_state = states[-1]
+    while any(end_state not in allpostdoms[n] for n in states):
+        if ipostdom[end_state] is end_state:
+            raise NotImplementedError(f'Could not find an appropriate post-dominator for deallocation of "{data_name}"')
+        end_state = ipostdom[end_state]
+
+    # TODO(later): If any of the symbols were not yet defined, or have changed afterwards, fail
+    # raise NotImplementedError
+
+    return start_state, end_state

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -77,7 +77,7 @@ def infer_symbols_from_datadescriptor(sdfg: SDFG, args: Dict[str, Any],
     exclude = set(symbolic.symbol(s) for s in exclude)
     equations = []
     symbols = set()
-    
+
     # Collect equations and symbols from arguments and shapes
     for arg_name, arg_val in args.items():
         if arg_name in sdfg.arrays:
@@ -203,7 +203,19 @@ class DaceProgram(pycommon.SDFGConvertible):
         return autoopt.auto_optimize(sdfg, self.device, symbols=symbols)
 
     def to_sdfg(self, *args, simplify=None, save=False, validate=False, use_cache=False, **kwargs) -> SDFG:
-        """ Parses the DaCe function into an SDFG. """
+        """
+        Creates an SDFG from the DaCe function. If no type hints are provided on the function, example arrays/scalars
+        (i.e., with the same shape and type) must be given to this method in order to construct a valid SDFG.
+
+        :param args: JIT (i.e., without type hints) argument examples.
+        :param kwargs: JIT (i.e., without type hints) keyword argument examples.
+        :param simplify: Whether to simplify the SDFG after parsing (default is None, which uses the .dace.conf setting)
+        :param save: Whether to save the SDFG to a file after parsing
+        :param validate: Whether to validate the parsed SDFG
+        :param use_cache: If True, tries to find an already parsed SDFG in the local cache. Otherwise, re-parses SDFG.
+        :return: An SDFG object that can be transformed, saved, or called.
+        """
+
         if use_cache:
             # Update global variables with current closure
             self.global_vars = _get_locals_and_globals(self.f)
@@ -403,7 +415,6 @@ class DaceProgram(pycommon.SDFGConvertible):
             sdfg = self._auto_optimize(sdfg, symbols=sdfg_args)
             sdfg.simplify()
 
-
         # Compile SDFG (note: this is done after symbol inference due to shape
         # altering transformations such as Vectorization)
         binaryobj = sdfg.compile(validate=self.validate)
@@ -555,8 +566,14 @@ class DaceProgram(pycommon.SDFGConvertible):
                         if curarg is None and not _is_empty(sig_arg.default):
                             curarg = sig_arg.default
                         elif curarg is None:
-                            raise SyntaxError('Not enough arguments given to program (missing '
-                                              f'argument: "{aname}").')
+                            if _is_empty(ann):
+                                raise SyntaxError('Not enough arguments given to program (missing '
+                                                  f'argument: "{aname}"). Since no type hint is decorated on the '
+                                                  'function parameter, an example parameter (e.g., array of the same '
+                                                  'shape and type) must be given.')
+                            else:
+                                raise SyntaxError('Not enough arguments given to program (missing '
+                                                  f'argument: "{aname}").')
                     else:
                         if curarg is None:
                             curarg = given_args[arg_ind]
@@ -568,8 +585,15 @@ class DaceProgram(pycommon.SDFGConvertible):
                             if curarg is None and not _is_empty(sig_arg.default):
                                 curarg = sig_arg.default
                             elif curarg is None:
-                                raise SyntaxError('Not enough arguments given to program (missing '
-                                                  f'argument: "{aname}").')
+                                if _is_empty(ann):
+                                    raise SyntaxError(
+                                        'Not enough arguments given to program (missing '
+                                        f'argument: "{aname}"). Since no type hint is decorated on the '
+                                        'function parameter, an example parameter (e.g., array of the same '
+                                        'shape and type) must be given.')
+                                else:
+                                    raise SyntaxError('Not enough arguments given to program (missing '
+                                                      f'argument: "{aname}").')
                         elif curarg is None:
                             curarg = given_kwargs[aname]
                     else:
@@ -582,8 +606,14 @@ class DaceProgram(pycommon.SDFGConvertible):
                         if curarg is None and not _is_empty(sig_arg.default):
                             curarg = sig_arg.default
                         elif curarg is None:
-                            raise SyntaxError('Not enough arguments given to program (missing '
-                                              f'argument: "{aname}").')
+                            if _is_empty(ann):
+                                raise SyntaxError('Not enough arguments given to program (missing '
+                                                  f'argument: "{aname}"). Since no type hint is decorated on the '
+                                                  'function parameter, an example parameter (e.g., array of the same '
+                                                  'shape and type) must be given.')
+                            else:
+                                raise SyntaxError('Not enough arguments given to program (missing '
+                                                  f'argument: "{aname}").')
                     elif curarg is None:
                         curarg = given_kwargs[aname]
 
@@ -731,14 +761,14 @@ class DaceProgram(pycommon.SDFGConvertible):
             if v.dtype.type is None:
                 global_vars[k] = None
                 removed_args.add(k)
-        
+
         # Set module aliases to point to their actual names
         modules = {k: v.__name__ for k, v in global_vars.items() if dtypes.ismodule(v)}
         modules['builtins'] = ''
 
         # Add symbols as globals with their actual names (sym_0 etc.)
         global_vars.update({v.name: v for _, v in global_vars.items() if isinstance(v, symbolic.symbol)})
-        
+
         # Add default arguments to global vars
         unspecified_default_args = {k: v for k, v in self.default_args.items() if k not in specified}
         removed_args.update(unspecified_default_args)
@@ -750,7 +780,6 @@ class DaceProgram(pycommon.SDFGConvertible):
         argtypes = {k: v for k, v in argtypes.items() if k not in removed_args}
         for argtype in argtypes.values():
             global_vars.update({v.name: v for v in argtype.free_symbols})
-
 
         # Parse AST to create the SDFG
         parsed_ast, closure = preprocessing.preprocess_dace_program(dace_func,

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -620,6 +620,10 @@ class DaceProgram(pycommon.SDFGConvertible):
         else:
             sdfg = None
 
+        # Move "self" from an argument into the closure
+        if self.methodobj is not None:
+            self.global_vars[self.objname] = self.methodobj
+
         # Perform preprocessing to obtain closure
         argtypes, _, constant_args, given_args = self._get_type_annotations(args, kwargs)
 

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
+import collections
 import copy
 from dataclasses import dataclass
 import inspect
@@ -10,7 +11,7 @@ import sympy
 import sys
 import warnings
 
-from typing import Any, Callable, Dict, List, Optional, OrderedDict, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import dace
 from dace import data, dtypes, subsets, symbolic, sdfg as sd
 from dace.config import Config
@@ -25,13 +26,11 @@ class DaceRecursionError(Exception):
     The exception includes the id of the topmost function as a stopping
     condition for parsing.
     """
-
     def __init__(self, fid: int):
         self.fid = fid
 
     def __str__(self) -> str:
-        return ('Non-analyzable recursion detected, function cannot be parsed '
-                'as data-centric')
+        return ('Non-analyzable recursion detected, function cannot be parsed ' 'as data-centric')
 
 
 @dataclass
@@ -50,7 +49,6 @@ class PreprocessedAST:
 class StructTransformer(ast.NodeTransformer):
     """ A Python AST transformer that replaces `Call`s to create structs with
         the custom StructInitializer AST node. """
-
     def __init__(self, gvars):
         super().__init__()
         self._structs = {k: v for k, v in gvars.items() if isinstance(v, dtypes.struct)}
@@ -79,7 +77,6 @@ class StructTransformer(ast.NodeTransformer):
 
 # Replaces instances of modules Y imported with "import X as Y" by X
 class ModuleResolver(ast.NodeTransformer):
-
     def __init__(self, modules: Dict[str, str], always_replace=False):
         self.modules = modules
         self.should_replace = False
@@ -112,7 +109,6 @@ class RewriteSympyEquality(ast.NodeTransformer):
     This is done because a test ``if x == 0`` where ``x`` is a symbol would
     result in False, even in indeterminate cases.
     """
-
     def __init__(self, globals: Dict[str, Any]) -> None:
         super().__init__()
         self.globals = globals
@@ -149,7 +145,6 @@ class ConditionalCodeResolver(ast.NodeTransformer):
     """ 
     Replaces if conditions by their bodies if can be evaluated at compile time.
     """
-
     def __init__(self, globals: Dict[str, Any]):
         super().__init__()
         self.globals_and_locals = copy.copy(globals)
@@ -199,7 +194,6 @@ class _FindBreakContinueStmts(ast.NodeVisitor):
     Find control statements in the given loop (break / continue), without
     traversing into nested loops.
     """
-
     def __init__(self) -> None:
         super().__init__()
         self.has_cflow = False
@@ -227,7 +221,6 @@ class _FindBreakContinueStmts(ast.NodeVisitor):
 
 class DeadCodeEliminator(ast.NodeTransformer):
     """ Removes any code within scope after return/break/continue/raise. """
-
     def generic_visit(self, node: ast.AST):
         for field, old_value in ast.iter_fields(node):
             if isinstance(old_value, list):
@@ -325,6 +318,7 @@ def _create_unflatten_instruction(arg: ast.AST) -> Tuple[Callable, int]:
         def make_remake(kwnames):
             def remake_dict(args):
                 return {k: a for k, a in zip(kwnames, args)}
+
             return remake_dict
 
         # Remake keyword argument names from AST
@@ -354,7 +348,7 @@ def flatten_callback(func: Callable, node: ast.Call):
     """
 
     # Find out if any Python arguments should be flattened
-    unflatten_instructions: Dict[int, Tuple[Callable, int]] = OrderedDict()
+    unflatten_instructions: Dict[int, Tuple[Callable, int]] = collections.OrderedDict()
     curarg = 0
     instructions_exist = False
     for arg in node.args:
@@ -395,8 +389,9 @@ def flatten_callback(func: Callable, node: ast.Call):
                 kwargs = {kw: arg for kw, arg in zip(keywords, unflattened[poscount:])}
                 return func(*args, **kwargs)
 
-            return cb_func        
+            return cb_func
     else:
+
         def make_cb(keywords, poscount, _):
             def cb_func(*all_args):
                 args = all_args[:poscount]
@@ -411,7 +406,6 @@ def flatten_callback(func: Callable, node: ast.Call):
 class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
     """ Resolves global constants and lambda expressions if not
         already defined in the given scope. """
-
     def __init__(self, globals: Dict[str, Any], resolve_functions: bool = False, default_args: Set[str] = None):
         self._globals = globals
         self.resolve_functions = resolve_functions
@@ -810,7 +804,6 @@ class ContextManagerInliner(ast.NodeTransformer, astutils.ASTHelperMixin):
     in the right places, i.e., at the end of the body or when the context is left due to
     a return statement, or top-level break/continue statements.
     """
-
     def __init__(self, globals: Dict[str, Any], filename: str, closure_resolver: GlobalResolver) -> None:
         super().__init__()
         self.with_statements: List[ast.With] = []
@@ -1140,7 +1133,6 @@ class LoopUnroller(ast.NodeTransformer):
 
 
 class CallTreeResolver(ast.NodeVisitor):
-
     def __init__(self, closure: SDFGClosure, globals: Dict[str, Any]) -> None:
         self.closure = closure
         self.seen_calls: Set[str] = set()
@@ -1286,7 +1278,6 @@ class CallTreeResolver(ast.NodeVisitor):
 
 
 class ArrayClosureResolver(ast.NodeVisitor):
-
     def __init__(self, closure: SDFGClosure):
         self.closure = closure
         self.arrays: Set[str] = set()
@@ -1298,7 +1289,6 @@ class ArrayClosureResolver(ast.NodeVisitor):
 
 
 class AugAssignExpander(ast.NodeTransformer):
-
     def visit_AugAssign(self, node: ast.AugAssign) -> ast.Assign:
         target = self.generic_visit(node.target)
         value = self.generic_visit(node.value)

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -655,7 +655,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
         try:
             global_val = astutils.evalnode(node, self.globals)
         except SyntaxError:
-            return node  # Do NOT use generic_visit here as it may modify the attribute value too soon
+            return self.generic_visit(node)
 
         if not isinstance(global_val, dtypes.typeclass):
             newnode = self.global_value_to_node(global_val,

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -652,7 +652,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
         try:
             global_val = astutils.evalnode(node, self.globals)
         except SyntaxError:
-            return self.generic_visit(node)
+            return node  # Do NOT use generic_visit here as it may modify the attribute value too soon
 
         if not isinstance(global_val, dtypes.typeclass):
             newnode = self.global_value_to_node(global_val,
@@ -661,7 +661,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                                                 recurse=True)
             if newnode is not None:
                 return newnode
-        return self.generic_visit(node)
+        return node  # Do NOT use generic_visit here as it may modify the attribute value too soon
 
     def visit_Subscript(self, node: ast.Subscript) -> Any:
         # First visit the subscripted value alone, then the whole subscript
@@ -1407,8 +1407,7 @@ def preprocess_dace_program(f: Callable[..., Any],
         ctr.visit(src_ast)
     except DaceRecursionError as ex:
         if id(f) == ex.fid:
-            raise TypeError('Parsing failed due to recursion in a data-centric '
-                            'context called from this function')
+            raise TypeError('Parsing failed due to recursion in a data-centric ' 'context called from this function')
         else:
             raise ex
     used_arrays = ArrayClosureResolver(closure_resolver.closure)

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -618,6 +618,9 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
         return self.visit_FunctionDef(node)
 
+    def visit_Lambda(self, node: ast.Lambda) -> Any:
+        return self.visit_FunctionDef(node)
+
     def visit_AugAssign(self, node: ast.AugAssign):
         # Node target in augassign is ast.Store, even though it is updating an existing value
         oldvalue = self.ignore_node_ctx

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -623,7 +623,7 @@ class OrderedDiGraph(Graph[NodeT, EdgeT], Generic[NodeT, EdgeT]):
         try:
             return next(n for i, n in enumerate(self._nodes.keys()) if i == id)
         except StopIteration:
-            raise IndexError
+            raise NodeNotFoundError
 
     def node_id(self, node: NodeT) -> int:
         try:

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -675,7 +675,7 @@ class MapEntry(EntryNode):
             if nid is not None:
                 exit_node = context['sdfg_state'].node(nid)
                 exit_node.map = m
-        except IndexError:  # Exit node has a higher node ID
+        except graph.NodeNotFoundError:  # Exit node has a higher node ID
             # Connection of the scope nodes handled in MapExit
             pass
 
@@ -885,7 +885,7 @@ class ConsumeEntry(EntryNode):
             if nid is not None:
                 exit_node = context['sdfg_state'].node(nid)
                 exit_node.consume = c
-        except IndexError:  # Exit node has a higher node ID
+        except graph.NodeNotFoundError:  # Exit node has a higher node ID
             # Connection of the scope nodes handled in ConsumeExit
             pass
 

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -739,7 +739,7 @@ class MapExit(ExitNode):
             entry_node = context['sdfg_state'].node(int(json_obj['scope_entry']))
 
             ret = cls(map=entry_node.map)
-        except (IndexError, TypeError):
+        except (IndexError, TypeError, graph.NodeNotFoundError):
             # Entry node has a higher ID than exit node
             # Connection of the scope nodes handled in MapEntry
             ret = cls(cls.map_type()('_', [], []))
@@ -948,7 +948,7 @@ class ConsumeExit(ExitNode):
             # Set consume reference to entry node
             entry_node = context['sdfg_state'].node(int(json_obj['scope_entry']))
             ret = ConsumeExit(consume=entry_node.consume)
-        except (IndexError, TypeError):
+        except (IndexError, TypeError, graph.NodeNotFoundError):
             # Entry node has a higher ID than exit node
             # Connection of the scope nodes handled in ConsumeEntry
             ret = ConsumeExit(Consume("", ['i', 1], None))

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1976,7 +1976,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         # Argument checks
         if loop_var is None and (initialize_expr or increment_expr):
-            raise ValueError("Cannot initalize or increment an empty loop" " variable")
+            raise ValueError("Cannot initalize or increment an empty loop variable")
 
         # Handling empty states
         if loop_end_state is None:
@@ -2187,7 +2187,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                 unnecessary_args.extend(kwargs.keys())
             else:
                 unnecessary_args = [k for k in kwargs.keys() if k not in expected_args]
-            raise RuntimeError("Too many arguments to SDFG. Unnecessary " "arguments: %s" % ', '.join(unnecessary_args))
+            raise RuntimeError("Too many arguments to SDFG. Unnecessary arguments: %s" % ', '.join(unnecessary_args))
         positional_args = list(args)
         for i, arg in enumerate(expected_args):
             expected = expected_args[arg]
@@ -2200,7 +2200,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
             if types_only:
                 desc = dt.create_datadescriptor(passed)
                 if not expected.is_equivalent(desc):
-                    raise TypeError("Type mismatch for argument: " "expected %s, got %s" % (expected, desc))
+                    raise TypeError("Type mismatch for argument: expected %s, got %s" % (expected, desc))
                 else:
                     continue
             if isinstance(expected, dace.data.Array):

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1164,7 +1164,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         # Add free inter-state symbols
         for e in self.edges():
-            defined_syms |= set(e.data.new_symbols(self, {}).keys())
+            defined_syms |= set(e.data.assignments.keys())
             free_syms |= e.data.free_symbols
 
         defined_syms |= set(self.constants.keys())

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -191,6 +191,9 @@ class InterstateEdge(object):
         :param repl: Replacement dictionary.
         :param replace_keys: If False, skips replacing assignment keys.
         """
+        if not repl:
+            return
+
         if replace_keys:
             for name, new_name in repl.items():
                 _replace_dict_keys(self.assignments, name, new_name)
@@ -461,7 +464,6 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         :param jsondict: If not None, uses given JSON dictionary as input.
         :return: The hash (in SHA-256 format).
         '''
-
         def keyword_remover(json_obj: Any, last_keyword=""):
             # Makes non-unique in SDFG hierarchy v2
             # Recursively remove attributes from the SDFG which are not used in
@@ -1823,8 +1825,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
             if find_new_name:
                 name = self._find_new_name(name)
             else:
-                raise NameError('Array or Stream with name "%s" already exists '
-                                "in SDFG" % name)
+                raise NameError('Array or Stream with name "%s" already exists ' "in SDFG" % name)
         self._arrays[name] = datadesc
 
         # Add free symbols to the SDFG global symbol storage
@@ -1975,8 +1976,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
         # Argument checks
         if loop_var is None and (initialize_expr or increment_expr):
-            raise ValueError("Cannot initalize or increment an empty loop"
-                             " variable")
+            raise ValueError("Cannot initalize or increment an empty loop" " variable")
 
         # Handling empty states
         if loop_end_state is None:
@@ -2187,8 +2187,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
                 unnecessary_args.extend(kwargs.keys())
             else:
                 unnecessary_args = [k for k in kwargs.keys() if k not in expected_args]
-            raise RuntimeError("Too many arguments to SDFG. Unnecessary "
-                               "arguments: %s" % ', '.join(unnecessary_args))
+            raise RuntimeError("Too many arguments to SDFG. Unnecessary " "arguments: %s" % ', '.join(unnecessary_args))
         positional_args = list(args)
         for i, arg in enumerate(expected_args):
             expected = expected_args[arg]
@@ -2201,8 +2200,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
             if types_only:
                 desc = dt.create_datadescriptor(passed)
                 if not expected.is_equivalent(desc):
-                    raise TypeError("Type mismatch for argument: "
-                                    "expected %s, got %s" % (expected, desc))
+                    raise TypeError("Type mismatch for argument: " "expected %s, got %s" % (expected, desc))
                 else:
                     continue
             if isinstance(expected, dace.data.Array):

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -621,6 +621,17 @@ class AND(sympy.Function):
         return True
 
 
+class ROUND(sympy.Function):
+
+    @classmethod
+    def eval(cls, x):
+        if x.is_Number:
+            return round(x)
+
+    def _eval_is_integer(self):
+        return True
+
+
 def sympy_intdiv_fix(expr):
     """ Fix for SymPy printing out reciprocal values when they should be
         integral in "ceiling/floor" sympy functions.
@@ -848,6 +859,7 @@ def pystr_to_symbolic(expr, symbol_map=None, simplify=None) -> sympy.Basic:
         'NotEq': sympy.Ne,
         'floor': sympy.floor,
         'ceil': sympy.ceiling,
+        'round': ROUND,
         # Convert and/or to special sympy functions to avoid boolean evaluation
         'And': AND,
         'Or': OR,

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -440,7 +440,7 @@ def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType, toplevel_o
                     continue
                 # Only convert arrays where the size depends on SDFG parameters
                 try:
-                    if desc.total_size.free_symbols - fsyms:
+                    if set(map(str, desc.total_size.free_symbols)) - fsyms:
                         not_persistent.add(dnode.data)
                         continue
                 except AttributeError:  # total_size is an integer / has no free symbols

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -430,7 +430,7 @@ def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType, toplevel_o
             for dnode in state.data_nodes():
                 if dnode.data in not_persistent:
                     continue
-                desc = dnode.desc(sdfg)
+                desc = dnode.desc(nsdfg)
                 # Only convert arrays and scalars that are not registers
                 if not desc.transient or type(desc) not in {dt.Array, dt.Scalar}:
                     not_persistent.add(dnode.data)
@@ -439,9 +439,12 @@ def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType, toplevel_o
                     not_persistent.add(dnode.data)
                     continue
                 # Only convert arrays where the size depends on SDFG parameters
-                if desc.total_size.free_symbols - fsyms:
-                    not_persistent.add(dnode.data)
-                    continue
+                try:
+                    if desc.total_size.free_symbols - fsyms:
+                        not_persistent.add(dnode.data)
+                        continue
+                except AttributeError:  # total_size is an integer / has no free symbols
+                    pass
                 
                 # Only convert arrays with top-level access nodes
                 if sdict[dnode] is not None:

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -426,7 +426,6 @@ def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType, toplevel_o
         not_persistent: Set[str] = set()
 
         for state in nsdfg.nodes():
-            sdict = state.scope_dict()
             for dnode in state.data_nodes():
                 if dnode.data in not_persistent:
                     continue
@@ -447,7 +446,7 @@ def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType, toplevel_o
                     pass
                 
                 # Only convert arrays with top-level access nodes
-                if sdict[dnode] is not None:
+                if xfh.get_parent_map(state, dnode) is not None:
                     if toplevel_only:
                         not_persistent.add(dnode.data)
                         continue

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -406,27 +406,58 @@ def set_fast_implementations(sdfg: SDFG, device: dtypes.DeviceType, blocklist: L
                     node.implementation = 'CUDA (device)'
 
 
-def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType) -> None:
+def make_transients_persistent(sdfg: SDFG, device: dtypes.DeviceType, toplevel_only: bool = True) -> None:
     ''' 
     Helper function to change several storage and scheduling properties
     - Makes non-view array lifetimes persistent, with some 
       restrictions depending on the device 
     - Reset nonatomic WCR edges on GPU 
+    The only arrays that are made persistent by default are ones that do not exist inside a scope (and thus may be
+    allocated multiple times), and whose symbols are always given as parameters to the SDFG (so that they can be
+    allocated in a persistent manner).
+
     :param sdfg: SDFG
     :param device: Device type
+    :param toplevel_only: If True, only converts access nodes that do not appear in any scope.
     '''
-    for nsdfg in sdfg.all_sdfgs_recursive():
-        for aname, arr in nsdfg.arrays.items():
-            if arr.transient and not isinstance(arr, dt.View) and not symbolic.issymbolic(arr.total_size):
-                if arr.storage != dtypes.StorageType.Register:
-                    arr.lifetime = dtypes.AllocationLifetime.Persistent
+    for nsdfg in sdfg.all_sdfgs_recursive():       
+        fsyms: Set[str] = nsdfg.free_symbols
+        persistent: Set[str] = set()
+        not_persistent: Set[str] = set()
+
+        for state in nsdfg.nodes():
+            sdict = state.scope_dict()
+            for dnode in state.data_nodes():
+                if dnode.data in not_persistent:
+                    continue
+                desc = dnode.desc(sdfg)
+                # Only convert arrays and scalars that are not registers
+                if not desc.transient or type(desc) not in {dt.Array, dt.Scalar}:
+                    not_persistent.add(dnode.data)
+                    continue
+                if desc.storage == dtypes.StorageType.Register:
+                    not_persistent.add(dnode.data)
+                    continue
+                # Only convert arrays where the size depends on SDFG parameters
+                if desc.total_size.free_symbols - fsyms:
+                    not_persistent.add(dnode.data)
+                    continue
+                
+                # Only convert arrays with top-level access nodes
+                if sdict[dnode] is not None:
+                    if toplevel_only:
+                        not_persistent.add(dnode.data)
+                        continue
+                    elif desc.lifetime == dtypes.AllocationLifetime.Scope:
+                        not_persistent.add(dnode.data)
+                        continue
+                
+                persistent.add(dnode.data)                               
+
+        for aname in (persistent - not_persistent):
+            nsdfg.arrays[aname].lifetime = dtypes.AllocationLifetime.Persistent
 
     if device == dtypes.DeviceType.GPU:
-        for aname, arr in sdfg.arrays.items():
-            if arr.transient and not isinstance(arr, dt.View):  #and size only depends on SDFG params
-                if arr.storage == dtypes.StorageType.GPU_Global:
-                    arr.lifetime = dtypes.AllocationLifetime.Persistent
-
         # Reset nonatomic WCR edges
         for n, _ in sdfg.all_nodes_recursive():
             if isinstance(n, SDFGState):
@@ -551,11 +582,9 @@ def auto_optimize(sdfg: SDFG,
 
     # Set all Default storage types that are constant sized to registers
     move_small_arrays_to_stack(sdfg)
-    '''
-    # Fix storage and allocation properties, e.g., for benchmarking purposes
-    # FORNOW: Leave out
+
+    # Make all independent arrays persistent
     make_transients_persistent(sdfg, device)
-    '''
 
     # Validate at the end
     if validate or validate_all:

--- a/dace/transformation/interstate/move_loop_into_map.py
+++ b/dace/transformation/interstate/move_loop_into_map.py
@@ -25,7 +25,6 @@ class MoveLoopIntoMap(DetectLoop, transformation.MultiStateTransformation):
     """
     Moves a loop around a map into the map
     """
-
     def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
         # Is this even a loop
         if not super().can_be_applied(graph, expr_index, sdfg, permissive):
@@ -57,7 +56,10 @@ class MoveLoopIntoMap(DetectLoop, transformation.MultiStateTransformation):
         # Check that everything else is independent of the loop's itervar
         subgraph = body.scope_subgraph(maps[0])
         map_exit = body.exit_node(maps[0])
+        descs: Set[str] = set()
         for e in body.edges():
+            if not e.data.is_empty():
+                descs.add(e.data.data)
             if e.src in subgraph.nodes() or e.dst in subgraph.nodes():
                 continue
             if e.dst is maps[0] and isinstance(e.src, nodes.AccessNode):
@@ -70,6 +72,13 @@ class MoveLoopIntoMap(DetectLoop, transformation.MultiStateTransformation):
             if n in subgraph.nodes():
                 continue
             if str(itervar) in n.free_symbols:
+                return False
+
+        # Check for iteration variable in map and data descriptors
+        if str(itervar) in maps[0].free_symbols:
+            return False
+        for arr in descs:
+            if str(itervar) in set(map(str, sdfg.arrays[arr].free_symbols)):
                 return False
 
         def test_subset_dependency(subset: sbs.Subset, mparams: Set[int]) -> Tuple[bool, List[int]]:

--- a/dace/transformation/passes/scalar_to_symbol.py
+++ b/dace/transformation/passes/scalar_to_symbol.py
@@ -19,6 +19,7 @@ from dace.frontend.python import astutils
 from dace.sdfg import SDFG
 from dace.sdfg import graph as gr
 from dace.sdfg import utils as sdutils
+from dace.sdfg.replace import replace_properties_dict
 from dace.sdfg.sdfg import InterstateEdge
 from dace.transformation import helpers as xfh
 from dace.transformation import pass_pipeline as passes
@@ -543,6 +544,9 @@ def remove_scalar_reads(sdfg: sd.SDFG, array_names: Dict[str, str]):
                         dst.remove_in_connector(e.dst_conn)
                         dst.sdfg.symbols[tmp_symname] = sdfg.arrays[node.data].dtype
                         dst.symbol_mapping[tmp_symname] = symname
+                    elif isinstance(dst, nodes.EntryNode) and e.dst_conn and not e.dst_conn.startswith('IN_'):
+                        # Dynamic scope input, replace in node
+                        replace_properties_dict(dst, {e.dst_conn: symname})
                     elif isinstance(dst, (nodes.EntryNode, nodes.ExitNode)):
                         # Skip
                         continue

--- a/dace/transformation/passes/scalar_to_symbol.py
+++ b/dace/transformation/passes/scalar_to_symbol.py
@@ -419,8 +419,8 @@ def _cpp_indirection_promoter(
                 first_nonscalar_dim = 0
 
             # Make subset out of range and new sub-expression
-            other_subset = subsets.Range([(0, 0, 1)] * first_nonscalar_dim + [(subexpr, subexpr, 1)] + [(0, 0, 1)] *
-                                         (len(orig_subset) - first_nonscalar_dim - 1))
+            other_subset = subsets.Range(orig_subset.ndrange()[:first_nonscalar_dim] + [(subexpr, subexpr, 1)] +
+                                         orig_subset.ndrange()[first_nonscalar_dim + 1:])
             subset = orig_subset.compose(other_subset)
 
             # Check if range can be collapsed

--- a/samples/fpga/gemv_fpga.py
+++ b/samples/fpga/gemv_fpga.py
@@ -203,8 +203,8 @@ def run_gemv(n: int, m: int, specialize: bool):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("N", type=int)
-    parser.add_argument("M", type=int)
+    parser.add_argument("n", type=int)
+    parser.add_argument("m", type=int)
     parser.add_argument("-specialize", default=False, action="store_true", help="Also fix M in hardware")
     args = parser.parse_args()
 

--- a/tests/codegen/unparse_tasket_test.py
+++ b/tests/codegen/unparse_tasket_test.py
@@ -33,6 +33,20 @@ def test_integer_power_constant():
     assert ':pow(' not in sdfg.generate_code()[0].clean_code
 
 
+def test_equality():
+    @dace.program
+    def nested(a, b, c):
+        pass
+
+    @dace.program
+    def program(a: dace.float64[10], b: dace.float64[10]):
+        for c in range(2):
+            nested(a, b, (c == 1))
+
+    program.to_sdfg(simplify=False).compile()
+
+
 if __name__ == '__main__':
     test_integer_power()
     test_integer_power_constant()
+    test_equality()

--- a/tests/compile_sdfg_test.py
+++ b/tests/compile_sdfg_test.py
@@ -1,14 +1,14 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
 import numpy as np
+import pytest
 
 import dace as dp
-from dace.sdfg import SDFG
 from dace.memlet import Memlet
+from dace.sdfg import SDFG
 
 
 # Constructs an SDFG manually and runs it
 def test():
-    print('SDFG direct compilation test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
     N.set(20)
@@ -45,5 +45,17 @@ def test():
     assert diff <= 1e-5
 
 
+def test_bad_cast_csdfg():
+    @dp.program
+    def tester(a: int):
+        return a + 1
+
+    csdfg = tester.to_sdfg().compile()
+    with pytest.warns(None, match='Casting'):
+        result = csdfg(0.1)
+    assert result.item() == 1
+
+
 if __name__ == "__main__":
     test()
+    test_bad_cast_csdfg()

--- a/tests/inlining_test.py
+++ b/tests/inlining_test.py
@@ -187,15 +187,14 @@ def test_inline_symexpr():
 
 
 def test_inline_unsqueeze():
-
     @dace.program
     def nested_squeezed(c: dace.int32[5], d: dace.int32[5]):
         d[:] = c
-    
+
     @dace.program
     def inline_unsqueeze(A: dace.int32[2, 5], B: dace.int32[5, 3]):
         nested_squeezed(A[1, :], B[:, 1])
-    
+
     sdfg = inline_unsqueeze.to_sdfg()
     sdfg.apply_transformations(InlineSDFG)
 
@@ -204,22 +203,21 @@ def test_inline_unsqueeze():
     sdfg(A, B)
     for i in range(3):
         if i == 1:
-            assert(np.array_equal(B[:, i], A[1, :]))
+            assert (np.array_equal(B[:, i], A[1, :]))
         else:
-            assert(np.array_equal(B[:, i], np.zeros((5,), np.int32)))
+            assert (np.array_equal(B[:, i], np.zeros((5, ), np.int32)))
 
 
 def test_inline_unsqueeze2():
-
     @dace.program
     def nested_squeezed(c, d):
         d[:] = c
-    
+
     @dace.program
     def inline_unsqueeze(A: dace.int32[2, 5], B: dace.int32[5, 3]):
         for i in range(2):
-            nested_squeezed(A[i, :], B[:, 1-i])
-    
+            nested_squeezed(A[i, :], B[:, 1 - i])
+
     sdfg = inline_unsqueeze.to_sdfg()
     sdfg.apply_transformations(InlineSDFG)
 
@@ -228,22 +226,21 @@ def test_inline_unsqueeze2():
     sdfg(A, B)
     for i in range(3):
         if i < 2:
-            assert(np.array_equal(B[:, 1-i], A[i, :]))
+            assert (np.array_equal(B[:, 1 - i], A[i, :]))
         else:
-            assert(np.array_equal(B[:, i], np.zeros((5,), np.int32)))
+            assert (np.array_equal(B[:, i], np.zeros((5, ), np.int32)))
 
 
 def test_inline_unsqueeze3():
-
     @dace.program
     def nested_squeezed(c, d):
         d[:] = c
-    
+
     @dace.program
     def inline_unsqueeze(A: dace.int32[2, 5], B: dace.int32[5, 3]):
         for i in range(2):
-            nested_squeezed(A[i, i:i+2], B[i+1:i+3, 1-i])
-    
+            nested_squeezed(A[i, i:i + 2], B[i + 1:i + 3, 1 - i])
+
     sdfg = inline_unsqueeze.to_sdfg()
     sdfg.apply_transformations(InlineSDFG)
 
@@ -252,22 +249,21 @@ def test_inline_unsqueeze3():
     sdfg(A, B)
     for i in range(3):
         if i < 2:
-            assert(np.array_equal(B[i+1:i+3, 1-i], A[i, i:i+2]))
+            assert (np.array_equal(B[i + 1:i + 3, 1 - i], A[i, i:i + 2]))
         else:
-            assert(np.array_equal(B[:, i], np.zeros((5,), np.int32)))
+            assert (np.array_equal(B[:, i], np.zeros((5, ), np.int32)))
 
 
 def test_inline_unsqueeze4():
-
     @dace.program
     def nested_squeezed(c, d):
         d[:] = c
-    
+
     @dace.program
     def inline_unsqueeze(A: dace.int32[2, 5], B: dace.int32[5, 3]):
         for i in range(2):
-            nested_squeezed(A[i, i:2*i+2], B[i+1:2*i+3, 1-i])
-    
+            nested_squeezed(A[i, i:2 * i + 2], B[i + 1:2 * i + 3, 1 - i])
+
     sdfg = inline_unsqueeze.to_sdfg()
     sdfg.apply_transformations(InlineSDFG)
 
@@ -276,9 +272,28 @@ def test_inline_unsqueeze4():
     sdfg(A, B)
     for i in range(3):
         if i < 2:
-            assert(np.array_equal(B[i+1:2*i+3, 1-i], A[i, i:2*i+2]))
+            assert (np.array_equal(B[i + 1:2 * i + 3, 1 - i], A[i, i:2 * i + 2]))
         else:
-            assert(np.array_equal(B[:, i], np.zeros((5,), np.int32)))
+            assert (np.array_equal(B[:, i], np.zeros((5, ), np.int32)))
+
+
+def test_inline_symbol_assignment():
+    def nested(a, num):
+        cat = num - 1
+        last_step = (cat == 0)
+        if last_step is True:
+            return a + 1
+
+        return a
+
+    @dace.program
+    def tester(a: dace.float64[20], b: dace.float64[10, 20]):
+        for i in range(10):
+            cat = nested(a, i)
+            b[i] = cat
+
+    sdfg = tester.to_sdfg()
+    sdfg.compile()
 
 
 if __name__ == "__main__":
@@ -293,3 +308,4 @@ if __name__ == "__main__":
     test_inline_unsqueeze2()
     test_inline_unsqueeze3()
     test_inline_unsqueeze4()
+    test_inline_symbol_assignment()

--- a/tests/passes/scalar_to_symbol_test.py
+++ b/tests/passes/scalar_to_symbol_test.py
@@ -15,7 +15,6 @@ import pytest
 
 def test_find_promotable():
     """ Find promotable and non-promotable symbols. """
-
     @dace.program
     def testprog1(A: dace.float32[20, 20], scal: dace.float32):
         tmp = dace.ndarray([20, 20], dtype=dace.float32)
@@ -42,7 +41,6 @@ def test_find_promotable():
 
 def test_promote_simple():
     """ Simple promotion with Python tasklets. """
-
     @dace.program
     def testprog2(A: dace.float64[20, 20]):
         j = 5
@@ -70,7 +68,6 @@ def test_promote_simple():
 
 def test_promote_simple_c():
     """ Simple promotion with C++ tasklets. """
-
     @dace.program
     def testprog3(A: dace.float32[20, 20]):
         i = 0
@@ -113,7 +110,6 @@ def test_promote_simple_c():
 
 def test_promote_disconnect():
     """ Promotion that disconnects tasklet from map. """
-
     @dace.program
     def testprog4(A: dace.float64[20, 20]):
         j = 5
@@ -180,7 +176,6 @@ def test_promote_copy():
 
 def test_promote_array_assignment():
     """ Simple promotion with array assignment. """
-
     @dace.program
     def testprog6(A: dace.float64[20, 20]):
         j = A[1, 1]
@@ -209,7 +204,6 @@ def test_promote_array_assignment():
 
 def test_promote_array_assignment_tasklet():
     """ Simple promotion with array assignment. """
-
     @dace.program
     def testprog7(A: dace.float64[20, 20]):
         j = dace.define_local_scalar(dace.int64)
@@ -239,7 +233,6 @@ def test_promote_array_assignment_tasklet():
 
 class LoopTester(ld.DetectLoop, xf.MultiStateTransformation):
     """ Tester method that sets loop index on a guard state. """
-
     def can_be_applied(self, graph, expr_index, sdfg, permissive):
         if super().can_be_applied(graph, expr_index, sdfg, permissive):
             return False
@@ -304,7 +297,6 @@ def test_promote_loops():
 
 def test_promote_indirection():
     """ Indirect access in promotion. """
-
     @dace.program
     def testprog10(A: dace.float64[2, 3, 4, 5], B: dace.float64[4]):
         i = 2
@@ -355,7 +347,6 @@ def test_promote_indirection():
 
 def test_promote_output_indirection():
     """ Indirect output access in promotion. """
-
     @dace.program
     def testprog11(A: dace.float64[10]):
         i = 2
@@ -384,7 +375,6 @@ def test_promote_output_indirection():
 
 def test_promote_indirection_c():
     """ Indirect access in promotion with C++ tasklets. """
-
     @dace.program
     def testprog12(A: dace.float64[10]):
         i = 2
@@ -417,7 +407,6 @@ def test_promote_indirection_c():
 
 def test_promote_indirection_impossible():
     """ Indirect access that cannot be promoted. """
-
     @dace.program
     def testprog13(A: dace.float64[20, 20], scal: dace.int32):
         i = 2
@@ -587,7 +576,6 @@ def test_indirection_with_reindex(language):
 
 
 def test_multiple_boolop():
-
     @dace.program
     def tester():
         a = 1
@@ -603,6 +591,41 @@ def test_multiple_boolop():
     sdfg.validate()
 
     assert tester() == 0
+
+
+def test_multidim_cpp():
+    sdfg = dace.SDFG('tester')
+    sdfg.add_array('A', [20, 10], dace.float64)
+    sdfg.add_scalar('sz1', dace.int32, transient=True)
+    sdfg.add_scalar('sz2', dace.int32, transient=True)
+    sdfg.add_scalar('ind1', dace.int32, transient=True)
+    sdfg.add_scalar('ind2', dace.int32, transient=True)
+
+    state = sdfg.add_state()
+    state.add_edge(state.add_tasklet('s1', {}, {'o'}, 'o = 20;', language=dace.Language.CPP), 'o',
+                   state.add_write('sz1'), None, dace.Memlet('sz1'))
+    state.add_edge(state.add_tasklet('s2', {}, {'o'}, 'o = 10;', language=dace.Language.CPP), 'o',
+                   state.add_write('sz2'), None, dace.Memlet('sz2'))
+
+    state = sdfg.add_state_after(state)
+    t1 = state.add_tasklet('w1', {'i'}, {'o'}, 'o = i - 5;', language=dace.Language.CPP)
+    t2 = state.add_tasklet('w2', {'i'}, {'o'}, 'o = i - 3;', language=dace.Language.CPP)
+    state.add_edge(state.add_read('sz1'), None, t1, 'i', dace.Memlet('sz1'))
+    state.add_edge(state.add_read('sz2'), None, t2, 'i', dace.Memlet('sz2'))
+    state.add_edge(t1, 'o', state.add_write('ind1'), None, dace.Memlet('ind1'))
+    state.add_edge(t2, 'o', state.add_write('ind2'), None, dace.Memlet('ind2'))
+
+    state = sdfg.add_state_after(state)
+    t3 = state.add_tasklet('warr', {'i1', 'i2'}, {'arr'}, 'arr[i1][i2] = 1.0;', language=dace.Language.CPP)
+    state.add_edge(state.add_read('ind1'), None, t3, 'i1', dace.Memlet('ind1'))
+    state.add_edge(state.add_read('ind2'), None, t3, 'i2', dace.Memlet('ind2'))
+    state.add_edge(t3, 'arr', state.add_write('A'), None, dace.Memlet('A'))
+
+    scalar_to_symbol.ScalarToSymbolPromotion().apply_pass(sdfg, {})
+    new_edge = sdfg.sink_nodes()[0].edges()[0]
+
+    assert new_edge.data.data == 'A'
+    assert str(new_edge.data.subset) == 'ind1, ind2'
 
 
 if __name__ == '__main__':
@@ -624,3 +647,4 @@ if __name__ == '__main__':
     test_indirection_with_reindex(dace.Language.CPP)
     test_indirection_with_reindex(dace.Language.Python)
     test_multiple_boolop()
+    test_multidim_cpp()

--- a/tests/python_frontend/global_folding_test.py
+++ b/tests/python_frontend/global_folding_test.py
@@ -169,6 +169,24 @@ def test_dead_code_elimination_unreachable():
     assert '3' in parsed_code and '2' in parsed_code  # Reachable code
 
 
+def test_lambda_args():
+    y = 5
+
+    @dace.program
+    def tester(a: dace.float64[1], b: dace.float64[1]):
+        x = a
+        with dace.tasklet:
+            inp << x[0]
+            s = inp
+            s >> b(1, lambda x, y: x + y)
+
+    a = np.random.rand(1, 1)
+    b = np.random.rand(1, 1)
+    expected = b + a
+    tester(a, b)
+    assert np.allclose(b, expected)
+
+
 if __name__ == '__main__':
     test_instantiated_global()
     test_instantiated_global_resolve_functions()
@@ -177,3 +195,4 @@ if __name__ == '__main__':
     test_dead_code_elimination_ifexp()
     test_dead_code_elimination_noelse()
     test_dead_code_elimination_unreachable()
+    test_lambda_args()

--- a/tests/transformations/move_loop_into_map_test.py
+++ b/tests/transformations/move_loop_into_map_test.py
@@ -31,8 +31,20 @@ def multiple_edges(data: dace.float64[I, J]):
             data[i, j] = data[i - 1, j] + data[i - 2, j]
 
 
-class MoveLoopIntoMapTest(unittest.TestCase):
+@dace.program
+def should_not_apply_1():
+    for i in range(20):
+        a = np.zeros([i])
 
+
+@dace.program
+def should_not_apply_2():
+    for i in range(2, 20):
+        a = np.ndarray([i], np.float64)
+        a[0:2] = 0
+
+
+class MoveLoopIntoMapTest(unittest.TestCase):
     def semantic_eq(self, program):
         A1 = np.random.rand(16, 16)
         A2 = np.copy(A1)
@@ -54,6 +66,16 @@ class MoveLoopIntoMapTest(unittest.TestCase):
 
     def test_multiple_edges(self):
         self.semantic_eq(multiple_edges)
+
+    def test_itervar_in_map_range(self):
+        sdfg = should_not_apply_1.to_sdfg(simplify=True)
+        count = sdfg.apply_transformations(MoveLoopIntoMap)
+        self.assertEquals(count, 0)
+
+    def test_itervar_in_data(self):
+        sdfg = should_not_apply_2.to_sdfg(simplify=True)
+        count = sdfg.apply_transformations(MoveLoopIntoMap)
+        self.assertEquals(count, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [x] Fix Eq/Ne in interstate conditions
- [x] Informative type errors (with argument name) and better casting for compiled SDFGs
- [x] Fix preprocessing errors and loading precompiled methods
- [x] Fix regression in multidimensional array indirection promotion for C++ tasklets (Fixes #1033)
- [x] Re-add a safer `make_transients_persistent` to auto-optimize
- [x] Fix scope allocation for same-size arrays allocated in branches (fixes #1014)
   * Fix for general case is still pending semantics decision
- [x] Fix minor regression in persistent memory CUDA code generation
- [x] Condition fixes for `MoveLoopIntoMap`
- [x] Fix multi-state inline for edge assignments that coincide with outer arrays