### PR TITLE
ConditionalOptionalArrayResolver pass in preprocess

### DIFF
--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -564,6 +564,7 @@ class DaceProgram(pycommon.SDFGConvertible):
                 is_constant = False
                 is_optional = None
                 if not _is_empty(ann):
+                    is_optional = False
                     # If constant, use given argument
                     if ann is dtypes.compiletime:
                         curarg = None
@@ -662,8 +663,8 @@ class DaceProgram(pycommon.SDFGConvertible):
 
                 # Set type
                 types[aname] = create_datadescriptor(curarg)
-                if is_optional is True and isinstance(types[aname], data.Array):
-                    types[aname].optional = True
+                if is_optional is not None and isinstance(types[aname], data.Array):
+                    types[aname].optional = is_optional
 
         # Set __return* arrays from return type annotations
         rettype = self.signature.return_annotation
@@ -892,6 +893,5 @@ class DaceProgram(pycommon.SDFGConvertible):
             # Set regenerate and recompile flags
             sdfg._regenerate_code = self.regenerate_code
             sdfg._recompile = self.recompile
-
 
         return sdfg, cached

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -322,7 +322,7 @@ class DaceProgram(pycommon.SDFGConvertible):
         else:
             return {k: eval(v, self.global_vars) if isinstance(v, str) else v for k, v in reevaluate.items()}
 
-    def closure_resolver(self, constant_args, given_args, parent_closure=None):
+    def closure_resolver(self, constant_args, given_args, argtypes={}, parent_closure=None):
         # Parse allowed global variables
         # (for inferring types and values in the DaCe program)
         global_vars = copy.copy(self.global_vars)
@@ -354,7 +354,8 @@ class DaceProgram(pycommon.SDFGConvertible):
         global_vars.update(gvars)
 
         # Parse AST to create the SDFG
-        _, closure = preprocessing.preprocess_dace_program(self.f, {},
+        _, closure = preprocessing.preprocess_dace_program(self.f,
+                                                           argtypes,
                                                            global_vars,
                                                            modules,
                                                            resolve_functions=self.resolve_functions,

--- a/tests/python_frontend/optional_array_test.py
+++ b/tests/python_frontend/optional_array_test.py
@@ -195,10 +195,10 @@ def test_optional_array_inference_via_parse():
 
 
 if __name__ == '__main__':
-    # test_type_hint()
-    # test_optional_arg_hint()
-    # test_optional_argcheck()
-    # test_optional_dead_state(False)
-    # test_optional_dead_state(True)
+    test_type_hint()
+    test_optional_arg_hint()
+    test_optional_argcheck()
+    test_optional_dead_state(False)
+    test_optional_dead_state(True)
     test_optional_array_inference_via_parse()
-    # test_optional_array_inference_via_simplify()
+    test_optional_array_inference_via_simplify()

--- a/tests/python_frontend/optional_array_test.py
+++ b/tests/python_frontend/optional_array_test.py
@@ -132,41 +132,66 @@ def test_optional_array_inference_via_simplify():
 def test_optional_array_inference_via_parse():
 
     @dace.program
-    def outer(yes: Optional[dace.float64[20]], no: dace.float64[20], unknown):
+    def nested(nested_none_arr: Optional[dace.float64[20]], nested_arr: dace.float64[20]):
+        if nested_none_arr is None:
+            nested_none_arr[:] = 10
+
+        if nested_arr is None:
+            nested_arr[:] = 10
+
+    @dace.program
+    def outer(none_arr: Optional[dace.float64[20]], arr: dace.float64[20], unknown):
         # Add loop to challenge unconditional traversal
         for _ in range(10):
             pass
 
-        if yes is None:
-            yes[:] = 10
-
-        if no is None:
-            no[:] = 10
-
-        if unknown is None:
+        if none_arr is None:
+            none_arr[:] = 10
+        else:
             unknown[:] = 10
 
-    yes_arr = None
-    no_arr = np.zeros(3)
+        if arr is None:
+            arr[:] = 10
+
+        nested(none_arr, nested_arr=arr)
+
+    g_none_arr = None
+    g_arr = np.zeros(3)
     unknown_arr = np.zeros(3)
 
-    sdfg = outer.to_sdfg(yes_arr, no_arr, unknown_arr, simplify=False)
+    sdfg = outer.to_sdfg(g_none_arr, g_arr, unknown_arr, simplify=False)
+    sdfg.save("debug.sdfg")
     sdfg.validate()
 
-    assert sdfg.arrays['yes'].optional is True
-    assert sdfg.arrays['no'].optional is False
+    # Check arrays are properly optional is properly handle
+    # with correct type hint
+    assert sdfg.arrays['none_arr'].optional is True
+    assert sdfg.arrays['arr'].optional is False
     assert sdfg.arrays['unknown'].optional is None
+    assert sdfg.sdfg_list[1].arrays['nested_none_arr'].optional is True
+    assert sdfg.sdfg_list[1].arrays['nested_arr'].optional is False
 
-    no_is_assigned = False
-    yes_is_assigned = False
-    for node, _state in sdfg.all_nodes_recursive():
-        if isinstance(node, dace.nodes.AccessNode):
-            no_is_assigned |= node.data == 'no'
-        if isinstance(node, dace.nodes.AccessNode):
-            yes_is_assigned |= node.data == 'yes'
+    # Check that the ConditionalOptionalArrayResolver pass in preprocess
+    # combined with ConditionalCodeResolver and DeadCodeEliminator lead
+    # to the branch elimination of None array
+    arr_is_assigned = False
+    none_arr_is_assigned = False
+    unknown_is_assigned = False
+    nested_arr_is_assigned = False
+    nested_none_arr_is_assigned = False
+    for node, state in sdfg.all_nodes_recursive():
+        if isinstance(node, dace.nodes.AccessNode) and node.has_writes(state):
+            arr_is_assigned |= (node.data == 'arr')
+            none_arr_is_assigned |= (node.data == 'none_arr')
+            unknown_is_assigned |= (node.data == 'unknown')
+            nested_arr_is_assigned |= (node.data == 'nested_arr')
+            nested_none_arr_is_assigned |= (node.data == 'nested_none_arr')
 
-    assert no_is_assigned
-    assert not yes_is_assigned
+    assert arr_is_assigned
+    assert not none_arr_is_assigned
+    assert unknown_is_assigned
+    assert nested_arr_is_assigned
+    assert not nested_none_arr_is_assigned
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Introduce a new pass in preprocessing that aims to reduce the well define case of optional hinted arrays. E.g.

```python
def program(array: Optional[]):
  if array is None:
    ...
  else:
    ...
    
program(None, ...)
 ```

See #1209 for full background

The PR adds a new pass and fix the `optional` flag on sdfg.arrays.
Test `test_optional_array_inference_via_parse` in `tests/python_frontend/optional_array_test.py`