### PR TITLE
Simplifying LIKWID Instrumentation

### DIFF
--- a/dace/codegen/instrumentation/likwid.py
+++ b/dace/codegen/instrumentation/likwid.py
@@ -42,68 +42,77 @@ class LIKWIDInstrumentationCPU(InstrumentationProvider):
         if sdfg.parent is not None:
             return
 
+        self.codegen = codegen
+
         # Configure CMake project and counters
         self.configure_likwid()
-
         if not self._likwid_used:
             return
 
-        self.codegen = codegen
-
-        likwid_marker_file = Path(sdfg.build_folder) / "perf" / "likwid_marker.out"
-
-        # Add instrumentation includes and initialize LIKWID
+        # Include LIKWID
         header_code = '''
-#include <omp.h>
 #include <likwid.h>
-#include <likwid-marker.h>
 
 #include <unistd.h>
 #include <string>
 #include <sys/types.h>
 
-#define MAX_NUM_EVENTS 256
+int* cpu_list = nullptr;
+int LIKWID_ACTIVE_GID = -1;
 '''
         global_stream.write(header_code, sdfg)
 
         init_code = f'''
-if(getenv("LIKWID_PIN"))
+// Initialize topology module
+int error = topology_init();
+if (error < 0)
 {{
-    printf("Instrumentation must not be wrapped by likwid-perfctr. Results may be incorrect.\\n");
+    printf("Failed to initialize LIKWID's topology module\\n");
+    exit(1);
 }}
 
-setenv("LIKWID_FILEPATH", "{likwid_marker_file.absolute()}", 0);
-// Mode = "0" (direct), "1" (accessdaemon), "2" (perf_event)
-setenv("LIKWID_MODE", "2", 0);
-setenv("LIKWID_FORCE", "1", 0);
-setenv("LIKWID_EVENTS", "{self._default_events}", 0);
+// Create affinity domains: Enables reading uncore counters
+affinity_init();
 
-// Set pid for perf_event backend
-std::string execpid = std::to_string(getpid());
-setenv("LIKWID_PERF_PID", execpid.c_str(), 1);
-
-int num_threads = 0;
-if (getenv("OMP_NUM_THREADS") != NULL) {{
-    num_threads = atoi(getenv("OMP_NUM_THREADS"));
-}}
-else {{
-    num_threads = omp_get_num_procs();
-}}
-omp_set_num_threads(num_threads);
-
-std::string thread_pinning = "0";
-for (int i = 1; i < num_threads; i++)
+// Create list of CPU ids.
+CpuTopology_t topo = get_cpuTopology();
+cpu_list = (int*) malloc(topo->numHWThreads * sizeof(int));
+if (!cpu_list)
 {{
-    thread_pinning += "," + std::to_string(i);
+    exit(1);
 }}
-setenv("LIKWID_THREADS", thread_pinning.c_str(), 1);
-
-LIKWID_MARKER_INIT;
-
-#pragma omp parallel
+for (int i = 0;i < topo->numHWThreads; i++)
 {{
-    int thread_id = omp_get_thread_num();
-    likwid_pinThread(thread_id);
+    cpu_list[i] = topo->threadPool[i].apicId;
+}}
+
+// Initialize likwid's perfmon module
+error = perfmon_init(topo->numHWThreads, cpu_list);
+if (error < 0)
+{{
+    printf("Failed to initialize LIKWID's perfmon module\\n");
+    topology_finalize();
+    exit(1);
+}}
+free(cpu_list);
+
+// Configure group via env variable LIKWID_EVENTS
+LIKWID_ACTIVE_GID = perfmon_addEventSet(NULL);
+if (LIKWID_ACTIVE_GID < 0)
+{{
+    printf("Failed to add group %s to LIKWID's perfmon module\\n", getenv("LIKWID_EVENTS"));
+    perfmon_finalize();
+    topology_finalize();
+    exit(1);
+}}
+
+error = perfmon_setupCounters(LIKWID_ACTIVE_GID);
+if (error < 0)
+{{
+    printf("Failed to setup group in LIKWID's perfmon module\\n");
+    perfmon_finalize();
+    topology_finalize();
+    exit(1);
 }}
 '''
         codegen._initcode.write(init_code)
@@ -112,56 +121,10 @@ LIKWID_MARKER_INIT;
         if not self._likwid_used or sdfg.parent is not None:
             return
 
-        outer_code = f'''
-int num_threads;
-#pragma omp parallel
-{{
-    #pragma omp single
-    num_threads = omp_get_num_threads();
-}}
-
-double events[num_threads][MAX_NUM_EVENTS];
-double time[num_threads];
-'''
-        local_stream.write(outer_code, sdfg)
-
-        for region, sdfg_id, state_id, node_id in self._regions:
-            report_code = f'''
-#pragma omp parallel
-{{
-    int thread_id = omp_get_thread_num();
-    int nevents = MAX_NUM_EVENTS;
-    int count = 0;
-
-    LIKWID_MARKER_GET("{region}", &nevents, events[thread_id], time + thread_id, &count);
-
-    #pragma omp barrier
-    #pragma omp single
-    {{
-        int gid = perfmon_getIdOfActiveGroup();
-        char* group_name = perfmon_getGroupName(gid);
-
-        for (int t = 0; t < num_threads; t++)
-        {{
-            __state->report.add_completion("Timer", "likwid", 0, time[t] * 1000 * 1000, t, {sdfg_id}, {state_id}, {node_id});
-        }}
-
-        for (int i = 0; i < nevents; i++)
-        {{
-            char* event_name = perfmon_getEventName(gid, i); 
-            
-            for (int t = 0; t < num_threads; t++)
-            {{
-                __state->report.add_counter("{region}", "likwid", event_name, events[t][i], t, {sdfg_id}, {state_id}, {node_id});
-            }}
-        }}
-    }}
-}}
-'''
-            local_stream.write(report_code)
-
         exit_code = '''
-LIKWID_MARKER_CLOSE;
+perfmon_finalize();
+affinity_finalize;
+topology_finalize();
 '''
         self.codegen._exitcode.write(exit_code, sdfg)
 
@@ -176,30 +139,17 @@ LIKWID_MARKER_CLOSE;
             region = f"state_{sdfg_id}_{state_id}_{node_id}"
             self._regions.append((region, sdfg_id, state_id, node_id))
 
-            marker_code = f'''
-#pragma omp parallel
+            start_counters_code = f'''
+int error = perfmon_startCounters();
+if (error < 0)
 {{
-    LIKWID_MARKER_REGISTER("{region}");
-
-    /* Temporary fix:
-     *  Case: multiple exeuctions
-     *  Problem: Markers need to be reset before new execution.
-     *  Bug: If we do this immediately after LIKEID_MARKER_GET
-     *  and before LIKWID_MARKER_CLOSE, likwid prints an false
-     *  warning complaining it can't evaluate those regions.
-     *  To avoid this ugly warning, we reset them before measuring
-     *  again.
-     */
-    #pragma omp barrier
-    LIKWID_MARKER_START("{region}");
-    LIKWID_MARKER_STOP("{region}");
-    LIKWID_MARKER_RESET("{region}");
-
-    #pragma omp barrier
-    LIKWID_MARKER_START("{region}");
+    printf("Failed to start counters for group %d for thread %d\\n", LIKWID_ACTIVE_GID, (-1*error)-1);
+    perfmon_finalize();
+    topology_finalize();
+    exit(1);
 }}
 '''
-            local_stream.write(marker_code)
+            local_stream.write(start_counters_code)
 
     def on_state_end(self, sdfg, state, local_stream, global_stream):
         if not self._likwid_used:
@@ -211,57 +161,74 @@ LIKWID_MARKER_CLOSE;
             node_id = -1
             region = f"state_{sdfg_id}_{state_id}_{node_id}"
 
-            marker_code = f'''
-#pragma omp parallel
+            stop_counters_code = f'''
+error = perfmon_stopCounters();
+if (error < 0)
 {{
-    LIKWID_MARKER_STOP("{region}");
+    printf("Failed to stop counters for group %d for thread %d\\n", LIKWID_ACTIVE_GID, (-1*error)-1);
+    perfmon_finalize();
+    topology_finalize();
+    exit(1);
+}}
+
+CpuTopology_t topo = get_cpuTopology();
+int num_events = perfmon_getNumberOfEvents(LIKWID_ACTIVE_GID);
+for (int j = 0; j < num_events; j++)
+{{
+    char* event_name = perfmon_getEventName(LIKWID_ACTIVE_GID, j);
+    for (int i = 0; i < topo->numHWThreads; i++)
+    {{
+        double result = perfmon_getResult(LIKWID_ACTIVE_GID, j, i);
+        __state->report.add_counter("{region}", "likwid", event_name, result, i, {sdfg_id}, {state_id}, {node_id});
+    }}
 }}
 '''
-            local_stream.write(marker_code)
+            local_stream.write(stop_counters_code)
 
-    def on_scope_entry(self, sdfg, state, node, outer_stream, inner_stream, global_stream):
-        if not self._likwid_used or node.instrument != dace.InstrumentationType.LIKWID_CPU:
-            return
 
-        if not isinstance(node, dace.nodes.MapEntry) or xfh.get_parent_map(state, node) is not None:
-            raise TypeError("Only top-level map scopes supported")
-        elif node.schedule not in LIKWIDInstrumentationCPU.perf_whitelist_schedules:
-            raise TypeError("Unsupported schedule on scope")
+#     def on_scope_entry(self, sdfg, state, node, outer_stream, inner_stream, global_stream):
+#         if not self._likwid_used or node.instrument != dace.InstrumentationType.LIKWID_CPU:
+#             return
 
-        sdfg_id = sdfg.sdfg_id
-        state_id = sdfg.node_id(state)
-        node_id = state.node_id(node)
-        region = f"scope_{sdfg_id}_{state_id}_{node_id}"
+#         if not isinstance(node, dace.nodes.MapEntry) or xfh.get_parent_map(state, node) is not None:
+#             raise TypeError("Only top-level map scopes supported")
+#         elif node.schedule not in LIKWIDInstrumentationCPU.perf_whitelist_schedules:
+#             raise TypeError("Unsupported schedule on scope")
 
-        self._regions.append((region, sdfg_id, state_id, node_id))
-        marker_code = f'''
-#pragma omp parallel
-{{
-    LIKWID_MARKER_REGISTER("{region}");
+#         sdfg_id = sdfg.sdfg_id
+#         state_id = sdfg.node_id(state)
+#         node_id = state.node_id(node)
+#         region = f"scope_{sdfg_id}_{state_id}_{node_id}"
 
-    #pragma omp barrier
-    LIKWID_MARKER_START("{region}");
-}}
-'''
-        outer_stream.write(marker_code)
+#         self._regions.append((region, sdfg_id, state_id, node_id))
+#         marker_code = f'''
+# #pragma omp parallel
+# {{
+#     LIKWID_MARKER_REGISTER("{region}");
 
-    def on_scope_exit(self, sdfg, state, node, outer_stream, inner_stream, global_stream):
-        entry_node = state.entry_node(node)
-        if not self._likwid_used or entry_node.instrument != dace.InstrumentationType.LIKWID_CPU:
-            return
+#     #pragma omp barrier
+#     LIKWID_MARKER_START("{region}");
+# }}
+# '''
+#         outer_stream.write(marker_code)
 
-        sdfg_id = sdfg.sdfg_id
-        state_id = sdfg.node_id(state)
-        node_id = state.node_id(entry_node)
-        region = f"scope_{sdfg_id}_{state_id}_{node_id}"
+#     def on_scope_exit(self, sdfg, state, node, outer_stream, inner_stream, global_stream):
+#         entry_node = state.entry_node(node)
+#         if not self._likwid_used or entry_node.instrument != dace.InstrumentationType.LIKWID_CPU:
+#             return
 
-        marker_code = f'''
-#pragma omp parallel
-{{
-    LIKWID_MARKER_STOP("{region}");
-}}
-'''
-        outer_stream.write(marker_code)
+#         sdfg_id = sdfg.sdfg_id
+#         state_id = sdfg.node_id(state)
+#         node_id = state.node_id(entry_node)
+#         region = f"scope_{sdfg_id}_{state_id}_{node_id}"
+
+#         marker_code = f'''
+# #pragma omp parallel
+# {{
+#     LIKWID_MARKER_STOP("{region}");
+# }}
+# '''
+#         outer_stream.write(marker_code)
 
 
 @registry.autoregister_params(type=dtypes.InstrumentationType.LIKWID_GPU)

--- a/samples/instrumentation/matmul_likwid.py
+++ b/samples/instrumentation/matmul_likwid.py
@@ -54,14 +54,18 @@ C = np.zeros((m, n), dtype=np.float32)
 # We will now iterate through the SDFG and set the instrumentation
 # type to LIKWID_CPU for all states and top-level map entries.
 # Non-top-level map entries are currently not supported!
-for nsdfg in sdfg.all_sdfgs_recursive():
-    for state in nsdfg.nodes():
-        state.instrument = dace.InstrumentationType.LIKWID_CPU
+for state in sdfg.states():
+    state.instrument = dace.InstrumentationType.LIKWID_CPU
 
 ## 3. Compile and execute
 # During execution, the counters for different parts of the SDFG and different
 # threads are measured by likwid and written into a performance report
 # in form of events. This report is saved at .dacecache/matmul/perf.
+import os
+
+os.environ["LIKWID_EVENTS"] = "FLOPS_SP"
+os.environ["LIKWID_FORCE"] = "1"
+
 csdfg = sdfg.compile()
 csdfg(A=A, B=B, C=C, K=k, M=m, N=n)
 


### PR DESCRIPTION
This PR simplifies usage of LIKWID for user-space instrumentation.

- Switch from LIKWID markerAPI to perfmon module API. This removes the dependency on the likwid-perfctr application.

When likwid is built with the perf_event backend, the only setup which needs to be done by a sys admin is to reduce the paranoid level to a level that allows for performance counter measurements. This is necessary for all tools, not just likwid.