### PR TITLE
Cutout Improvements and Transformation Affected Nodes API

### DIFF
--- a/dace/sdfg/analysis/cutout.py
+++ b/dace/sdfg/analysis/cutout.py
@@ -301,7 +301,7 @@ def _extend_subgraph_with_access_nodes(state: SDFGState, subgraph: StateSubgraph
 
             # We don't want to extend access nodes over scope entry nodes, but rather we
             # want to introduce alibi data containers for the correct subset instead. Handled separately.
-            if isinstance(e.src, nd.EntryNode):
+            if isinstance(e.src, nd.EntryNode) and e.src not in result and state.exit_node(e.src) not in result:
                 continue
             else:
                 mpath = state.memlet_path(e)
@@ -317,7 +317,7 @@ def _extend_subgraph_with_access_nodes(state: SDFGState, subgraph: StateSubgraph
 
             # We don't want to extend access nodes over scope entry nodes, but rather we
             # want to introduce alibi data containers for the correct subset instead. Handled separately.
-            if isinstance(e.dst, nd.ExitNode):
+            if isinstance(e.dst, nd.ExitNode) and e.dst not in result and state.entry_node(e.dst) not in result:
                 continue
             else:
                 mpath = state.memlet_path(e)

--- a/dace/sdfg/analysis/cutout.py
+++ b/dace/sdfg/analysis/cutout.py
@@ -5,13 +5,125 @@ testing or optimization.
 """
 from collections import deque
 import copy
-from typing import Deque, Dict, List, Set
+from typing import Deque, Dict, List, Set, Tuple
 from dace import data
 from dace.sdfg import nodes as nd, SDFG, SDFGState, utils as sdutil
+from dace.sdfg.graph import SubgraphView
 from dace.sdfg.state import StateSubgraphView
 
 
-def cutout_state(state: SDFGState, *nodes: nd.Node, make_copy: bool = True) -> SDFG:
+def _stateset_frontier(sdfg: SDFG, states: Set[SDFGState]) -> Tuple[Set[SDFGState], Set]:
+    frontier = set()
+    frontier_edges = set()
+    for state in states:
+        for iedge in sdfg.in_edges(state):
+            if iedge.src not in states:
+                if iedge.src not in frontier:
+                    frontier.add(iedge.src)
+                if iedge not in frontier_edges:
+                    frontier_edges.add(iedge)
+    return frontier, frontier_edges
+
+
+def multistate_cutout(
+    sdfg: SDFG, *states: SDFGState, inserted_states: Dict[SDFGState, SDFGState] = None
+) -> SDFG:
+    create_element = copy.deepcopy
+
+    cutout_states: Set[SDFGState] = set(states)
+
+    # Determine the start state and ensure there IS a unique start state. If there is no unique
+    # start state, keep adding states from the predecessor frontier in the state machine until
+    # a unique start state can be determined.
+    start_state: SDFGState = None
+    for state in cutout_states:
+        if state == sdfg.start_state:
+            start_state = state
+            break
+
+    if start_state is None:
+        bfs_queue = deque()
+        bfs_queue.append(_stateset_frontier(sdfg, cutout_states))
+
+        while len(bfs_queue) > 0:
+            frontier, frontier_edges = bfs_queue.popleft()
+            if len(frontier_edges) == 0:
+                # No explicit start state, but also no frontier to select from.
+                return sdfg
+            elif len(frontier_edges) == 1:
+                # The destination of the only frontier edge must be the
+                # start state, since only one edge leads into the subgraph.
+                start_state = list(frontier_edges)[0].dst
+            else:
+                if len(frontier) == 0:
+                    # No explicit start state, but also no frontier to select from.
+                    return sdfg
+                if len(frontier) == 1:
+                    # For many frontier edges but only one frontier state,
+                    # the frontier state is the new start state and is
+                    # included in the cutout.
+                    start_state = list(frontier)[0]
+                    cutout_states.add(start_state)
+                else:
+                    for s in frontier:
+                        cutout_states.add(s)
+                    bfs_queue.append(
+                        _stateset_frontier(sdfg, cutout_states)
+                    )
+
+    subgraph: SubgraphView = SubgraphView(sdfg, cutout_states)
+
+    # Make a new SDFG with the included constants, used symbols, and data containers
+    new_sdfg = SDFG(f'{sdfg.name}_cutout', sdfg.constants_prop)
+    defined_symbols: Dict[str, data.Data] = dict()
+    free_symbols: Set[str] = set()
+    for state in cutout_states:
+        free_symbols |= state.free_symbols
+        state_defined_symbols = state.defined_symbols()
+        for sym in state_defined_symbols:
+            defined_symbols[sym] = state_defined_symbols[sym]
+    for sym in free_symbols:
+        new_sdfg.add_symbol(sym, defined_symbols[sym])
+
+    for state in cutout_states:
+        for dnode in state.data_nodes():
+            if dnode.data in new_sdfg.arrays:
+                continue
+            new_desc = sdfg.arrays[dnode.data].clone()
+            # TODO: If transient is defined outside, it becomes a global
+            #if dnode.data in other_arrays:
+            #    new_desc.transient = False
+            new_sdfg.add_datadesc(dnode.data, new_desc)
+
+    if inserted_states is None:
+        inserted_states: Dict[SDFGState, SDFGState] = {}
+    for is_edge in subgraph.edges():
+        if is_edge.src not in inserted_states:
+            inserted_states[is_edge.src] = create_element(is_edge.src)
+            new_sdfg.add_node(inserted_states[is_edge.src], is_start_state=(is_edge.src == start_state))
+            inserted_states[is_edge.src].parent = new_sdfg
+        if is_edge.dst not in inserted_states:
+            inserted_states[is_edge.dst] = create_element(is_edge.dst)
+            new_sdfg.add_node(inserted_states[is_edge.dst], is_start_state=(is_edge.dst == start_state))
+            inserted_states[is_edge.dst].parent = new_sdfg
+        new_sdfg.add_edge(
+            inserted_states[is_edge.src],
+            inserted_states[is_edge.dst],
+            create_element(is_edge.data)
+        )
+
+    for state in subgraph.nodes():
+        if state not in inserted_states:
+            inserted_states[state] = create_element(state)
+            new_sdfg.add_node(inserted_states[state], is_start_state=(state == start_state))
+            inserted_states[state].parent = new_sdfg
+
+    return new_sdfg
+
+
+def cutout_state(
+    state: SDFGState, *nodes: nd.Node, make_copy: bool = True, inserted_nodes: Dict[nd.Node, nd.Node] = None
+) -> SDFG:
     """
     Cut out a subgraph of a state from an SDFG to run separately for localized testing or optimization.
     The subgraph defined by the list of nodes will be extended to include access nodes of data containers necessary
@@ -45,7 +157,8 @@ def cutout_state(state: SDFGState, *nodes: nd.Node, make_copy: bool = True) -> S
 
     # Add a single state with the extended subgraph
     new_state = new_sdfg.add_state(state.label, is_start_state=True)
-    inserted_nodes: Dict[nd.Node, nd.Node] = {}
+    if inserted_nodes is None:
+        inserted_nodes: Dict[nd.Node, nd.Node] = {}
     for e in subgraph.edges():
         if e.src not in inserted_nodes:
             inserted_nodes[e.src] = create_element(e.src)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -124,10 +124,10 @@ class InterstateEdge(object):
         loop iterates).
     """
 
-    assignments = Property(dtype=dict,
-                           desc="Assignments to perform upon transition (e.g., 'x=x+1; y = 0')",
-                           from_string=_assignments_from_string,
-                           to_string=_assignments_to_string)
+    assignments = DictProperty(str, str,
+                               desc="Assignments to perform upon transition (e.g., 'x=x+1; y = 0')",
+                               from_string=_assignments_from_string,
+                               to_string=_assignments_to_string)
     condition = CodeProperty(desc="Transition condition", default=CodeBlock("1"))
 
     def __init__(self, condition: CodeBlock = None, assignments=None):

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -6,7 +6,7 @@ import copy
 import itertools
 import sympy as sp
 import networkx as nx
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from dace import dtypes, memlet, nodes, registry, sdfg as sd, symbolic, subsets
 from dace.properties import Property, make_properties, CodeBlock
@@ -89,6 +89,34 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
         desc='The name of the iteration variable (optional).',
     )
 
+    def _get_loop_body(self, sdfg: SDFG, body_states: Set[SDFGState] = None) -> Set[SDFGState]:
+        if body_states is None:
+            body_states = set()
+        to_visit = [self.loop_begin]
+        while to_visit:
+            state = to_visit.pop(0)
+            for _, dst, _ in sdfg.out_edges(state):
+                if dst not in body_states and dst is not self.loop_guard:
+                    to_visit.append(dst)
+            body_states.add(state)
+        return body_states
+
+    def affected_nodes(self, sdfg: SDFG) -> Set[Union[nodes.Node, SDFGState]]:
+        if sdfg is None:
+            raise Exception('LoopToMap requires an sdfg argument to check for affected nodes')
+
+        affected_nodes = set([self.loop_guard, self.exit_state])
+
+        affected_nodes = self._get_loop_body(sdfg, affected_nodes)
+
+        # ALL incoming nodes to a valid loop construct are affected, since one of the incoming edges
+        # contains the loop variable initial assignment.
+        for iedge in sdfg.in_edges(self.loop_guard):
+            if iedge.src not in affected_nodes:
+                affected_nodes.add(iedge.src)
+
+        return affected_nodes
+
     def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
         # Is this even a loop
         if not super().can_be_applied(graph, expr_index, sdfg, permissive):
@@ -115,14 +143,7 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
                 return False
 
         # Find all loop-body states
-        states = set()
-        to_visit = [begin]
-        while to_visit:
-            state = to_visit.pop(0)
-            for _, dst, _ in sdfg.out_edges(state):
-                if dst not in states and dst is not guard:
-                    to_visit.append(dst)
-            states.add(state)
+        states = self._get_loop_body(sdfg)
 
         assert (body_end in states)
 
@@ -254,14 +275,7 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
         itervar, (start, end, step), (_, body_end) = find_for_loop(sdfg, guard, body, itervar=self.itervar)
 
         # Find all loop-body states
-        states = set()
-        to_visit = [body]
-        while to_visit:
-            state = to_visit.pop(0)
-            for _, dst, _ in sdfg.out_edges(state):
-                if dst not in states and dst is not guard:
-                    to_visit.append(dst)
-            states.add(state)
+        states = self._get_loop_body(sdfg)
 
         # Nest loop-body states
         if len(states) > 1:

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -392,10 +392,9 @@ class PatternTransformation(TransformationBase):
         serialize.set_properties_from_json(ret, json_obj, context=context, ignore_properties={'transformation', 'type'})
         return ret
 
-    def affected_nodes(self, sdfg: SDFG) -> Set[Union[nd.Node, SDFGState]]:
+    def affected_nodes(self) -> Set[Union[nd.Node, SDFGState]]:
         """
         Returns the set of graph nodes in a given SDFG affected by this transformation.
-        :param sdfg: The SDFG in which to look for affected nodes.
         """
         affected_nodes = set()
         for k, _ in self._get_pattern_nodes().items():

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -392,6 +392,20 @@ class PatternTransformation(TransformationBase):
         serialize.set_properties_from_json(ret, json_obj, context=context, ignore_properties={'transformation', 'type'})
         return ret
 
+    def affected_nodes(self, sdfg: SDFG) -> Set[Union[nd.Node, SDFGState]]:
+        """
+        Returns the set of graph nodes in a given SDFG affected by this transformation.
+        :param sdfg: The SDFG in which to look for affected nodes.
+        """
+        affected_nodes = set()
+        for k, _ in self._get_pattern_nodes().items():
+            try:
+                affected_nodes.add(getattr(self, k))
+            except KeyError:
+                # Ignored.
+                pass
+        return affected_nodes
+
 
 @make_properties
 class SingleStateTransformation(PatternTransformation, abc.ABC):


### PR DESCRIPTION
# Multistate Cutouts

Allow cutouts from SDFG where the cutout consists of one or more entire states that form a coherent, self-contained SDFG. In practice, that means that there is a single distinct entry state to the cutout's state machine. This mode of constructing cutouts will _always_ create a copy of states and does not contain a reference-cutout mode like in-state cutouts, since states hold a back reference to the SDFG they're contained in and that reference must point to the new cutout SDFG for the cutout to validate.

# Transformation Affected Nodes API

This gives transformations a `get_affected_nodes` API method where the set of nodes touched by the transformation is returned. For most pattern transformations, this set of nodes is equivalent to the matched pattern nodes. However, some transformations (like `MapToLoop`) may modify additional nodes (or states) that are NOT matched by the pattern nodes, like loop bodies. This makes it impossible for anything other than the transformation itself to report what nodes are affected. With this API call, a transformation author can (and must) provide this information transparently _iff_ the set of affected nodes diverges from the patched pattern nodes. If not overridden, the standard pattern node matches are used.

# "Alibi Nodes" in Cutouts

If a cutout inside of a scope region borders one of the scope nodes (exit or entry), the cutout attempts to cross the scope via each memlet path to connect the corresponding data containers. In the example image below, a cutout of the tasklet `prog_39` would result in the cutout procedure attempting to add the map exit and the access node to `C` to the cutout. Having only the map exit in the cutout, but not the entry trivially leads to a fault. Including the entry node would require including the entire content of the scope. Both these solutions are not what the cutout should intuitively contain.

![image](https://user-images.githubusercontent.com/9193712/184473352-ffb99f7e-c1ae-4720-8d99-228583698cc3.png)

To address this, this PR adds "Alibi Nodes" to cutouts that cross scope borders. What this means, is that in the example above, the access across the map exit border is detected and instead of inserting both the exit node and the outside access node to the cutout, the outgoing memlet from `prog_39` is analyzed, and a new data container with a shape corresponding to the accessed subset is inserted into the cutout SDFG. The memlet is then attached to that new alibi data container instead. This further solves the problem that the memlet crossing the scope border may have symbols in the index term, which can only be defined by the map itself.

# Miscellaneous Other Points

- Changes the `assignments` property on `InterstateEdge`s to a `DictProperty` (from a regular property with `dtype=dict`). This is necessary to get proper metadata which can be used to infer what type of information this property contains.