### PR TITLE
GPU User Experience Improvements

### DIFF
--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -31,7 +31,7 @@ def generate_headers(sdfg: SDFG, frame: framecode.DaCeCodeGenerator) -> str:
     exit_params = (sdfg.name, sdfg.name)
     proto += 'typedef void * %sHandle_t;\n' % sdfg.name
     proto += 'extern "C" %sHandle_t __dace_init_%s(%s);\n' % init_params
-    proto += 'extern "C" void __dace_exit_%s(%sHandle_t handle);\n' % exit_params
+    proto += 'extern "C" int __dace_exit_%s(%sHandle_t handle);\n' % exit_params
     proto += 'extern "C" void __program_%s(%sHandle_t handle%s);\n' % params
     return proto
 
@@ -69,15 +69,16 @@ def generate_dummy(sdfg: SDFG, frame: framecode.DaCeCodeGenerator) -> str:
 
 int main(int argc, char **argv) {{
     {sdfg.name}Handle_t handle;
+    int err;
 {allocations}
 
     handle = __dace_init_{sdfg.name}({init_params});
     __program_{sdfg.name}(handle{params});
-    __dace_exit_{sdfg.name}(handle);
+    err = __dace_exit_{sdfg.name}(handle);
 
 {deallocations}
 
-    return 0;
+    return err;
 }}
 '''
 

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -5,14 +5,14 @@ import os
 import re
 import shutil
 import subprocess
-from typing import Any, Callable, Dict, List, Tuple, Optional, Type
+from typing import Any, Callable, Dict, List, Tuple, Optional, Type, Union
 import warnings
 
 import numpy as np
 import sympy as sp
 
 from dace import data as dt, dtypes, hooks, symbolic
-from dace.codegen import exceptions as cgx
+from dace.codegen import exceptions as cgx, common
 from dace.config import Config
 from dace.frontend import operations
 
@@ -22,6 +22,7 @@ class ReloadableDLL(object):
     A reloadable shared object (or dynamically linked library), which
     bypasses Python's dynamic library reloading issues.
     """
+
     def __init__(self, library_filename, program_name):
         """
         Creates a new reloadable shared object.
@@ -181,6 +182,7 @@ class CompiledSDFG(object):
         self._init = lib.get_symbol('__dace_init_{}'.format(sdfg.name))
         self._init.restype = ctypes.c_void_p
         self._exit = lib.get_symbol('__dace_exit_{}'.format(sdfg.name))
+        self._exit.restype = ctypes.c_int
         self._cfunc = lib.get_symbol('__program_{}'.format(sdfg.name))
 
         # Cache SDFG return values
@@ -196,6 +198,17 @@ class CompiledSDFG(object):
         self._sig = self._sdfg.signature_arglist(with_types=False, arglist=self._typedict)
         self._free_symbols = self._sdfg.free_symbols
         self.argnames = argnames
+
+        self.has_gpu_code = False
+        for _, _, aval in self._sdfg.arrays_recursive():
+            if aval.storage in dtypes.GPU_STORAGES:
+                self.has_gpu_code = True
+                break
+        if not self.has_gpu_code:
+            for node, _ in self._sdfg.all_nodes_recursive():
+                if getattr(node, 'schedule', False) in dtypes.GPU_SCHEDULES:
+                    self.has_gpu_code = True
+                    break
 
     def get_exported_function(self, name: str, restype=None) -> Optional[Callable[..., Any]]:
         """
@@ -297,8 +310,20 @@ class CompiledSDFG(object):
 
     def finalize(self):
         if self._exit is not None:
-            self._exit(self._libhandle)
+            res: int = self._exit(self._libhandle)
             self._initialized = False
+            if res != 0:
+                raise RuntimeError(
+                    f'An error was detected after running "{self._sdfg.name}": {self._get_error_text(res)}')
+
+    def _get_error_text(self, result: Union[str, int]) -> str:
+        if self.has_gpu_code:
+            if isinstance(result, int):
+                result = common.get_gpu_runtime_error_string(result)
+            return (f'{result}. Consider enabling synchronous debugging mode (environment variable: '
+                    'DACE_compiler_cuda_syncdebug=1) to see where the issue originates from.')
+        else:
+            return result
 
     def __call__(self, *args, **kwargs):
         # Update arguments from ordered list
@@ -312,10 +337,16 @@ class CompiledSDFG(object):
             if self._initialized is False:
                 self._lib.load()
                 self._initialize(initargtuple)
-            
+
             with hooks.invoke_compiled_sdfg_call_hooks(self, argtuple):
                 if self.do_not_execute is False:
                     self._cfunc(self._libhandle, *argtuple)
+
+            if self.has_gpu_code:
+                lasterror = common.get_gpu_runtime_last_error()
+                if lasterror is not None:
+                    raise RuntimeError(
+                        f'An error was detected when calling "{self._sdfg.name}": {self._get_error_text(lasterror)}')
 
             return self._convert_return_values()
         except (RuntimeError, TypeError, UnboundLocalError, KeyError, cgx.DuplicateDLLError, ReferenceError):
@@ -544,7 +575,6 @@ class CompiledSDFG(object):
                 # Create an array with the properties of the SDFG array
                 arr = self._create_array(*shape_desc)
                 self._return_arrays.append(arr)
-
 
     def _convert_return_values(self):
         # Return the values as they would be from a Python function

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -346,7 +346,7 @@ class CUDACodeGen(TargetCodeGenerator):
 {file_header}
 
 DACE_EXPORTED int __dace_init_cuda({sdfg.name}_t *__state{params});
-DACE_EXPORTED void __dace_exit_cuda({sdfg.name}_t *__state);
+DACE_EXPORTED int __dace_exit_cuda({sdfg.name}_t *__state);
 
 {other_globalcode}
 
@@ -388,8 +388,12 @@ int __dace_init_cuda({sdfg.name}_t *__state{params}) {{
     return 0;
 }}
 
-void __dace_exit_cuda({sdfg.name}_t *__state) {{
+int __dace_exit_cuda({sdfg.name}_t *__state) {{
     {exitcode}
+
+    // Synchronize and check for CUDA errors
+    int __err = 0;
+    __err = static_cast<int>({backend}DeviceSynchronize());
 
     // Destroy {backend} streams and events
     for(int i = 0; i < {nstreams}; ++i) {{
@@ -400,6 +404,7 @@ void __dace_exit_cuda({sdfg.name}_t *__state) {{
     }}
 
     delete __state->gpu_context;
+    return __err;
 }}
 
 DACE_EXPORTED bool __dace_gpu_set_stream({sdfg.name}_t *__state, int streamid, gpuStream_t stream)

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -149,8 +149,9 @@ DACE_EXPORTED int __dace_init_intel_fpga({sdfg.name}_t *__state{signature}) {{{e
     return 0;
 }}
 
-DACE_EXPORTED void __dace_exit_intel_fpga({sdfg.name}_t *__state) {{
+DACE_EXPORTED int __dace_exit_intel_fpga({sdfg.name}_t *__state) {{
     delete __state->fpga_context;
+    return 0;
 }}
 
 {host_code}""".format(signature=params_comma,

--- a/dace/codegen/targets/mpi.py
+++ b/dace/codegen/targets/mpi.py
@@ -46,7 +46,7 @@ int __dace_comm_rank = 0;
 {file_header}
 
 DACE_EXPORTED int __dace_init_mpi({sdfg.name}_t *__state{params});
-DACE_EXPORTED void __dace_exit_mpi({sdfg.name}_t *__state);
+DACE_EXPORTED int __dace_exit_mpi({sdfg.name}_t *__state);
 
 int __dace_init_mpi({sdfg.name}_t *__state{params}) {{
     int isinit = 0;
@@ -72,6 +72,7 @@ void __dace_exit_mpi({sdfg.name}_t *__state) {{
 
     printf(\"MPI was finalized on proc %i of %i\\n\", __dace_comm_rank,
            __dace_comm_size);
+    return 0;
 }}
 """.format(params=params_comma, sdfg=sdfg, file_header=fileheader.getvalue()), 'cpp', MPICodeGen, 'MPI')
         return [codeobj]

--- a/dace/codegen/targets/snitch.py
+++ b/dace/codegen/targets/snitch.py
@@ -1080,7 +1080,7 @@ class SnitchCodeGen(TargetCodeGenerator):
         hdrs += 'typedef void * %sHandle_t;\n' % sdfg.name
         hdrs += '#ifdef __cplusplus\nextern "C" {\n#endif\n'
         hdrs += '%sHandle_t __dace_init_%s(%s);\n' % init_params
-        hdrs += 'void __dace_exit_%s(%sHandle_t handle);\n' % exit_params
+        hdrs += 'int __dace_exit_%s(%sHandle_t handle);\n' % exit_params
         hdrs += 'void __program_%s(%sHandle_t handle%s);\n' % params
         hdrs += '#ifdef __cplusplus\n}\n#endif\n'
 

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -149,8 +149,9 @@ DACE_EXPORTED int __dace_init_xilinx({sdfg.name}_t *__state{signature}) {{
     return 0;
 }}
 
-DACE_EXPORTED void __dace_exit_xilinx({sdfg.name}_t *__state) {{
+DACE_EXPORTED int __dace_exit_xilinx({sdfg.name}_t *__state) {{
     delete __state->fpga_context;
+    return 0;
 }}
 
 {host_code}""".format(signature=params_comma,

--- a/doc/setup/integration.rst
+++ b/doc/setup/integration.rst
@@ -103,7 +103,8 @@ A compiled SDFG library contains three functions, which are named after the SDFG
       The function returns a handle to the state object, which is a struct containing all information that will persist
       between invocations of the SDFG. The other functions take this handle as their first argument. The arguments to
       this function are only the symbols used in the SDFG, ordered by name.
-    * ``__dace_exit_<SDFG name>``: Deallocates all arrays and frees all data descriptors in the given handle.
+    * ``__dace_exit_<SDFG name>``: Deallocates all arrays and frees all data descriptors in the given handle. Returns
+                                   a value of 0 if finalized successfully, or another value on failure.
     * ``__program_<SDFG name>``: The actual SDFG function, which takes the handle as its first argument, followed by
       the arguments to the SDFG, ordered by name, followed by the symbol arguments, also ordered by name.
 


### PR DESCRIPTION
- [x] Post-SDFG error checking and informative guidance
- [ ] More information in syncdebug prints (e.g., actual grid/block sizes)
- [ ] Warnings/errors on conflicting behavior with gpu_block_size, configuration, and intenal maps
- [ ] Validation error upon reading from a non-accessible host memory (e.g. GPU global) outside an accelerator context
- [ ] Argument errors
- [ ] `__launch_bounds__` support in map nodes: `-1` disables, `0` (default) sets if block size is constant, any other number sets explicitly