### PR TITLE
Scalar Write Shadow Analysis Fix

### DIFF
--- a/dace/transformation/passes/analysis.py
+++ b/dace/transformation/passes/analysis.py
@@ -425,11 +425,13 @@ class ScalarWriteShadowScopes(ppl.Pass):
                         if other_write is not None and other_write[1] is write_node and other_write[0] is write_state:
                             continue
                         if other_write is None or other_write[0] in dominators:
-                            if any([a_state in reach for a_state, _ in other_accesses]):
-                                other_accesses.update(accesses)
-                                other_accesses.add(write)
-                                to_remove.add(write)
-                                result[desc][write] = set()
+                            noa = len(other_accesses)
+                            if noa > 0 and (noa > 1 or list(other_accesses)[0] != other_write):
+                                if any([a_state in reach for a_state, _ in other_accesses]):
+                                    other_accesses.update(accesses)
+                                    other_accesses.add(write)
+                                    to_remove.add(write)
+                                    result[desc][write] = set()
                 for write in to_remove:
                     del result[desc][write]
             top_result[sdfg.sdfg_id] = result

--- a/tests/passes/scalar_write_shadow_scopes_analysis_test.py
+++ b/tests/passes/scalar_write_shadow_scopes_analysis_test.py
@@ -378,8 +378,142 @@ def test_scalar_write_shadow_interstate_pred():
                                          (loop_2_3, loop2_read_b)])
 
 
+def test_loop_fake_shadow():
+    sdfg = dace.SDFG('loop_fake_shadow')
+    sdfg.add_array('A', [1], dace.float64, transient=True)
+    sdfg.add_array('B', [1], dace.float64)
+    init = sdfg.add_state('init')
+    guard = sdfg.add_state('guard')
+    loop = sdfg.add_state('loop')
+    loop2 = sdfg.add_state('loop2')
+    end = sdfg.add_state('end')
+
+    init_access = init.add_access('A')
+    init_tasklet = init.add_tasklet('init', {}, {'a'}, 'a = 0')
+    init.add_edge(init_tasklet, 'a', init_access, None, dace.Memlet('A[0]'))
+
+    loop_access = loop.add_access('A')
+    loop_access_b = loop.add_access('B')
+    loop_tasklet_1 = loop.add_tasklet('loop_1', {}, {'a'}, 'a = 1')
+    loop_tasklet_2 = loop.add_tasklet('loop_2', {'a'}, {'b'}, 'b = a')
+    loop.add_edge(loop_tasklet_1, 'a', loop_access, None, dace.Memlet('A[0]'))
+    loop.add_edge(loop_access, None, loop_tasklet_2, 'a', dace.Memlet('A[0]'))
+    loop.add_edge(loop_tasklet_2, 'b', loop_access_b, None, dace.Memlet('B[0]'))
+
+    loop2_access = loop2.add_access('A')
+    loop2_access_b = loop2.add_access('B')
+    loop2_tasklet_1 = loop2.add_tasklet('loop_1', {}, {'a'}, 'a = 2')
+    loop2_tasklet_2 = loop2.add_tasklet('loop_2', {'a'}, {'b'}, 'b = a')
+    loop2.add_edge(loop2_tasklet_1, 'a', loop2_access, None, dace.Memlet('A[0]'))
+    loop2.add_edge(loop2_access, None, loop2_tasklet_2, 'a', dace.Memlet('A[0]'))
+    loop2.add_edge(loop2_tasklet_2, 'b', loop2_access_b, None, dace.Memlet('B[0]'))
+
+    end_access = end.add_access('A')
+    end_access_b = end.add_access('B')
+    end_tasklet = end.add_tasklet('end', {'a'}, {'b'}, 'b = a')
+    end.add_edge(end_access, None, end_tasklet, 'a', dace.Memlet('A[0]'))
+    end.add_edge(end_tasklet, 'b', end_access_b, None, dace.Memlet('B[0]'))
+
+    sdfg.add_edge(init, guard, dace.InterstateEdge(assignments={'i': 0}))
+    sdfg.add_edge(guard, loop, dace.InterstateEdge(condition='i < 10'))
+    sdfg.add_edge(loop, loop2, dace.InterstateEdge())
+    sdfg.add_edge(loop2, guard, dace.InterstateEdge(assignments={'i': 'i + 1'}))
+    sdfg.add_edge(guard, end, dace.InterstateEdge(condition='i >= 10'))
+
+    ppl = Pipeline([ScalarWriteShadowScopes()])
+    res = ppl.apply_pass(sdfg, {})[ScalarWriteShadowScopes.__name__]
+
+    assert res[0]['A'][(init, init_access)] == {(loop, loop_access), (loop2, loop2_access), (end, end_access)}
+
+
+def test_loop_fake_complex_shadow():
+    sdfg = dace.SDFG('loop_fake_shadow')
+    sdfg.add_array('A', [1], dace.float64, transient=True)
+    sdfg.add_array('B', [1], dace.float64)
+    init = sdfg.add_state('init')
+    guard = sdfg.add_state('guard')
+    loop = sdfg.add_state('loop')
+    loop2 = sdfg.add_state('loop2')
+    end = sdfg.add_state('end')
+
+    init_access = init.add_access('A')
+    init_tasklet = init.add_tasklet('init', {}, {'a'}, 'a = 0')
+    init.add_edge(init_tasklet, 'a', init_access, None, dace.Memlet('A[0]'))
+
+    loop_access = loop.add_access('A')
+    loop_access_b = loop.add_access('B')
+    loop_tasklet_2 = loop.add_tasklet('loop_2', {'a'}, {'b'}, 'b = a')
+    loop.add_edge(loop_access, None, loop_tasklet_2, 'a', dace.Memlet('A[0]'))
+    loop.add_edge(loop_tasklet_2, 'b', loop_access_b, None, dace.Memlet('B[0]'))
+
+    loop2_access = loop2.add_access('A')
+    loop2_access_b = loop2.add_access('B')
+    loop2_tasklet_1 = loop2.add_tasklet('loop_1', {}, {'a'}, 'a = 2')
+    loop2_tasklet_2 = loop2.add_tasklet('loop_2', {'a'}, {'b'}, 'b = a')
+    loop2.add_edge(loop2_tasklet_1, 'a', loop2_access, None, dace.Memlet('A[0]'))
+    loop2.add_edge(loop2_access, None, loop2_tasklet_2, 'a', dace.Memlet('A[0]'))
+    loop2.add_edge(loop2_tasklet_2, 'b', loop2_access_b, None, dace.Memlet('B[0]'))
+
+    sdfg.add_edge(init, guard, dace.InterstateEdge(assignments={'i': 0}))
+    sdfg.add_edge(guard, loop, dace.InterstateEdge(condition='i < 10'))
+    sdfg.add_edge(loop, loop2, dace.InterstateEdge())
+    sdfg.add_edge(loop2, guard, dace.InterstateEdge(assignments={'i': 'i + 1'}))
+    sdfg.add_edge(guard, end, dace.InterstateEdge(condition='i >= 10'))
+
+    ppl = Pipeline([ScalarWriteShadowScopes()])
+    res = ppl.apply_pass(sdfg, {})[ScalarWriteShadowScopes.__name__]
+
+    assert res[0]['A'][(init, init_access)] == {(loop, loop_access), (loop2, loop2_access)}
+
+
+def test_loop_real_shadow():
+    sdfg = dace.SDFG('loop_fake_shadow')
+    sdfg.add_array('A', [1], dace.float64, transient=True)
+    sdfg.add_array('B', [1], dace.float64)
+    init = sdfg.add_state('init')
+    guard = sdfg.add_state('guard')
+    loop = sdfg.add_state('loop')
+    loop2 = sdfg.add_state('loop2')
+    end = sdfg.add_state('end')
+
+    init_access = init.add_access('A')
+    init_tasklet = init.add_tasklet('init', {}, {'a'}, 'a = 0')
+    init.add_edge(init_tasklet, 'a', init_access, None, dace.Memlet('A[0]'))
+
+    loop_access = loop.add_access('A')
+    loop_access_b = loop.add_access('B')
+    loop_tasklet_1 = loop.add_tasklet('loop_1', {}, {'a'}, 'a = 1')
+    loop_tasklet_2 = loop.add_tasklet('loop_2', {'a'}, {'b'}, 'b = a')
+    loop.add_edge(loop_tasklet_1, 'a', loop_access, None, dace.Memlet('A[0]'))
+    loop.add_edge(loop_access, None, loop_tasklet_2, 'a', dace.Memlet('A[0]'))
+    loop.add_edge(loop_tasklet_2, 'b', loop_access_b, None, dace.Memlet('B[0]'))
+
+    loop2_access = loop2.add_access('A')
+    loop2_access_b = loop2.add_access('B')
+    loop2_tasklet_1 = loop2.add_tasklet('loop_1', {}, {'a'}, 'a = 2')
+    loop2_tasklet_2 = loop2.add_tasklet('loop_2', {'a'}, {'b'}, 'b = a')
+    loop2.add_edge(loop2_tasklet_1, 'a', loop2_access, None, dace.Memlet('A[0]'))
+    loop2.add_edge(loop2_access, None, loop2_tasklet_2, 'a', dace.Memlet('A[0]'))
+    loop2.add_edge(loop2_tasklet_2, 'b', loop2_access_b, None, dace.Memlet('B[0]'))
+
+    sdfg.add_edge(init, guard, dace.InterstateEdge(assignments={'i': 0}))
+    sdfg.add_edge(guard, loop, dace.InterstateEdge(condition='i < 10'))
+    sdfg.add_edge(loop, loop2, dace.InterstateEdge())
+    sdfg.add_edge(loop2, guard, dace.InterstateEdge(assignments={'i': 'i + 1'}))
+    sdfg.add_edge(guard, end, dace.InterstateEdge(condition='i >= 10'))
+
+    ppl = Pipeline([ScalarWriteShadowScopes()])
+    res = ppl.apply_pass(sdfg, {})[ScalarWriteShadowScopes.__name__]
+
+    assert res[0]['A'][(loop, loop_access)] == {(loop, loop_access)}
+    assert res[0]['A'][(loop2, loop2_access)] == {(loop2, loop2_access)}
+
+
 if __name__ == '__main__':
     test_scalar_write_shadow_split()
     test_scalar_write_shadow_fused()
     test_scalar_write_shadow_interstate_self()
     test_scalar_write_shadow_interstate_pred()
+    test_loop_fake_shadow()
+    test_loop_fake_complex_shadow()
+    test_loop_real_shadow()


### PR DESCRIPTION
Scalar write shadow analysis was trying to be too conservative in the context of loops and consequently coarsened the scope of writes incorrectly, which caused problems for Scalar Fission.