### PR TITLE
Codegen-fix-negative-access-indics

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -993,7 +993,7 @@ class InterstateEdgeUnparser(cppunparse.CPPUnparser):
 
     def _Subscript(self, t: ast.Subscript):
         from dace.frontend.python.astutils import subscript_to_slice
-        target, rng = subscript_to_slice(t, self.sdfg.arrays)
+        target, rng = subscript_to_slice(t, self.sdfg.arrays, allow_actual_negative=True)
         rng = subsets.Range(rng)
         if rng.num_elements() != 1:
             raise SyntaxError('Range subscripts disallowed in interstate edges')

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -264,7 +264,7 @@ def unparse(node):
 
 # Helper function to convert an ND subscript AST node to a list of 3-tuple
 # slice strings
-def subscript_to_slice(node, arrays, without_array=False):
+def subscript_to_slice(node, arrays, without_array=False, allow_actual_negative=False):
     """ Converts an AST subscript to slice on the form
         (<name>, [<3-tuples of indices>]). If an ast.Name is passed, return
         (name, None), implying the full range. """
@@ -275,7 +275,7 @@ def subscript_to_slice(node, arrays, without_array=False):
     else:
         arrname = None
 
-    rng = astrange_to_symrange(ast_slice, arrays, arrname)
+    rng = astrange_to_symrange(ast_slice, arrays, arrname, allow_actual_negative)
     if without_array:
         return rng
     else:
@@ -287,7 +287,7 @@ def slice_to_subscript(arrname, range):
     return ast.parse(f'{arrname}[{range}]').body[0].value
 
 
-def astrange_to_symrange(astrange, arrays, arrname=None):
+def astrange_to_symrange(astrange, arrays, arrname=None, allow_actual_negative=False):
     """ Converts an AST range (array, [(start, end, skip)]) to a symbolic math 
         range, using the obtained array sizes and resolved symbols. """
     if arrname is not None:
@@ -335,7 +335,7 @@ def astrange_to_symrange(astrange, arrays, arrname=None):
         else:
             # In the case where a single element is given
             begin = symbolic.pystr_to_symbolic(unparse(r))
-            if (begin < 0) == True:
+            if not allow_actual_negative and (begin < 0) == True:
                 begin += arrdesc.shape[i]
             end = begin
             skip = symbolic.pystr_to_symbolic(1)

--- a/tests/codegen/negative_access_indices_test.py
+++ b/tests/codegen/negative_access_indices_test.py
@@ -1,0 +1,51 @@
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests (relative) negative access indices. """
+import dace
+import numpy as np
+
+
+def test_negative_access():
+
+    M, N = dace.symbol('M'), dace.symbol('N')
+    K, L = dace.symbol('K'), dace.symbol('L')
+
+    sdfg = dace.SDFG('negative_access')
+    for s in ('M', 'N', 'K', 'L'):
+        sdfg.add_symbol(s, dace.int32)
+    sdfg.add_array('A', [M, N], dace.int32, strides=[1, M])
+    sdfg.add_array('B', [M, N], dace.int32, strides=[1, M])
+    state = sdfg.add_state('state')
+
+    nsdfg = dace.SDFG('nested_sdfg')
+    nsdfg.add_array('A', [L-K, L-K], dace.int32, strides=[1, M])
+    nsdfg.add_array('B', [L-K, L-K], dace.int32, strides=[1, M])
+    nstate_0 = nsdfg.add_state('nested_state_0')
+    nstate_1 = nsdfg.add_state('nested_state_1')
+    nstate_2 = nsdfg.add_state('nested_state_2')
+    nsdfg.add_edge(nstate_0, nstate_1, dace.InterstateEdge(condition='A[-1,-2] == 10'))
+    nsdfg.add_edge(nstate_0, nstate_2, dace.InterstateEdge(condition='A[-1,-2] != 10'))
+
+    nb1 = nstate_1.add_write('B')
+    t1 = nstate_1.add_tasklet('t1', {}, {'b'}, 'b = 1')
+    nstate_1.add_edge(t1, 'b', nb1, None, dace.Memlet(data='B', subset='-2, -1'))
+
+    nb2 = nstate_2.add_write('B')
+    t2 = nstate_2.add_tasklet('t2', {}, {'b'}, 'b = 2')
+    nstate_2.add_edge(t2, 'b', nb2, None, dace.Memlet(data='B', subset='-2, -1'))
+
+    t = state.add_nested_sdfg(nsdfg, sdfg, {'A'}, {'B'})
+    a = state.add_read('A')
+    b = state.add_write('B')
+    state.add_edge(a, None, t, 'A', dace.Memlet('A[K:L, K:L]'))
+    state.add_edge(t, 'B', b, None, dace.Memlet('B[K:L, K:L]'))
+
+    A = np.asfortranarray(np.arange(100, dtype=np.int32).reshape(10, 10))
+    B = np.asfortranarray(np.zeros((10, 10), dtype=np.int32))
+    func = sdfg.compile(validate=False)
+    func(A=A, B=B, M=10, N=10, K=2, L=7)
+    K, L = 2, 7
+    assert B[K-2, K-1] == 1
+
+
+if __name__ == '__main__':
+    test_negative_access()


### PR DESCRIPTION
This PR address an issue where memlet accesses with negative indices in InterstateEdges lead to erroneous code-generation of those accesses.

NOTE: Do not merge (yet)!