### PR TITLE
OTFMapFusion re-implemented

### DIFF
--- a/dace/transformation/dataflow/otf_map_fusion.py
+++ b/dace/transformation/dataflow/otf_map_fusion.py
@@ -237,6 +237,21 @@ class OTFMapFusion(transformation.SingleStateTransformation):
 
     @staticmethod
     def solve(first_params, write_accesses, second_params, read_accesses):
+        """ Infers the memory access for the write memlet given the
+            location/parameters of the read access.
+
+            Example:
+            - Write memlet: A[i + 1, j]
+            - Read memlet: A[k, l]
+            - Infer: k -> i - 1, l - > j
+
+            :param first_params: parameters of the first_map_entry.
+            :param write_accesses: subset ranges of the write memlet.
+            :param second_params: parameters of the second map_entry.
+            :param read_accesses: subset ranges of the read memlet.
+            :return: mapping of parameters.
+        """
+
         # Make sure that parameters of first_map_entry
         # are different symbols than parameters of
         # second_map_entry

--- a/dace/transformation/dataflow/otf_map_fusion.py
+++ b/dace/transformation/dataflow/otf_map_fusion.py
@@ -68,17 +68,17 @@ class OTFMapFusion(transformation.SingleStateTransformation):
 
             write_memlets[array] = memlet
 
-        # Volume of read must match volume of write
-        # Could be relaxed in the future
+        # Memlets access must be inferable
+        first_map_entry = graph.entry_node(self.first_map_exit)
         for edge in graph.out_edges(self.second_map_entry):
             read_memlet = edge.data
             if read_memlet.data not in write_memlets:
                 continue
 
             write_memlet = write_memlets[read_memlet.data]
-            # Shortcut
-            # FIXME: Check full compatible
-            if write_memlet.volume != read_memlet.volume:
+            param_subs = OTFMapFusion.solve(first_map_entry.map.params, write_memlet.subset.ranges,
+                                            self.second_map_entry.map.params, read_memlet.subset.ranges)
+            if param_subs is None:
                 return False
 
         # Success

--- a/dace/transformation/dataflow/otf_map_fusion.py
+++ b/dace/transformation/dataflow/otf_map_fusion.py
@@ -4,7 +4,6 @@ This module contains classes that implement the OTF map fusion transformation.
 """
 import copy
 import sympy
-import random
 
 from dace.sdfg.sdfg import SDFG
 from dace.sdfg.state import SDFGState
@@ -106,7 +105,7 @@ class OTFMapFusion(transformation.SingleStateTransformation):
         connector_mapping = {}
         for edge in graph.in_edges(first_map_entry):
             old_in_connector = edge.dst_conn
-            new_in_connector = "IN_" + str(random.randint(32, 65536))
+            new_in_connector = self.second_map_entry.next_connector(old_in_connector)
             if self.second_map_entry.add_in_connector(new_in_connector):
                 memlet = copy.deepcopy(edge.data)
                 graph.add_edge(edge.src, edge.src_conn, self.second_map_entry, new_in_connector, memlet)

--- a/dace/transformation/dataflow/otf_map_fusion.py
+++ b/dace/transformation/dataflow/otf_map_fusion.py
@@ -1,5 +1,6 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-""" This module contains classes that implement the OTF map fusion transformation.
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+"""
+This module contains classes that implement the OTF map fusion transformation.
 """
 import copy
 import sympy
@@ -17,8 +18,9 @@ from dace import symbolic
 
 
 class OTFMapFusion(transformation.SingleStateTransformation):
-    """ Performs fusion of two maps by replicating the contents of the first into the second map
-        until all the input dependencies (memlets) of the second one are met.
+    """
+    Performs fusion of two maps by replicating the contents of the first into the second map
+    until all the input dependencies (memlets) of the second one are met.
     """
     first_map_exit = transformation.PatternNode(nds.ExitNode)
     array = transformation.PatternNode(nds.AccessNode)
@@ -183,9 +185,9 @@ class OTFMapFusion(transformation.SingleStateTransformation):
                         ranges = []
                         for i, access in enumerate(memlet.subset.ranges):
                             b, e, s = access
-                            b = sympy.sympify(b)
-                            e = sympy.sympify(e)
-                            s = sympy.sympify(s)
+                            b = symbolic.pystr_to_symbolic(b)
+                            e = symbolic.pystr_to_symbolic(e)
+                            s = symbolic.pystr_to_symbolic(s)
 
                             for param, sub in param_subs[i].items():
                                 b = b.subs(param, sub)
@@ -261,33 +263,34 @@ class OTFMapFusion(transformation.SingleStateTransformation):
 
     @staticmethod
     def solve(first_params, write_accesses, second_params, read_accesses):
-        """ Infers the memory access for the write memlet given the
-            location/parameters of the read access.
+        """
+        Infers the memory access for the write memlet given the
+        location/parameters of the read access.
 
-            Example:
-            - Write memlet: A[i + 1, j]
-            - Read memlet: A[k, l]
-            - Infer: k -> i - 1, l - > j
+        Example:
+        - Write memlet: ``A[i + 1, j]``
+        - Read memlet: ``A[k, l]``
+        - Infer: ``k -> i - 1, l - > j``
 
-            :param first_params: parameters of the first_map_entry.
-            :param write_accesses: subset ranges of the write memlet.
-            :param second_params: parameters of the second map_entry.
-            :param read_accesses: subset ranges of the read memlet.
-            :return: mapping of parameters.
+        :param first_params: parameters of the first_map_entry.
+        :param write_accesses: subset ranges of the write memlet.
+        :param second_params: parameters of the second map_entry.
+        :param read_accesses: subset ranges of the read memlet.
+        :return: mapping of parameters.
         """
 
         # Make sure that parameters of first_map_entry are different symbols than parameters of second_map_entry.
         first_params_subs = {}
         first_params_subs_ = {}
         for i, param in enumerate(first_params):
-            s = sympy.symbols(f'f_{i}')
+            s = symbolic.symbol(f'f_{i}')
             first_params_subs[param] = s
             first_params_subs_[s] = param
 
         second_params_subs = {}
         second_params_subs_ = {}
         for i, param in enumerate(second_params):
-            s = sympy.symbols(f's_{i}')
+            s = symbolic.symbol(f's_{i}')
             second_params_subs[param] = s
             second_params_subs_[s] = param
 
@@ -297,9 +300,9 @@ class OTFMapFusion(transformation.SingleStateTransformation):
             if isinstance(e0, symbolic.SymExpr):
                 return None
 
-            b0 = sympy.sympify(b0)
-            e0 = sympy.sympify(e0)
-            s0 = sympy.sympify(s0)
+            b0 = symbolic.pystr_to_symbolic(b0)
+            e0 = symbolic.pystr_to_symbolic(e0)
+            s0 = symbolic.pystr_to_symbolic(s0)
             for param in first_params_subs:
                 b0 = b0.subs(param, first_params_subs[param])
                 e0 = e0.subs(param, first_params_subs[param])
@@ -309,9 +312,9 @@ class OTFMapFusion(transformation.SingleStateTransformation):
             if isinstance(e1, symbolic.SymExpr):
                 return None
 
-            b1 = sympy.sympify(b1)
-            e1 = sympy.sympify(e1)
-            s1 = sympy.sympify(s1)
+            b1 = symbolic.pystr_to_symbolic(b1)
+            e1 = symbolic.pystr_to_symbolic(e1)
+            s1 = symbolic.pystr_to_symbolic(s1)
             for param in second_params_subs:
                 b1 = b1.subs(param, second_params_subs[param])
                 e1 = e1.subs(param, second_params_subs[param])

--- a/tests/transformations/otf_map_fusion_test.py
+++ b/tests/transformations/otf_map_fusion_test.py
@@ -221,11 +221,13 @@ def fusion_tree(A: dace.float64[10, 20], B: dace.float64[10, 20], C: dace.float6
 
 
 def test_memlet_equation():
-    i, j = sympy.symbols('i, j')
+    i = dace.symbolic.symbol('i')
+    j = dace.symbolic.symbol('j')
     write_params = [i, j]
     write_accesses = ((i, i, 1), (j - 1, j - 1, 1))
 
-    k, l = sympy.symbols('k, l')
+    k = dace.symbolic.symbol('k')
+    l = dace.symbolic.symbol('l')
     read_params = [k, l]
     read_accesses = ((k, k, 1), (l + 2, l + 2, 1))
 
@@ -235,7 +237,8 @@ def test_memlet_equation():
 
 
 def test_memlet_equation_same_symbols():
-    i, j = sympy.symbols('i, j')
+    i = dace.symbolic.symbol('i')
+    j = dace.symbolic.symbol('j')
     write_params = [i, j]
     write_accesses = ((i, i, 1), (j - 1, j - 1, 1))
 
@@ -248,7 +251,7 @@ def test_memlet_equation_same_symbols():
 
 
 def test_memlet_equation_constant_read():
-    i = sympy.symbols('i')
+    i = dace.symbolic.symbol('i')
     write_params = [i]
     write_accesses = ((i, i, 1), )
 
@@ -282,7 +285,7 @@ def test_memlet_equation_constant_read_and_write_fail():
 
 
 def test_memlet_equation_constant_write():
-    i = sympy.symbols('i')
+    i = dace.symbolic.symbol('i')
     write_params = [i]
     write_accesses = ((0, 0, 1), )
 

--- a/tests/transformations/otf_map_fusion_test.py
+++ b/tests/transformations/otf_map_fusion_test.py
@@ -1,10 +1,14 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import numpy as np
 import dace
+import sympy
 
 from scipy.signal import convolve2d
 
 from dace.transformation.dataflow import OTFMapFusion
+
+N = dace.symbol("N")
+M = dace.symbol("M")
 
 
 def count_maps(sdfg):
@@ -19,13 +23,6 @@ def count_maps(sdfg):
 
 @dace.program
 def fusion_chain(A: dace.float64[10, 20], B: dace.float64[10, 20]):
-    tmp1 = A * 2
-    tmp2 = tmp1 * 4
-    B[:] = tmp2 + 5
-
-
-@dace.program
-def fusion_permutation(A: dace.float64[10, 20], B: dace.float64[10, 20]):
     tmp = dace.define_local([10, 20], dtype=A.dtype)
     for i, j in dace.map[0:10, 0:20]:
         with dace.tasklet:
@@ -34,7 +31,7 @@ def fusion_permutation(A: dace.float64[10, 20], B: dace.float64[10, 20]):
 
             b = a * a
 
-    for j, i in dace.map[0:20, 0:10]:
+    for i, j in dace.map[0:10, 0:20]:
         with dace.tasklet:
             a << tmp[i, j]
             b >> B[i, j]
@@ -43,7 +40,61 @@ def fusion_permutation(A: dace.float64[10, 20], B: dace.float64[10, 20]):
 
 
 @dace.program
-def fusion_recomputation(A: dace.float64[20, 20], B: dace.float64[16, 16]):
+def fusion_chain_renamed(A: dace.float64[10, 20], B: dace.float64[10, 20]):
+    tmp = dace.define_local([10, 20], dtype=A.dtype)
+    for i, j in dace.map[0:10, 0:20]:
+        with dace.tasklet:
+            a << A[i, j]
+            b >> tmp[i, j]
+
+            b = a * a
+
+    for k, l in dace.map[0:10, 0:20]:
+        with dace.tasklet:
+            a << tmp[k, l]
+            b >> B[k, l]
+
+            b = a + 2
+
+
+@dace.program
+def fusion_flip(A: dace.float64[N, M], B: dace.float64[N, M]):
+    tmp = dace.define_local([N, M], dtype=A.dtype)
+    for i, j in dace.map[0:N, 0:M]:
+        with dace.tasklet:
+            a << A[i, j]
+            b >> tmp[i, j]
+
+            b = a * a
+
+    for k, l in dace.map[0:N, 0:M]:
+        with dace.tasklet:
+            a << tmp[N - k - 1, M - l - 1]
+            b >> B[k, l]
+
+            b = a + 2
+
+
+@dace.program
+def fusion_transposed(A: dace.float64[10, 20], B: dace.float64[20, 10]):
+    tmp = dace.define_local([10, 20], dtype=A.dtype)
+    for i, j in dace.map[0:10, 0:20]:
+        with dace.tasklet:
+            a << A[i, j]
+            b >> tmp[i, j]
+
+            b = a * a
+
+    for i, j in dace.map[0:20, 0:10]:
+        with dace.tasklet:
+            a << tmp[j, i]
+            b >> B[i, j]
+
+            b = a + 2
+
+
+@dace.program
+def fusion_convolve(A: dace.float64[20, 20], B: dace.float64[16, 16]):
     tmp = dace.define_local([18, 18], dtype=A.dtype)
     for i, j in dace.map[1:19, 1:19]:
         with dace.tasklet:
@@ -76,13 +127,117 @@ def fusion_recomputation(A: dace.float64[20, 20], B: dace.float64[16, 16]):
             b = (a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8) / 9.0
 
 
+@dace.program
+def fusion_convolve_transposed(A: dace.float64[20, 20], B: dace.float64[16, 16]):
+    tmp = dace.define_local([18, 18], dtype=A.dtype)
+    for i, j in dace.map[1:19, 1:19]:
+        with dace.tasklet:
+            a0 << A[i - 1, j - 1]
+            a1 << A[i - 1, j]
+            a2 << A[i - 1, j + 1]
+            a3 << A[i, j - 1]
+            a4 << A[i, j]
+            a5 << A[i, j + 1]
+            a6 << A[i + 1, j - 1]
+            a7 << A[i + 1, j]
+            a8 << A[i + 1, j + 1]
+            b >> tmp[i - 1, j - 1]
+
+            b = (a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8) / 9.0
+
+    for i, j in dace.map[1:17, 1:17]:
+        with dace.tasklet:
+            a0 << tmp[j - 1, i - 1]
+            a1 << tmp[j, i - 1]
+            a2 << tmp[j + 1, i - 1]
+            a3 << tmp[j - 1, i]
+            a4 << tmp[j, i]
+            a5 << tmp[j + 1, i]
+            a6 << tmp[j - 1, i + 1]
+            a7 << tmp[j, i + 1]
+            a8 << tmp[j + 1, i + 1]
+            b >> B[i - 1, j - 1]
+
+            b = (a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8) / 9.0
+
+
+def test_memlet_equation():
+    i, j = sympy.symbols('i, j')
+    write_params = [i, j]
+    write_accesses = ((i, i, 1), (j - 1, j - 1, 1))
+
+    k, l = sympy.symbols('k, l')
+    read_params = [k, l]
+    read_accesses = ((k, k, 1), (l + 2, l + 2, 1))
+
+    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
+    assert sol[0] == {i: k}
+    assert sol[1] == {j: l + 3}
+
+
+def test_memlet_equation_same_symbols():
+    i, j = sympy.symbols('i, j')
+    write_params = [i, j]
+    write_accesses = ((i, i, 1), (j - 1, j - 1, 1))
+
+    read_params = [i, j]
+    read_accesses = ((i, i, 1), (j + 2, j + 2, 1))
+
+    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
+    assert sol[0] == {i: i}
+    assert sol[1] == {j: j + 3}
+
+
+def test_memlet_equation_constant_read():
+    i = sympy.symbols('i')
+    write_params = [i]
+    write_accesses = ((i, i, 1), )
+
+    read_params = [i]
+    read_accesses = ((0, 0, 1), )
+
+    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
+    assert sol[0] == {i: 0}
+
+
+def test_memlet_equation_constant_read_and_write_match():
+    write_params = []
+    write_accesses = ((2, 2, 1), )
+
+    read_params = []
+    read_accesses = ((2, 2, 1), )
+
+    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
+    assert sol[0] == {2: 2}
+
+
+def test_memlet_equation_constant_read_and_write_fail():
+    write_params = []
+    write_accesses = ((0, 0, 1), )
+
+    read_params = []
+    read_accesses = ((1, 1, 1), )
+
+    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
+    assert sol is None
+
+
+def test_memlet_equation_constant_write():
+    i = sympy.symbols('i')
+    write_params = [i]
+    write_accesses = ((0, 0, 1), )
+
+    read_params = [i]
+    read_accesses = ((i, i, 1), )
+
+    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
+    assert sol is None
+
+
 def test_fusion_chain():
     sdfg = fusion_chain.to_sdfg()
     sdfg.simplify()
 
-    assert count_maps(sdfg) == 3
-
-    sdfg.apply_transformations(OTFMapFusion)
     assert count_maps(sdfg) == 2
 
     sdfg.apply_transformations(OTFMapFusion)
@@ -90,37 +245,18 @@ def test_fusion_chain():
 
     # Validate output
 
-    A = np.random.rand(10, 20)
+    A = np.random.rand(10, 20).astype(np.float64)
     B = np.zeros_like(A)
-    target = A * 2 * 4 + 5
-    sdfg(A=A, B=B)
 
-    diff = np.linalg.norm(target - B)
-    assert diff <= 1e-4
-
-
-def test_fusion_permutation():
-    sdfg = fusion_permutation.to_sdfg()
-    sdfg.simplify()
-
-    assert count_maps(sdfg) == 2
-
-    sdfg.apply_transformations(OTFMapFusion)
-    assert count_maps(sdfg) == 1
-
-    # Validate output
-
-    A = np.random.rand(10, 20)
-    B = np.zeros_like(A)
     target = A * A + 2
     sdfg(A=A, B=B)
 
     diff = np.linalg.norm(target - B)
-    assert diff <= 1e-4
+    assert diff <= 1e-12
 
 
-def test_fusion_recomputation():
-    sdfg = fusion_recomputation.to_sdfg()
+def test_fusion_chain_renamed():
+    sdfg = fusion_chain_renamed.to_sdfg()
     sdfg.simplify()
 
     assert count_maps(sdfg) == 2
@@ -130,10 +266,74 @@ def test_fusion_recomputation():
 
     # Validate output
 
-    A = np.random.rand(20, 20)
+    A = np.random.rand(10, 20).astype(np.float64)
+    B = np.zeros_like(A)
+
+    target = A * A + 2
+    sdfg(A=A, B=B)
+
+    diff = np.linalg.norm(target - B)
+    assert diff <= 1e-12
+
+
+def test_fusion_flip():
+    sdfg = fusion_flip.to_sdfg()
+    sdfg.simplify()
+
+    assert count_maps(sdfg) == 2
+
+    sdfg.apply_transformations(OTFMapFusion)
+    assert count_maps(sdfg) == 1
+
+    # Validate output
+
+    A = np.random.rand(10, 20).astype(np.float64)
+    B = np.zeros_like(A)
+
+    target = np.flip(A * A + 2, axis=(0, 1))
+    sdfg(A=A, B=B, M=20, N=10)
+
+    diff = np.linalg.norm(target - B)
+    assert diff <= 1e-12
+
+
+def test_fusion_transposed():
+    sdfg = fusion_transposed.to_sdfg()
+    sdfg.simplify()
+
+    assert count_maps(sdfg) == 2
+
+    sdfg.apply_transformations(OTFMapFusion)
+    assert count_maps(sdfg) == 1
+
+    # Validate output
+
+    A = np.random.rand(10, 20).astype(np.float64)
+    B = np.zeros((20, 10), dtype=np.float64)
+
+    target = A * A
+    target = target.T + 2
+    sdfg(A=A, B=B)
+
+    diff = np.linalg.norm(target - B)
+    assert diff <= 1e-12
+
+
+def test_fusion_convolve():
+    sdfg = fusion_convolve.to_sdfg()
+    sdfg.simplify()
+
+    assert count_maps(sdfg) == 2
+
+    sdfg.apply_transformations(OTFMapFusion, validate_all=False)
+    assert count_maps(sdfg) == 1
+
+    # Validate output
+
+    A = np.random.rand(20, 20).astype(np.float64)
     B = np.zeros((16, 16), dtype=np.float64)
 
-    mask = np.ones((3, 3)) / 9.0
+    mask = np.ones((3, 3), dtype=A.dtype) / 9.0
     tmp = np.zeros((18, 18), dtype=A.dtype)
     target = np.zeros((16, 16), dtype=A.dtype)
 
@@ -143,8 +343,40 @@ def test_fusion_recomputation():
     sdfg(A=A, B=B)
 
     diff = np.linalg.norm(target - B)
-    assert diff <= 1e-4
+    assert diff <= 1e-12
+
+
+def test_fusion_convolve_transposed():
+    sdfg = fusion_convolve_transposed.to_sdfg()
+    sdfg.simplify()
+
+    assert count_maps(sdfg) == 2
+
+    sdfg.apply_transformations(OTFMapFusion, validate_all=False)
+    assert count_maps(sdfg) == 1
+
+    # Validate output
+
+    A = np.random.rand(20, 20).astype(np.float64)
+    B = np.zeros((16, 16), dtype=np.float64)
+
+    mask = np.ones((3, 3), dtype=A.dtype) / 9.0
+    tmp = np.zeros((18, 18), dtype=A.dtype)
+    target = np.zeros((16, 16), dtype=A.dtype)
+
+    tmp = convolve2d(A, mask, mode="valid")
+    target = convolve2d(tmp.T, mask, mode="valid")
+
+    sdfg(A=A, B=B)
+
+    diff = np.linalg.norm(target - B)
+    assert diff <= 1e-12
 
 
 if __name__ == '__main__':
     test_fusion_chain()
+    test_fusion_chain_renamed()
+    test_fusion_flip()
+    test_fusion_transposed()
+    test_fusion_convolve()
+    test_fusion_convolve_transposed()

--- a/tests/transformations/otf_map_fusion_test.py
+++ b/tests/transformations/otf_map_fusion_test.py
@@ -7,6 +7,9 @@ from scipy.signal import convolve2d
 
 from dace.transformation.dataflow import OTFMapFusion
 
+N = dace.symbol("N")
+M = dace.symbol("M")
+
 
 def count_maps(sdfg):
     maps = 0
@@ -52,10 +55,6 @@ def fusion_chain_renamed(A: dace.float64[10, 20], B: dace.float64[10, 20]):
             b >> B[k, l]
 
             b = a + 2
-
-
-N = dace.symbol("N")
-M = dace.symbol("M")
 
 
 @dace.program
@@ -346,16 +345,11 @@ def test_fusion_flip():
     assert count_maps(sdfg) == 1
 
     # Validate output
+    A = np.random.rand(10, 20).astype(np.float64)
+    target = np.flip(A * A + 2)
 
-    M = 20
-    N = 10
-
-    A = np.random.rand(N, M).astype(np.float64)
     B = np.zeros_like(A)
-
-    target = np.flip(A * A + 2, axis=(0, 1))
-
-    sdfg(A=A, B=B, M=M, N=N)
+    sdfg(A=A, B=B, M=20, N=10)
 
     diff = np.linalg.norm(target - B)
     assert diff <= 1e-12


### PR DESCRIPTION
So far, OTFMapFusion was only appliable in cases where the map parameters of both maps did match. I generalized the implementation by solving the equation systems of the memlets, i.e., 

second map reads tmp[i, j]
first map writes tmp[k, l]

we know: i -> k, j -> l

I am also renaming the map parameters temporarily in the equations so that the two maps can have the same parameters but in permuted order:

second map reads tmp[i, j]
first map writes tmp[j, i]
 
j -> i, i -> j

Update:

- I added support for tree-like cases
- Fixed a frequently occurring problem where the in_connector name was already taken