### PR TITLE
Add proper symbolic equality checks for broadcasting

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -30,7 +30,7 @@ from dace.memlet import Memlet
 from dace.properties import LambdaProperty, CodeBlock
 from dace.sdfg import SDFG, SDFGState
 from dace.sdfg.replace import replace_datadesc_names
-from dace.symbolic import pystr_to_symbolic
+from dace.symbolic import pystr_to_symbolic, inequal_symbols
 
 import numpy
 import sympy
@@ -2466,7 +2466,11 @@ class ProgramVisitor(ExtNodeVisitor):
                 squeezed.squeeze(offset=False)
                 squeezed_op = copy.deepcopy(op_subset)
                 squeezed_op.squeeze(offset=False)
-                if squeezed.size() != squeezed_op.size() or op:
+
+                ssize = squeezed.size()
+                osize = squeezed_op.size()
+
+                if len(ssize) != len(osize) or any(inequal_symbols(s, o) for s, o in zip(ssize, osize)) or op:
 
                     _, all_idx_tuples, _, _, inp_idx = _broadcast_to(squeezed.size(), op_subset.size())
 

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -21,7 +21,7 @@ from dace.frontend.python import astutils
 from dace.frontend.python.nested_call import NestedCall
 from dace.memlet import Memlet
 from dace.sdfg import nodes, SDFG, SDFGState
-from dace.symbolic import pystr_to_symbolic, issymbolic
+from dace.symbolic import pystr_to_symbolic, issymbolic, inequal_symbols
 
 import numpy as np
 import sympy as sp
@@ -1130,7 +1130,7 @@ def _broadcast_together(arr1_shape, arr2_shape, unidirectional=False):
     for i, (dim1, dim2) in enumerate(itertools.zip_longest(reversed(arr1_shape), reversed(arr2_shape))):
         all_idx.append(get_idx(i))
 
-        if dim1 == dim2:
+        if not inequal_symbols(dim1, dim2):
             a1_idx.append(get_idx(i))
             a2_idx.append(get_idx(i))
 

--- a/tests/numpy/assignment_test.py
+++ b/tests/numpy/assignment_test.py
@@ -89,6 +89,27 @@ def test_assign_wild(A: dace.float32[3, 5, 10, 13], B: dace.float32[2, 1, 4]):
     return A
 
 
+def test_assign_wild_symbolic():
+
+    N = dace.symbol("N")
+    I = dace.symbol("I")
+
+    @dace.program
+    def test_assign_wile_symbolic(A: dace.float32[3, N, 10, 13], B: dace.float32[N * (I + 1) - N * I, 1, 4]):
+        A[2, :, :, 8:12] = B
+        return A
+
+    N = 5
+
+    A = np.arange(3 * N * 10 * 13).astype(np.float32).reshape(3, N, 10, 13).copy()
+    B = np.arange(N * 4, dtype=np.float32).reshape(N, 1, 4).copy()
+
+    expected = A.copy()
+    expected[2, :, :, 8:12] = B.copy()
+
+    test_assign_wile_symbolic(A, B, I=42, N=5)
+
+
 @compare_numpy_output(positive=True)
 def test_assign_squeezed(A: dace.float32[3, 5, 10, 20, 13], B: dace.float32[2, 1, 4]):
     A[2, 2:4, :, 1, 8:12] = B
@@ -132,3 +153,4 @@ if __name__ == '__main__':
     test_broadcast5()
     test_assign_wild()
     test_annotated_assign_type()
+    test_assign_wild_symbolic()

--- a/tests/numpy/binop_broadcasting_test.py
+++ b/tests/numpy/binop_broadcasting_test.py
@@ -1,4 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import numpy as np
+
 import dace
 from common import compare_numpy_output
 
@@ -232,6 +234,23 @@ def test_both_match(A: dace.float64[5, 1], B: dace.float64[1, 3]):
     return A + B
 
 
+def test_symbolic_bcast_same():
+
+    N = dace.symbol("N")
+    I = dace.symbol("I")
+
+    @dace.program
+    def symbolic_bcast(A: dace.float64[N, 4], B: dace.float64[N * (I + 1) - N * I, 1]):
+        return A + B
+
+    A = np.arange(40).astype(np.float64).reshape(10, 4)
+    B = np.arange(10).astype(np.float64).reshape(10, 1)
+
+    result = symbolic_bcast(A.copy(), B.copy(), I=42, N=10)
+    expected = A + B
+    np.testing.assert_allclose(result, expected)
+
+
 if __name__ == '__main__':
     # generate this with
     # cat binop_broadcasting_test.py | grep -oP '(?<=f ).*(?=\()' | awk '{print $0 "()"}'
@@ -271,3 +290,4 @@ if __name__ == '__main__':
     test_multr4()
     test_bitorr4()
     test_regression_result_none()
+    test_symbolic_bcast_same()


### PR DESCRIPTION
Previously, broadcasting with symbolic shapes would not do symbolic equality checking when checking broadcasting. For example, the following arrays would not broadcast together:
```
A: shape [N,]
B: shape [N * (j + 1) - N * j]
```

I'm pretty sure that there are many other cases where this is being done incorrectly, but this helps for my use case for now.