### PR TITLE
Fix nested access with nested symbol dependency

### DIFF
--- a/.github/workflows/fpga-ci.yml
+++ b/.github/workflows/fpga-ci.yml
@@ -20,9 +20,11 @@ jobs:
         rm -rf .dacecache tests/.dacecache
         . /opt/setupenv
         python -m pip install --upgrade pip
-        pip install pytest-xdist flake8 coverage codecov
+        pip install pytest-xdist flake8 coverage
         pip uninstall -y dace
         pip install -e ".[testing]"
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
 
     - name: Run FPGA Tests
       run: |
@@ -35,7 +37,7 @@ jobs:
         reachable=0
         ping -W 2 -c 1 codecov.io || reachable=$?
         if [ $reachable -eq 0 ]; then
-          codecov
+          ./codecov
         else
           echo "Codecov.io is unreachable"
         fi

--- a/.github/workflows/general-ci.yml
+++ b/.github/workflows/general-ci.yml
@@ -31,8 +31,10 @@ jobs:
         sudo apt-get install -y libpapi-dev papi-tools  # Instrumentation dependencies
         sudo apt-get install -y verilator # RTL simulation dependencies
         python -m pip install --upgrade pip
-        pip install flake8 pytest-xdist coverage codecov
+        pip install flake8 pytest-xdist coverage
         pip install -e ".[testing]"
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
 
     - name: Test dependencies
       run: |
@@ -52,7 +54,7 @@ jobs:
             export DACE_optimizer_automatic_simplification=${{ matrix.simplify }}
         fi
         pytest -n auto --cov-report=xml --cov=dace --tb=short -m "not gpu and not verilator and not tensorflow and not mkl and not sve and not papi and not mlir and not lapack and not fpga and not mpi and not rtl_hardware and not scalapack and not datainstrument"
-        codecov
+        ./codecov
 
     - name: Test OpenBLAS LAPACK
       run: |
@@ -68,7 +70,7 @@ jobs:
             export DACE_optimizer_automatic_simplification=${{ matrix.simplify }}
         fi
         pytest -n 1 --cov-report=xml --cov=dace --tb=short -m "lapack"
-        codecov
+        ./codecov
 
     - name: Run other tests
       run: |
@@ -81,4 +83,4 @@ jobs:
         ./tests/polybench_test.sh
         ./tests/xform_test.sh
         coverage combine .; coverage report; coverage xml
-        codecov
+        ./codecov

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -20,10 +20,12 @@ jobs:
         rm -rf .dacecache tests/.dacecache
         . /opt/setupenv
         python -m pip install --upgrade pip
-        pip install flake8 pytest-xdist coverage codecov
+        pip install flake8 pytest-xdist coverage
         pip install mpi4py
         pip uninstall -y dace
         pip install -e ".[testing]"
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
 
     - name: Test dependencies
       run: |
@@ -52,7 +54,7 @@ jobs:
         reachable=0
         ping -W 2 -c 1 codecov.io || reachable=$?
         if [ $reachable -eq 0 ]; then
-          codecov
+          ./codecov
         else
           echo "Codecov.io is unreachable"
         fi

--- a/.github/workflows/heterogeneous-ci.yml
+++ b/.github/workflows/heterogeneous-ci.yml
@@ -20,10 +20,12 @@ jobs:
         rm -rf .dacecache tests/.dacecache
         . /opt/setupenv
         python -m pip install --upgrade pip
-        pip install flake8 pytest-xdist coverage codecov
+        pip install flake8 pytest-xdist coverage
         pip install mpi4py pytest-mpi
         pip uninstall -y dace
         pip install -e ".[testing]"
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
 
     - name: Test dependencies
       run: |
@@ -73,7 +75,7 @@ jobs:
         reachable=0
         ping -W 2 -c 1 codecov.io || reachable=$?
         if [ $reachable -eq 0 ]; then
-          codecov
+          ./codecov
         else
           echo "Codecov.io is unreachable"
         fi

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2913,8 +2913,11 @@ class ProgramVisitor(ExtNodeVisitor):
                 for s, sr in self.symbols.items():
                     if s in symbolic.symlist(r).values():
                         ignore_indices.append(i)
-                        if any(t in self.sdfg.arrays for t in sr.free_symbols):
+                        if any(t in self.sdfg.arrays or t in (str(sym) for sym in self.symbols)
+                               for t in sr.free_symbols):
                             sym_rng.append(subsets.Range([(0, parent_array.shape[i] - 1, 1)]))
+                            repl_dict = {}
+                            break
                         else:
                             sym_rng.append(sr)
                             # NOTE: Assume that the i-th index of the range is

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -138,6 +138,24 @@ def test_nested_dec_offset_access_dappy():
     assert (np.allclose(out, ref))
 
 
+def test_nested_offset_access_nested_dependency():
+    @dc.program
+    def nested_offset_access_nested_dep(inp: dc.float64[6, 5, 5]):
+        out = np.zeros((5, 5, 5), np.float64)
+        for i, j in dc.map[0:5, 0:5]:
+            out[i, j, 0] = 0.25 * (inp[i + 1, j, 1] + inp[i, j, 1])
+            for k in range(1, 4):
+                for l in range(k, 5):
+                    out[i, j, k] = 0.25 * (inp[i + 1, j, l - k + 1] + inp[i, j, l - k + 1])
+        return out
+
+    inp = np.reshape(np.arange(6 * 5 * 5, dtype=np.float64), (6, 5, 5)).copy()
+    out = nested_offset_access_nested_dep(inp)
+    ref = nested_offset_access_nested_dep.f(inp)
+    assert (np.allclose(out, ref))
+
+
+
 if __name__ == "__main__":
     test_nested_name_accesses()
     test_nested_offset_access()
@@ -146,3 +164,4 @@ if __name__ == "__main__":
     test_nested_multi_offset_access_dappy()
     test_nested_dec_offset_access()
     test_nested_dec_offset_access_dappy()
+    test_nested_offset_access_nested_dependency()

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace as dc
 import numpy as np
+import os
 
 N = dc.symbol('N')
 
@@ -150,8 +151,11 @@ def test_nested_offset_access_nested_dependency():
         return out
 
     inp = np.reshape(np.arange(6 * 5 * 5, dtype=np.float64), (6, 5, 5)).copy()
+    last_value = os.environ.get('DACE_testing_serialization', '0')
+    os.environ['DACE_testing_serialization'] = '0'
     with dc.config.set_temporary('testing', 'serialization', value=False):
         out = nested_offset_access_nested_dep(inp)
+    os.environ['DACE_testing_serialization'] = last_value
     ref = nested_offset_access_nested_dep.f(inp)
     assert (np.allclose(out, ref))
 


### PR DESCRIPTION
In the Python frontend, when accessing an array from a higher-level scope, we try to "squeeze" the access to begin from index 0 while propagating the correct offset to the edge connecting the outer data to the nested scope (NestedSDFG). To achieve this, any access utilizing a symbol `k` that is local to the nested scope with an access method `f(k)` is altered to `f(k) - f(min(range(k))` so that it starts from index 0, while the offset `f(min(range(k))` is propagated to the outer edge.

However, issues arise when the symbol `k` range depends on other symbols local to the nested scope. In those cases, the symbols have to be altered/replaced recursively so that no local symbol remains in the offset; otherwise, it is impossible to propagate it to the outer edge, which then starts from index 0, leading to erroneous accesses in the nested scope.

This PR solves the above issue by simply skipping the elaborate and strict squeezing of the local-symbol-dependent sub-ranges when meeting such cases.