### PR TITLE
Fix-gpu-transform-copy-out

### DIFF
--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -8,6 +8,7 @@ from dace.transformation import transformation, helpers as xfh
 from dace.properties import Property, make_properties
 from collections import defaultdict
 from copy import deepcopy as dc
+from sympy import floor
 from typing import Dict
 
 gpu_storage = [dtypes.StorageType.GPU_Global, dtypes.StorageType.GPU_Shared, dtypes.StorageType.CPU_Pinned]
@@ -218,7 +219,7 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
             cloned_arrays[onodename] = name
 
             # The following ensures that when writing to a subset of an array, we don't overwrite the rest of the array
-            # when copying back to the host. This is done by adding the array to the `inputs_nodes,` while will copy
+            # when copying back to the host. This is done by adding the array to the `inputs_nodes,` which will copy
             # the entire array to the GPU.
             if (onodename, onode) not in input_nodes:
                 found_full_write = False
@@ -229,13 +230,21 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
                             if (isinstance(node, nodes.AccessNode) and node.data == onodename):
                                 for e in state.in_edges(node):
                                     if e.data.get_dst_subset(e, state) == full_subset:
+                                        is_full = True
+                                        for pe in state.memlet_tree(e):
+                                            vol = pe.data.volume
+                                            size = pe.data.get_dst_subset(pe, state).num_elements()
+                                            if pe.data.dynamic or vol / size != floor(vol / size):
+                                                is_full = False
+                                                break
+                                        if not is_full:
+                                            continue
                                         found_full_write = True
                                         raise StopIteration
                 except StopIteration:
                     assert found_full_write
                 if not found_full_write:
                     input_nodes.append((onodename, onode))
-
 
         # Replace nodes
         for state in sdfg.nodes():

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -1,7 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ Contains inter-state transformations of an SDFG to run on the GPU. """
 
-from dace import data, memlet, dtypes, registry, sdfg as sd, symbolic
+from dace import data, memlet, dtypes, registry, sdfg as sd, symbolic, subsets as sbs, propagate_memlets_sdfg
 from dace.sdfg import nodes, scope
 from dace.sdfg import utils as sdutil
 from dace.transformation import transformation, helpers as xfh
@@ -162,6 +162,9 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
         output_nodes = []
         global_code_nodes: Dict[sd.SDFGState, nodes.Tasklet] = defaultdict(list)
 
+        # Propagate memlets to ensure that we can find the true array subsets that are written.
+        propagate_memlets_sdfg(sdfg)
+
         for state in sdfg.nodes():
             sdict = state.scope_dict()
             for node in state.nodes():
@@ -213,6 +216,26 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
             newdesc.transient = True
             name = sdfg.add_datadesc('gpu_' + onodename, newdesc, find_new_name=True)
             cloned_arrays[onodename] = name
+
+            # The following ensures that when writing to a subset of an array, we don't overwrite the rest of the array
+            # when copying back to the host. This is done by adding the array to the `inputs_nodes,` while will copy
+            # the entire array to the GPU.
+            if (onodename, onode) not in input_nodes:
+                found_full_write = False
+                full_subset = sbs.Range.from_array(onode)
+                try:
+                    for state in sdfg.nodes():
+                        for node in state.nodes():
+                            if (isinstance(node, nodes.AccessNode) and node.data == onodename):
+                                for e in state.in_edges(node):
+                                    if e.data.get_dst_subset(e, state) == full_subset:
+                                        found_full_write = True
+                                        raise StopIteration
+                except StopIteration:
+                    assert found_full_write
+                if not found_full_write:
+                    input_nodes.append((onodename, onode))
+
 
         # Replace nodes
         for state in sdfg.nodes():

--- a/tests/transformations/gpu_transform_test.py
+++ b/tests/transformations/gpu_transform_test.py
@@ -58,6 +58,7 @@ def test_scalar_to_symbol_in_nested_sdfg():
     assert np.array_equal(out, np.array([0, 10] * 5, dtype=np.int32))
 
 
+@pytest.mark.gpu
 def test_write_subset():
 
     @dace.program
@@ -77,7 +78,6 @@ def test_write_subset():
     assert np.array_equal(ref, val)
 
 
-@pytest.mark.gpu
 def test_write_full():
 
     M, N = dace.symbol('M'), dace.symbol('N')

--- a/tests/transformations/gpu_transform_test.py
+++ b/tests/transformations/gpu_transform_test.py
@@ -45,13 +45,13 @@ def test_scalar_to_symbol_in_nested_sdfg():
             else:
                 out[i] = 10
                 a /= 2
-    
+
     @dace.program
     def main_program(a: dace.int32):
-        out = np.ndarray((10,), dtype=np.int32)
+        out = np.ndarray((10, ), dtype=np.int32)
         nested_program(a, out)
         return out
-    
+
     sdfg = main_program.to_sdfg(simplify=False)
     sdfg.apply_transformations(GPUTransformSDFG)
     out = sdfg(a=4)
@@ -64,7 +64,7 @@ def test_write_subset():
     def write_subset(A: dace.int32[20, 20]):
         for i, j in dace.map[2:18, 2:18]:
             A[i, j] = i + j
-    
+
     sdfg = write_subset.to_sdfg(simplify=True)
     sdfg.apply_transformations(GPUTransformSDFG)
 
@@ -77,7 +77,51 @@ def test_write_subset():
     assert np.array_equal(ref, val)
 
 
+@pytest.mark.gpu
+def test_write_full():
+
+    M, N = dace.symbol('M'), dace.symbol('N')
+
+    @dace.program
+    def write_full(A: dace.int32[M, N]):
+        for i, j in dace.map[0:M, 0:N]:
+            A[i, j] = i + j
+
+    sdfg = write_full.to_sdfg(simplify=True)
+    sdfg.apply_transformations(GPUTransformSDFG)
+
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.nodes.AccessNode) and node.data == 'A':
+                assert state.out_degree(node) == 0
+
+
+@pytest.mark.gpu
+def test_write_subset_dynamic():
+
+    @dace.program
+    def write_subset_dynamic(A: dace.int32[20, 20], x: dace.int32[20], y: dace.int32[20]):
+        for i, j in dace.map[2:18, 2:18]:
+            A[x[i], y[j]] = i + j
+
+    sdfg = write_subset_dynamic.to_sdfg(simplify=True)
+    sdfg.apply_transformations(GPUTransformSDFG)
+
+    ref = np.ones((20, 20), dtype=np.int32)
+    val = np.copy(ref)
+
+    x = np.random.permutation(20).astype(np.int32)
+    y = np.random.permutation(20).astype(np.int32)
+
+    write_subset_dynamic.f(ref, x, y)
+    sdfg(A=val, x=x, y=y)
+
+    assert np.array_equal(ref, val)
+
+
 if __name__ == '__main__':
     test_toplevel_transient_lifetime()
     test_scalar_to_symbol_in_nested_sdfg()
     test_write_subset()
+    test_write_full()
+    test_write_subset_dynamic()

--- a/tests/transformations/gpu_transform_test.py
+++ b/tests/transformations/gpu_transform_test.py
@@ -58,6 +58,26 @@ def test_scalar_to_symbol_in_nested_sdfg():
     assert np.array_equal(out, np.array([0, 10] * 5, dtype=np.int32))
 
 
+def test_write_subset():
+
+    @dace.program
+    def write_subset(A: dace.int32[20, 20]):
+        for i, j in dace.map[2:18, 2:18]:
+            A[i, j] = i + j
+    
+    sdfg = write_subset.to_sdfg(simplify=True)
+    sdfg.apply_transformations(GPUTransformSDFG)
+
+    ref = np.ones((20, 20), dtype=np.int32)
+    val = np.copy(ref)
+
+    write_subset.f(ref)
+    sdfg(A=val)
+
+    assert np.array_equal(ref, val)
+
+
 if __name__ == '__main__':
     test_toplevel_transient_lifetime()
     test_scalar_to_symbol_in_nested_sdfg()
+    test_write_subset()


### PR DESCRIPTION
This PR solves an issue with GPUTransform where copying an array from GPU global memory back to the host overwrites values that weren't updated in the kernel.