### PR TITLE
throw in DACE_CUDA_CHECK to stop runtime on CUDA error

### DIFF
--- a/dace/runtime/include/dace/cuda/cudacommon.cuh
+++ b/dace/runtime/include/dace/cuda/cudacommon.cuh
@@ -24,6 +24,7 @@ typedef cudaEvent_t gpuEvent_t;
     if(errr != (cudaError_t)0)                                               \
     {                                                                        \
         printf("CUDA ERROR at %s:%d, code: %d\n", __FILE__, __LINE__, errr); \
+        throw;                                                               \
     }                                                                        \
 } while(0)
 #endif


### PR DESCRIPTION
The `syncdebug` option in DaCe allows to check for CUDA errors after each maps. In a context of a large codebase with plenty of logs some of those errors are easy to miss since runtime keeps going. In the case of a 701 (where the kernel silently doesn't run) this can lead to numerical instability way later. Hard to debug for non-power user.

This introduces a simple `throw;` in the macro which triggers a SIGABRT right after the issue, creating a much more clear debug situation.

(co-authored with Tal Ben-Nun)