### PR TITLE
OTFMapFusion: Support for WCR, nested maps & connector renaming fixed

### DIFF
--- a/dace/transformation/dataflow/otf_map_fusion.py
+++ b/dace/transformation/dataflow/otf_map_fusion.py
@@ -140,23 +140,15 @@ class OTFMapFusion(transformation.SingleStateTransformation):
         # c. Add edges for in access nodes of first map to second map
         connector_mapping = {}
         for edge in graph.in_edges(first_map_entry):
-            old_in_connector = edge.dst_conn
-            if not edge.data is None and not edge.data.data is None:
-                suffix = edge.data.data
-            else:
-                suffix = "OTF"
-
-            new_in_connector = "IN_" + suffix
+            new_in_connector = self.second_map_entry.next_connector(edge.dst_conn[3:])
+            new_in_connector = "IN_" + new_in_connector
             if not self.second_map_entry.add_in_connector(new_in_connector):
-                for n in range(2, 65536):
-                    new_in_connector = "IN_" + suffix + "_" + str(n)
-                    if self.second_map_entry.add_in_connector(new_in_connector):
-                        break
+                raise ValueError("Failed to add new in connector")
 
             memlet = copy.deepcopy(edge.data)
             graph.add_edge(edge.src, edge.src_conn, self.second_map_entry, new_in_connector, memlet)
 
-            connector_mapping[old_in_connector] = new_in_connector
+            connector_mapping[edge.dst_conn] = new_in_connector
 
         # Phase 2: Memlet matching
         # Collect memlet-array map

--- a/dace/transformation/dataflow/otf_map_fusion.py
+++ b/dace/transformation/dataflow/otf_map_fusion.py
@@ -66,7 +66,7 @@ class OTFMapFusion(transformation.SingleStateTransformation):
                 return False
 
             # In general, WCR requires initialization of the data with the identity of the reduction. In the special case of "0"-identity, we don't need to explicitly initialize but can set the "setzero" flag at creation of the data. This avoids adding states.
-            if not memlet.wcr is None:
+            if memlet.wcr is not None:
                 red_type = detect_reduction_type(memlet.wcr)
                 if red_type == dtypes.ReductionType.Custom:
                     return False
@@ -90,7 +90,7 @@ class OTFMapFusion(transformation.SingleStateTransformation):
         for edge in graph.out_edges(self.second_map_entry):
             memlet = edge.data
 
-            if not memlet.data in first_memlets:
+            if memlet.data not in first_memlets:
                 continue
 
             # Only fuse scalars
@@ -235,14 +235,14 @@ class OTFMapFusion(transformation.SingleStateTransformation):
                         graph.remove_edge(edge)
                         tmp_memlet = Memlet(tmp_name)
                         tmp_memlet.wcr = edge.data.wcr
-                        if not tmp_memlet.wcr is None:
+                        if tmp_memlet.wcr is not None:
                             tmp_memlet.src_subset = Range([(0, 0, 1)])
                         graph.add_edge(edge.src, edge.src_conn, tmp_access, None, tmp_memlet)
 
                     # Connect new OTF nodes to second map entry for read
                     for edge in graph.edges_between(first_map_entry, node):
                         memlet = copy.deepcopy(edge.data)
-                        if not memlet.wcr is None and memlet.data == self.array.data:
+                        if memlet.wcr is not None and memlet.data == self.array.data:
                             memlet.data = tmp_name
 
                         in_connector = edge.src_conn.replace("OUT", "IN")

--- a/tests/transformations/otf_map_fusion_test.py
+++ b/tests/transformations/otf_map_fusion_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import numpy as np
 import dace
+import math
 
 from scipy.signal import convolve2d
 
@@ -220,29 +221,60 @@ def fusion_tree(A: dace.float64[10, 20], B: dace.float64[10, 20], C: dace.float6
 
 
 @dace.program
-def hdiff(in_field: dace.float32[128 + 4, 128 + 4, 64],
-          out_field: dace.float32[128, 128, 64], coeff: dace.float32[128, 128, 64]):
+def hdiff(in_field: dace.float32[128 + 4, 128 + 4, 64], out_field: dace.float32[128, 128, 64],
+          coeff: dace.float32[128, 128, 64]):
     lap_field = 4.0 * in_field[1:128 + 3, 1:128 + 3, :] - (
-        in_field[2:128 + 4, 1:128 + 3, :] + in_field[0:128 + 2, 1:128 + 3, :] +
-        in_field[1:128 + 3, 2:128 + 4, :] + in_field[1:128 + 3, 0:128 + 2, :])
+        in_field[2:128 + 4, 1:128 + 3, :] + in_field[0:128 + 2, 1:128 + 3, :] + in_field[1:128 + 3, 2:128 + 4, :] +
+        in_field[1:128 + 3, 0:128 + 2, :])
 
     res1 = lap_field[1:, 1:128 + 1, :] - lap_field[:128 + 1, 1:128 + 1, :]
     flx_field = np.where(
-        (res1 *
-         (in_field[2:128 + 3, 2:128 + 2, :] - in_field[1:128 + 2, 2:128 + 2, :])) > 0,
+        (res1 * (in_field[2:128 + 3, 2:128 + 2, :] - in_field[1:128 + 2, 2:128 + 2, :])) > 0,
         0,
         res1,
     )
     res2 = lap_field[1:128 + 1, 1:, :] - lap_field[1:128 + 1, :128 + 1, :]
     fly_field = np.where(
-        (res2 *
-         (in_field[2:128 + 2, 2:128 + 3, :] - in_field[2:128 + 2, 1:128 + 2, :])) > 0,
+        (res2 * (in_field[2:128 + 2, 2:128 + 3, :] - in_field[2:128 + 2, 1:128 + 2, :])) > 0,
         0,
         res2,
     )
     out_field[:, :, :] = in_field[2:128 + 2, 2:128 + 2, :] - coeff[:, :, :] * (
-        flx_field[1:, :, :] - flx_field[:-1, :, :] + fly_field[:, 1:, :] -
-        fly_field[:, :-1, :])
+        flx_field[1:, :, :] - flx_field[:-1, :, :] + fly_field[:, 1:, :] - fly_field[:, :-1, :])
+
+
+@dace.program
+def prime_fusion(A: dace.int64[128], B: dace.int64[128]):
+    tmp = dace.define_local([128], dtype=dace.bool)
+    for i in dace.map[0:128]:
+        num = A[i]
+
+        stop = int(math.ceil(math.sqrt(num)))
+        is_prime = True
+
+        j = 2
+        while j <= stop:
+            if num % j == 0:
+                is_prime = False
+                break
+
+            j = j + 1
+
+        tmp[i] = is_prime
+
+    for j in dace.map[0:128]:
+        num = A[j]
+        is_prime = tmp[j]
+
+        if not is_prime:
+            B[j] = 0
+        else:
+            i = 1
+            while i < 3:
+                num = num + i
+                i = i + 1
+
+            B[j] = num
 
 
 def test_memlet_equation():
@@ -490,6 +522,7 @@ def test_fusion_tree():
     diff = np.linalg.norm(c_target - C)
     assert diff <= 1e-12
 
+
 def test_connector_collision():
     sdfg = hdiff.to_sdfg()
     sdfg.simplify()
@@ -502,6 +535,24 @@ def test_connector_collision():
     sdfg.validate()
 
 
+def test_prime_fusion():
+    sdfg = prime_fusion.to_sdfg()
+    sdfg.simplify()
+
+    assert count_maps(sdfg) == 2
+
+    nums = np.arange(2, 130, 1, dtype=np.int64)
+    res = np.zeros((128, ), dtype=np.int64)
+    sdfg(A=nums, B=res)
+
+    sdfg.apply_transformations(OTFMapFusion)
+    assert count_maps(sdfg) == 1
+
+    res_fused = np.zeros((128, ), dtype=np.int64)
+    sdfg(A=nums, B=res_fused)
+    assert (res == res_fused).all()
+
+
 if __name__ == '__main__':
     test_fusion_chain()
     test_fusion_chain_renamed()
@@ -512,3 +563,4 @@ if __name__ == '__main__':
     test_fusion_convolve_transposed()
     test_fusion_tree()
     test_connector_collision()
+    test_prime_fusion()

--- a/tests/transformations/otf_map_fusion_test.py
+++ b/tests/transformations/otf_map_fusion_test.py
@@ -232,22 +232,22 @@ def test_memlet_equation():
     read_accesses = ((k, k, 1), (l + 2, l + 2, 1))
 
     sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
-    assert sol[0] == {i: k}
-    assert sol[1] == {j: l + 3}
+    assert sol[i] == k
+    assert sol[j] == l + 3
 
 
-def test_memlet_equation_same_symbols():
+def test_memlet_equation_transposed():
     i = dace.symbolic.symbol('i')
     j = dace.symbolic.symbol('j')
     write_params = [i, j]
     write_accesses = ((i, i, 1), (j - 1, j - 1, 1))
 
-    read_params = [i, j]
-    read_accesses = ((i, i, 1), (j + 2, j + 2, 1))
+    read_params = [j, i]
+    read_accesses = ((j + 2, j + 2, 1), (i, i, 1))
 
     sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
-    assert sol[0] == {i: i}
-    assert sol[1] == {j: j + 3}
+    assert sol[i] == j + 2
+    assert sol[j] == i + 1
 
 
 def test_memlet_equation_constant_read():
@@ -259,18 +259,7 @@ def test_memlet_equation_constant_read():
     read_accesses = ((0, 0, 1), )
 
     sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
-    assert sol[0] == {i: 0}
-
-
-def test_memlet_equation_constant_read_and_write_match():
-    write_params = []
-    write_accesses = ((2, 2, 1), )
-
-    read_params = []
-    read_accesses = ((2, 2, 1), )
-
-    sol = OTFMapFusion.solve(write_params, write_accesses, read_params, read_accesses)
-    assert sol[0] == {2: 2}
+    assert sol[i] == 0
 
 
 def test_memlet_equation_constant_read_and_write_fail():


### PR DESCRIPTION
This PR extends and fixes OTFMapFusion

- Fusion of maps with WCR in second map
- Fusion of maps with NestedSDFGs
- Renaming of symbols to avoid symbol collision of map parameters
- Renaming of symbols in NestedSDFG to avoid collision with map parameters
