### PR TITLE
Tuning Compatibility Fixes

### DIFF
--- a/dace/codegen/instrumentation/likwid.py
+++ b/dace/codegen/instrumentation/likwid.py
@@ -62,7 +62,7 @@ class LIKWIDInstrumentationCPU(InstrumentationProvider):
 #include <string>
 #include <sys/types.h>
 
-#define MAX_NUM_EVENTS 64
+#define MAX_NUM_EVENTS 256
 '''
         global_stream.write(header_code, sdfg)
 

--- a/dace/sdfg/analysis/cutout.py
+++ b/dace/sdfg/analysis/cutout.py
@@ -212,8 +212,7 @@ class SDFGCutout(SDFG):
         # Remove remaining dangling connectors from scope nodes and add new data containers corresponding to accesses
         # for dangling connectors on other nodes.
         translation_add_pairs: Set[Tuple[nd.AccessNode, nd.AccessNode]] = set()
-        for orig_node in in_translation.keys():
-            new_node = in_translation[orig_node]
+        for orig_node, new_node in in_translation.items():
             if isinstance(new_node, nd.Node):
                 if isinstance(orig_node, (nd.EntryNode, nd.ExitNode)):
                     used_connectors = set(e.dst_conn for e in new_state.in_edges(new_node))

--- a/dace/transformation/dataflow/tiling.py
+++ b/dace/transformation/dataflow/tiling.py
@@ -78,7 +78,7 @@ class MapTiling(transformation.SingleStateTransformation):
 
             dim_idx -= removed_maps
             # If tile size is trivial, skip strip-mining map dimension
-            if tile_size == map_entry.map.range.size()[dim_idx]:
+            if not self.tile_trivial and tile_size == map_entry.map.range.size()[dim_idx]:
                 continue
 
             stripmine = StripMining()


### PR DESCRIPTION
Changes:

- Increased the maximum number of events allowed in LIKWID GPU instrumentation.
- Allow for trivial tiling in MapTiling, which facilitates transfer tuning to different input sizes.
- Switched iteration style in Cutout API. It should be semantically identical code, but somehow fixes a bug in the API. This needs to be investigated later in detail.