### PR TITLE
Fix SDFGState.add_nested_sdfg and RefineNestedAccess transformation

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1107,6 +1107,12 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], StateGraphView
 
         # Validate missing symbols
         missing_symbols = [s for s in symbols if s not in symbol_mapping]
+        if missing_symbols and parent:
+            # If symbols are missing, try to get them from the parent SDFG
+            parent_mapping = {s: s for s in missing_symbols if s in parent.symbols}
+            symbol_mapping.update(parent_mapping)
+            s.symbol_mapping = symbol_mapping
+            missing_symbols = [s for s in symbols if s not in symbol_mapping]
         if missing_symbols:
             raise ValueError('Missing symbols on nested SDFG "%s": %s' % (name, missing_symbols))
 

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -981,7 +981,8 @@ class RefineNestedAccess(transformation.SingleStateTransformation):
                 if len(nstate.ranges) > 0:
                     # Re-annotate loop ranges, in case someone changed them
                     # TODO: Move out of here!
-                    nstate.ranges = {}
+                    for ns in nsdfg.sdfg.states():
+                        ns.ranges = {}
                     from dace.sdfg.propagation import _annotate_loop_ranges
                     _annotate_loop_ranges(nsdfg.sdfg, [])
 


### PR DESCRIPTION
- When adding a NestedSDFG and there are missing symbols, check if they are defined in the parent. If yes, add them to the symbol mapping.
- RefineNestedAccess resets the loop ranges in the candidate nested SDFGState because they might have been altered from another transformation (is this valid any longer?). However, the loop ranges of all the states must be reset due to how `_annotate_loop_ranges` works (if the guard is correctly annotated, it skips annotating the body).
