### PR TITLE
Fix-interstate-free-symbols

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
 import collections
 import copy
@@ -214,7 +214,31 @@ class InterstateEdge(object):
     @property
     def free_symbols(self) -> Set[str]:
         """ Returns a set of symbols used in this edge's properties. """
-        return self.read_symbols() - set(self.assignments.keys())
+        # NOTE: The former algorithm for computing an edge's free symbols was:
+        #       `self.read_symbols() - set(self.assignments.keys())`
+        #       The issue with the above algorithm is that any symbols that are first read and then assigned will not
+        #       be considered free symbols. For example, the former algorithm will fail for the following edges:
+        #       - assignments = {'i': 'i + 1'}
+        #       - condition = 'i < 10', assignments = {'i': '3'}
+        #       - assignments = {'j': 'i + 1', 'i': '3'}
+        #       The new algorithm below addresses the issue by iterating over the edge's condition and assignments and
+        #       exlcuding keys from being considered "defined" if they have been already read.
+
+        # Symbols in conditions are always free, because the condition is executed before the assignments
+        cond_symbols = set(map(str, dace.symbolic.symbols_in_ast(self.condition.code[0])))
+        # Symbols in assignment keys are candidate defined symbols
+        lhs_symbols = set()
+        # Symbols in assignment values are candidate free symbols
+        rhs_symbols = set()
+        for lhs, rhs in self.assignments.items():
+            # Always add LHS symbols to the set of candidate free symbols
+            rhs_symbols |= symbolic.free_symbols_and_functions(rhs)
+            # Add the RHS to the set of candidate defined symbols ONLY if it has not been read yet
+            # This also solves the ordering issue that may arise in cases like the 3rd example above
+            if lhs not in cond_symbols and lhs not in rhs_symbols:
+                lhs_symbols.add(lhs)
+        # Return the set of candidate free symbols minus the set of candidate defined symbols
+        return (cond_symbols | rhs_symbols) - lhs_symbols
 
     def replace_dict(self, repl: Dict[str, str], replace_keys=True) -> None:
         """
@@ -1288,8 +1312,11 @@ class SDFG(OrderedDiGraph[SDFGState, InterstateEdge]):
 
             # Add free inter-state symbols
             for e in self.out_edges(state):
-                defined_syms |= set(e.data.assignments.keys())
+                # NOTE: First we get the true InterstateEdge free symbols, then we compute the newly defined symbols by
+                # subracting the (true) free symbols from the edge's assignment keys. This way we can correctly
+                # compute the symbols that are used before being assigned.
                 efsyms = e.data.free_symbols
+                defined_syms |= set(e.data.assignments.keys()) - efsyms
                 used_before_assignment.update(efsyms - defined_syms)
                 free_syms |= efsyms
 

--- a/tests/sdfg/free_symbols_test.py
+++ b/tests/sdfg/free_symbols_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import math
 
@@ -72,8 +72,67 @@ def test_constants():
     assert sdfg.free_symbols == {'M', 'N'}
 
 
+def test_interstate_edge_symbols():
+    i, j, k = (dace.symbol(s) for s in 'ijk')
+
+    edge = dace.InterstateEdge(assignments={'i': 'j + k'})
+    assert 'j' in edge.free_symbols
+    assert 'k' in edge.free_symbols
+    assert 'i' not in edge.free_symbols
+
+    edge = dace.InterstateEdge(assignments={'i': 'i+1'})
+    assert 'i' in edge.free_symbols
+
+    edge = dace.InterstateEdge(condition='i < j', assignments={'i': '3'})
+    assert 'i' in edge.free_symbols
+    assert 'j' in edge.free_symbols
+
+    edge = dace.InterstateEdge(assignments={'j': 'i + 1', 'i': '3'})
+    assert 'i' in edge.free_symbols
+    assert 'j' not in edge.free_symbols
+
+
+def test_nested_sdfg_free_symbols():
+    i, j, k = (dace.symbol(s) for s in 'ijk')
+
+    outer_sdfg = dace.SDFG('outer')
+    outer_init_state = outer_sdfg.add_state('outer_init')
+    outer_guard_state = outer_sdfg.add_state('outer_guard')
+    outer_body_state_1 = outer_sdfg.add_state('outer_body_1')
+    outer_body_state_2 = outer_sdfg.add_state('outer_body_2')
+    outer_exit_state = outer_sdfg.add_state('outer_exit')
+    outer_sdfg.add_edge(outer_init_state, outer_guard_state, dace.InterstateEdge(assignments={'i': '0'}))
+    outer_sdfg.add_edge(outer_guard_state, outer_body_state_1,
+                        dace.InterstateEdge(condition='i < 10', assignments={'j': 'i + 1'}))
+    outer_sdfg.add_edge(outer_guard_state, outer_exit_state, dace.InterstateEdge(condition='i >= 10'))
+    outer_sdfg.add_edge(outer_body_state_1, outer_guard_state,
+                        dace.InterstateEdge(condition='j >= 10', assignments={'i': 'i + 1'}))
+    outer_sdfg.add_edge(outer_body_state_1, outer_body_state_2, dace.InterstateEdge(condition='j < 10'))
+    outer_sdfg.add_edge(outer_body_state_2, outer_body_state_1, dace.InterstateEdge(assignments={'j': 'j + 1'}))
+
+    inner_sdfg = dace.SDFG('inner')
+    inner_init_state = inner_sdfg.add_state('inner_init')
+    inner_guard_state = inner_sdfg.add_state('inner_guard')
+    inner_body_state = inner_sdfg.add_state('inner_body')
+    inner_exit_state = inner_sdfg.add_state('inner_exit')
+    inner_sdfg.add_edge(inner_init_state, inner_guard_state, dace.InterstateEdge(assignments={'k': 'j + 1'}))
+    inner_sdfg.add_edge(inner_guard_state, inner_body_state, dace.InterstateEdge(condition='k < 10'))
+    inner_sdfg.add_edge(inner_guard_state, inner_exit_state,
+                        dace.InterstateEdge(condition='k >= 10', assignments={'j': 'j + 1'}))
+    inner_sdfg.add_edge(inner_body_state, inner_guard_state, dace.InterstateEdge(assignments={'k': 'k + 1'}))
+
+    outer_body_state_2.add_nested_sdfg(inner_sdfg, None, {}, {}, symbol_mapping={'j': 'j'})
+
+    assert not outer_sdfg.free_symbols
+    assert 'i' not in inner_sdfg.free_symbols
+    assert 'j' in inner_sdfg.free_symbols
+    assert 'k' not in inner_sdfg.free_symbols
+
+
 if __name__ == '__main__':
     test_single_state()
     test_state_subgraph()
     test_sdfg()
     test_constants()
+    test_interstate_edge_symbols()
+    test_nested_sdfg_free_symbols()


### PR DESCRIPTION
This PR attempts to fix a long standing issue with the computation of an SDFG's free symbols, especially symbols that are used before being assigned. The PR introduces a new algorithm for computingg an InterstateEdge's free symbbols, which is subsequently used to correctly compute the used-before-assigned SDFG free symbols.