### PR TITLE
Fix map indirection

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -254,8 +254,7 @@ def parse_dace_program(name: str,
     except Exception:
         # Print the offending line causing the exception
         li = visitor.current_lineinfo
-        print('Exception raised while parsing DaCe program:\n'
-              f'  in File "{li.filename}", line {li.start_line}')
+        print('Exception raised while parsing DaCe program:\n' f'  in File "{li.filename}", line {li.start_line}')
         lines = preprocessed_ast.src.split('\n')
         lineid = li.start_line - preprocessed_ast.src_line - 1
         if lineid >= 0 and lineid < len(lines):
@@ -602,7 +601,6 @@ class TaskletTransformer(ExtNodeTransformer):
     """ A visitor that traverses a data-centric tasklet, removes memlet
         annotations and returns input and output memlets.
     """
-
     def __init__(self,
                  visitor,
                  defined,
@@ -1793,7 +1791,9 @@ class ProgramVisitor(ExtNodeVisitor):
                         if candidate in self.variables and self.variables[candidate] in self.sdfg.arrays:
                             candidate = self.variables[candidate]
 
-                        if candidate in self.sdfg.arrays and (isinstance(self.sdfg.arrays[candidate], data.Scalar) or (isinstance(self.sdfg.arrays[candidate], data.Array) and self.sdfg.arrays[candidate].shape == (1,))):
+                        if candidate in self.sdfg.arrays and (isinstance(self.sdfg.arrays[candidate], data.Scalar) or
+                                                              (isinstance(self.sdfg.arrays[candidate], data.Array)
+                                                               and self.sdfg.arrays[candidate].shape == (1, ))):
                             newvar = '__%s_%s%d' % (name, vid, ctr)
                             repldict[atomstr] = newvar
                             map_inputs[newvar] = Memlet.from_array(candidate, self.sdfg.arrays[candidate])
@@ -4804,7 +4804,6 @@ class ProgramVisitor(ExtNodeVisitor):
         """ Parses the slice attribute of an ast.Subscript node.
             Scalar data are promoted to symbols.
         """
-
         def _promote(node: ast.AST) -> Union[Any, str, symbolic.symbol]:
             node_str = astutils.unparse(node)
             sym = None

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1793,7 +1793,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         if candidate in self.variables and self.variables[candidate] in self.sdfg.arrays:
                             candidate = self.variables[candidate]
 
-                        if candidate in self.sdfg.arrays and isinstance(self.sdfg.arrays[candidate], data.Scalar):
+                        if candidate in self.sdfg.arrays and (isinstance(self.sdfg.arrays[candidate], data.Scalar) or (isinstance(self.sdfg.arrays[candidate], data.Array) and self.sdfg.arrays[candidate].shape == (1,))):
                             newvar = '__%s_%s%d' % (name, vid, ctr)
                             repldict[atomstr] = newvar
                             map_inputs[newvar] = Memlet.from_array(candidate, self.sdfg.arrays[candidate])

--- a/tests/python_frontend/indirection_in_map_test.py
+++ b/tests/python_frontend/indirection_in_map_test.py
@@ -1,0 +1,40 @@
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import numpy as np
+import scipy as sp
+import scipy.sparse as sparse
+
+M = dace.symbol('M')
+N = dace.symbol('N')
+K = dace.symbol('K')
+nnz_A = dace.symbol('nnz_A')
+nnz_B = dace.symbol('nnz_B')
+'''
+C = A @ B
+[M, K] = [M, N] @ [N, K]
+C[i, k] = A[i, j] * B[j, k]
+'''
+
+
+@dace.program
+def spmspm_csr_csr(A2_pos: dace.int32[M + 1], A2_crd: dace.int32[nnz_A], A_val: dace.float64[nnz_A],
+                   B2_pos: dace.int32[N + 1], B2_crd: dace.int32[nnz_B], B_val: dace.float64[nnz_B],
+                   C: dace.float64[M, K]):
+    for i in dace.map[0:M]:
+        for pj in dace.map[A2_pos[i]:A2_pos[i + 1]]:
+            for pk in dace.map[B2_pos[A2_crd[pj]]:B2_pos[A2_crd[pj] + 1]]:
+                C[i, B2_crd[pk]] += A_val[pj] * B_val[pk]
+
+
+def test_spmspm_csr_csr():
+    csr_A = sparse.random(200, 100, density=0.5, format='csr')
+    csr_B = sparse.random(100, 150, density=0.5, format='csr')
+    ref_dense_C = (csr_A @ csr_B).todense()
+    dace_dense_C = np.zeros_like(ref_dense_C)
+    spmspm_csr_csr(csr_A.indptr, np.copy(csr_A.indices), np.copy(csr_A.data), csr_B.indptr, np.copy(csr_B.indices),
+                   np.copy(csr_B.data), dace_dense_C)
+    assert np.allclose(ref_dense_C, dace_dense_C)
+
+
+if __name__ == '__main__':
+    test_spmspm_csr_csr()


### PR DESCRIPTION
For programs like CSR times CSR matrix:
```python
@dace.program
def spmspm_csr_csr(A2_pos: dace.int32[M + 1], A2_crd: dace.int32[nnz_A], A_val: dace.float64[nnz_A],
                   B2_pos: dace.int32[N + 1], B2_crd: dace.int32[nnz_B], B_val: dace.float64[nnz_B],
                   C: dace.float64[M, K]):
    for i in dace.map[0:M]:
        for pj in dace.map[A2_pos[i]:A2_pos[i + 1]]:
            for pk in dace.map[B2_pos[A2_crd[pj]]:B2_pos[A2_crd[pj] + 1]]:
                C[i, B2_crd[pk]] += A_val[pj] * B_val[pk]
```

`to_sdfg()` fails to parse `B2_pos[A2_crd[pj]]`.

Fixed the corner case in `_parse_map_inputs` where `candidate` can be either `Scalar` or  `Array` of shape (1,).