### PR TITLE
Fix internal subscript access if already existed

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3021,9 +3021,9 @@ class ProgramVisitor(ExtNodeVisitor):
         if name in self.sdfg.arrays:
             return (name, None)
         elif (name, rng, 'w') in self.accesses:
-            return self.accesses[(name, rng, 'w')]
+            return self.accesses[(name, rng, 'w')][0], rng
         elif (name, rng, 'r') in self.accesses:
-            return self.accesses[(name, rng, 'r')]
+            return self.accesses[(name, rng, 'r')][0], rng
         elif name in self.variables:
             return (self.variables[name], None)
         elif name in self.scope_vars:
@@ -3047,7 +3047,7 @@ class ProgramVisitor(ExtNodeVisitor):
         if name in self.sdfg.arrays:
             return (name, None)
         if (name, rng, 'w') in self.accesses:
-            return self.accesses[(name, rng, 'w')]
+            return self.accesses[(name, rng, 'w')][0], rng
         elif name in self.variables:
             return (self.variables[name], None)
         elif (name, rng, 'r') in self.accesses or name in self.scope_vars:

--- a/tests/numpy/subarray_in_nested_call_test.py
+++ b/tests/numpy/subarray_in_nested_call_test.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+import math
 import numpy as np
 import dace
 
@@ -45,6 +46,34 @@ def test_inout_connector():
     assert np.allclose(a, ref)
 
 
+def test_indirect_symbolic_access():
+
+    @dace.program
+    def tester(a: dace.float64[20], b: dace.float64[3], c: dace.float64[19]):
+        for i in dace.map[0:10]:
+            xtmp: dace.float64 = 0
+
+            local_offset_i = (i + 1) % 2
+
+            if local_offset_i < 3 % 2:
+                for kx in dace.unroll(range(math.ceil(3 / 2))):
+                    ind_i = (i + 1 - kx * 2) // 2
+                    kind_i = local_offset_i + kx * 2
+                    if ind_i >= 0 and ind_i < 20:
+                        xtmp += a[ind_i] * b[kind_i]
+
+            c[i] = xtmp
+
+    a = np.random.rand(20)
+    b = np.random.rand(15)
+    c = np.random.rand(10)
+    refc = np.copy(c)
+    tester.f(a, b, refc)
+    tester(a, b, c)
+    assert np.allclose(c, refc)
+
+
 if __name__ == '__main__':
     test()
     test_inout_connector()
+    test_indirect_symbolic_access()

--- a/tests/python_frontend/indirections_test.py
+++ b/tests/python_frontend/indirections_test.py
@@ -60,6 +60,23 @@ def test_indirection_scalar_nsdfg():
 
 
 @dc.program
+def indirection_scalar2_nsdfg(A: dc.float64[10], x: dc.int32[10]):
+    B = np.empty_like(A)
+    for i in dc.map[0:A.shape[0]]:
+        a = x[i]
+        B[i] = A[a]
+        B[i] = A[a]
+    return B
+
+
+def test_indirection_scalar2_nsdfg():
+    A = np.random.randn(10).astype(np.float64)
+    x = np.random.randint(0, 10, size=(10, ), dtype=np.int32)
+    res = indirection_scalar2_nsdfg(A, x)
+    assert (np.allclose(res, A[x]))
+
+
+@dc.program
 def indirection_scalar_assign_nsdfg(A: dc.float64[10], x: dc.int32[10]):
     B = np.empty_like(A)
     # TODO: This doesn't work with 0:A.shape[0]
@@ -169,6 +186,7 @@ def test_indirection_scalar_range():
 
 
 def test_indirection_scalar_range_nsdfg():
+
     @dc.program
     def indirection_scalar_range_nsdfg(A: dc.float64[10], x: dc.int32[11]):
         B = np.empty_like(A)
@@ -374,6 +392,7 @@ if __name__ == "__main__":
     test_indirection_scalar_assign()
     test_indirection_scalar_augassign()
     test_indirection_scalar_nsdfg()
+    test_indirection_scalar2_nsdfg()
     test_indirection_scalar_assign_nsdfg()
     test_indirection_scalar_augassign_nsdfg()
     test_indirection_scalar_multi()


### PR DESCRIPTION
In the Python frontend, if an indirect access to the same range appears more than once, the second time onwards will not create a slice access. This PR fixes it to always create a slice as necessary.