### PR TITLE
Assortment of fixes for dynamic Maps on GPU (dynamic thread blocks)

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -1600,6 +1600,10 @@ void  *{kname}_args[] = {{ {kargs} }};
             (kernel_name, ', '.join(state_param + kernel_args_typed + extra_call_args_typed)), sdfg, state_id,
             scope_entry)
 
+        # If there are dynamic Map inputs, put the kernel invocation in its own scope to avoid redefinitions.
+        if dace.sdfg.has_dynamic_map_inputs(state, scope_entry):
+            callsite_stream.write('{', sdfg, state_id, scope_entry)
+
         # Synchronize all events leading to dynamic map range connectors
         for e in dace.sdfg.dynamic_map_inputs(state, scope_entry):
             if hasattr(e, '_cuda_event'):
@@ -1618,6 +1622,10 @@ void  *{kname}_args[] = {{ {kargs} }};
              ', '.join(['__state'] + [cpp.ptr(aname, arg, sdfg, self._frame)
                                       for aname, arg in kernel_args.items()] + extra_call_args)), sdfg, state_id,
             scope_entry)
+
+        # If there are dynamic Map inputs, put the kernel invocation in its own scope to avoid redefinitions.
+        if dace.sdfg.has_dynamic_map_inputs(state, scope_entry):
+            callsite_stream.write('}', sdfg, state_id, scope_entry)
 
         synchronize_streams(sdfg, state, state_id, scope_entry, scope_exit, callsite_stream, self)
 

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -1973,8 +1973,6 @@ void  *{kname}_args[] = {{ {kargs} }};
                     raise ValueError('Block size has to be constant for block-wide dynamic map schedule (got %s)' %
                                      str(bdim))
                 total_block_size *= bdim
-            # if _expr(scope_map.range[0][2]) != 1:
-            #     raise NotImplementedError('Skip not implemented for dynamic thread-block map schedule')
 
             ##### TODO (later): Generalize
             # Find thread-block param map and its name
@@ -2000,7 +1998,6 @@ void  *{kname}_args[] = {{ {kargs} }};
                 'if ({} < {}) {{'.format(outer_scope.map.params[0],
                                          _topy(subsets.Range(outer_scope.map.range[::-1]).max_element()[0] + 1)), sdfg,
                 state_id, scope_entry)
-            open_if = True
 
             # NOTE: Dynamic map inputs must be defined both outside and inside the dynamic Map schedule.
             # They define inside the schedule the bounds of the any nested Maps.
@@ -2019,27 +2016,13 @@ void  *{kname}_args[] = {{ {kargs} }};
                 dynmap_var = f'{dynmap_var}_idx'
                 dynmap_begin = 0
                 dynmap_end = f'int_ceil({dynmap_end - dynmap_begin}, {dynmap_step})'
-            # callsite_stream.write(
-            #     '__dace_dynmap_begin = {begin};\n'
-            #     '__dace_dynmap_end = {end};'.format(begin=scope_map.range[0][0], end=scope_map.range[0][1] + 1), sdfg,
-            #     state_id, scope_entry)
             callsite_stream.write(
                 '__dace_dynmap_begin = {begin};\n'
-                '__dace_dynmap_end = {end};'.format(begin=dynmap_begin, end=dynmap_end), sdfg,
-                state_id, scope_entry)
+                '__dace_dynmap_end = {end};'.format(begin=dynmap_begin, end=dynmap_end), sdfg, state_id, scope_entry)
 
             # close if
             callsite_stream.write('}', sdfg, state_id, scope_entry)
 
-            # callsite_stream.write(
-            #     'dace::DynamicMap<{fine_grained}, {bsize}>::'
-            #     'schedule(dace_dyn_map_shared, __dace_dynmap_begin, '
-            #     '__dace_dynmap_end, {kmapIdx}, [&](auto {kmapIdx}, '
-            #     'auto {param}) {{'.format(fine_grained=('true' if Config.get_bool(
-            #         'compiler', 'cuda', 'dynamic_map_fine_grained') else 'false'),
-            #                               bsize=total_block_size,
-            #                               kmapIdx=outer_scope.map.params[0],
-            #                               param=scope_map.params[0]), sdfg, state_id, scope_entry)
             callsite_stream.write(
                 'dace::DynamicMap<{fine_grained}, {bsize}>::'
                 'schedule(dace_dyn_map_shared, __dace_dynmap_begin, '
@@ -2049,14 +2032,16 @@ void  *{kname}_args[] = {{ {kargs} }};
                                           bsize=total_block_size,
                                           kmapIdx=outer_scope.map.params[0],
                                           param=dynmap_var), sdfg, state_id, scope_entry)
-            
+
             for e in dace.sdfg.dynamic_map_inputs(dfg, scope_entry):
                 callsite_stream.write(
                     self._cpu_codegen.memlet_definition(sdfg, e.data, False, e.dst_conn,
                                                         e.dst.in_connectors[e.dst_conn]), sdfg, state_id, scope_entry)
-            
+
             if dynmap_step != 1:
-                callsite_stream.write(f'auto {scope_map.params[0]} = {scope_map.range[0][0]} + {dynmap_step} * {dynmap_var};', sdfg, state_id, scope_entry)
+                callsite_stream.write(
+                    f'auto {scope_map.params[0]} = {scope_map.range[0][0]} + {dynmap_step} * {dynmap_var};', sdfg,
+                    state_id, scope_entry)
 
         elif scope_map.schedule == dtypes.ScheduleType.GPU_Device:
             dfg_kernel = self._kernel_state.scope_subgraph(self._kernel_map)

--- a/tests/dynamic_tb_map_cudatest.py
+++ b/tests/dynamic_tb_map_cudatest.py
@@ -12,8 +12,10 @@ nnz = dace.symbol('nnz')
 
 @dace.program(dace.uint32[H + 1], dace.uint32[nnz], dace.float32[nnz], dace.float32[W], dace.float32[H])
 def spmv(A_row, A_col, A_val, x, b):
+
     @dace.mapscope(_[0:H])
     def compute_row(i):
+
         @dace.map(_[A_row[i]:A_row[i + 1]])
         def compute(j):
             a << A_val[j]
@@ -64,5 +66,153 @@ def test_dynamic_map():
     assert diff <= 1e-5
 
 
+def _copy_to_gpu(sdfg):
+    for k, v in sdfg.arrays.items():
+        if not v.transient and isinstance(v, dace.data.Array):
+            v.storage = dace.dtypes.StorageType.GPU_Global
+
+
+@pytest.mark.gpu
+def test_nested_dynamic_map():
+    """ Tests the case where the dynamic map inputs are defined in an outer scope. """
+
+    M = dace.symbol('M')
+    N = dace.symbol('N')
+    K = dace.symbol('K')
+    nnz_A = dace.symbol('nnz_A')
+    nnz_D = dace.symbol('nnz_D')
+
+    @dace.program
+    def sddmm(D_vals: dace.float32[nnz_D], A2_crd: dace.int32[nnz_A], A2_pos: dace.int32[M + 1],
+              A_vals: dace.float32[nnz_A], B: dace.float32[M, K], C: dace.float32[K, N]):
+        for i in dace.map[0:M]:
+            for j in dace.map[A2_pos[i]:A2_pos[i + 1]]:
+                for k in dace.map[0:K]:
+                    D_vals[j] += A_vals[j] * B[i, k] * C[k, A2_crd[j]]
+
+    sdfg = sddmm.to_sdfg(simplify=True)
+
+    ime, jme, kme = None, None, None
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.sdfg.nodes.MapEntry):
+                if node.map.params[0] == 'i':
+                    ime = node
+                elif node.map.params[0] == 'j':
+                    jme = node
+                elif node.map.params[0] == 'k':
+                    kme = node
+    assert ime is not None and jme is not None and kme is not None
+
+    from dace.transformation.dataflow import MapInterchange, TrivialTaskletElimination
+    MapInterchange.apply_to(sdfg, outer_map_entry=jme, inner_map_entry=kme)
+    sdfg.apply_transformations_repeated(TrivialTaskletElimination)
+
+    sdfg.apply_gpu_transformations()
+    ime.map.schedule = dace.ScheduleType.GPU_Device
+    kme.map.schedule = dace.ScheduleType.GPU_ThreadBlock_Dynamic
+
+    dtype = np.float32
+    rng = np.random.default_rng(42)
+    problem_size = 1024
+    density = 0.01
+    B = rng.random((problem_size, problem_size), dtype=dtype)
+    C = rng.random((problem_size, problem_size), dtype=dtype)
+    A = scipy.sparse.random(problem_size, problem_size, density=density, format='csr', dtype=dtype, random_state=rng)
+    val = np.zeros_like(A.data)
+    ref = np.empty_like(A.data)
+
+    sdfg(D_vals=val,
+         A2_crd=A.indices.copy(),
+         A2_pos=A.indptr.copy(),
+         A_vals=A.data.copy(),
+         B=B,
+         C=C,
+         M=problem_size,
+         N=problem_size,
+         K=problem_size,
+         nnz_A=A.nnz,
+         nnz_D=A.nnz)
+    tmp = B @ C
+    for row in range(problem_size):
+        for j in range(A.indptr[row], A.indptr[row + 1]):
+            col = A.indices[j]
+            ref[j] = A.data[j] * tmp[row, col]
+    assert np.allclose(val, ref.data)
+
+
+@pytest.mark.gpu
+def test_dynamic_map_with_step():
+
+    M = dace.symbol('M')
+    N = dace.symbol('N')
+    nnz_A = dace.symbol('nnz_A')
+    nnz_D = dace.symbol('nnz_D')
+
+    @dace.program
+    def sddvm(D_vals: dace.float32[nnz_D], A2_crd: dace.int32[nnz_A], A2_pos: dace.int32[M + 1],
+              A_vals: dace.float32[nnz_A], B: dace.float32[M], C: dace.float32[N]):
+        for i in dace.map[0:M]:
+            for j in dace.map[A2_pos[i]:A2_pos[i + 1]]:
+                D_vals[j] += A_vals[j] * B[i] * C[A2_crd[j]]
+
+    sdfg = sddvm.to_sdfg(simplify=True)
+
+    ime, jme = None, None
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.sdfg.nodes.MapEntry):
+                if node.map.params[0] == 'i':
+                    ime = node
+                elif node.map.params[0] == 'j':
+                    jme = node
+    assert ime is not None and jme is not None
+
+    from dace.transformation.dataflow import StripMining, TrivialTaskletElimination
+    sdfg.apply_transformations_repeated(TrivialTaskletElimination)
+    StripMining.apply_to(sdfg, map_entry=jme)
+
+    tile_jme = None, None
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.sdfg.nodes.MapEntry):
+                if node.map.params[0] == 'tile_j':
+                    tile_jme = node
+    assert tile_jme is not None
+
+    sdfg.apply_gpu_transformations()
+    ime.map.schedule = dace.ScheduleType.GPU_Device
+    tile_jme.map.schedule = dace.ScheduleType.GPU_ThreadBlock_Dynamic
+
+    dtype = np.float32
+    rng = np.random.default_rng(42)
+    problem_size = 1024
+    density = 0.01
+    B = rng.random((problem_size, ), dtype=dtype)
+    C = rng.random((problem_size, ), dtype=dtype)
+    A = scipy.sparse.random(problem_size, problem_size, density=density, format='csr', dtype=dtype, random_state=rng)
+    val = np.zeros_like(A.data)
+    ref = np.empty_like(A.data)
+
+    sdfg(D_vals=val,
+         A2_crd=A.indices.copy(),
+         A2_pos=A.indptr.copy(),
+         A_vals=A.data.copy(),
+         B=B,
+         C=C,
+         M=problem_size,
+         N=problem_size,
+         nnz_A=A.nnz,
+         nnz_D=A.nnz)
+    tmp = np.outer(B, C)
+    for row in range(problem_size):
+        for j in range(A.indptr[row], A.indptr[row + 1]):
+            col = A.indices[j]
+            ref[j] = A.data[j] * tmp[row, col]
+    assert np.allclose(val, ref.data)
+
+
 if __name__ == '__main__':
     test_dynamic_map()
+    test_nested_dynamic_map()
+    test_dynamic_map_with_step()


### PR DESCRIPTION
This PR addresses the following issues:
- [x] Adds support for dynamic thread blocks with step > 1.
- [x] Adds missing dynamic Map inputs definitions in the CUDA code generator (must be defined before and inside the dynamic Map GPU schedule).
- [x] In the case of Maps with dynamic inputs and GPU Device schedule, puts their host-side invocation in a scope of their own to avoid potential naming clashes.