### PR TITLE
Measurements API

### DIFF
--- a/dace/optimization/measure/__init__.py
+++ b/dace/optimization/measure/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+from dace.optimization.measure.measure import measure
+from dace.optimization.measure.arguments import random_arguments, create_data_report, arguments_from_data_report

--- a/dace/optimization/measure/arguments.py
+++ b/dace/optimization/measure/arguments.py
@@ -1,0 +1,170 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+import random
+import numpy as np
+
+from typing import Dict, List, Set, Tuple, Union, Sequence
+from dace import dtypes as ddtypes
+from dace.data import Data, Scalar, make_array_from_descriptor, Array
+from dace.sdfg import SDFG
+
+from dace import SDFG, DataInstrumentationType
+from dace import config, nodes, symbolic
+from dace.codegen.instrumentation.data.data_report import InstrumentedDataReport
+from dace.libraries.standard.memory import aligned_ndarray
+
+
+def random_arguments(sdfg: SDFG) -> Dict:
+    """
+    Creates random inputs and empty output containers for the SDFG.
+
+    :param SDFG: the SDFG.
+    :return: a dict containing the arguments.
+    """
+    # Symbols
+    symbols = {}
+    for k, v in sdfg.constants.items():
+        symbols[k] = int(v)
+    for k in sdfg.free_symbols:
+        symbols[k] = random.randint(1, 3)
+
+    arguments = {**symbols}
+    for state in sdfg.nodes():
+        for dnode in state.data_nodes():
+            if dnode.data in arguments:
+                continue
+
+            array = sdfg.arrays[dnode.data]
+            if state.in_degree(dnode) == 0 or state.out_degree(dnode) == 0 or not array.transient:
+                if state.in_degree(dnode) == 0:
+                    np_array = _random_container(array, symbols_map=symbols)
+                else:
+                    np_array = _empty_container(array, symbols_map=symbols)
+
+                arguments[dnode.data] = np_array
+
+    return arguments
+
+
+def create_data_report(sdfg: SDFG, arguments: Dict, transients: bool = False) -> InstrumentedDataReport:
+    """
+    Creates a data instrumentation report for the given SDFG and arguments.
+
+    :param SDFG: the SDFG.
+    :param arguments: the arguments to use.
+    :param transients: whether to instrument transient array.
+    :return: the data report.
+    """
+    for state in sdfg.nodes():
+        for node in state.nodes():
+            if isinstance(node, nodes.AccessNode):
+                if sdfg.arrays[node.data].transient and not transients:
+                    continue
+                if state.entry_node(node) is not None:
+                    continue
+
+                node.instrument = DataInstrumentationType.Save
+
+    with config.set_temporary('compiler', 'allow_view_arguments', value=True):
+        _ = sdfg(**arguments)
+
+    # Disable data instrumentation again
+    for state in sdfg.nodes():
+        for node in state.nodes():
+            if isinstance(node, nodes.AccessNode):
+                if sdfg.arrays[node.data].transient and not transients:
+                    continue
+                if state.entry_node(node) is not None:
+                    continue
+
+                node.instrument = DataInstrumentationType.No_Instrumentation
+
+    dreport = sdfg.get_instrumented_data()
+    return dreport
+
+
+def arguments_from_data_report(sdfg: SDFG, data_report: InstrumentedDataReport) -> Dict:
+    """
+    Creates the arguments for the SDFG from the data report.
+
+    :param SDFG: the SDFG.
+    :param data_report: the data report.
+    :return: a dict containing the arguments.
+    """
+    symbols = {}
+    for k, v in sdfg.constants.items():
+        symbols[k] = int(v)
+
+    arguments = {**symbols}
+    for state in sdfg.nodes():
+        for dnode in state.data_nodes():
+            if dnode.data in arguments:
+                continue
+
+            array = sdfg.arrays[dnode.data]
+            if state.in_degree(dnode) == 0 or state.out_degree(dnode) == 0 or not array.transient:
+                data = data_report[dnode.data]
+                if isinstance(data, Sequence):
+                    data = data.__iter__().__next__()
+
+                if isinstance(array, Array):
+                    arguments[dnode.data] = make_array_from_descriptor(array, data, symbols=sdfg.constants)
+                else:
+                    scalar = data.astype(array.dtype.as_numpy_dtype()).item()
+                    arguments[dnode.data] = scalar
+
+    return arguments
+
+
+def _random_container(array: Data, symbols_map: Dict[str, int]) -> np.ndarray:
+    shape = symbolic.evaluate(array.shape, symbols=symbols_map)
+    newdata = _uniform_sampling(array, shape)
+    if isinstance(array, Scalar):
+        return newdata
+    else:
+        return _align_container(array, symbols_map, newdata)
+
+
+def _empty_container(array: Data, symbols_map: Dict[str, int]) -> Union[int, float, np.ndarray]:
+    if isinstance(array, Scalar):
+        npdt = array.dtype.as_numpy_dtype()
+        if npdt in [np.float16, np.float32, np.float64]:
+            return 0.0
+        else:
+            return 0
+    else:
+        shape = symbolic.evaluate(array.shape, symbols=symbols_map)
+        empty_container = np.zeros(shape).astype(array.dtype.as_numpy_dtype())
+        return _align_container(array, symbols_map, empty_container)
+
+
+def _align_container(array: Data, symbols_map: Dict[str, int], container: np.ndarray) -> np.ndarray:
+    view: np.ndarray = make_array_from_descriptor(array, container, symbols_map)
+    if isinstance(array, Array) and array.alignment:
+        return aligned_ndarray(view, array.alignment)
+    else:
+        return view
+
+
+def _uniform_sampling(array: Data, shape: Union[List, Tuple]):
+    npdt = array.dtype.as_numpy_dtype()
+    if npdt in [np.float16, np.float32, np.float64]:
+        low = 0.0
+        high = 1.0
+        if isinstance(array, Scalar):
+            return np.random.uniform(low=low, high=high)
+        else:
+            return np.random.uniform(low=low, high=high, size=shape).astype(npdt)
+    elif npdt in [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
+        low = 0
+        high = 1
+        if isinstance(array, Scalar):
+            return np.random.randint(low, high)
+        else:
+            return np.random.randint(low, high, size=shape).astype(npdt)
+    elif array.dtype in [ddtypes.bool, ddtypes.bool_]:
+        if isinstance(array, Scalar):
+            return np.random.randint(low=0, high=2)
+        else:
+            return np.random.randint(low=0, high=2, size=shape).astype(npdt)
+    else:
+        raise TypeError()

--- a/dace/optimization/measure/measure.py
+++ b/dace/optimization/measure/measure.py
@@ -1,0 +1,106 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+import math
+import time
+import numpy as np
+
+import traceback
+import multiprocessing as mp
+
+from typing import Dict, Tuple
+
+from dace.codegen.compiled_sdfg import CompiledSDFG, ReloadableDLL
+from dace import SDFG, config, InstrumentationType
+
+
+def measure(sdfg: SDFG,
+            arguments: Dict,
+            measurements: int,
+            warmup: int = 0,
+            timeout: float = None) -> Tuple[float, float, Dict]:
+    """
+    A helper function to measure the median runtime of a SDFG over several measurements. The measurement is executed in a subprocess that can be killed after a specific timeout. This function will add default Timer instrumentation to the SDFG and return the full SDFG's runtime. The instrumentation report with the individual runtimes and the additional instrumentation is available afterwards as well.
+
+    :param SDFG: the SDFG to be measured.
+    :param arguments: the arguments provided to the SDFG.
+    :param measurements: the number of measurements.
+    :param warmup: optional warmup iterations (default = 0) which are excluded from the median.
+    :param timeout: optional timeout to kill the measurement.
+    :return: a tuple of median runtime, time of the whole measurement and the modified arguments (results). The second time is useful to determine a tight timeout for a transformed SDFG.
+    """
+    with config.set_temporary('instrumentation', 'report_each_invocation', value=False):
+        with config.set_temporary('compiler', 'allow_view_arguments', value=True):
+            sdfg.instrument = InstrumentationType.Timer
+            csdfg = sdfg.compile(validate=False, in_place=True)
+
+            proc = MeasureProcess(target=_measure,
+                                  args=(sdfg.to_json(), sdfg.build_folder, csdfg._lib._library_filename, arguments,
+                                        warmup, measurements))
+
+            start = time.time()
+            proc.start()
+            proc.join(timeout)
+            process_time = time.time() - start
+
+            # Handle failure
+            if proc.exitcode != 0:
+                if proc.is_alive():
+                    proc.kill()
+                return math.inf, process_time
+
+            if proc.exception:
+                if proc.is_alive():
+                    proc.kill()
+                error, traceback = proc.exception
+                print(error)
+                print(traceback)
+                return math.inf, process_time
+
+            # Handle success
+            if proc.is_alive():
+                proc.kill()
+
+            report = sdfg.get_latest_report()
+            durations = list(report.durations.values())[0]
+            durations = list(durations.values())[0]
+            durations = list(durations.values())[0]
+            runtime = np.median(np.array(durations[warmup:]))
+            return runtime, process_time
+
+
+def _measure(sdfg_json: Dict, build_folder: str, filename: str, arguments: Dict, warmup: int, measurements: int):
+    sdfg = SDFG.from_json(sdfg_json)
+    sdfg.build_folder = build_folder
+    lib = ReloadableDLL(filename, sdfg.name)
+    csdfg = CompiledSDFG(sdfg, lib, arguments.keys())
+
+    with config.set_temporary('instrumentation', 'report_each_invocation', value=False):
+        with config.set_temporary('compiler', 'allow_view_arguments', value=True):
+            for _ in range(warmup):
+                csdfg(**arguments)
+
+            for _ in range(measurements):
+                csdfg(**arguments)
+
+            csdfg.finalize()
+
+
+class MeasureProcess(mp.Process):
+
+    def __init__(self, *args, **kwargs):
+        mp.Process.__init__(self, *args, **kwargs)
+        self._pconn, self._cconn = mp.Pipe()
+        self._exception = None
+
+    def run(self):
+        try:
+            mp.Process.run(self)
+            self._cconn.send(None)
+        except Exception as e:
+            tb = traceback.format_exc()
+            self._cconn.send((e, tb))
+
+    @property
+    def exception(self):
+        if self._pconn.poll():
+            self._exception = self._pconn.recv()
+        return self._exception

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2086,13 +2086,14 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         dll = cs.ReloadableDLL(binary_filename, self.name)
         return dll.is_loaded()
 
-    def compile(self, output_file=None, validate=True) -> \
+    def compile(self, output_file=None, validate=True, in_place=False) -> \
             'dace.codegen.compiler.CompiledSDFG':
         """ Compiles a runnable binary from this SDFG.
             :param output_file: If not None, copies the output library file to
                                 the specified path.
             :param validate: If True, validates the SDFG prior to generating
                              code.
+            :param in_place: Compilation may modify the SDFG's contents.
             :return: A callable CompiledSDFG object.
         """
 
@@ -2112,7 +2113,10 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
         # DaCe Compilation Process #
 
         # Clone SDFG as the other modules may modify its contents
-        sdfg = copy.deepcopy(self)
+        if not in_place:
+            sdfg = copy.deepcopy(self)
+        else:
+            sdfg = self
         # Fix the build folder name on the copied SDFG to avoid it changing
         # if the codegen modifies the SDFG (thereby changing its hash)
         sdfg.build_folder = build_folder

--- a/tests/optimization/measure/arguments_test.py
+++ b/tests/optimization/measure/arguments_test.py
@@ -1,5 +1,6 @@
 import dace
 import numpy as np
+import multiprocessing
 
 from dace.sdfg.analysis.cutout import cutout_state
 from dace.optimization.measure import random_arguments, create_data_report, arguments_from_data_report
@@ -101,4 +102,7 @@ def test_cutout_arguments_from_dreport():
 
 
 if __name__ == '__main__':
+    test_create_data_report()
+    test_create_data_report_transients()
+    test_cutout_arguments_from_dreport()
     test_random_arguments()

--- a/tests/optimization/measure/arguments_test.py
+++ b/tests/optimization/measure/arguments_test.py
@@ -1,0 +1,104 @@
+import dace
+import numpy as np
+
+from dace.sdfg.analysis.cutout import cutout_state
+from dace.optimization.measure import random_arguments, create_data_report, arguments_from_data_report
+
+
+@dace.program
+def two_maps(A: dace.float64[10, 20], B: dace.float64[10, 20]):
+    tmp = dace.define_local([10, 20], dtype=A.dtype)
+    for i, j in dace.map[0:10, 0:20]:
+        with dace.tasklet:
+            a << A[i, j]
+            b >> tmp[i, j]
+
+            b = a * a
+
+    for i, j in dace.map[0:10, 0:20]:
+        with dace.tasklet:
+            a << tmp[i, j]
+            b >> B[i, j]
+
+            b = a + 2
+
+
+def test_random_arguments():
+    sdfg = two_maps.to_sdfg()
+    sdfg.simplify()
+
+    arguments = random_arguments(sdfg)
+    assert len(arguments) == 2
+
+    assert "A" in arguments
+    A = arguments["A"]
+    assert A.shape == (10, 20)
+    assert np.sum(A) != 0
+
+    assert "B" in arguments
+    B = arguments["B"]
+    assert B.shape == (10, 20)
+    assert np.all(B == 0.0)
+
+
+def test_create_data_report():
+    sdfg = two_maps.to_sdfg()
+    sdfg.simplify()
+
+    sdfg.clear_data_reports()
+
+    arguments = random_arguments(sdfg)
+    dreport = create_data_report(sdfg, arguments)
+
+    assert len(dreport.keys()) == 2
+
+
+def test_create_data_report_transients():
+    sdfg = two_maps.to_sdfg()
+    sdfg.simplify()
+
+    sdfg.clear_data_reports()
+
+    arguments = random_arguments(sdfg)
+    dreport = create_data_report(sdfg, arguments, transients=True)
+
+    assert len(dreport.keys()) == 3
+
+
+def test_cutout_arguments_from_dreport():
+    sdfg = two_maps.to_sdfg()
+    sdfg.simplify()
+
+    cutouts = []
+    for state in sdfg.nodes():
+        for node in state.nodes():
+            if not isinstance(node, dace.nodes.MapEntry):
+                continue
+
+            subgraph = state.scope_subgraph(node)
+            cutout = cutout_state(state, *subgraph.nodes())
+            cutouts.append(cutout)
+
+    sdfg.clear_data_reports()
+
+    arguments = random_arguments(sdfg)
+    dreport = create_data_report(sdfg, arguments, transients=True)
+
+    for cutout in cutouts:
+        args = arguments_from_data_report(cutout, dreport)
+        assert len(args) == 2
+
+        first_map = False
+        for node in cutout.start_state:
+            if isinstance(node, dace.nodes.AccessNode) and node.data == "A":
+                first_map = True
+                break
+
+        if first_map:
+            assert "A" in args and "tmp" in args
+        else:
+            assert "tmp" in args and "B" in args
+
+
+if __name__ == '__main__':
+    test_random_arguments()

--- a/tests/optimization/measure/measure_test.py
+++ b/tests/optimization/measure/measure_test.py
@@ -1,0 +1,55 @@
+import dace
+import math
+import numpy as np
+
+from dace.optimization.measure import measure
+
+
+@dace.program
+def matmul(A: dace.float64[10, 10], B: dace.float64[10, 10], C: dace.float64[10, 10]):
+    C[:] = A @ B
+
+
+def test_measure():
+    measurements = 3
+    warmup = 2
+
+    sdfg = matmul.to_sdfg()
+    sdfg.simplify()
+
+    A = np.random.rand(10, 10).astype(np.float64)
+    B = np.random.rand(10, 10).astype(np.float64)
+    C = np.zeros_like(B)
+
+    arguments = {"A": A, "B": B, "C": C}
+    target = A @ B
+
+    runtime, process_time = measure(sdfg, arguments, measurements=measurements, warmup=warmup)
+    assert runtime != math.inf and process_time != math.inf
+    assert (runtime / 1000) < process_time
+
+    report = sdfg.get_latest_report()
+    durations = list(report.durations.values())[0]
+    durations = list(durations.values())[0]
+    durations = list(durations.values())[0]
+
+    assert len(durations) == measurements + warmup
+    assert np.median(np.array(durations[warmup:])) == runtime
+
+
+def test_measure_exception():
+    sdfg = matmul.to_sdfg()
+    sdfg.simplify()
+
+    A = np.random.rand(10, 10).astype(np.float64)
+    B = np.random.rand(10, 10).astype(np.float64)
+
+    arguments = {"A": A, "B": B}
+
+    runtime, process_time = measure(sdfg, arguments, measurements=1)
+    assert runtime == math.inf
+    assert process_time != math.inf
+
+
+if __name__ == '__main__':
+    test_measure()

--- a/tests/optimization/measure/measure_test.py
+++ b/tests/optimization/measure/measure_test.py
@@ -1,6 +1,7 @@
 import dace
 import math
 import numpy as np
+import multiprocessing
 
 from dace.optimization.measure import measure
 
@@ -53,3 +54,4 @@ def test_measure_exception():
 
 if __name__ == '__main__':
     test_measure()
+    test_measure_exception()


### PR DESCRIPTION
This is the first step to cleaning up and generalizing the tuning API:

- A method to robustly measure runtimes in a subprocess. The sub-process can be killed with a timeout which is very useful for tuning when you've already searched good candidates.
- Methods to sample random arguments, create data reports and create arguments from data reports
- An additional parameter to compile which does not copy the SDFG. Everytime we call the sub-process measure, the SDFG gets copied, so this saves time when searching large search spaces