### PR TITLE
PyObject Callbacks

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -20,6 +20,7 @@ from dace.frontend import operations
 class ReloadableDLL(object):
     """ A reloadable shared object (or dynamically linked library), which
         bypasses Python's dynamic library reloading issues. """
+
     def __init__(self, library_filename, program_name):
         """ Creates a new reloadable shared object.
             :param library_filename: Path to library file.
@@ -159,6 +160,7 @@ def _array_interface_ptr(array: Any, array_type: dt.Array) -> int:
 
 class CompiledSDFG(object):
     """ A compiled SDFG object that can be called through Python. """
+
     def __init__(self, sdfg, lib: ReloadableDLL, argnames: List[str] = None):
         self._sdfg = sdfg
         self._lib = lib
@@ -176,6 +178,7 @@ class CompiledSDFG(object):
         self._create_new_arrays: bool = True
         self._return_syms: Dict[str, Any] = None
         self._retarray_shapes: List[Tuple[str, np.dtype, dtypes.StorageType, Tuple[int], Tuple[int], int]] = []
+        self._retarray_is_scalar: List[bool] = []
         self._return_arrays: List[np.ndarray] = []
         self._callback_retval_references: List[Any] = []  # Avoids garbage-collecting callback return values
 
@@ -301,7 +304,7 @@ class CompiledSDFG(object):
             else:
                 self._cfunc(self._libhandle, *argtuple)
 
-            return self._return_arrays
+            return self._convert_return_values()
         except (RuntimeError, TypeError, UnboundLocalError, KeyError, cgx.DuplicateDLLError, ReferenceError):
             self._lib.unload()
             raise
@@ -322,12 +325,8 @@ class CompiledSDFG(object):
         """
         # Return value initialization (for values that have not been given)
         self._initialize_return_values(kwargs)
-        if self._return_arrays is not None:
-            if len(self._retarray_shapes) == 1:
-                kwargs[self._retarray_shapes[0][0]] = self._return_arrays
-            else:
-                for desc, arr in zip(self._retarray_shapes, self._return_arrays):
-                    kwargs[desc[0]] = arr
+        for desc, arr in zip(self._retarray_shapes, self._return_arrays):
+            kwargs[desc[0]] = arr
 
         # Argument construction
         sig = self._sig
@@ -500,17 +499,9 @@ class CompiledSDFG(object):
                 else:
                     self._create_new_arrays = False
                     # Use stored sizes to recreate arrays (fast path)
-                    if self._return_arrays is None:
-                        return
-                    elif isinstance(self._return_arrays, tuple):
-                        self._return_arrays = tuple(kwargs[desc[0]] if desc[0] in kwargs else self._create_array(*desc)
-                                                    for desc in self._retarray_shapes)
-                        return
-                    else:  # Single array return value
-                        desc = self._retarray_shapes[0]
-                        arr = (kwargs[desc[0]] if desc[0] in kwargs else self._create_array(*desc))
-                        self._return_arrays = arr
-                        return
+                    self._return_arrays = tuple(kwargs[desc[0]] if desc[0] in kwargs else self._create_array(*desc)
+                                                for desc in self._retarray_shapes)
+                    return
 
         self._return_syms = syms
         self._create_new_arrays = False
@@ -533,16 +524,19 @@ class CompiledSDFG(object):
                 total_size = int(symbolic.evaluate(arr.total_size, syms))
                 strides = tuple(symbolic.evaluate(s, syms) * arr.dtype.bytes for s in arr.strides)
                 shape_desc = (arrname, dtype, arr.storage, shape, strides, total_size)
+                self._retarray_is_scalar.append(isinstance(arr, dt.Scalar) or isinstance(arr.dtype, dtypes.pyobject))
                 self._retarray_shapes.append(shape_desc)
 
                 # Create an array with the properties of the SDFG array
                 arr = self._create_array(*shape_desc)
                 self._return_arrays.append(arr)
 
-        # Set up return_arrays field
-        if len(self._return_arrays) == 0:
-            self._return_arrays = None
+
+    def _convert_return_values(self):
+        # Return the values as they would be from a Python function
+        if self._return_arrays is None or len(self._return_arrays) == 0:
+            return None
         elif len(self._return_arrays) == 1:
-            self._return_arrays = self._return_arrays[0]
+            return self._return_arrays[0].item() if self._retarray_is_scalar[0] else self._return_arrays[0]
         else:
-            self._return_arrays = tuple(self._return_arrays)
+            return tuple(r.item() if scalar else r for r, scalar in zip(self._return_arrays, self._retarray_is_scalar))

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -513,6 +513,7 @@ class CompiledSDFG(object):
             if arrname.startswith('__return') and not arr.transient:
                 if arrname in kwargs:
                     self._return_arrays.append(kwargs[arrname])
+                    self._retarray_is_scalar.append(isinstance(arr, dt.Scalar))
                     self._retarray_shapes.append((arrname, ))
                     continue
 

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -746,6 +746,14 @@ required:
                     Stricter mode of operation where callbacks into Python don't participate
                     in state fusion transformations.
 
+            typed_callbacks_only:
+                type: bool
+                title: Only allow typed callbacks
+                default: false
+                description: >
+                    Stricter mode of operation where callbacks into Python must have explicit return value
+                    types in order to compile.
+
             unroll_threshold:
                 type: int
                 title: Automatic unroll loop size threshold

--- a/dace/data.py
+++ b/dace/data.py
@@ -993,6 +993,8 @@ def make_reference_from_descriptor(descriptor: Array,
     import numpy as np
     symbols = symbols or {}
 
+    original_array: int = ctypes.cast(original_array, ctypes.c_void_p).value
+
     free_syms = set(map(str, descriptor.free_symbols)) - symbols.keys()
     if free_syms:
         raise NotImplementedError(f'Cannot make Python references to arrays with undefined symbolic sizes: {free_syms}')

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -1009,9 +1009,9 @@ class callback(typeclass):
             elif isinstance(arg, data.Scalar) and isinstance(arg.dtype, pyobject):
                 inp_arraypos.append(index)
                 inp_types_and_sizes.append((ctypes.py_object, []))
-                inp_converters.append(lambda a, *args: ctypes.cast(a, ctypes.py_object).value)
+                inp_converters.append(lambda a, *args: a)
             else:
-                inp_converters.append(lambda a: a)
+                inp_converters.append(lambda a, *args: a)
         offset = len(self.input_types)
         for index, arg in enumerate(self.return_types):
             if isinstance(arg, data.Array):

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -826,6 +826,7 @@ class pyobject(opaque):
     def __init__(self):
         super().__init__('pyobject')
         self.bytes = ctypes.sizeof(ctypes.c_void_p)
+        self.type = numpy.object_
 
     def as_ctypes(self):
         return ctypes.py_object
@@ -1028,7 +1029,7 @@ class callback(typeclass):
             elif isinstance(arg, data.Scalar) and isinstance(arg.dtype, pyobject):
                 ret_arraypos.append(index + offset)
                 ret_types_and_sizes.append((ctypes.py_object, []))
-                ret_converters.append(lambda a, *args: id(a))
+                ret_converters.append(lambda a, *args: a)
             else:
                 if not self.is_scalar_function():
                     ret_arraypos.append(index + offset)

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -611,7 +611,7 @@ class pointer(typeclass):
     def __init__(self, wrapped_typeclass):
         self._typeclass = wrapped_typeclass
         self.type = wrapped_typeclass.type
-        self.bytes = int64.bytes
+        self.bytes = ctypes.sizeof(ctypes.c_void_p)
         self.ctype = wrapped_typeclass.ctype + "*"
         self.ctype_unaligned = wrapped_typeclass.ctype_unaligned + "*"
         self.dtype = self
@@ -816,6 +816,27 @@ class struct(typeclass):
         )
 
 
+class pyobject(opaque):
+    """
+    A generic data type for Python objects in un-annotated callbacks.
+    It cannot be used inside a DaCe program, but can be passed back to other Python callbacks.
+    Use with caution, and ensure the value is not removed by the garbage collector or the program will crash.
+    """
+
+    def __init__(self):
+        super().__init__('pyobject')
+        self.bytes = ctypes.sizeof(ctypes.c_void_p)
+
+    def as_ctypes(self):
+        return ctypes.py_object
+
+    def as_numpy_dtype(self):
+        return numpy.dtype(numpy.object_)
+
+    def to_python(self, obj_id: int):
+        return ctypes.cast(obj_id, ctypes.py_object).value
+
+
 class compiletime:
     """
     Data descriptor type hint signalling that argument evaluation is
@@ -886,16 +907,19 @@ class callback(typeclass):
         return_ctype = self.cfunc_return_type().as_ctypes()
         input_ctypes = []
 
-        if self.is_scalar_function():
-            args = self.input_types
-        else:
-            args = itertools.chain(self.input_types, self.return_types)
-
-        for some_arg in args:
+        for some_arg in self.input_types:
             if isinstance(some_arg, data.Array):
                 input_ctypes.append(ctypes.c_void_p)
             else:
                 input_ctypes.append(some_arg.dtype.as_ctypes() if some_arg is not None else None)
+
+        if not self.is_scalar_function():
+            for some_arg in self.return_types:
+                if isinstance(some_arg, data.Array):
+                    input_ctypes.append(ctypes.c_void_p)
+                else:
+                    input_ctypes.append(pointer(some_arg.dtype).as_ctypes() if some_arg is not None else None)
+
         if input_ctypes == [None]:
             input_ctypes = []
         cf_object = ctypes.CFUNCTYPE(return_ctype, *input_ctypes)
@@ -929,12 +953,7 @@ class callback(typeclass):
 
         input_type_cstring = []
 
-        if self.is_scalar_function():
-            args = self.input_types
-        else:
-            args = itertools.chain(self.input_types, self.return_types)
-
-        for arg in args:
+        for arg in self.input_types:
             if arg is None:
                 continue
             if isinstance(arg, data.Array):
@@ -943,10 +962,21 @@ class callback(typeclass):
             else:
                 input_type_cstring.append(arg.ctype)
 
+        if not self.is_scalar_function():
+            for arg in self.return_types:
+                if arg is None:
+                    continue
+                if isinstance(arg, data.Array):
+                    # const hack needed to prevent error in casting const int* to int*
+                    input_type_cstring.append(arg.dtype.ctype + " const *")
+                else:
+                    input_type_cstring.append(pointer(arg.dtype).ctype)
+
+
         retval = self.cfunc_return_type()
         return f'{retval} (*{name})({", ".join(input_type_cstring)})'
 
-    def get_trampoline(self, pyfunc, other_arguments):
+    def get_trampoline(self, pyfunc, other_arguments, refs):
         from functools import partial
         from dace import data, symbolic
 
@@ -975,6 +1005,10 @@ class callback(typeclass):
                 inp_arraypos.append(index)
                 inp_types_and_sizes.append((ctypes.c_void_p, []))
                 inp_converters.append(lambda a, *args: ctypes.cast(a, ctypes.c_void_p).value)
+            elif isinstance(arg, data.Scalar) and isinstance(arg.dtype, pyobject):
+                inp_arraypos.append(index)
+                inp_types_and_sizes.append((ctypes.py_object, []))
+                inp_converters.append(lambda a, *args: ctypes.cast(a, ctypes.py_object).value)
             else:
                 inp_converters.append(lambda a: a)
         offset = len(self.input_types)
@@ -988,11 +1022,20 @@ class callback(typeclass):
                 ret_types_and_sizes.append((ctypes.c_char_p, []))
                 ret_converters.append(lambda a, *args: ctypes.cast(a, ctypes.c_char_p).value.decode('utf-8'))
             elif isinstance(arg, data.Scalar) and isinstance(arg.dtype, pointer):
-                ret_arraypos.append(index)
+                ret_arraypos.append(index + offset)
                 ret_types_and_sizes.append((ctypes.c_void_p, []))
                 ret_converters.append(lambda a, *args: ctypes.cast(a, ctypes.c_void_p).value)
+            elif isinstance(arg, data.Scalar) and isinstance(arg.dtype, pyobject):
+                ret_arraypos.append(index + offset)
+                ret_types_and_sizes.append((ctypes.py_object, []))
+                ret_converters.append(lambda a, *args: id(a))
             else:
-                ret_converters.append(lambda a, *args: a)
+                if not self.is_scalar_function():
+                    ret_arraypos.append(index + offset)
+                    ret_types_and_sizes.append((arg.dtype.as_ctypes(), arg.shape))
+                    ret_converters.append(partial(data.make_reference_from_descriptor, arg))
+                else:
+                    ret_converters.append(lambda a, *args: a)
         if len(inp_arraypos) == 0 and len(ret_arraypos) == 0:
             return pyfunc
 
@@ -1004,7 +1047,7 @@ class callback(typeclass):
             list_of_other_inputs = list(other_inputs[:last_input])
             list_of_outputs = []
             if ret_indices:
-                list_of_outputs = list(other_inputs[ret_indices[0]:])
+                list_of_outputs = list(other_inputs[last_input:])
             for j, i in enumerate(indices):
                 data_type, size = data_types_and_sizes[j]
                 non_symbolic_sizes = []
@@ -1014,22 +1057,33 @@ class callback(typeclass):
                     else:
                         non_symbolic_sizes.append(s)
                 list_of_other_inputs[i] = inp_converters[i](other_inputs[i], other_arguments)
-            for j, i in enumerate(ret_indices):
-                data_type, size = ret_data_types_and_sizes[j]
-                non_symbolic_sizes = []
-                for s in size:
-                    if isinstance(s, symbolic.symbol):
-                        non_symbolic_sizes.append(other_arguments[str(s)])
+            if list_of_outputs:
+                for j, i in enumerate(ret_indices):
+                    data_type, size = ret_data_types_and_sizes[j]
+                    non_symbolic_sizes = []
+                    for s in size:
+                        if isinstance(s, symbolic.symbol):
+                            non_symbolic_sizes.append(other_arguments[str(s)])
+                        else:
+                            non_symbolic_sizes.append(s)
+                    outind = i - last_input
+                    if len(other_inputs) > i:
+                        list_of_outputs[outind] = ret_converters[outind](other_inputs[i], other_arguments)
                     else:
-                        non_symbolic_sizes.append(s)
-                list_of_outputs[i - ret_indices[0]] = ret_converters[i - ret_indices[0]](other_inputs[i],
-                                                                                         other_arguments)
+                        list_of_outputs[outind] = None
+
             if ret_indices:
                 ret = orig_function(*list_of_other_inputs)
-                if len(list_of_outputs) == 1:
+                if len(list_of_outputs) == 0:
+                    refs.append(ret)  # Keep reference so that garbage collection does not free object
+                    return ret_converters[0](ret, other_arguments)
+                elif len(list_of_outputs) == 1:
                     ret = [ret]
                 for v, r in zip(list_of_outputs, ret):
-                    v[:] = r
+                    if v is not None:  # Was converted to an assignable pointer
+                        v[:] = r
+
+                    refs.append(r)  # Keep reference so that garbage collection does not free object
                 return
             return orig_function(*list_of_other_inputs)
 
@@ -1125,6 +1179,7 @@ float64 = typeclass(numpy.float64)
 complex64 = typeclass(numpy.complex64)
 complex128 = typeclass(numpy.complex128)
 string = stringtype()
+
 
 @undefined_safe_enum
 @extensible_enum

--- a/dace/frontend/python/common.py
+++ b/dace/frontend/python/common.py
@@ -3,6 +3,7 @@ import ast
 import collections
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
+
 from dace import data
 from dace.sdfg.sdfg import SDFG
 

--- a/dace/frontend/python/common.py
+++ b/dace/frontend/python/common.py
@@ -24,11 +24,12 @@ class DaceSyntaxError(Exception):
             line = 0
             col = 0
 
+        col_suffix = f', column {col}' if col > 0 else ''
+
         if self.visitor is not None:
-            return (self.message + "\n  File \"" + str(self.visitor.filename) + "\", line " + str(line) + ", column " +
-                    str(col))
+            return self.message + f'\n  encountered in File "{self.visitor.filename}", line {line}{col_suffix}'
         else:
-            return (self.message + "\n  in line " + str(line) + ":" + str(col))
+            return self.message + f'\n  encountered in line {line}{col_suffix}'
 
 
 def inverse_dict_lookup(dict: Dict[str, Any], value: Any):

--- a/dace/frontend/python/interface.py
+++ b/dace/frontend/python/interface.py
@@ -113,6 +113,16 @@ def method(f: F,
             self.wrapped[objid] = prog
             return prog
 
+        def __call__(self, *call_args, **call_kwargs):
+            # When called as-is, treat as an unbounded function (dace.program)
+            if None not in self.wrapped:
+                prog = parser.DaceProgram(f, args, kwargs, auto_optimize, device, constant_functions, method=False)
+                self.wrapped[None] = prog
+            else:
+                prog = self.wrapped[None]
+
+            return prog(*call_args, **call_kwargs)
+
     return MethodWrapper()
 
 
@@ -144,6 +154,7 @@ class MapGenerator:
 
     def __iter__(self):
         return ndloop.ndrange(self.rng)
+
 
 class MapMetaclass(type):
     """ Metaclass for map, to enable ``dace.map[0:N]`` syntax. """

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -4597,6 +4597,18 @@ class ProgramVisitor(ExtNodeVisitor):
         else:
             operand2, op2type = None, None
 
+        # Type-check operands in order to provide a clear error message
+        if (isinstance(operand1, str) and operand1 in self.defined
+                and isinstance(self.defined[operand1].dtype, dtypes.pyobject)):
+            raise DaceSyntaxError(
+                self, op1, 'Trying to operate on a callback return value with an undefined type. '
+                f'Please add a type hint to "{operand1}" to enable using it within the program.')
+        if (isinstance(operand2, str) and operand2 in self.defined
+                and isinstance(self.defined[operand2].dtype, dtypes.pyobject)):
+            raise DaceSyntaxError(
+                self, op2, 'Trying to operate on a callback return value with an undefined type. '
+                f'Please add a type hint to "{operand2}" to enable using it within the program.')
+
         func = oprepo.Replacements.getop(op1type, opname, otherclass=op2type)
         if func is None:
             # Check for SDFG as fallback

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3916,13 +3916,17 @@ class ProgramVisitor(ExtNodeVisitor):
         func: Callable[..., Any]
         _, func, _ = self.closure.callbacks[funcname]
 
+        skip_args = getattr(node, 'skip_args', [])
+        skip_kwargs = getattr(node, 'skip_keywords', [])
+
         # Infer the type of the function arguments and return value
         argtypes = []
         args = []
         outargs = []
         allargs = []
-        kwargs = [kw.value for kw in node.keywords]
-        for arg in itertools.chain(node.args, kwargs):
+        nodeargs = [a for i, a in enumerate(node.args) if i not in skip_args]
+        kwargs = [kw.value for i, kw in enumerate(node.keywords) if i not in skip_kwargs]
+        for arg in itertools.chain(nodeargs, kwargs):
             parsed_args = self._parse_function_arg(arg)
 
             # Flatten literal arguments in call (will be unflattened in callback,

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -246,6 +246,18 @@ def parse_dace_program(name: str,
             initial, total = ProgramVisitor.progress_bar
             ProgramVisitor.progress_bar = tqdm(total=total, initial=initial, desc='Parsing Python program')
         ProgramVisitor.increment_progress()
+    except SkipCall:
+        raise
+    except Exception:
+        # Print the offending line causing the exception
+        li = visitor.current_lineinfo
+        print('Exception raised while parsing DaCe program:\n'
+              f'  in File "{li.filename}", line {li.start_line}')
+        lines = preprocessed_ast.src.split('\n')
+        lineid = li.start_line - preprocessed_ast.src_line - 1
+        if lineid >= 0 and lineid < len(lines):
+            print(f'    {lines[lineid].strip()}')
+        raise
     finally:
         if teardown_progress:
             if not isinstance(ProgramVisitor.progress_bar, tuple):
@@ -264,8 +276,8 @@ DISALLOWED_STMTS = [
 ]
 # Extra AST node types that are disallowed after preprocessing
 _DISALLOWED_STMTS = DISALLOWED_STMTS + [
-    'Global', 'Assert', 'Print', 'Nonlocal', 'Raise', 'Starred', 'AsyncFor', 'ListComp', 'GeneratorExp',
-    'SetComp', 'DictComp', 'comprehension'
+    'Global', 'Assert', 'Print', 'Nonlocal', 'Raise', 'Starred', 'AsyncFor', 'ListComp', 'GeneratorExp', 'SetComp',
+    'DictComp', 'comprehension'
 ]
 
 TaskletType = Union[ast.FunctionDef, ast.With, ast.For]

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -322,11 +322,11 @@ def _create_unflatten_instruction(arg: ast.AST, global_vars: Dict[str, Any]) -> 
         pass
 
     if isinstance(arg, ast.List):
-        return (list, len(arg.elts))
+        return (list, len(arg.elts), False)
     elif isinstance(arg, ast.Tuple):
-        return (tuple, len(arg.elts))
+        return (tuple, len(arg.elts), False)
     elif isinstance(arg, ast.Set):
-        return (set, len(arg.elts))
+        return (set, len(arg.elts), False)
     elif isinstance(arg, ast.Dict):
         # Use two levels of functions to preserve keyword names
         def make_remake(kwnames):

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -394,16 +394,16 @@ def flatten_callback(func: Callable, node: ast.Call, global_vars: Dict[str, Any]
 
     # Filter arguments from AST
     poscount = len(node.args)
-    node.args = [a for i, a in enumerate(node.args) if i not in args_to_remove]
 
     # Nothing to do, early exit
     if not node.keywords and not instructions_exist:
         return func
 
     keywords = [kw.arg for kw in node.keywords]
-
-    # Filter keyword arguments from AST
-    node.keywords = [a for i, a in enumerate(node.keywords) if i not in kwargs_to_remove]
+    
+    # Annotate that these arguments should not be visited during callback generation
+    node.skip_args = args_to_remove
+    node.skip_keywords = kwargs_to_remove
 
     # Using two levels of functions to ensure keywords are stored with the callback
     if instructions_exist:

--- a/dace/runtime/include/dace/pyinterop.h
+++ b/dace/runtime/include/dace/pyinterop.h
@@ -37,6 +37,7 @@ private:
     iterator end_;
 };
 
+typedef void *pyobject;
 
 // Sympy functions
 template <typename U, typename... T>

--- a/tests/python_frontend/assignment_statements_test.py
+++ b/tests/python_frontend/assignment_statements_test.py
@@ -114,6 +114,7 @@ def test_ann_assign_supported_type():
 
 
 def test_assignment_to_nonexistent_variable():
+
     @dace.program
     def badprog(B: dace.float64):
         A[...] = B
@@ -131,10 +132,42 @@ def test_assign_return_symbols():
             a = 5
         a -= 1
         return i, a
-    
+
     result = assign_symbols()
     a = result[1][0]
     assert a == 4
+
+
+def test_assign_to_compiletime_scalar():
+
+    class MyScalar:
+
+        def __init__(self) -> None:
+            self.scalar = 5
+
+        @dace.method
+        def method(self):
+            self.scalar = 1
+
+    obj = MyScalar()
+    with pytest.raises(DaceSyntaxError):
+        obj.method()
+
+
+def test_augassign_to_compiletime_scalar():
+
+    class MyScalar:
+
+        def __init__(self) -> None:
+            self.scalar = 5
+
+        @dace.method
+        def method(self):
+            self.scalar += 1
+
+    obj = MyScalar()
+    with pytest.raises(DaceSyntaxError):
+        obj.method()
 
 
 if __name__ == "__main__":
@@ -150,3 +183,6 @@ if __name__ == "__main__":
     test_assignment_to_nonexistent_variable()
 
     test_assign_return_symbols()
+
+    test_assign_to_compiletime_scalar()
+    test_augassign_to_compiletime_scalar()

--- a/tests/python_frontend/callback_autodetect_test.py
+++ b/tests/python_frontend/callback_autodetect_test.py
@@ -803,6 +803,56 @@ def test_unknown_pyobject():
     assert success_counter == 20
 
 
+def test_pyobject_return():
+    counter = 1
+
+    class MyCustomObject:
+
+        @dace_inhibitor
+        def __init__(self) -> None:
+            nonlocal counter
+            self.q = counter
+            counter += 1
+
+        def __str__(self):
+            return f'MyCustomObject(q={self.q})'
+
+    @dace
+    def tester():
+        MyCustomObject()
+        return MyCustomObject()
+
+    obj = tester()
+    assert isinstance(obj, MyCustomObject)
+    assert obj.q == 2
+
+
+def test_pyobject_return_tuple():
+    counter = 1
+
+    class MyCustomObject:
+
+        @dace_inhibitor
+        def __init__(self) -> None:
+            nonlocal counter
+            self.q = counter
+            counter += 1
+
+        def __str__(self):
+            return f'MyCustomObject(q={self.q})'
+
+    @dace
+    def tester():
+        MyCustomObject()
+        return MyCustomObject(), MyCustomObject()
+
+    obj, obj2 = tester()
+    assert isinstance(obj, MyCustomObject)
+    assert obj.q == 2
+    assert isinstance(obj2, MyCustomObject)
+    assert obj2.q == 3
+
+
 def test_custom_generator():
 
     def reverse_range(sz):
@@ -925,6 +975,8 @@ if __name__ == '__main__':
     test_callback_with_nested_calls()
     test_string_callback()
     test_unknown_pyobject()
+    test_pyobject_return()
+    test_pyobject_return_tuple()
     test_custom_generator()
     test_custom_generator_with_break()
     # test_matplotlib_with_compute()

--- a/tests/python_frontend/callback_autodetect_test.py
+++ b/tests/python_frontend/callback_autodetect_test.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ Tests automatic detection and baking of callbacks in the Python frontend. """
+from typing import Dict, Union
 import dace
 import numpy as np
 import pytest
@@ -765,6 +766,129 @@ def test_string_callback():
     assert result == ('hello', 'world')
 
 
+def test_unknown_pyobject():
+    counter = 1334
+    last_seen = counter
+    success_counter = 0
+
+    class MyCustomObject:
+
+        def __init__(self) -> None:
+            nonlocal counter
+            self.q = counter
+            counter += 1
+
+        def __str__(self):
+            return f'MyCustomObject(q={self.q})'
+
+    @dace_inhibitor
+    def checkit(obj: Union[MyCustomObject, Dict[str, Union[int, str]]]):
+        nonlocal last_seen
+        nonlocal success_counter
+        if obj == {'a': 1, 'b': '2'}:
+            success_counter += 1
+        elif isinstance(obj, MyCustomObject) and obj.q == last_seen:
+            success_counter += 1
+            last_seen += 1
+
+    @dace
+    def tester(unused):
+        for _ in dace.unroll(range(10)):
+            a = dict(a=1, b='2')
+            b = MyCustomObject()
+            checkit(a)
+            checkit(b)
+
+    tester(np.random.rand(20))
+    assert success_counter == 20
+
+
+def test_custom_generator():
+
+    def reverse_range(sz):
+        cur = sz
+        for _ in range(sz):
+            yield cur
+            cur -= 1
+
+    @dace
+    def tester(a: dace.float64[20]):
+        gen = reverse_range(20)
+        for i in range(20):
+            val: int = next(gen)
+            a[i] = val
+
+    aa = np.ones((20, ), np.float64)
+    tester(aa)
+    assert np.allclose(aa, np.arange(20, 0, -1))
+
+
+def test_custom_generator_with_break():
+
+    def reverse_range(sz):
+        cur = sz
+        for _ in range(sz):
+            yield cur
+            cur -= 1
+
+    @dace_inhibitor
+    def my_next(generator):
+        try:
+            return next(generator), False
+        except StopIteration:
+            return None, True
+
+    @dace
+    def tester(a: dace.float64[20]):
+        gen = reverse_range(20)
+        for i in range(21):
+            val: int = 0
+            stop: bool = True
+            val, stop = my_next(gen)
+            if stop:
+                break
+            a[i] = val
+
+    aa = np.ones((21, ), np.float64)
+    expected = np.copy(aa)
+    expected[:20] = np.arange(20, 0, -1)
+
+    tester(aa)
+    assert np.allclose(aa, expected)
+
+
+@pytest.mark.skip
+def test_matplotlib_with_compute():
+    """
+    Stacked bar plot example from Matplotlib using callbacks and pyobjects.
+    https://matplotlib.org/3.1.1/gallery/lines_bars_and_markers/bar_stacked.html#sphx-glr-gallery-lines-bars-and-markers-bar-stacked-py
+    """
+    import matplotlib.pyplot as plt
+
+    menMeans = (20, 35, 30, 35, 27)
+    womenMeans = (25, 32, 34, 20, 25)
+    menStd = (2, 3, 4, 1, 2)
+    womenStd = (3, 5, 2, 3, 3)
+
+    @dace
+    def tester():
+
+        ind = np.arange(5)  # the x locations for the groups
+        width = 0.35  # the width of the bars: can also be len(x) sequence
+
+        p1 = plt.bar(ind, menMeans, width, yerr=menStd)
+        p2 = plt.bar(ind, womenMeans, width, bottom=menMeans, yerr=womenStd)
+
+        plt.ylabel('Scores')
+        plt.title('Scores by group and gender')
+        plt.xticks(ind, ('G1', 'G2', 'G3', 'G4', 'G5'))
+        plt.yticks(np.arange(0, 81, 10))
+        plt.legend((p1[0], p2[0]), ('Men', 'Women'))
+        plt.show()
+
+    tester()
+
+
 if __name__ == '__main__':
     test_automatic_callback()
     test_automatic_callback_2()
@@ -795,9 +919,12 @@ if __name__ == '__main__':
     test_builtin_callback_kwargs()
     test_callback_literal_list(False)
     test_callback_literal_list(True)
-    test_callback_literal_dict()
     test_callback_literal_dict(False)
     test_callback_literal_dict(True)
     test_unused_callback()
     test_callback_with_nested_calls()
     test_string_callback()
+    test_unknown_pyobject()
+    test_custom_generator()
+    test_custom_generator_with_break()
+    # test_matplotlib_with_compute()

--- a/tests/python_frontend/method_test.py
+++ b/tests/python_frontend/method_test.py
@@ -46,8 +46,11 @@ class MyTestClass:
 
 
 class MyTestCallAttributesClass:
+
     class SDFGMethodTestClass:
+
         def __sdfg__(self, *args, **kwargs):
+
             @dace.program
             def call(A):
                 A[:] = 7.0
@@ -139,6 +142,7 @@ def test_nested_methods():
 
 
 def mydec(a):
+
     def mutator(func):
         dp = dace.program(func)
 
@@ -163,6 +167,7 @@ def someprog_indirection(a):
 
 
 def test_decorator():
+
     @dace.program(constant_functions=True)
     def otherprog(A: dace.float64[20]):
         res = np.empty_like(A)
@@ -199,7 +204,9 @@ def test_sdfgattr_method_jit_with_scalar():
 
 
 def test_nested_field_in_map():
+
     class B:
+
         def __init__(self) -> None:
             self.field = np.random.rand(10, 10)
 
@@ -208,6 +215,7 @@ def test_nested_field_in_map():
             return self.field[1, 1]
 
     class A:
+
         def __init__(self, nested: B):
             self.nested = nested
 
@@ -225,7 +233,9 @@ def test_nested_field_in_map():
 
 
 def test_nested_callback_in_map():
+
     class B:
+
         def __init__(self) -> None:
             self.field = np.random.rand(10, 10)
 
@@ -234,6 +244,7 @@ def test_nested_callback_in_map():
             val[i] = time.time()
 
     class A:
+
         def __init__(self, nested: B):
             self.nested = nested
 
@@ -254,6 +265,16 @@ def test_nested_callback_in_map():
     assert result[0] >= old_time and result[0] <= new_time
 
 
+def test_unbounded_method():
+
+    @dace.method
+    def tester(a):
+        return a + 1
+
+    aa = np.random.rand(20)
+    assert np.allclose(tester(aa), aa + 1)
+
+
 if __name__ == '__main__':
     test_method_jit()
     test_method()
@@ -270,3 +291,4 @@ if __name__ == '__main__':
     test_sdfgattr_method_jit_with_scalar()
     test_nested_field_in_map()
     test_nested_callback_in_map()
+    test_unbounded_method()


### PR DESCRIPTION
Callbacks can return arbitrary pyobjects, which are only reusable in other callbacks.
Also includes bugfixes for callbacks and return values, as well as tests.
