### PR TITLE
Closure array handling update

### DIFF
--- a/tests/python_frontend/fields_and_global_arrays_test.py
+++ b/tests/python_frontend/fields_and_global_arrays_test.py
@@ -687,6 +687,34 @@ def test_nested_transient_field():
     assert np.allclose(1.0, A)
 
 
+def test_multiple_global_accesses():
+
+    A = np.ones((10, 10))
+
+    def get_A():
+        return A
+    
+    def get_A2():
+        return A
+    
+    @dace.program
+    def multiple_gets():
+        inp0 = np.empty_like(A)
+        inp1 = np.empty_like(A)
+        inp2 = np.empty_like(A)
+        for i, j in dace.map[0:10, 0:10]:
+            A0 = get_A()
+            inp0[i, j] = A0[i, j]
+            A1 = get_A()
+            inp1[i, j] = A1[i, j]
+            A2 = get_A2()
+            inp2[i, j] = A2[i, j]
+        return inp0 + inp1 + inp2
+    
+    val = multiple_gets()
+    assert np.array_equal(val, np.ones((10, 10)) * 3)
+
+
 if __name__ == '__main__':
     test_dynamic_closure()
     test_external_ndarray_readonly()
@@ -718,3 +746,4 @@ if __name__ == '__main__':
     test_two_inner_methods()
     test_transient_field()
     test_nested_transient_field()
+    test_multiple_global_accesses()


### PR DESCRIPTION
This PR alters how closure arrays are added to (nested) SDFGs. Instead of matching (and updating) by name, potentially causing ambiguities, it uses the actual array objects. The new algorithm handles the following cases:
- Closure array has not been added yet (see `ProgramVIsitor.nested_closure_arrays`):
  - Add to the SDFG with, if needed, a new name.
- Closure array has already been added:
  - Array doesn't exist in the SDFG, i.e., it is in a nested scope:
    - Add it to the SDFG with the same name.
  - Array exists in the SDFG:
    - Don't add it to the SDFG

In all the above cases, the array should end up in the (nested) SDFG's arguments with the appropriate name.
 