### PR TITLE
Explicit support for string literals in Python frontend

### DIFF
--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -527,12 +527,16 @@ class CPPUnparser:
         self.leave()
 
     def _write_constant(self, value):
-        result = repr(value)
-        if isinstance(value, (float, complex)):
-            # Substitute overflowing decimal literal for AST infinities.
-            self.write(result.replace("inf", INFSTR))
+        # Special case for byte literal
+        if isinstance(value, str) and value[:2] == "b'":
+            self.write(repr(value))
         else:
-            self.write(result.replace('\'', '\"'))
+            result = repr(value)
+            if isinstance(value, (float, complex)):
+                # Substitute overflowing decimal literal for AST infinities.
+                self.write(result.replace("inf", INFSTR))
+            else:
+                self.write(result.replace('\'', '\"'))
 
     def _Constant(self, t):
         value = t.value

--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -527,14 +527,14 @@ class CPPUnparser:
         self.leave()
 
     def _write_constant(self, value):
-        # Special case for byte literal
-        if isinstance(value, str) and value[:2] == "b'":
-            self.write(repr(value))
+        result = repr(value)
+        if isinstance(value, (float, complex)):
+            # Substitute overflowing decimal literal for AST infinities.
+            self.write(result.replace("inf", INFSTR))
         else:
-            result = repr(value)
-            if isinstance(value, (float, complex)):
-                # Substitute overflowing decimal literal for AST infinities.
-                self.write(result.replace("inf", INFSTR))
+            # Special case for strings of containing byte literals (but are still strings).
+            if result.find("b'") >= 0:
+                self.write(result)
             else:
                 self.write(result.replace('\'', '\"'))
 

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -949,8 +949,8 @@ class callback(typeclass):
 
         def _string_converter(a: str, *args):
             tmp = ctypes.cast(a, ctypes.c_char_p).value.decode('utf-8')
-            if tmp[:2] == "b'":
-                return bytes(tmp[2:-1], 'utf-8')
+            if tmp.startswith(chr(0xFFFF)):
+                return bytes(tmp[1:], 'utf-8')
             return tmp
 
         inp_arraypos = []

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -947,6 +947,12 @@ class callback(typeclass):
         from functools import partial
         from dace import data, symbolic
 
+        def _string_converter(a: str, *args):
+            tmp = ctypes.cast(a, ctypes.c_char_p).value.decode('utf-8')
+            if tmp[:2] == "b'":
+                return bytes(tmp[2:-1], 'utf-8')
+            return tmp
+
         inp_arraypos = []
         ret_arraypos = []
         inp_types_and_sizes = []
@@ -961,7 +967,7 @@ class callback(typeclass):
             elif isinstance(arg, data.Scalar) and arg.dtype == string:
                 inp_arraypos.append(index)
                 inp_types_and_sizes.append((ctypes.c_char_p, []))
-                inp_converters.append(lambda a, *args: ctypes.cast(a, ctypes.c_char_p).value.decode('utf-8'))
+                inp_converters.append(_string_converter)
             elif isinstance(arg, data.Scalar) and isinstance(arg.dtype, pointer):
                 inp_arraypos.append(index)
                 inp_types_and_sizes.append((ctypes.c_void_p, []))

--- a/dace/frontend/common/einsum.py
+++ b/dace/frontend/common/einsum.py
@@ -11,6 +11,7 @@ from dace.sdfg.nodes import AccessNode
 from dace.sdfg import SDFG, SDFGState, InterstateEdge
 from dace.memlet import Memlet
 from dace.frontend.common import op_repository as oprepo
+from dace.frontend.python.common import StringLiteral
 
 
 def _is_sequential(index_list):
@@ -161,7 +162,7 @@ def prod(iterable):
 def create_einsum_sdfg(pv: 'dace.frontend.python.newast.ProgramVisitor',
                        sdfg: SDFG,
                        state: SDFGState,
-                       einsum_string: str,
+                       einsum_string: StringLiteral,
                        *arrays: str,
                        dtype: Optional[dtypes.typeclass] = None,
                        optimize: bool = False,
@@ -170,7 +171,7 @@ def create_einsum_sdfg(pv: 'dace.frontend.python.newast.ProgramVisitor',
                        beta: Optional[symbolic.SymbolicType] = 0.0):
     return _create_einsum_internal(sdfg,
                                    state,
-                                   einsum_string,
+                                   str(einsum_string),
                                    *arrays,
                                    dtype=dtype,
                                    optimize=optimize,

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -687,7 +687,7 @@ def create_constant(value: Any, node: Optional[ast.AST] = None) -> ast.AST:
 def escape_string(value: Union[bytes, str]):
     """ Converts special Python characters in strings back to their parsable version (e.g., newline to ``\n``) """
     if isinstance(value, bytes):
-        return value
+        return f"{chr(0xFFFF)}{value.decode('utf-8')}"
     if sys.version_info >= (3, 0):
         return value.encode("unicode_escape").decode("utf-8")
     # Python 2.x

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -10,7 +10,7 @@ import numbers
 import numpy
 import sympy
 import sys
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Union
 
 from dace import dtypes, symbolic
 
@@ -684,8 +684,10 @@ def create_constant(value: Any, node: Optional[ast.AST] = None) -> ast.AST:
     return newnode
 
 
-def escape_string(value: str):
+def escape_string(value: Union[bytes, str]):
     """ Converts special Python characters in strings back to their parsable version (e.g., newline to ``\n``) """
+    if isinstance(value, bytes):
+        return value
     if sys.version_info >= (3, 0):
         return value.encode("unicode_escape").decode("utf-8")
     # Python 2.x

--- a/dace/frontend/python/cached_program.py
+++ b/dace/frontend/python/cached_program.py
@@ -38,6 +38,12 @@ def _make_hashable(obj):
     except TypeError:
         return repr(obj)
 
+def _make_sortable(obj):
+    try:
+        obj < obj
+        return obj
+    except TypeError:
+        return repr(obj)
 
 @dataclass
 class ProgramCacheKey:
@@ -58,7 +64,7 @@ class ProgramCacheKey:
             tuple((k, str(v.to_json())) for k, v in sorted(arg_types.items())),
             tuple((k, str(v.to_json())) for k, v in sorted(closure_types.items())),
             tuple((k, _make_hashable(v)) for k, v in sorted(closure_constants.items())),
-            tuple(sorted(specified_args)),
+            tuple(sorted(_make_sortable(a) for a in specified_args)),
         )
 
     def __hash__(self) -> int:

--- a/dace/frontend/python/common.py
+++ b/dace/frontend/python/common.py
@@ -8,6 +8,7 @@ from dace.sdfg.sdfg import SDFG
 
 
 class DaceSyntaxError(Exception):
+
     def __init__(self, visitor, node: ast.AST, message: str):
         self.visitor = visitor
         self.node = node
@@ -37,10 +38,20 @@ def inverse_dict_lookup(dict: Dict[str, Any], value: Any):
     return None
 
 
+@dataclass(unsafe_hash=True)
+class StringLiteral:
+    """ A string literal found in a parsed DaCe program. """
+    value: Union[str, bytes]
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class SDFGConvertible(object):
     """ 
     A mixin that defines the interface to annotate SDFG-convertible objects.
     """
+
     def __sdfg__(self, *args, **kwargs) -> SDFG:
         """
         Returns an SDFG representation of this object.

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3925,7 +3925,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     if isinstance(parsed_arg, StringLiteral):
                         # Special case for strings
                         parsed_arg = f'"{astutils.escape_string(parsed_arg.value)}"'
-                        atype = data.Scalar(dtypes.string())
+                        atype = data.Scalar(dtypes.string)
                     elif isinstance(parsed_arg, (Number, numpy.number, type(None))):
                         atype = data.create_datadescriptor(type(parsed_arg))
                     else:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -262,7 +262,7 @@ DISALLOWED_STMTS = [
 ]
 # Extra AST node types that are disallowed after preprocessing
 _DISALLOWED_STMTS = DISALLOWED_STMTS + [
-    'Global', 'Assert', 'Print', 'Nonlocal', 'Raise', 'Starred', 'AsyncFor', 'Bytes', 'ListComp', 'GeneratorExp',
+    'Global', 'Assert', 'Print', 'Nonlocal', 'Raise', 'Starred', 'AsyncFor', 'ListComp', 'GeneratorExp',
     'SetComp', 'DictComp', 'comprehension'
 ]
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2,7 +2,6 @@
 import ast
 from collections import OrderedDict
 import copy
-from dataclasses import dataclass
 import itertools
 import inspect
 import re
@@ -19,7 +18,8 @@ from dace import sourcemap
 from dace.config import Config
 from dace.frontend.common import op_repository as oprepo
 from dace.frontend.python import astutils
-from dace.frontend.python.common import (DaceSyntaxError, SDFGClosure, SDFGConvertible, inverse_dict_lookup)
+from dace.frontend.python.common import (DaceSyntaxError, SDFGClosure, SDFGConvertible, inverse_dict_lookup,
+                                         StringLiteral)
 from dace.frontend.python.astutils import ExtNodeVisitor, ExtNodeTransformer
 from dace.frontend.python.astutils import rname
 from dace.frontend.python import nested_call, replacements, preprocessing
@@ -47,10 +47,6 @@ ShapeList = List[Size]
 Shape = Union[ShapeTuple, ShapeList]
 DependencyType = Dict[str, Tuple[SDFGState, Union[Memlet, nodes.Tasklet], Tuple[int]]]
 
-@dataclass(unsafe_hash=True)
-class StringLiteral:
-    """ A string literal found in a parsed DaCe program. """
-    value: Union[str, bytes]
 
 class SkipCall(Exception):
     """ Exception used to skip calls to functions that cannot be parsed. """
@@ -585,6 +581,7 @@ class TaskletTransformer(ExtNodeTransformer):
     """ A visitor that traverses a data-centric tasklet, removes memlet
         annotations and returns input and output memlets.
     """
+
     def __init__(self,
                  visitor,
                  defined,
@@ -4628,6 +4625,7 @@ class ProgramVisitor(ExtNodeVisitor):
         """ Parses the slice attribute of an ast.Subscript node.
             Scalar data are promoted to symbols.
         """
+
         def _promote(node: ast.AST) -> Union[Any, str, symbolic.symbol]:
             node_str = astutils.unparse(node)
             sym = None

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ DaCe Python parsing functionality and entry point to Python frontend. """
+import ast
 from dataclasses import dataclass
 import inspect
 import itertools
@@ -523,7 +524,7 @@ class DaceProgram(pycommon.SDFGConvertible):
 
                 types.update({f'__arg{j}': create_datadescriptor(varg) for j, varg in enumerate(vargs)})
                 arg_mapping.update({f'__arg{j}': varg for j, varg in enumerate(vargs)})
-                gvar_mapping[aname] = tuple(f'__arg{j}' for j in range(len(vargs)))
+                gvar_mapping[aname] = tuple(ast.Name(id=f'__arg{j}') for j in range(len(vargs)))
                 specified_args.update(set(gvar_mapping[aname]))
                 # Shift arg_ind to the end
                 arg_ind = len(given_args)
@@ -538,7 +539,7 @@ class DaceProgram(pycommon.SDFGConvertible):
                                       f'arguments (invalid argument name: "{aname}").')
                 types.update({f'__kwarg_{k}': v for k, v in vargs.items()})
                 arg_mapping.update({f'__kwarg_{k}': given_kwargs[k] for k in vargs.keys()})
-                gvar_mapping[aname] = {k: f'__kwarg_{k}' for k in vargs.keys()}
+                gvar_mapping[aname] = {k: ast.Name(id=f'__kwarg_{k}') for k in vargs.keys()}
                 specified_args.update({f'__kwarg_{k}' for k in vargs.keys()})
             # END OF VARIABLE-LENGTH ARGUMENTS
             else:

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -474,6 +474,8 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
         elif isinstance(value, symbolic.symbol):
             # Symbols resolve to the symbol name
             newnode = ast.Name(id=value.name, ctx=ast.Load())
+        elif isinstance(value, ast.Name):
+            newnode = ast.Name(id=value.id, ctx=ast.Load())
         elif (dtypes.isconstant(value) or isinstance(value, SDFG) or hasattr(value, '__sdfg__')):
             # Could be a constant, an SDFG, or SDFG-convertible object
             if isinstance(value, SDFG) or hasattr(value, '__sdfg__'):

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -17,7 +17,7 @@ from dace import data, dtypes, subsets, symbolic, sdfg as sd
 from dace.config import Config
 from dace.sdfg import SDFG
 from dace.frontend.python import astutils
-from dace.frontend.python.common import (DaceSyntaxError, SDFGConvertible, SDFGClosure)
+from dace.frontend.python.common import (DaceSyntaxError, SDFGConvertible, SDFGClosure, StringLiteral)
 
 
 class DaceRecursionError(Exception):
@@ -476,10 +476,12 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
             newnode = ast.Name(id=value.name, ctx=ast.Load())
         elif isinstance(value, ast.Name):
             newnode = ast.Name(id=value.id, ctx=ast.Load())
-        elif (dtypes.isconstant(value) or isinstance(value, SDFG) or hasattr(value, '__sdfg__')):
+        elif (dtypes.isconstant(value) or isinstance(value, (StringLiteral, SDFG)) or hasattr(value, '__sdfg__')):
             # Could be a constant, an SDFG, or SDFG-convertible object
             if isinstance(value, SDFG) or hasattr(value, '__sdfg__'):
                 self.closure.closure_sdfgs[id(value)] = (qualname, value)
+            elif isinstance(value, StringLiteral):
+                value = value.value
             else:
                 # If this is a function call to a None function, do not add its result to the closure
                 if isinstance(parent_node, ast.Call):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ cmake_requires = ['scikit-build', 'cmake']
 cmake_path = shutil.which('cmake')
 if cmake_path:
     # CMake is available, check version
-    output = subprocess.check_output([cmake_path, '--version'], text=True)
+    output = subprocess.check_output([cmake_path, '--version']).decode('utf-8')
     cmake_version = tuple(int(t) for t in output.splitlines()[0].split(' ')[-1].split('.'))
     # If version meets minimum requirements, CMake is not necessary
     if cmake_version >= (3, 15):

--- a/tests/python_frontend/string_test.py
+++ b/tests/python_frontend/string_test.py
@@ -2,6 +2,8 @@
 
 import dace
 import numpy as np
+import pytest
+
 
 def callback_inhibitor(f):
     return f
@@ -26,5 +28,48 @@ def test_string_literal_in_callback():
     assert success is True
 
 
+def test_bytes_literal_in_callback():
+    success = False
+    @callback_inhibitor
+    def cb(a):
+        nonlocal success
+        if a == b'Hello World!':
+            success = True
+
+
+    @dace
+    def tester(a):
+        cb(b'Hello World!')
+
+    
+    a = np.random.rand(1)
+    tester(a)
+
+    assert success is True
+
+
+@pytest.mark.skip
+def test_string_literal():
+
+    @dace
+    def tester():
+        return 'Hello World!'
+    
+    assert tester()[0] == 'Hello World!'
+
+
+@pytest.mark.skip
+def test_bytes_literal():
+
+    @dace
+    def tester():
+        return b'Hello World!'
+    
+    assert tester()[0] == b'Hello World!'
+
+
 if __name__ == '__main__':
     test_string_literal_in_callback()
+    test_bytes_literal_in_callback()
+    # test_string_literal()
+    # test_bytes_literal()

--- a/tests/python_frontend/string_test.py
+++ b/tests/python_frontend/string_test.py
@@ -48,6 +48,26 @@ def test_bytes_literal_in_callback():
     assert success is True
 
 
+def test_string_literal_in_callback_2():
+    success = False
+    @callback_inhibitor
+    def cb(a):
+        nonlocal success
+        if a == "b'Hello World!'":
+            success = True
+
+
+    @dace
+    def tester(a):
+        cb("b'Hello World!'")
+
+    
+    a = np.random.rand(1)
+    tester(a)
+
+    assert success is True
+
+
 @pytest.mark.skip
 def test_string_literal():
 
@@ -71,5 +91,6 @@ def test_bytes_literal():
 if __name__ == '__main__':
     test_string_literal_in_callback()
     test_bytes_literal_in_callback()
+    test_string_literal_in_callback_2()
     # test_string_literal()
     # test_bytes_literal()

--- a/tests/python_frontend/string_test.py
+++ b/tests/python_frontend/string_test.py
@@ -1,0 +1,30 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+
+import dace
+import numpy as np
+
+def callback_inhibitor(f):
+    return f
+
+def test_string_literal_in_callback():
+    success = False
+    @callback_inhibitor
+    def cb(a):
+        nonlocal success
+        if a == 'a':
+            success = True
+
+
+    @dace
+    def tester(a):
+        cb('a')
+
+    
+    a = np.random.rand(1)
+    tester(a)
+
+    assert success is True
+
+
+if __name__ == '__main__':
+    test_string_literal_in_callback()


### PR DESCRIPTION
Before this PR, there was effectively no difference between a string and an array name.

Fixes #1072 