### PR TITLE
Transformation Fixes Round 2

### DIFF
--- a/dace/transformation/passes/constant_propagation.py
+++ b/dace/transformation/passes/constant_propagation.py
@@ -171,15 +171,22 @@ class ConstantPropagation(ppl.Pass):
         # Traverse SDFG topologically
         for state in optional_progressbar(sdfg.topological_sort(start_state), 'Collecting constants',
                                           sdfg.number_of_nodes(), self.progress):
-            if state in result:
+            # NOTE: We must always check the start-state regardless if there are initial symbols. This is necessary
+            # when the start-state is a scope's guard instead of a special initialization state, i.e., when the start-
+            # state has incoming edges that may involve the initial symbols. See also:
+            # `tests.passes.constant_propagation_test.test_for_with_external_init_nested_start_with_guard``
+            if state in result and state is not start_state:
                 continue
 
             # Get predecessors
             in_edges = sdfg.in_edges(state)
             if len(in_edges) == 1:  # Special case, propagate as-is
-                result[state] = {}
+                if state not in result:  # Condition evaluates to False when state is the start-state
+                    result[state] = {}
+                
                 # First the prior state
-                self._propagate(result[state], result[in_edges[0].src])
+                if in_edges[0].src in result:  # Condition evaluates to False when state is the start-state
+                    self._propagate(result[state], result[in_edges[0].src])
 
                 # Then assignments on the incoming edge
                 self._propagate(result[state], self._data_independent_assignments(in_edges[0].data, arrays))
@@ -205,7 +212,8 @@ class ConstantPropagation(ppl.Pass):
                     else:
                         assignments[aname] = aval
 
-            result[state] = {}
+            if state not in result:  # Condition may evaluate to False when state is the start-state
+                result[state] = {}
             self._propagate(result[state], assignments)
 
         return result

--- a/tests/passes/constant_propagation_test.py
+++ b/tests/passes/constant_propagation_test.py
@@ -356,7 +356,7 @@ def test_for_with_external_init_nested():
 
     N = dace.symbol('N')
 
-    sdfg = dace.SDFG('for_with_external_init')
+    sdfg = dace.SDFG('for_with_external_init_nested')
     sdfg.add_array('A', (N, ), dace.int32)
     init = sdfg.add_state('init', is_start_state=True)
     main = sdfg.add_state('main')
@@ -393,6 +393,49 @@ def test_for_with_external_init_nested():
     assert np.allclose(val1, ref)
 
 
+def test_for_with_external_init_nested_start_with_guard():
+    """
+    This test differs from the one above in lacking an initialization SDFGState in the NestedSDFG. Instead, the guard
+    of the nested for-loop is explicitly set as the start-state of the NestedSDFG.
+    """
+
+    N = dace.symbol('N')
+
+    sdfg = dace.SDFG('for_with_external_init_nested_start_with_guard')
+    sdfg.add_array('A', (N, ), dace.int32)
+    init = sdfg.add_state('init', is_start_state=True)
+    main = sdfg.add_state('main')
+    sdfg.add_edge(init, main, dace.InterstateEdge(assignments={'i': '1'}))
+
+    nsdfg = dace.SDFG('nested_sdfg')
+    nsdfg.add_array('inner_A', (N,), dace.int32)
+    nguard = nsdfg.add_state('nested_guard', is_start_state=True)
+    nbody = nsdfg.add_state('nested_body')
+    nexit = nsdfg.add_state('nested_exit')
+    nsdfg.add_edge(nguard, nbody, dace.InterstateEdge(condition='i <= N'))
+    nsdfg.add_edge(nbody, nguard, dace.InterstateEdge(assignments={'i': 'i+1'}))
+    nsdfg.add_edge(nguard, nexit, dace.InterstateEdge(condition='i > N'))
+
+    na = nbody.add_access('inner_A')
+    nt = nbody.add_tasklet('tasklet', {}, {'__out'}, '__out = i-1')
+    nbody.add_edge(nt, '__out', na, None, dace.Memlet('inner_A[i-1]'))
+
+    a = main.add_access('A')
+    t = main.add_nested_sdfg(nsdfg, None, {}, {'inner_A'}, {'N': 'N', 'i': 'i'})
+    main.add_edge(t, 'inner_A', a, None, dace.Memlet.from_array('A', sdfg.arrays['A']))
+
+    sdfg.validate()
+
+    ref = np.arange(10, dtype=np.int32)
+    val0 = np.ndarray((10, ), dtype=np.int32)
+    sdfg(A=val0, N=10)
+    assert np.allclose(val0, ref)
+    ConstantPropagation().apply_pass(sdfg, {})
+    val1 = np.ndarray((10, ), dtype=np.int32)
+    sdfg(A=val1, N=10)
+    assert np.allclose(val1, ref)
+
+
 if __name__ == '__main__':
     test_simple_constants()
     test_nested_constants()
@@ -408,3 +451,4 @@ if __name__ == '__main__':
     test_allocation_varying(True)
     test_for_with_external_init()
     test_for_with_external_init_nested()
+    test_for_with_external_init_nested_start_with_guard()


### PR DESCRIPTION
Assortment of fixes in transformations and passes:
- [x] Constant propagation when the start-state is a scope's guard instead of a dedicated initialization state.
