### PR TITLE
Support constants in SDFG.data, Propagate constants into NestedSDFGs.

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -304,27 +304,29 @@ def emit_memlet_reference(dispatcher,
     else:
         datadef = ptr(memlet.data, desc, sdfg, dispatcher.frame)
 
+    def make_const(expr):
+        # check whether const has already been added before
+        if not expr.startswith("const "):
+            return "const " + expr
+        else:
+            return expr
+
     if (defined_type == DefinedType.Pointer
             or (defined_type == DefinedType.ArrayInterface and isinstance(desc, data.View))):
         if not is_scalar and desc.dtype == conntype.base_type:
             # Cast potential consts
             typedef = defined_ctype
 
-        make_const = False
         if is_scalar:
             defined_type = DefinedType.Scalar
             if is_write is False:
-                make_const = True
+                typedef = make_const(typedef)
             ref = '&'
         else:
             # constexpr arrays
             if memlet.data in dispatcher.frame.symbols_and_constants(sdfg):
-                make_const = True
                 ref = '*'
-
-        # check whether const has already been added before
-        if make_const and not typedef.startswith("const "):
-            typedef = f'const {typedef}'
+                typedef = make_const(typedef)
 
     elif defined_type == DefinedType.ArrayInterface:
         base_ctype = conntype.base_type.ctype
@@ -332,6 +334,8 @@ def emit_memlet_reference(dispatcher,
         is_scalar = False
     elif defined_type == DefinedType.Scalar:
         typedef = defined_ctype if is_scalar else (defined_ctype + '*')
+        if is_write is False:
+            typedef = make_const(typedef)
         ref = '&' if is_scalar else ''
         defined_type = DefinedType.Scalar if is_scalar else DefinedType.Pointer
         offset_expr = ''

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -309,16 +309,23 @@ def emit_memlet_reference(dispatcher,
         if not is_scalar and desc.dtype == conntype.base_type:
             # Cast potential consts
             typedef = defined_ctype
+
+        make_const = False
         if is_scalar:
             defined_type = DefinedType.Scalar
             if is_write is False:
-                typedef = f'const {typedef}'
+                make_const = True
             ref = '&'
         else:
             # constexpr arrays
             if memlet.data in dispatcher.frame.symbols_and_constants(sdfg):
-                typedef = f'const {typedef}'
+                make_const = True
                 ref = '*'
+
+        # check whether const has already been added before
+        if make_const and not typedef.startswith("const "):
+            typedef = f'const {typedef}'
+
     elif defined_type == DefinedType.ArrayInterface:
         base_ctype = conntype.base_type.ctype
         typedef = f"{base_ctype}*" if is_write else f"const {base_ctype}*"

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -64,6 +64,7 @@ class DaCeCodeGenerator(object):
 
                 # found a new nested sdfg: resolve symbols and constants
                 result = nsdfg.free_symbols.union(nsdfg.constants_prop.keys())
+                result |= self._symbols_and_constants[nsdfg._parent_sdfg.sdfg_id]
 
                 # check for constant inputs
                 for edge in state.in_edges(nested):

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -54,7 +54,7 @@ class DaCeCodeGenerator(object):
 
         # resolve all symbols and constants
         # first handle root
-        self._symbols_and_constants[sdfg.sdfg_id] = sdfg.free_symbols.union(sdfg.constants.keys())
+        self._symbols_and_constants[sdfg.sdfg_id] = sdfg.free_symbols.union(sdfg.constants_prop.keys())
         # then recurse
         for nested, state in sdfg.all_nodes_recursive():
             if isinstance(nested, nodes.NestedSDFG):
@@ -63,7 +63,7 @@ class DaCeCodeGenerator(object):
                 nsdfg = nested.sdfg
 
                 # found a new nested sdfg: resolve symbols and constants
-                result = nsdfg.free_symbols.union(nsdfg.constants.keys())
+                result = nsdfg.free_symbols.union(nsdfg.constants_prop.keys())
 
                 # check for constant inputs
                 for edge in state.in_edges(nested):

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -64,11 +64,13 @@ class DaCeCodeGenerator(object):
 
                 # found a new nested sdfg: resolve symbols and constants
                 result = nsdfg.free_symbols.union(nsdfg.constants_prop.keys())
-                result |= self._symbols_and_constants[nsdfg._parent_sdfg.sdfg_id]
+
+                parent_constants = self._symbols_and_constants[nsdfg._parent_sdfg.sdfg_id]
+                result |= parent_constants
 
                 # check for constant inputs
                 for edge in state.in_edges(nested):
-                    if edge.data.data in state.parent.constants_prop:
+                    if edge.data.data in parent_constants:
                         # this edge is constant => propagate to nested sdfg
                         result.add(edge.dst_conn)
 

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -67,7 +67,7 @@ class DaCeCodeGenerator(object):
 
                 # check for constant inputs
                 for edge in state.in_edges(nested):
-                    if edge.src.data in state.parent.constants_prop:
+                    if edge.data.data in state.parent.constants_prop:
                         # this edge is constant => propagate to nested sdfg
                         result.add(edge.dst_conn)
 

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -52,13 +52,30 @@ class DaCeCodeGenerator(object):
         fsyms = self.free_symbols(sdfg)
         self.arglist = sdfg.arglist(scalars_only=False, free_symbols=fsyms)
 
+        # resolve all symbols and constants
+        # first handle root
+        self._symbols_and_constants[sdfg.sdfg_id] = sdfg.free_symbols.union(sdfg.constants.keys())
+        # then recurse
+        for nested, state in sdfg.all_nodes_recursive():
+            if isinstance(nested, nodes.NestedSDFG):
+                state: SDFGState
+
+                nsdfg = nested.sdfg
+
+                # found a new nested sdfg: resolve symbols and constants
+                result = nsdfg.free_symbols.union(nsdfg.constants.keys())
+
+                # check for constant inputs
+                for edge in state.in_edges(nested):
+                    if edge.src.data in state.parent.constants_prop:
+                        # this edge is constant => propagate to nested sdfg
+                        result.add(edge.dst_conn)
+
+                self._symbols_and_constants[nsdfg.sdfg_id] = result
+
     # Cached fields
     def symbols_and_constants(self, sdfg: SDFG):
-        if sdfg.sdfg_id in self._symbols_and_constants:
-            return self._symbols_and_constants[sdfg.sdfg_id]
-        result = sdfg.free_symbols.union(sdfg.constants.keys())
-        self._symbols_and_constants[sdfg.sdfg_id] = result
-        return result
+        return self._symbols_and_constants[sdfg.sdfg_id]
 
     def free_symbols(self, obj: Any):
         k = id(obj)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -530,6 +530,8 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
             return self._arrays[dataname]
         if str(dataname) in self.symbols:
             return self.symbols[str(dataname)]
+        if dataname in self.constants_prop:
+            return self.constants_prop[dataname][0]
         raise KeyError('Data descriptor with name "%s" not found in SDFG' % dataname)
 
     def replace(self, name: str, new_name: str):
@@ -2577,7 +2579,7 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
            :param array: the name of the array
            :return: a Memlet that fully transfers array
         """
-        return dace.Memlet.from_array(array, self.arrays[array])
+        return dace.Memlet.from_array(array, self.data(array))
 
 
 def _get_optimizer_class(class_override):


### PR DESCRIPTION
Previously, the code generator would not be aware when an input to a NestedSDFG is constant, causing compiler errors related to ``const``.