### PR TITLE
Fix for #1220

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -8,6 +8,7 @@ import copy
 import functools
 import itertools
 import math
+import numbers
 import warnings
 
 import sympy as sp
@@ -1251,12 +1252,13 @@ class DaCeKeywordRemover(ExtNodeTransformer):
         if isinstance(node.op, ast.Pow):
             from dace.frontend.python import astutils
             try:
-                unparsed = symbolic.pystr_to_symbolic(
-                    astutils.evalnode(node.right, {
-                        **self.constants, 'dace': dace,
-                        'math': math
-                    }))
-                evaluated = symbolic.symstr(symbolic.evaluate(unparsed, self.constants), cpp_mode=True)
+                evaluated_node = astutils.evalnode(node.right, {**self.constants, 'dace': dace,'math': math})
+                unparsed = symbolic.pystr_to_symbolic(evaluated_node)
+                evaluated_constant = symbolic.evaluate(unparsed, self.constants)
+                evaluated = symbolic.symstr(evaluated_constant, cpp_mode=True)
+                value = ast.parse(evaluated).body[0].value
+                if isinstance(evaluated_node, numbers.Number) and evaluated_node != value.n:
+                    raise TypeError
                 node.right = ast.parse(evaluated).body[0].value
             except (TypeError, AttributeError, NameError, KeyError, ValueError, SyntaxError):
                 return self.generic_visit(node)

--- a/tests/codegen/unparse_tasklet_test.py
+++ b/tests/codegen/unparse_tasklet_test.py
@@ -1,5 +1,6 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
+import numpy as np
 
 
 def test_integer_power():
@@ -46,7 +47,22 @@ def test_equality():
     program.to_sdfg(simplify=False).compile()
 
 
+def test_pow_with_implicit_casting():
+
+    @dace.program
+    def f32_pow_failure(array):
+        return array**3.3
+
+    rng = np.random.default_rng(42)
+    arr = rng.random((10, ), dtype=np.float32)
+    ref = f32_pow_failure.f(arr)
+    val = f32_pow_failure(arr)
+    assert np.allclose(ref, val)
+    assert ref.dtype == val.dtype
+
+
 if __name__ == '__main__':
     test_integer_power()
     test_integer_power_constant()
     test_equality()
+    test_pow_with_implicit_casting()


### PR DESCRIPTION
This PR addresses the issue of implicit casting in (floating point) pow operations being stripped from the generated code due to an optimization concerning integer pow operations.
