### PR TITLE
Inline preprocessor command

### DIFF
--- a/dace/frontend/python/interface.py
+++ b/dace/frontend/python/interface.py
@@ -334,6 +334,16 @@ def nounroll(generator):
     yield from generator
 
 
+def inline(expression):
+    """
+    Explicitly annotates that an expression should be evaluated and inlined during parsing.
+
+    :param expression: The expression to evaluate.
+    :note: Only use with stateless and compile-time evaluateable expressions!
+    """
+    return expression
+
+
 def in_program() -> bool:
     """
     Returns True if in a DaCe program parsing context. This function can be used to test whether the current

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -52,6 +52,7 @@ class StructTransformer(ast.NodeTransformer):
     A Python AST transformer that replaces ``Call`` nodes to create structs with
     the custom ``StructInitializer`` AST node.
     """
+
     def __init__(self, gvars):
         super().__init__()
         self._structs = {k: v for k, v in gvars.items() if isinstance(v, dtypes.struct)}
@@ -597,6 +598,8 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
 
                 # From this point on, any failure will result in a callback
                 newnode = ast.Name(id=cbname, ctx=ast.Load())
+                if isinstance(parent_node, ast.Call):
+                    newnode.oldnode = parent_node.func
 
                 # Decorated or functions with missing source code
                 sast, _, _, _ = astutils.function_to_ast(value)
@@ -748,7 +751,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
         return self._visit_potential_constant(node, True)
 
     def visit_Call(self, node: ast.Call) -> Any:
-        from dace.frontend.python.interface import in_program  # Avoid import loop
+        from dace.frontend.python.interface import in_program, inline  # Avoid import loop
 
         if hasattr(node.func, 'n') and isinstance(node.func.n, SDFGConvertible):
             # Skip already-parsed calls
@@ -760,6 +763,9 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
             # Built-in functions are resolved directly
             if global_func is in_program:
                 return self.global_value_to_node(True, parent_node=node, qualname=astutils.unparse(node), recurse=True)
+            # Inline contents are kept as-is
+            if global_func is inline:
+                return node
 
             if self.resolve_functions:
                 global_val = astutils.evalnode(node, self.globals)
@@ -787,6 +793,8 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                                                 detect_callables=callables)
             if newnode is not None:
                 node.func = newnode
+                if hasattr(newnode, 'oldnode'):
+                    node.oldnode = newnode.oldnode
                 return self.generic_visit(node)
         return self.generic_visit(node)
 
@@ -1206,6 +1214,63 @@ class LoopUnroller(ast.NodeTransformer):
         return self.visit_For(node)
 
 
+class ExpressionInliner(ast.NodeTransformer):
+    """
+    Replaces dace.inline() expressions by their bodies if they can be
+    compile-time evaluated.
+    """
+
+    def __init__(self, globals: Dict[str, Any], filename: str, closure_resolver: GlobalResolver):
+        super().__init__()
+        self.globals = globals
+        self.filename = filename
+        self.resolver = closure_resolver
+
+    def visit_Call(self, node: ast.Call) -> Any:
+        # Avoid import loop
+        from dace.frontend.python.interface import inline
+
+        node = self.generic_visit(node)
+
+        try:
+            nfunc = astutils.evalnode(node.func, self.globals)
+        except SyntaxError:
+            nfunc = None
+
+        if nfunc is not inline:
+            return node
+
+        if len(node.args) != 1:
+            raise DaceSyntaxError(None, node, 'dace.inline must be called with one argument')
+
+        # Try to inline the expression on the current AST
+        try:
+            contents = astutils.evalnode(node.args[0], self.globals)
+        except SyntaxError:
+            raise DaceSyntaxError(
+                None, node, 'Cannot inline expression with dace.inline, it '
+                'cannot be evaluated at compile time.')
+
+        ##########################################
+
+        # Already AST
+        def _convert_to_ast(contents: Any):
+            if isinstance(contents, ast.AST):
+                newnode = contents
+            elif isinstance(contents, (numbers.Number, str)):
+                # Compatibility check since Python changed their AST nodes
+                newnode = astutils.create_constant(contents)
+            elif isinstance(contents, (list, tuple, set)):
+                newnode = ast.copy_location(ast.Tuple(elts=[_convert_to_ast(c) for c in contents], ctx=ast.Load()),
+                                            node)
+            else:
+                # Augment closure with new value
+                newnode = self.resolver.global_value_to_node(e, node, f'inlined_{id(contents)}', True, keep_object=True)
+            return newnode
+
+        return _convert_to_ast(contents)
+
+
 class CallTreeResolver(ast.NodeVisitor):
 
     def __init__(self, closure: SDFGClosure, globals: Dict[str, Any]) -> None:
@@ -1525,6 +1590,7 @@ def preprocess_dace_program(f: Callable[..., Any],
             src_ast = closure_resolver.visit(src_ast)
             DisallowedAssignmentChecker(src_file).visit(src_ast)
             src_ast = LoopUnroller(resolved, src_file, closure_resolver).visit(src_ast)
+            src_ast = ExpressionInliner(resolved, src_file, closure_resolver).visit(src_ast)
             src_ast = ContextManagerInliner(resolved, src_file, closure_resolver).visit(src_ast)
             src_ast = ConditionalCodeResolver(resolved).visit(src_ast)
             src_ast = DeadCodeEliminator().visit(src_ast)

--- a/tests/python_frontend/inline_preprocessing_test.py
+++ b/tests/python_frontend/inline_preprocessing_test.py
@@ -1,0 +1,135 @@
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+"""
+Tests the ``dace.inline`` preprocessor call.
+"""
+
+import dace
+from dace.frontend.python.common import DaceSyntaxError
+import math
+import numpy as np
+import pytest
+
+
+def _find_in_tasklet(sdfg: dace.SDFG, term: str) -> bool:
+    for n, _ in sdfg.all_nodes_recursive():
+        if isinstance(n, dace.nodes.Tasklet) and term in n.code.as_string:
+            return True
+    return False
+
+
+def _find_in_memlet(sdfg: dace.SDFG, term: str) -> bool:
+    for e, _ in sdfg.all_edges_recursive():
+        if isinstance(e.data, dace.Memlet) and term in str(e.data.subset):
+            return True
+    return False
+
+
+def test_inlinepp_simple():
+
+    def complex_function(a: int, b: float):
+        c = np.random.rand()
+        return int(c + ((math.ceil(b) + a) // 2) - c)
+
+    N = 20
+
+    @dace.program
+    def tester(a):
+        # a[11] = 13
+        a[dace.inline(complex_function(N + 1, 0.4))] = dace.inline(complex_function(5, N) + 1)
+
+    a = np.random.rand(N)
+    tester(a)
+    assert np.allclose(a[11], 13)
+
+    sdfg = tester.to_sdfg(a)
+    assert _find_in_tasklet(sdfg, '13'), 'Inlined expression not found in tasklets'
+    assert _find_in_memlet(sdfg, '11'), 'Inlined expression not found in memlets'
+
+
+def test_inlinepp_fail():
+
+    def f(x):
+        return x + 1
+
+    @dace.program
+    def tester(a):
+        a[dace.inline(a[0])] = 1
+
+    a = np.random.rand(20)
+    with pytest.raises(DaceSyntaxError):
+        tester(a)
+
+
+def test_inlinepp_tuple_retval():
+
+    def divmod(a, b):
+        return a // b, a % b
+
+    @dace.program
+    def tester(a: dace.float64[20], b: dace.float64[20]):
+        for i in dace.map[0:20]:
+            d, m = dace.inline(divmod(4, 3))
+            a[i] = d
+            b[i] = m
+
+    a = np.random.rand(20)
+    b = np.random.rand(20)
+    tester(a, b)
+    d, m = divmod(4, 3)
+    assert np.allclose(a, d)
+    assert np.allclose(b, m)
+
+
+def test_inlinepp_stateful():
+    ctr = 11
+
+    def stateful():
+        nonlocal ctr
+        ctr += 1
+        return ctr
+
+    @dace.program
+    def tester(a: dace.float64[3]):
+        a[0] = dace.inline(stateful())
+        a[1] = dace.inline(stateful())
+        a[2] = dace.inline(stateful() * 2)
+
+    sdfg = tester.to_sdfg()
+    assert _find_in_tasklet(sdfg, '12')
+    assert _find_in_tasklet(sdfg, '13')
+    assert _find_in_tasklet(sdfg, '28')
+
+    a = np.random.rand(3)
+    sdfg(a)
+    assert np.allclose(a, np.array([12, 13, 28]))
+
+
+def test_inlinepp_in_unroll():
+    ctr = 11
+
+    def stateful(i):
+        nonlocal ctr
+        ctr += 1
+        return ctr + i
+
+    @dace.program
+    def tester(a: dace.float64[3]):
+        for i in dace.unroll(range(3)):
+            a[i] = dace.inline(stateful(i))
+
+    sdfg = tester.to_sdfg()
+    assert _find_in_tasklet(sdfg, '12')
+    assert _find_in_tasklet(sdfg, '14')
+    assert _find_in_tasklet(sdfg, '16')
+
+    a = np.random.rand(3)
+    sdfg(a)
+    assert np.allclose(a, np.array([12, 14, 16]))
+
+
+if __name__ == '__main__':
+    test_inlinepp_simple()
+    test_inlinepp_fail()
+    test_inlinepp_tuple_retval()
+    test_inlinepp_stateful()
+    test_inlinepp_in_unroll()


### PR DESCRIPTION
This PR adds the `dace.inline` function to the Python frontend. The preprocessor will call the internal expression at compile-time and replace the value with the results.