### PR TITLE
auto_optimize now properly chooses GPUAuto expansion for reduce nodes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,5 +30,6 @@ Carl-Johannes Johnsen
 Jannis Widmer
 Neville Walo
 Lukas Trümper
+Cliff Hodel
 
 and other contributors listed in https://github.com/spcl/dace/graphs/contributors

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -1359,7 +1359,7 @@ class ExpandReduceGPUAuto(pm.ExpandTransformation):
             input_subset = input_subset[:-2]
             input_subset.append(f'0:{schedule.sequential[0]}')
             input_subset.append('_g * 32 + _b1')
-            inmm = dace.Memlet(f'_in[{",".join(input_subset)}]')
+            inmm = dace.Memlet(f'_in[{",".join(input_subset)}]', dynamic=True)
 
             if schedule.multi_axes:
                 # Add initialization

--- a/dace/libraries/standard/reduction_planner.py
+++ b/dace/libraries/standard/reduction_planner.py
@@ -138,8 +138,6 @@ def get_reduction_schedule(in_array: Array,
     :return: ReductionSchedule object that descibes the GPU schedule used to perform the reduction
     """
 
-    # use_mini_warps = False
-
     @dataclasses.dataclass
     class ReductionSchedule:
         grid: List[Size]  #: dimension of the grid
@@ -269,9 +267,7 @@ def get_reduction_schedule(in_array: Array,
         # we are reducing a non-contiguous dimension
 
         schedule.grid = shape[:axes[0]]  # add all leading dimensions into the grid
-        grid_dim = symbolic.int_ceil(shape[contiguous_dimension], 32) if isinstance(
-            shape[contiguous_dimension], Expr) else shape[contiguous_dimension] / 32
-        # schedule.grid.append(symbolic.int_ceil(shape[contiguous_dimension], 32))  # each block computes 32 output values
+        grid_dim = symbolic.int_ceil(shape[contiguous_dimension], 32) # each block computes 32 output values
         schedule.grid.append(grid_dim)
 
         schedule.block = [16, 32]  # we use 16 threads per output value (could be any value in {1, ... , 32})

--- a/dace/libraries/standard/reduction_planner.py
+++ b/dace/libraries/standard/reduction_planner.py
@@ -19,7 +19,8 @@ def combine(shape, strides, dims):
 
     new_stride_element = strides[dims[0]]
     for d in dims[0:]:
-        new_stride_element = min(new_stride_element, strides[d])
+        if (strides[d] < new_stride_element) == True:
+            new_stride_element = strides[d]
 
     combined_strides = strides[0:dims[0]]
     combined_strides.append(new_stride_element)
@@ -99,7 +100,7 @@ def simplify_input(shape, strides, axes):
         r = rem[1]
         s = shape[rem[0]]
         for i in range(len(out_strides)):
-            if out_strides[i] > r:
+            if (out_strides[i] > r) == True:
                 out_strides[i] //= s
 
     return shape, strides, axes, out_shape, out_strides
@@ -267,7 +268,7 @@ def get_reduction_schedule(in_array: Array,
         schedule.shared_mem_size = 32  # each block uses 32 shared memory locations
         schedule.sequential = [shape[axes[0]]]  # the 16 threads sum up the whole axis
 
-        if use_mini_warps and shape[contiguous_dimension] <= 16:
+        if use_mini_warps and (shape[contiguous_dimension] <= 16) == True:
             # we turn on mini_warps
             schedule.mini_warps = True
             schedule.num_mini_warps = warp_size // shape[contiguous_dimension]
@@ -279,14 +280,15 @@ def get_reduction_schedule(in_array: Array,
     num_threads = 1
     for t in schedule.block:
         num_threads *= t
-    if num_threads > 1024:
+    if (num_threads > 1024) == True:
         # too many threads per block
         schedule.error = 'Schedule is invalid (more than 1024 threads per block). Falling back to pure expansion.'
     whole_grid = schedule.additional_grid + schedule.grid
     last_grid_dim = 1
     for b in whole_grid[:-2]:
         last_grid_dim *= b
-    if whole_grid[-1] > 2147483647 or (len(whole_grid) > 1 and whole_grid[-2] > 65535) or last_grid_dim > 65535:
+    if (whole_grid[-1] > 2147483647) == True or (len(whole_grid) > 1
+                                                 and whole_grid[-2] > 65535) == True or (last_grid_dim > 65535) == True:
         # grid dimension must not exceed 2147483647, resp . 65535
         schedule.error = 'Schedule is invalid (some grid dimension too large). Falling back to pure expansion.'
 

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -412,6 +412,11 @@ def set_fast_implementations(sdfg: SDFG, device: dtypes.DeviceType, blocklist: L
                 if device == dtypes.DeviceType.GPU and node.schedule == dtypes.ScheduleType.Sequential:
                     node.implementation = "pure"
                     continue
+                # use GPUAuto expansion if applicable
+                if ('GPUAuto' in node.implementations and not is_devicelevel_gpu_kernel(state.parent, state, node)
+                        and state.scope_dict()[node] is None):
+                    node.implementation = 'GPUAuto'
+                    continue
                 # Use CUB for device-level reductions
                 if ('CUDA (device)' in node.implementations
                         and not is_devicelevel_gpu_kernel(state.parent, state, node)


### PR DESCRIPTION
This PR adds very little code to `auto_optimize.py`. The added code ensures that the `GPUAutoExpansion` gets used for reduce nodes, when `auto_optimize` is used to optimize the produced SDFG.

Before, it would always choose `CUDA (device)` even though the `GPUAuto` expansion is higher in the `implementation_prio`.