### PR TITLE
Fix compile errors

### DIFF
--- a/dace/codegen/targets/snitch.py
+++ b/dace/codegen/targets/snitch.py
@@ -1090,8 +1090,6 @@ class SnitchCodeGen(TargetCodeGenerator):
         code._code = code._code.replace('dace::float64', '(double)')
         code._code = code._code.replace('dace::int64', '(int64_t)')
         code._code = code._code.replace('dace::math::pow', 'pow')
-        # __unused is reserved in C
-        code._code = code._code.replace('__unused', '_unused_var')
 
         # change new/delete to malloc/free
         code._code = re.sub(r"new (.+) \[(\d*)\];", r"(\1*)malloc(\2*sizeof(\1));", code._code)

--- a/dace/libraries/blas/nodes/dot.py
+++ b/dace/libraries/blas/nodes/dot.py
@@ -44,7 +44,7 @@ class ExpandDotPure(ExpandTransformation):
         state = sdfg.add_state_after(init_state, node.label + "_state")
 
         # Initialization map
-        init_state.add_mapped_tasklet("_i_dotnit", {"__unused": "0:1"}, {},
+        init_state.add_mapped_tasklet("_i_dotnit", {"__i_unused": "0:1"}, {},
                                       "_out = 0", {"_out": dace.Memlet("_result[0]")},
                                       external_edges=True)
 

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -27,7 +27,7 @@ from dace.transformation import transformation as pm
 from dace.symbolic import symstr, issymbolic
 from dace.libraries.standard.environments.cuda import CUDA
 
-import dace.libraries.standard.reduction_planner as red_planner
+from dace.libraries.standard import reduction_planner as red_planner
 
 
 @dace.library.expansion

--- a/dace/transformation/subgraph/composite.py
+++ b/dace/transformation/subgraph/composite.py
@@ -9,7 +9,7 @@ from dace.transformation.subgraph import stencil_tiling
 import dace.transformation.transformation as transformation
 from dace.transformation.subgraph import SubgraphFusion, MultiExpansion
 from dace.transformation.subgraph.stencil_tiling import StencilTiling
-import dace.transformation.subgraph.helpers as helpers
+from dace.transformation.subgraph import helpers
 
 from dace import dtypes, registry, symbolic, subsets, data
 from dace.properties import EnumProperty, make_properties, Property, ShapeProperty


### PR DESCRIPTION
- Some import paths were not compatible with python3.6
- The g++ compiler on MacOS installed through Homebrew seems to rely on MacOS SDK built with clang, for which __unused is a reserved word (an attribute), therefore variables cannot be named __unused.