### PR TITLE
Frontend errors and behavior fix

### DIFF
--- a/dace/frontend/python/common.py
+++ b/dace/frontend/python/common.py
@@ -3,6 +3,7 @@ import ast
 import collections
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
+
 from dace import data
 from dace.sdfg.sdfg import SDFG
 

--- a/dace/frontend/python/interface.py
+++ b/dace/frontend/python/interface.py
@@ -113,6 +113,16 @@ def method(f: F,
             self.wrapped[objid] = prog
             return prog
 
+        def __call__(self, *call_args, **call_kwargs):
+            # When called as-is, treat as an unbounded function (dace.program)
+            if None not in self.wrapped:
+                prog = parser.DaceProgram(f, args, kwargs, auto_optimize, device, constant_functions, method=False)
+                self.wrapped[None] = prog
+            else:
+                prog = self.wrapped[None]
+
+            return prog(*call_args, **call_kwargs)
+
     return MethodWrapper()
 
 
@@ -144,6 +154,7 @@ class MapGenerator:
 
     def __iter__(self):
         return ndloop.ndrange(self.rng)
+
 
 class MapMetaclass(type):
     """ Metaclass for map, to enable ``dace.map[0:N]`` syntax. """

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3916,13 +3916,17 @@ class ProgramVisitor(ExtNodeVisitor):
         func: Callable[..., Any]
         _, func, _ = self.closure.callbacks[funcname]
 
+        skip_args = getattr(node, 'skip_args', [])
+        skip_kwargs = getattr(node, 'skip_keywords', [])
+
         # Infer the type of the function arguments and return value
         argtypes = []
         args = []
         outargs = []
         allargs = []
-        kwargs = [kw.value for kw in node.keywords]
-        for arg in itertools.chain(node.args, kwargs):
+        nodeargs = [a for i, a in enumerate(node.args) if i not in skip_args]
+        kwargs = [kw.value for i, kw in enumerate(node.keywords) if i not in skip_kwargs]
+        for arg in itertools.chain(nodeargs, kwargs):
             parsed_args = self._parse_function_arg(arg)
 
             # Flatten literal arguments in call (will be unflattened in callback,

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -246,6 +246,18 @@ def parse_dace_program(name: str,
             initial, total = ProgramVisitor.progress_bar
             ProgramVisitor.progress_bar = tqdm(total=total, initial=initial, desc='Parsing Python program')
         ProgramVisitor.increment_progress()
+    except SkipCall:
+        raise
+    except Exception:
+        # Print the offending line causing the exception
+        li = visitor.current_lineinfo
+        print('Exception raised while parsing DaCe program:\n'
+              f'  in File "{li.filename}", line {li.start_line}')
+        lines = preprocessed_ast.src.split('\n')
+        lineid = li.start_line - preprocessed_ast.src_line - 1
+        if lineid >= 0 and lineid < len(lines):
+            print(f'    {lines[lineid].strip()}')
+        raise
     finally:
         if teardown_progress:
             if not isinstance(ProgramVisitor.progress_bar, tuple):
@@ -264,8 +276,8 @@ DISALLOWED_STMTS = [
 ]
 # Extra AST node types that are disallowed after preprocessing
 _DISALLOWED_STMTS = DISALLOWED_STMTS + [
-    'Global', 'Assert', 'Print', 'Nonlocal', 'Raise', 'Starred', 'AsyncFor', 'ListComp', 'GeneratorExp',
-    'SetComp', 'DictComp', 'comprehension'
+    'Global', 'Assert', 'Print', 'Nonlocal', 'Raise', 'Starred', 'AsyncFor', 'ListComp', 'GeneratorExp', 'SetComp',
+    'DictComp', 'comprehension'
 ]
 
 TaskletType = Union[ast.FunctionDef, ast.With, ast.For]

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -322,11 +322,11 @@ def _create_unflatten_instruction(arg: ast.AST, global_vars: Dict[str, Any]) -> 
         pass
 
     if isinstance(arg, ast.List):
-        return (list, len(arg.elts))
+        return (list, len(arg.elts), False)
     elif isinstance(arg, ast.Tuple):
-        return (tuple, len(arg.elts))
+        return (tuple, len(arg.elts), False)
     elif isinstance(arg, ast.Set):
-        return (set, len(arg.elts))
+        return (set, len(arg.elts), False)
     elif isinstance(arg, ast.Dict):
         # Use two levels of functions to preserve keyword names
         def make_remake(kwnames):

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -394,16 +394,16 @@ def flatten_callback(func: Callable, node: ast.Call, global_vars: Dict[str, Any]
 
     # Filter arguments from AST
     poscount = len(node.args)
-    node.args = [a for i, a in enumerate(node.args) if i not in args_to_remove]
 
     # Nothing to do, early exit
     if not node.keywords and not instructions_exist:
         return func
 
     keywords = [kw.arg for kw in node.keywords]
-
-    # Filter keyword arguments from AST
-    node.keywords = [a for i, a in enumerate(node.keywords) if i not in kwargs_to_remove]
+    
+    # Annotate that these arguments should not be visited during callback generation
+    node.skip_args = args_to_remove
+    node.skip_keywords = kwargs_to_remove
 
     # Using two levels of functions to ensure keywords are stored with the callback
     if instructions_exist:

--- a/tests/python_frontend/assignment_statements_test.py
+++ b/tests/python_frontend/assignment_statements_test.py
@@ -114,6 +114,7 @@ def test_ann_assign_supported_type():
 
 
 def test_assignment_to_nonexistent_variable():
+
     @dace.program
     def badprog(B: dace.float64):
         A[...] = B
@@ -131,10 +132,42 @@ def test_assign_return_symbols():
             a = 5
         a -= 1
         return i, a
-    
+
     result = assign_symbols()
     a = result[1][0]
     assert a == 4
+
+
+def test_assign_to_compiletime_scalar():
+
+    class MyScalar:
+
+        def __init__(self) -> None:
+            self.scalar = 5
+
+        @dace.method
+        def method(self):
+            self.scalar = 1
+
+    obj = MyScalar()
+    with pytest.raises(DaceSyntaxError):
+        obj.method()
+
+
+def test_augassign_to_compiletime_scalar():
+
+    class MyScalar:
+
+        def __init__(self) -> None:
+            self.scalar = 5
+
+        @dace.method
+        def method(self):
+            self.scalar += 1
+
+    obj = MyScalar()
+    with pytest.raises(DaceSyntaxError):
+        obj.method()
 
 
 if __name__ == "__main__":
@@ -150,3 +183,6 @@ if __name__ == "__main__":
     test_assignment_to_nonexistent_variable()
 
     test_assign_return_symbols()
+
+    test_assign_to_compiletime_scalar()
+    test_augassign_to_compiletime_scalar()

--- a/tests/python_frontend/method_test.py
+++ b/tests/python_frontend/method_test.py
@@ -46,8 +46,11 @@ class MyTestClass:
 
 
 class MyTestCallAttributesClass:
+
     class SDFGMethodTestClass:
+
         def __sdfg__(self, *args, **kwargs):
+
             @dace.program
             def call(A):
                 A[:] = 7.0
@@ -139,6 +142,7 @@ def test_nested_methods():
 
 
 def mydec(a):
+
     def mutator(func):
         dp = dace.program(func)
 
@@ -163,6 +167,7 @@ def someprog_indirection(a):
 
 
 def test_decorator():
+
     @dace.program(constant_functions=True)
     def otherprog(A: dace.float64[20]):
         res = np.empty_like(A)
@@ -199,7 +204,9 @@ def test_sdfgattr_method_jit_with_scalar():
 
 
 def test_nested_field_in_map():
+
     class B:
+
         def __init__(self) -> None:
             self.field = np.random.rand(10, 10)
 
@@ -208,6 +215,7 @@ def test_nested_field_in_map():
             return self.field[1, 1]
 
     class A:
+
         def __init__(self, nested: B):
             self.nested = nested
 
@@ -225,7 +233,9 @@ def test_nested_field_in_map():
 
 
 def test_nested_callback_in_map():
+
     class B:
+
         def __init__(self) -> None:
             self.field = np.random.rand(10, 10)
 
@@ -234,6 +244,7 @@ def test_nested_callback_in_map():
             val[i] = time.time()
 
     class A:
+
         def __init__(self, nested: B):
             self.nested = nested
 
@@ -254,6 +265,16 @@ def test_nested_callback_in_map():
     assert result[0] >= old_time and result[0] <= new_time
 
 
+def test_unbounded_method():
+
+    @dace.method
+    def tester(a):
+        return a + 1
+
+    aa = np.random.rand(20)
+    assert np.allclose(tester(aa), aa + 1)
+
+
 if __name__ == '__main__':
     test_method_jit()
     test_method()
@@ -270,3 +291,4 @@ if __name__ == '__main__':
     test_sdfgattr_method_jit_with_scalar()
     test_nested_field_in_map()
     test_nested_callback_in_map()
+    test_unbounded_method()


### PR DESCRIPTION
- [x] Informative error when assigning to compile-time constants, fixes issue #985.
- [x] Allow `@dace.method` to be called on free functions, establishing one-decorator-fits-all.
- [x] StringLiterals in complex objects become strings (fixed by callbacks having compile-time arguments preserved)