### PR TITLE
Fix MapInterchange for Maps with dynamic inputs

### DIFF
--- a/dace/transformation/dataflow/map_interchange.py
+++ b/dace/transformation/dataflow/map_interchange.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 """ Implements the map interchange transformation. """
 
 from dace.sdfg import SDFG, SDFGState

--- a/dace/transformation/dataflow/map_interchange.py
+++ b/dace/transformation/dataflow/map_interchange.py
@@ -117,11 +117,19 @@ class MapInterchange(transformation.SingleStateTransformation):
         for e in new_entry_edges:
             path = graph.memlet_path(e)
             index = next(i for i, edge in enumerate(path) if e is edge)
-            e.data.subset = propagate_memlet(graph, path[index + 1].data, outer_map_entry, True).subset
+            if index < len(path) - 1:
+                edge_to_propagate = path[index + 1]
+            else:
+                edge_to_propagate = e
+            e.data.subset = propagate_memlet(graph, edge_to_propagate.data, outer_map_entry, True).subset
         for e in new_exit_edges:
             path = graph.memlet_path(e)
             index = next(i for i, edge in enumerate(path) if e is edge)
-            e.data.subset = propagate_memlet(graph, path[index - 1].data, outer_map_exit, True).subset
+            if index > 0:
+                edge_to_propagate = path[index - 1]
+            else:
+                edge_to_propagate = e
+            e.data.subset = propagate_memlet(graph, edge_to_propagate.data, outer_map_exit, True).subset
 
     @staticmethod
     def annotates_memlets():

--- a/tests/transformations/map_interchange_test.py
+++ b/tests/transformations/map_interchange_test.py
@@ -69,7 +69,7 @@ def test_map_interchange_with_dynamic_map_inputs():
                     kD = j * D2_dimension + k
                     A_vals[kB] = A_vals[kB] + (B_vals[kB] * C_vals[jC]) * D_vals[kD]
 
-    sdfg = sched_sddmm0compute.to_sdfg()
+    sdfg = sched_sddmm0compute.to_sdfg(simplify=True)
 
     # Find MapEntries of Maps over 'j' and 'kB'
     ome, ime = None, None

--- a/tests/transformations/map_interchange_test.py
+++ b/tests/transformations/map_interchange_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
 from dace.transformation.dataflow import MapInterchange
@@ -43,5 +43,68 @@ def test_map_interchange():
     assert np.allclose(B, expected)
 
 
+def test_map_interchange_with_dynamic_map_inputs():
+
+    C1_dimension = dace.symbol('C1_dimension')
+    C2_dimension = dace.symbol('C2_dimension')
+    D1_dimension = dace.symbol('D1_dimension')
+    D2_dimension = dace.symbol('D2_dimension')
+    size_A_vals = dace.symbol('size_A_vals')
+    size_B2_crd = dace.symbol('size_B2_crd')
+    size_B2_pos = dace.symbol('size_B2_pos')
+    size_B_vals = dace.symbol('size_B_vals')
+    size_C_vals = dace.symbol('size_C_vals')
+    size_D_vals = dace.symbol('size_D_vals')
+
+    @dace.program
+    def sched_sddmm0compute(A_vals: dace.float64[size_A_vals], B2_crd: dace.int32[size_B2_crd],
+                            B2_pos: dace.int32[size_B2_pos], B_vals: dace.float64[size_B_vals],
+                            C_vals: dace.float64[size_C_vals], D_vals: dace.float64[size_D_vals]):
+
+        for i in dace.map[0:C1_dimension:1]:
+            for j in dace.map[0:D1_dimension:1]:
+                jC = i * C2_dimension + j
+                for kB in dace.map[B2_pos[i]:B2_pos[(i + 1)]:1]:
+                    k = B2_crd[kB]
+                    kD = j * D2_dimension + k
+                    A_vals[kB] = A_vals[kB] + (B_vals[kB] * C_vals[jC]) * D_vals[kD]
+
+    sdfg = sched_sddmm0compute.to_sdfg()
+
+    # Find MapEntries of Maps over 'j' and 'kB'
+    ome, ime = None, None
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.sdfg.nodes.MapEntry):
+                if node.map.params[0] == 'j':
+                    ome = node
+                elif node.map.params[0] == 'kB':
+                    ime = node
+
+    # Assert the pattern MapEntry[j] -> MapEntry[kB] exists
+    assert ome is not None and ime is not None
+    state = sdfg.states()[0]
+    assert len(list(state.edges_between(ome, ime))) > 0
+    assert len(list(state.edges_between(ime, ome))) == 0
+
+    # Interchange the Maps
+    MapInterchange.apply_to(sdfg, outer_map_entry=ome, inner_map_entry=ime)
+    ome, ime = None, None
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.sdfg.nodes.MapEntry):
+                if node.map.params[0] == 'j':
+                    ome = node
+                elif node.map.params[0] == 'kB':
+                    ime = node
+
+    # Assert the pattern MapEntry[kB] -> MapEntry[j] exists
+    assert ome is not None and ime is not None
+    state = sdfg.states()[0]
+    assert len(list(state.edges_between(ome, ime))) == 0
+    assert len(list(state.edges_between(ime, ome))) > 0
+
+
 if __name__ == '__main__':
     test_map_interchange()
+    test_map_interchange_with_dynamic_map_inputs()


### PR DESCRIPTION
This PR fixes an issue with MapInterchange where accesses to Memlet paths go out of bounds because the algorithm expects a next (previous) edge that doesn't exist. This issue occurs with edges that carry dynamic Map inputs, i.e., the Memlet path stops at a MapEntry and not a CodeNode.
