### PR TITLE
Frontend fixes

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -764,8 +764,18 @@ required:
                     Perform an early type check on arguments passed to an SDFG when called directly (from 
                     ``SDFG.__call__``). Another type check is performed when calling compiled SDFGs.
 
+            avoid_wcr:
+                type: bool
+                default: false
+                title: Avoid using WCR for augmented assignments when possible
+                description: >
+                    Perform a map-symbol-dependency check on the write-subsets of augemented
+                    assignments that appear inside Maps to avoid using of WCR when possible.
+                    This feature works correctly only when there is a single augmented assignment
+                    for each data dimension inside a Map.
 
     #############################################
+
     # General settings
 
     debugprint:

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -769,8 +769,8 @@ required:
                 default: false
                 title: Avoid using WCR for augmented assignments when possible
                 description: >
-                    Perform a map-symbol-dependency check on the write-subsets of augemented
-                    assignments that appear inside Maps to avoid using of WCR when possible.
+                    Perform a map-symbol-dependency check on the write-subsets of augmented
+                    assignments that appear inside Maps to avoid using WCR when possible.
                     This feature works correctly only when there is a single augmented assignment
                     for each data dimension inside a Map.
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3193,7 +3193,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     independent = True
                     waccess = inverse_dict_lookup(self.accesses, (new_name, new_rng))
                     if self.map_symbols and waccess:
-                        if Config.get_bool('frontend', 'avoid_wcr'):
+                        if not Config.get_bool('frontend', 'avoid_wcr'):
                             independent = False
                         else:
                             for s in self.map_symbols:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3189,14 +3189,17 @@ class ProgramVisitor(ExtNodeVisitor):
             # Strict independent access check for augmented assignments
             if op:
                 independent = False
-                if Config.get_bool('frontend', 'avoid_wcr') and not _subset_is_local_symbol_dependent(new_rng, self):
+                if not _subset_is_local_symbol_dependent(new_rng, self):
                     independent = True
                     waccess = inverse_dict_lookup(self.accesses, (new_name, new_rng))
                     if self.map_symbols and waccess:
-                        for s in self.map_symbols:
-                            if s not in waccess[1].free_symbols:
-                                independent = False
-                                break
+                        if Config.get_bool('frontend', 'avoid_wcr'):
+                            independent = False
+                        else:
+                            for s in self.map_symbols:
+                                if s not in waccess[1].free_symbols:
+                                    independent = False
+                                    break
 
             # Handle output indirection
             output_indirection = None

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3158,7 +3158,7 @@ class ProgramVisitor(ExtNodeVisitor):
             # Strict independent access check for augmented assignments
             if op:
                 independent = False
-                if not _subset_is_local_symbol_dependent(new_rng, self):
+                if Config.get_bool('frontend', 'avoid_wcr') and not _subset_is_local_symbol_dependent(new_rng, self):
                     independent = True
                     waccess = inverse_dict_lookup(self.accesses, (new_name, new_rng))
                     if self.map_symbols and waccess:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import copy
 import itertools
 import inspect
+import networkx as nx
 import re
 import sys
 import time
@@ -2194,6 +2195,15 @@ class ProgramVisitor(ExtNodeVisitor):
                 # The state that all "break" edges go to
                 loop_end = self._add_state(f'postloop_{node.lineno}')
 
+            body_states = set()
+            to_visit = [first_loop_state]
+            while to_visit:
+                state = to_visit.pop(0)
+                for _, dst, _ in self.sdfg.out_edges(state):
+                    if dst not in body_states and dst is not loop_guard:
+                        to_visit.append(dst)
+                body_states.add(state)
+            
             continue_states = self.continue_states.pop()
             while continue_states:
                 next_state = continue_states.pop()
@@ -2209,6 +2219,12 @@ class ProgramVisitor(ExtNodeVisitor):
                     self.sdfg.remove_edge(e)
                 self.sdfg.add_edge(next_state, loop_end, dace.InterstateEdge())
             self.loop_idx -= 1
+
+            for state in body_states:
+                if not nx.has_path(self.sdfg.nx, loop_guard, state):
+                    for e in self.sdfg.all_edges(state):
+                        self.sdfg.remove_edge(e)
+                    self.sdfg.remove_node(state)
         else:
             raise DaceSyntaxError(self, node, 'Unsupported for-loop iterator "%s"' % iterator)
 
@@ -2302,6 +2318,15 @@ class ProgramVisitor(ExtNodeVisitor):
 
             # The state that all "break" edges go to
             loop_end = self._add_state(f'postwhile_{node.lineno}')
+        
+        body_states = set()
+        to_visit = [first_loop_state]
+        while to_visit:
+            state = to_visit.pop(0)
+            for _, dst, _ in self.sdfg.out_edges(state):
+                if dst not in body_states and dst is not loop_guard:
+                    to_visit.append(dst)
+            body_states.add(state)
 
         continue_states = self.continue_states.pop()
         while continue_states:
@@ -2318,6 +2343,12 @@ class ProgramVisitor(ExtNodeVisitor):
                 self.sdfg.remove_edge(e)
             self.sdfg.add_edge(next_state, loop_end, dace.InterstateEdge())
         self.loop_idx -= 1
+
+        for state in body_states:
+            if not nx.has_path(self.sdfg.nx, end_guard, state):
+                for e in self.sdfg.all_edges(state):
+                    self.sdfg.remove_edge(e)
+                self.sdfg.remove_node(state)
 
     def visit_Break(self, node: ast.Break):
         if self.loop_idx < 0:

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -192,7 +192,7 @@ def dfs_conditional(G, sources=None, condition=None, reverse=False, yield_parent
     will not be traversed.
     
 
-    :param G: An input DiGraph (assumed acyclic).
+    :param G: An input DiGraph (may have cycles).
     :param sources: (optional) node or list of nodes that
                     specify starting point(s) for depth-first search and return
                     edges in the component reachable from source. If None, traverses from

--- a/dace/transformation/passes/constant_propagation.py
+++ b/dace/transformation/passes/constant_propagation.py
@@ -173,11 +173,11 @@ class ConstantPropagation(ppl.Pass):
                                           sdfg.number_of_nodes(), self.progress):
             if state in result:
                 continue
-            result[state] = {}
 
             # Get predecessors
             in_edges = sdfg.in_edges(state)
             if len(in_edges) == 1:  # Special case, propagate as-is
+                result[state] = {}
                 # First the prior state
                 self._propagate(result[state], result[in_edges[0].src])
 
@@ -205,6 +205,7 @@ class ConstantPropagation(ppl.Pass):
                     else:
                         assignments[aname] = aval
 
+            result[state] = {}
             self._propagate(result[state], assignments)
 
         return result

--- a/tests/python_frontend/loops_test.py
+++ b/tests/python_frontend/loops_test.py
@@ -405,6 +405,7 @@ def test_nested_map_with_symbol():
 
 
 def test_for_else():
+
     @dace.program
     def for_else(A: dace.float64[20]):
         for i in range(1, 20):
@@ -435,6 +436,7 @@ def test_for_else():
 
 
 def test_while_else():
+
     @dace.program
     def while_else(A: dace.float64[2]):
         while A[0] < 5.0:
@@ -484,7 +486,6 @@ def branch_in_while(cond: dace.int32):
 
 def test_branch_in_while():
     sdfg = branch_in_while.to_sdfg(simplify=False)
-    sdfg.view()
     assert len(sdfg.source_nodes()) == 1
 
 

--- a/tests/python_frontend/loops_test.py
+++ b/tests/python_frontend/loops_test.py
@@ -457,6 +457,37 @@ def test_while_else():
     assert np.allclose(A, expected)
 
 
+@dace.program
+def branch_in_for(cond: dace.int32):
+    for i in range(10):
+        if cond > 0:
+            break
+        else:
+            continue
+
+
+def test_branch_in_for():
+    sdfg = branch_in_for.to_sdfg(simplify=False)
+    assert len(sdfg.source_nodes()) == 1
+
+
+@dace.program
+def branch_in_while(cond: dace.int32):
+    i = 0
+    while i < 10:
+        if cond > 0:
+            break
+        else:
+            i += 1
+            continue
+
+
+def test_branch_in_while():
+    sdfg = branch_in_while.to_sdfg(simplify=False)
+    sdfg.view()
+    assert len(sdfg.source_nodes()) == 1
+
+
 if __name__ == "__main__":
     test_for_loop()
     test_for_loop_with_break_continue()
@@ -478,3 +509,5 @@ if __name__ == "__main__":
     test_nested_map_with_symbol()
     test_for_else()
     test_while_else()
+    test_branch_in_for()
+    test_branch_in_while()


### PR DESCRIPTION
The PR addresses two issues:

The frontend has a feature where the write-subsets of augmented assignments appearing inside Maps are checked for dependency on the Map parameters. According to the results of this check, the frontend will avoid using WCR and instead generate a subgraph where the write-data appear explicitly as read-data too. However, this feature will not work correctly when a Map has multiple writes to the same dimension of a data container, with index expressions that create write-conflicts (see `tests.python_frontend.augassign_wcr_test.augassign_wcr4`). We cannot rectify the issue within the bounds of the frontend's current design, which is not to look ahead for the following statements in the code. Instead of removing the feature altogether, which may have undesired performance consequences for users (there is currently no `WCRtoAugAssign` transformation), a configuration variable `avoid_wcr` with default value `False` is added to enable/disable the feature.

When the frontend generates loops that contain an if-condition deciding between executing a break or continue statement, an extraneous source state is generated, which may lead to broken SDFGs after applying StateFusion. The issue is fixed by detecting these extraneous states and deleting them at the end of the frontend's loop-generation methods `visit_For` and `visit_While.` Note that the `visit_For` changes are ported from the `simplify-fixes` branch.
