### PR TITLE
Make-intermediate-map-writes-external

### DIFF
--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1419,18 +1419,18 @@ def make_map_internal_write_external(sdfg: SDFG, state: SDFGState, map_exit: nod
         for e in state.out_edges(access):
             if e in visited:
                 continue
-            visited.add(e)
-            # NOTE: We assume here that the intermediate write is happening just before the Map's exit node.
-            # Is this always correct?
-            src_subset = e.data.get_src_subset(e, state)
-            dst_subset = e.data.get_dst_subset(e, state)
-            state.add_edge(new_n,
-                           None,
-                           e.dst,
-                           e.dst_conn,
-                           memlet=Memlet(data=name,
-                                         subset=src_subset.offset(src_subset, negative=True),
-                                         other_subset=dst_subset))
+            offset = e.data.get_src_subset(e, state)
+            # NOTE: There can be nested Maps. Therefore, we need to iterate over the MemletTree.
+            for e2 in state.memlet_tree(e):
+                if e2 in visited:
+                    continue
+                visited.add(e2)
+                src_subset = e2.data.get_src_subset(e2, state)
+                dst_subset = e2.data.get_dst_subset(e2, state)
+                src = new_n if e2.src is access else e2.src
+                state.add_edge(
+                    src, e2.src_conn, e2.dst, e2.dst_conn,
+                    Memlet(data=name, subset=src_subset.offset_new(offset, negative=True), other_subset=dst_subset))
         for e in visited:
             state.remove_edge(e)
         state.remove_node(access)

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1339,3 +1339,86 @@ def can_run_state_on_fpga(state: SDFGState):
                 return False
 
     return True
+
+
+def make_map_internal_write_external(sdfg: SDFG, state: SDFGState, map_exit: nodes.MapExit, access: nodes.AccessNode,
+                                     sink: nodes.AccessNode):
+    """
+    Any writes to the Access node `access` that occur inside the Map with exit node `map_exit` are redirected to the
+    Access node `sink` that is outside the Map. This method will remove, if possible, `access` and replace it with a
+    transient.
+
+    :param sdfg: The SDFG in which the Access node resides.
+    :param state: The State in which the Access node resides.
+    :param map_exit: The exit node of the Map.
+    :param access: The Access node being written inside the Map.
+    :param sink: The Access node to be written outside the Map.
+    """
+
+    # Special case for scalars: if there is no write conflict resolution, then abort, since it is implied that the
+    # scalar is thread-local.
+    if isinstance(access.desc(sdfg), data.Scalar):
+        if any(e.data.wcr is None for e in state.in_edges(access)):
+            return
+
+    # Compute the union of the destination subsets of the edges that write to `access.`
+    in_union = None
+    for e in state.in_edges(access):
+        subset = e.data.get_dst_subset(e, state)
+        if in_union is None:
+            in_union = subset
+        else:
+            in_union = in_union.union(subset)
+
+    # Check if the union covers the output edges of `access.`
+    covers_out = True
+    if in_union is None:
+        covers_out = False
+    else:
+        for e in state.out_edges(access):
+            subset = e.data.get_src_subset(e, state)
+            if not in_union.covers(subset):
+                covers_out = False
+                break
+
+    # If the union covers the output edges of `access`, then we can remove `access` and replace it with a transient.
+    if covers_out:
+        shape = in_union.size()
+        if shape == [1]:
+            name, _ = sdfg.add_scalar(access.data, access.desc(sdfg).dtype, transient=True, find_new_name=True)
+        else:
+            name, _ = sdfg.add_array(access.data, shape, access.desc(sdfg).dtype, transient=True, find_new_name=True)
+        new_n = state.add_access(name)
+        for e in state.in_edges(access):
+            src_subset = e.data.get_src_subset(e, state)
+            dst_subset = e.data.get_dst_subset(e, state)
+            state.add_edge(
+                e.src, e.src_conn, new_n, None,
+                Memlet(data=name, subset=dst_subset.offset_new(dst_subset, negative=True), other_subset=src_subset))
+            state.add_memlet_path(new_n,
+                                  map_exit,
+                                  sink,
+                                  memlet=Memlet(data=sink.data,
+                                                subset=copy.deepcopy(dst_subset),
+                                                other_subset=dst_subset.offset_new(dst_subset, negative=True)))
+        for e in state.out_edges(access):
+            src_subset = e.data.get_src_subset(e, state)
+            dst_subset = e.data.get_dst_subset(e, state)
+            state.add_edge(new_n,
+                           None,
+                           e.dst,
+                           e.dst_conn,
+                           memlet=Memlet(data=name,
+                                         subset=src_subset.offset(src_subset, negative=True),
+                                         other_subset=dst_subset))
+        state.remove_node(access)
+    # Otherwise, we only add a memlet path to the sink.
+    else:
+        for e in state.in_edges(access):
+            subset = e.data.get_dst_subset(e, state)
+            state.add_memlet_path(access,
+                                  map_exit,
+                                  sink,
+                                  memlet=Memlet(data=sink.data,
+                                                subset=copy.deepcopy(subset),
+                                                other_subset=copy.deepcopy(subset)))

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1360,6 +1360,9 @@ def make_map_internal_write_external(sdfg: SDFG, state: SDFGState, map_exit: nod
     if isinstance(access.desc(sdfg), data.Scalar):
         if any(e.data.wcr is None for e in state.in_edges(access)):
             return
+    # Ignore views
+    if isinstance(access.desc(sdfg), data.View):
+        return
 
     # Compute the union of the destination subsets of the edges that write to `access.`
     in_union = None
@@ -1389,12 +1392,24 @@ def make_map_internal_write_external(sdfg: SDFG, state: SDFGState, map_exit: nod
         else:
             name, _ = sdfg.add_array(access.data, shape, access.desc(sdfg).dtype, transient=True, find_new_name=True)
         new_n = state.add_access(name)
+        visited = set()
         for e in state.in_edges(access):
+            if e in visited:
+                continue
+            offset = e.data.get_dst_subset(e, state)
+            # NOTE: There can be nested Maps. Therefore, we need to iterate over the MemletTree.
+            for e2 in state.memlet_tree(e):
+                if e2 in visited:
+                    continue
+                visited.add(e2)
+                src_subset = e2.data.get_src_subset(e2, state)
+                dst_subset = e2.data.get_dst_subset(e2, state)
+                dst = new_n if e2.dst is access else e2.dst
+                state.add_edge(
+                    e2.src, e2.src_conn, dst, e2.dst_conn,
+                    Memlet(data=name, subset=dst_subset.offset_new(offset, negative=True), other_subset=src_subset))
             src_subset = e.data.get_src_subset(e, state)
             dst_subset = e.data.get_dst_subset(e, state)
-            state.add_edge(
-                e.src, e.src_conn, new_n, None,
-                Memlet(data=name, subset=dst_subset.offset_new(dst_subset, negative=True), other_subset=src_subset))
             state.add_memlet_path(new_n,
                                   map_exit,
                                   sink,
@@ -1402,6 +1417,11 @@ def make_map_internal_write_external(sdfg: SDFG, state: SDFGState, map_exit: nod
                                                 subset=copy.deepcopy(dst_subset),
                                                 other_subset=dst_subset.offset_new(dst_subset, negative=True)))
         for e in state.out_edges(access):
+            if e in visited:
+                continue
+            visited.add(e)
+            # NOTE: We assume here that the intermediate write is happening just before the Map's exit node.
+            # Is this always correct?
             src_subset = e.data.get_src_subset(e, state)
             dst_subset = e.data.get_dst_subset(e, state)
             state.add_edge(new_n,
@@ -1411,6 +1431,8 @@ def make_map_internal_write_external(sdfg: SDFG, state: SDFGState, map_exit: nod
                            memlet=Memlet(data=name,
                                          subset=src_subset.offset(src_subset, negative=True),
                                          other_subset=dst_subset))
+        for e in visited:
+            state.remove_edge(e)
         state.remove_node(access)
     # Otherwise, we only add a memlet path to the sink.
     else:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -301,7 +301,7 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
             return False
 
         return True
-    
+
     def _is_array_thread_local(self, name: str, itervar: str, sdfg: SDFG, states: List[SDFGState]) -> bool:
         """
         This helper method checks whether an array used exclusively in the body of a detected for-loop is thread-local,
@@ -529,6 +529,15 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
         source_nodes = body.source_nodes()
         sink_nodes = body.sink_nodes()
 
+        # Check intermediate notes
+        intermediate_nodes = []
+        for node in body.nodes():
+            if isinstance(node, nodes.AccessNode) and body.in_degree(node) > 0 and node not in sink_nodes:
+                # Scalars written without WCR must be thread-local
+                if isinstance(node.desc(sdfg), dt.Scalar) and any(e.data.wcr is None for e in body.in_edges(node)):
+                    continue
+                intermediate_nodes.append(node)
+
         map = nodes.Map(body.label + "_map", [itervar], [(start, end, step)])
         entry = nodes.MapEntry(map)
         exit = nodes.MapExit(map)
@@ -579,6 +588,14 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
                     body.add_edge_pair(exit, e.src, n, new_memlet, internal_connector=e.src_conn)
             else:
                 body.add_nedge(n, exit, memlet.Memlet())
+        intermediate_sinks = {}
+        for n in intermediate_nodes:
+            if n.data in intermediate_sinks:
+                sink = intermediate_sinks[n.data]
+            else:
+                sink = body.add_access(n.data)
+                intermediate_sinks[n.data] = sink
+            helpers.make_map_internal_write_external(sdfg, body, exit, n, sink)
 
         # Here we handle the direct edges among source and sink access nodes.
         for e in direct_edges:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -590,6 +590,8 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
                 body.add_nedge(n, exit, memlet.Memlet())
         intermediate_sinks = {}
         for n in intermediate_nodes:
+            if isinstance(sdfg.arrays[n.data], dt.View):
+                continue
             if n.data in intermediate_sinks:
                 sink = intermediate_sinks[n.data]
             else:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -536,6 +536,15 @@ class LoopToMap(DetectLoop, xf.MultiStateTransformation):
                 # Scalars written without WCR must be thread-local
                 if isinstance(node.desc(sdfg), dt.Scalar) and any(e.data.wcr is None for e in body.in_edges(node)):
                     continue
+                # Arrays written with subsets that do not depend on the loop variable must be thread-local
+                map_dependency = False
+                for e in state.in_edges(node):
+                    subset = e.data.get_dst_subset(e, state)
+                    if any(str(s) == itervar for s in subset.free_symbols):
+                        map_dependency = True
+                        break
+                if not map_dependency:
+                    continue
                 intermediate_nodes.append(node)
 
         map = nodes.Map(body.label + "_map", [itervar], [(start, end, step)])


### PR DESCRIPTION
This PR added a helper method for redirecting a Map's internal write to an output Access node. It further amens LoopToMap to make use of this method.