### PR TITLE
Add warning when user calls to_sdfg on a function that shouldn't be reparsed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,5 +32,6 @@ Neville Walo
 Lukas Trümper
 Cliff Hodel
 Tiancheng Chen
+Yihang Luo
 
 and other contributors listed in https://github.com/spcl/dace/graphs/contributors

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -237,7 +237,7 @@ class DaceProgram(pycommon.SDFGConvertible):
             warnings.warn("You are calling to_sdfg() on a dace program that "
                           "has set 'recreate_sdfg' to False. "
                           "This may not what you want.")
-        if self.recompile == True:
+        if self.recompile == False:
             warnings.warn("You are calling to_sdfg() on a dace program that "
                           "has set 'recompile' to False. "
                           "This may not what you want.")

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -233,6 +233,15 @@ class DaceProgram(pycommon.SDFGConvertible):
         :return: An SDFG object that can be transformed, saved, or called.
         """
 
+        if self.recreate_sdfg == False:
+            warnings.warn("You are calling to_sdfg() on a dace program that "
+                          "has set 'recreate_sdfg' to False. "
+                          "This may not what you want.")
+        if self.recompile == True:
+            warnings.warn("You are calling to_sdfg() on a dace program that "
+                          "has set 'recompile' to False. "
+                          "This may not what you want.")
+
         if use_cache:
             # Update global variables with current closure
             self.global_vars = _get_locals_and_globals(self.f)

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -240,7 +240,7 @@ class DaceProgram(pycommon.SDFGConvertible):
         if self.recompile == False:
             warnings.warn("You are calling to_sdfg() on a dace program that "
                           "has set 'recompile' to False. "
-                          "This may not what you want.")
+                          "This may not be what you want.")
 
         if use_cache:
             # Update global variables with current closure

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -236,7 +236,7 @@ class DaceProgram(pycommon.SDFGConvertible):
         if self.recreate_sdfg == False:
             warnings.warn("You are calling to_sdfg() on a dace program that "
                           "has set 'recreate_sdfg' to False. "
-                          "This may not what you want.")
+                          "This may not be what you want.")
         if self.recompile == False:
             warnings.warn("You are calling to_sdfg() on a dace program that "
                           "has set 'recompile' to False. "


### PR DESCRIPTION
### Motivation
This is pr tries to fix the issue #1175, which suggests we can warn users when calling to_sdfg on a function that shouldn't be reparsed.

_This issues has been discussed before in #1204._

### Modification
Add a warning message in the method `to_sdfg` under `dace/frontend/python/parser.py`.
