### PR TITLE
Fix AutoTuner API breakage + utest for MapPermutation

### DIFF
--- a/dace/optimization/auto_tuner.py
+++ b/dace/optimization/auto_tuner.py
@@ -8,6 +8,7 @@ class AutoTuner:
     General API for automatic SDFG tuners.
     Contains a single method: ``optimize``, which initiates the tuning process.
     """
+
     def __init__(self, sdfg: dace.SDFG) -> None:
         self._sdfg = sdfg
 

--- a/dace/optimization/cutout_tuner.py
+++ b/dace/optimization/cutout_tuner.py
@@ -95,8 +95,11 @@ class CutoutTuner(auto_tuner.AutoTuner):
                 dreport_[dnode.data] = data
             except:
                 continue
-        
-        runtime = optim_utils.subprocess_measure(cutout=cutout, dreport=dreport_, repetitions=repetitions, timeout=timeout)
+
+        runtime = optim_utils.subprocess_measure(cutout=cutout,
+                                                 dreport=dreport_,
+                                                 repetitions=repetitions,
+                                                 timeout=timeout)
         return runtime
 
     def optimize(self, measurements: int = 30, apply: bool = False, **kwargs) -> Dict[Any, Any]:
@@ -106,7 +109,12 @@ class CutoutTuner(auto_tuner.AutoTuner):
             results = self.try_load(fn)
 
             if results is None:
-                results = self.search(cutout, measurements, **kwargs)
+                results = self.search(
+                    cutout=cutout,
+                    measurements=measurements,
+                    dreport=self._sdfg.get_instrumented_data(),
+                    **kwargs,
+                )
                 if results is None:
                     tuning_report[label] = None
                     continue
@@ -123,8 +131,7 @@ class CutoutTuner(auto_tuner.AutoTuner):
 
         return tuning_report
 
-    def search(self, cutout: SDFG, measurements: int,
-               **kwargs) -> Dict[str, float]:
+    def search(self, cutout: SDFG, measurements: int, **kwargs) -> Dict[str, float]:
         kwargs = self.pre_evaluate(cutout=cutout, measurements=measurements, **kwargs)
 
         results = {}
@@ -141,7 +148,8 @@ class CutoutTuner(auto_tuner.AutoTuner):
         all_configs = []
         for cutout_label in tuning_report:
             configs = tuning_report[cutout_label]
-            best_k_configs = [(key, value) for key, value in sorted(configs.items(), key=lambda item: item[1])][:min(len(configs), k)]
+            best_k_configs = [(key, value) for key, value in sorted(configs.items(), key=lambda item: item[1])
+                              ][:min(len(configs), k)]
             best_k_configs = filter(lambda c: c[1] != math.inf, best_k_configs)
             best_k_configs = list(map(lambda c: (cutout_label, c[0]), best_k_configs))
 

--- a/dace/optimization/data_layout_tuner.py
+++ b/dace/optimization/data_layout_tuner.py
@@ -5,7 +5,7 @@ import enum
 import copy
 import itertools
 
-from typing import Generator, Optional, Tuple, Dict, List, Sequence, Set
+from typing import Any, Generator, Optional, Tuple, Dict, List, Sequence, Set
 
 from dace import data as dt, SDFG, dtypes
 from dace.optimization import cutout_tuner
@@ -97,6 +97,20 @@ class DataLayoutTuner(cutout_tuner.CutoutTuner):
             # Yield configuration
             yield modified_arrays, new_arrays
 
+    def optimize(
+        self,
+        group_by: TuningGroups = TuningGroups.Separate,
+        measurements: int = 30,
+        apply: bool = False,
+        **kwargs,
+    ) -> Dict[Any, Any]:
+        return super().optimize(
+            group_by=group_by,
+            measurements=measurements,
+            apply=apply,
+            **kwargs,
+        )
+
     def config_from_key(self, key: str, **kwargs) -> List[int]:
         # TODO
         raise NotImplementedError
@@ -141,6 +155,8 @@ class DataLayoutTuner(cutout_tuner.CutoutTuner):
         cutout._arrays = new_arrays
         for marray in modified_arrays:
             arguments[marray] = dt.make_array_from_descriptor(cutout.arrays[marray], arguments[marray])
+
+        print(f"[DataLayout Tuner] {modified_arrays}, {new_arrays}.")
 
         return self.measure(cutout, arguments, measurements)
 

--- a/dace/optimization/distributed_cutout_tuner.py
+++ b/dace/optimization/distributed_cutout_tuner.py
@@ -92,9 +92,7 @@ class DistributedSpaceTuner:
 
         for cutout_hash in new_cutouts:
             cutout = cutouts[cutout_hash]
-            evaluate_kwargs = self._tuner.pre_evaluate(cutout=cutout,
-                                                       measurements=measurements,
-                                                       **kwargs)
+            evaluate_kwargs = self._tuner.pre_evaluate(cutout=cutout, measurements=measurements, **kwargs)
 
             configs = list(self._tuner.space(**(evaluate_kwargs["space_kwargs"])))
 

--- a/dace/optimization/on_the_fly_map_fusion_tuner.py
+++ b/dace/optimization/on_the_fly_map_fusion_tuner.py
@@ -26,7 +26,11 @@ except (ImportError, ModuleNotFoundError):
 
 class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
 
-    def __init__(self, sdfg: SDFG, i, j, measurement: dtypes.InstrumentationType = dtypes.InstrumentationType.Timer) -> None:
+    def __init__(self,
+                 sdfg: SDFG,
+                 i,
+                 j,
+                 measurement: dtypes.InstrumentationType = dtypes.InstrumentationType.Timer) -> None:
         super().__init__(task="OnTheFlyMapFusion", sdfg=sdfg, i=i, j=j)
         self.instrument = measurement
 
@@ -81,7 +85,6 @@ class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
             # Skip no-map-states
             return math.inf
 
-
         if config[0] == 0:
             # Baseline
             return self.measure(candidate, dreport, measurements)
@@ -101,7 +104,7 @@ class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
             if fuse_counter == 0:
                 return math.inf
 
-        return self.measure(candidate, dreport,  measurements)
+        return self.measure(candidate, dreport, measurements)
 
     def apply(self, config: Tuple[int, List[int]], label: str, **kwargs) -> None:
         if config[0] == 0:
@@ -236,7 +239,6 @@ class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
                             if base_runtime == math.inf:
                                 break
 
-
                         # Construct subgraph greedily
                         subgraph_maps = []
                         for desc in pattern:
@@ -252,7 +254,9 @@ class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
                         experiment_state.instrument = dace.InstrumentationType.GPU_Events
 
                         experiment_maps = list(map(lambda m_id: experiment_state.node(m_id), experiment_maps_ids))
-                        experiment_subgraph = helpers.subgraph_from_maps(sdfg=experiment_sdfg, graph=experiment_state, map_entries=experiment_maps)
+                        experiment_subgraph = helpers.subgraph_from_maps(sdfg=experiment_sdfg,
+                                                                         graph=experiment_state,
+                                                                         map_entries=experiment_maps)
 
                         map_fusion = sg.SubgraphOTFFusion()
                         map_fusion.setup_match(experiment_subgraph, experiment_sdfg.sdfg_id,
@@ -285,7 +289,6 @@ class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
                             best_pattern = subgraph_maps
                             best_pattern_runtime = fused_runtime
 
-
                     if best_pattern is not None:
                         subgraph = helpers.subgraph_from_maps(sdfg=nsdfg, graph=state, map_entries=best_pattern)
                         map_fusion = sg.SubgraphOTFFusion()
@@ -298,10 +301,10 @@ class OnTheFlyMapFusionTuner(cutout_tuner.CutoutTuner):
                     else:
                         break
 
-
     @staticmethod
     def map_descriptor(state: dace.SDFGState, map_entry: dace.nodes.MapEntry) -> str:
-        tasklets = filter(lambda node: isinstance(node, dace.nodes.Tasklet), map(lambda edge: edge.dst, state.out_edges(map_entry)))
+        tasklets = filter(lambda node: isinstance(node, dace.nodes.Tasklet),
+                          map(lambda edge: edge.dst, state.out_edges(map_entry)))
         tasklets = set(tasklets)
 
         desc = []

--- a/dace/optimization/subgraph_fusion_tuner.py
+++ b/dace/optimization/subgraph_fusion_tuner.py
@@ -25,7 +25,11 @@ except (ImportError, ModuleNotFoundError):
 
 class SubgraphFusionTuner(cutout_tuner.CutoutTuner):
 
-    def __init__(self, sdfg: SDFG, i, j, measurement: dtypes.InstrumentationType = dtypes.InstrumentationType.Timer) -> None:
+    def __init__(self,
+                 sdfg: SDFG,
+                 i,
+                 j,
+                 measurement: dtypes.InstrumentationType = dtypes.InstrumentationType.Timer) -> None:
         super().__init__(task="SubgraphFusion", sdfg=sdfg, i=i, j=j)
         self.instrument = measurement
 
@@ -257,7 +261,9 @@ class SubgraphFusionTuner(cutout_tuner.CutoutTuner):
                         experiment_state = experiment_sdfg.start_state
 
                         experiment_maps = list(map(lambda m_id: experiment_state.node(m_id), experiment_maps_ids))
-                        experiment_subgraph = helpers.subgraph_from_maps(sdfg=experiment_sdfg, graph=experiment_state, map_entries=experiment_maps)
+                        experiment_subgraph = helpers.subgraph_from_maps(sdfg=experiment_sdfg,
+                                                                         graph=experiment_state,
+                                                                         map_entries=experiment_maps)
 
                         subgraph_fusion = sg.CompositeFusion()
                         subgraph_fusion.setup_match(experiment_subgraph, experiment_sdfg.sdfg_id,
@@ -291,7 +297,6 @@ class SubgraphFusionTuner(cutout_tuner.CutoutTuner):
                             best_pattern_runtime = pattern_runtime
                             best_pattern = subgraph_maps
 
-
                     if best_pattern is not None:
                         subgraph = helpers.subgraph_from_maps(sdfg=nsdfg, graph=state, map_entries=best_pattern)
                         subgraph_fusion = sg.CompositeFusion()
@@ -306,10 +311,10 @@ class SubgraphFusionTuner(cutout_tuner.CutoutTuner):
                     else:
                         break
 
-
     @staticmethod
     def map_descriptor(state: dace.SDFGState, map_entry: dace.nodes.MapEntry) -> str:
-        tasklets = filter(lambda node: isinstance(node, dace.nodes.Tasklet), map(lambda edge: edge.dst, state.out_edges(map_entry)))
+        tasklets = filter(lambda node: isinstance(node, dace.nodes.Tasklet),
+                          map(lambda edge: edge.dst, state.out_edges(map_entry)))
         tasklets = set(tasklets)
 
         desc = []

--- a/tests/autotuner/map_permutation_tuner_test.py
+++ b/tests/autotuner/map_permutation_tuner_test.py
@@ -1,0 +1,40 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+from dace.optimization import MapPermutationTuner
+import dace.dtypes as dtypes
+import numpy as np
+import copy
+
+
+@dace.program
+def program_autotuned(arr_A, arr_B):
+    arr_A[:, :, :] = np.log(arr_B[:, :, :])
+
+
+def test_map_permutation_tuner():
+    shape = (3, 3, 100)
+    A = np.ones(shape)
+    B = np.ones(shape)
+
+    # program_autotuned(A, B)
+
+    sdfg = program_autotuned.to_sdfg(arr_A=A, arr_B=B)
+    sdfg_pre_tune = copy.deepcopy(sdfg)
+    for state, _node in sdfg_pre_tune.all_nodes_recursive():
+        if isinstance(state, dace.nodes.MapEntry) and state.label == "_numpy_log__map":
+            assert state.map.params[0] == "__i0"
+
+    tuner = MapPermutationTuner(sdfg)
+    tuner.dry_run(sdfg, arr_A=A, arr_B=B)
+    report = tuner.optimize(apply=True, measurements=10)
+    print(report)
+
+    sdfg.save("post_tune.sdfg")
+    sdfg_post_tune = copy.deepcopy(sdfg)
+    for state, _node in sdfg_post_tune.all_nodes_recursive():
+        if isinstance(state, dace.nodes.MapEntry) and state.label == "_numpy_log__map":
+            assert state.map.params[0] == "__i2"
+
+
+if __name__ == '__main__':
+    test_map_permutation_tuner()


### PR DESCRIPTION
Minimal work to reconnect the autotuner to the current state of DaCe.

- cutout_tuner: pass dreport downward 
- Fix subprocess execution readout 
- MapPermutationTuner:  unit test
- DataLayoutTuner: pass group_by 
- MapTilingTuner: verbose, parametrize search space, fix evaluation 
- Yapf the entire `dace/optimization` directory