### PR TITLE
Added mpi4py send/recv support and alltoall library node

### DIFF
--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -269,7 +269,7 @@ def _allreduce(pv: 'ProgramVisitor',
     libnode = Alltoall('_Alltoall_', grid)
     in_desc = sdfg.arrays[inbuffer]
     in_buffer = state.add_read(inbuffer)
-    out_desc = sdfg.arrays[inbuffer]
+    out_desc = sdfg.arrays[outbuffer]
     out_buffer = state.add_write(outbuffer)
     state.add_edge(in_buffer, None, libnode, '_inbuffer', Memlet.from_array(in_buffer, in_desc))
     state.add_edge(libnode, '_outbuffer', out_buffer, None, Memlet.from_array(out_buffer, out_desc))

--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -372,6 +372,7 @@ def _gather(pv: 'ProgramVisitor',
 
 ##### Point-To-Point Communication
 
+@oprepo.replaces('mpi4py.MPI.COMM_WORLD.Send')
 @oprepo.replaces('dace.comm.Send')
 def _send(pv: 'ProgramVisitor',
           sdfg: SDFG,
@@ -572,6 +573,7 @@ def _pgrid_isend(pv: 'ProgramVisitor',
     return req
 
 
+@oprepo.replaces('mpi4py.MPI.COMM_WORLD.Recv')
 @oprepo.replaces('dace.comm.Recv')
 def _recv(pv: 'ProgramVisitor',
           sdfg: SDFG,

--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -254,9 +254,37 @@ def _Reduce(pv: 'ProgramVisitor',
     return None
 
 
+@oprepo.replaces('mpi4py.MPI.COMM_WORLD.Alltoall')
+@oprepo.replaces('dace.comm.Alltoall')
+def _allreduce(pv: 'ProgramVisitor',
+               sdfg: SDFG,
+               state: SDFGState,
+               inbuffer: str,
+               outbuffer: str,
+               grid: str = None):
+
+    from dace.libraries.mpi.nodes.alltoall import Alltoall
+
+
+    libnode = Alltoall('_Alltoall_', grid)
+    in_desc = sdfg.arrays[inbuffer]
+    in_buffer = state.add_read(inbuffer)
+    out_desc = sdfg.arrays[inbuffer]
+    out_buffer = state.add_write(outbuffer)
+    state.add_edge(in_buffer, None, libnode, '_inbuffer', Memlet.from_array(in_buffer, in_desc))
+    state.add_edge(libnode, '_outbuffer', out_buffer, None, Memlet.from_array(out_buffer, out_desc))
+
+    return None
+
+
 @oprepo.replaces('mpi4py.MPI.COMM_WORLD.Allreduce')
 @oprepo.replaces('dace.comm.Allreduce')
-def _allreduce(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, buffer: str, op: str, grid: str = None):
+def _allreduce(pv: 'ProgramVisitor',
+               sdfg: SDFG,
+               state: SDFGState,
+               buffer: str,
+               op: str,
+               grid: str = None):
 
     from dace.libraries.mpi.nodes.allreduce import Allreduce
 

--- a/dace/libraries/mpi/nodes/__init__.py
+++ b/dace/libraries/mpi/nodes/__init__.py
@@ -10,5 +10,6 @@ from .gather import Gather, BlockGather
 from .reduce import Reduce
 from .allreduce import Allreduce
 from .allgather import Allgather
+from .alltoall import Alltoall
 from .dummy import Dummy
 from .redistribute import Redistribute

--- a/dace/libraries/mpi/nodes/alltoall.py
+++ b/dace/libraries/mpi/nodes/alltoall.py
@@ -1,0 +1,84 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace.library
+import dace.properties
+import dace.sdfg.nodes
+from dace.transformation.transformation import ExpandTransformation
+from .. import environments
+from dace.libraries.mpi.nodes.node import MPINode
+
+
+@dace.library.expansion
+class ExpandAlltoallMPI(ExpandTransformation):
+
+    environments = [environments.mpi.MPI]
+
+    @staticmethod
+    def expansion(node, parent_state, parent_sdfg, n=None, **kwargs):
+        (inbuffer, in_count_str), (outbuffer, out_count_str) = node.validate(parent_sdfg, parent_state)
+        in_mpi_dtype_str = dace.libraries.mpi.utils.MPI_DDT(inbuffer.dtype.base_type)
+        out_mpi_dtype_str = dace.libraries.mpi.utils.MPI_DDT(outbuffer.dtype.base_type)
+
+        if inbuffer.dtype.veclen > 1:
+            raise (NotImplementedError)
+
+        comm = "MPI_COMM_WORLD"
+        if node.grid:
+            comm = f"__state->{node.grid}_comm"
+
+        # code = f"""
+        #     MPI_Alltoall({buffer}, {count_str}, {mpi_dtype_str}, _outbuffer, {count_str}, {mpi_dtype_str}, {comm});
+        #     """
+        code = f"""
+            MPI_Alltoall(_inbuffer, {in_count_str}, {in_mpi_dtype_str}, \
+                        _outbuffer, {out_count_str}, {out_mpi_dtype_str}, \
+                        {comm});
+            """
+        tasklet = dace.sdfg.nodes.Tasklet(node.name,
+                                          node.in_connectors,
+                                          node.out_connectors,
+                                          code,
+                                          language=dace.dtypes.Language.CPP)
+        return tasklet
+
+
+@dace.library.node
+class Alltoall(MPINode):
+
+    # Global properties
+    implementations = {
+        "MPI": ExpandAlltoallMPI,
+    }
+    default_implementation = "MPI"
+
+    grid = dace.properties.Property(dtype=str, allow_none=True, default=None)
+
+    def __init__(self, name, grid=None, *args, **kwargs):
+        super().__init__(name, *args, inputs={"_inbuffer"}, outputs={"_outbuffer"}, **kwargs)
+        self.grid = grid
+
+    def validate(self, sdfg, state):
+        """
+        :return: A three-tuple (buffer, root) of the three data descriptors in the
+                 parent SDFG.
+        """
+
+        inbuffer, outbuffer = None, None
+        for e in state.out_edges(self):
+            if e.src_conn == "_outbuffer":
+                outbuffer = sdfg.arrays[e.data.data]
+        for e in state.in_edges(self):
+            if e.dst_conn == "_inbuffer":
+                inbuffer = sdfg.arrays[e.data.data]
+
+        in_count_str = "XXX"
+        out_count_str = "XXX"
+        for _, src_conn, _, _, data in state.out_edges(self):
+            if src_conn == '_outbuffer':
+                dims = [str(e) for e in data.subset.size_exact()]
+                out_count_str = "*".join(dims)
+        for _, _, _, dst_conn, data in state.in_edges(self):
+            if dst_conn == '_inbuffer':
+                dims = [str(e) for e in data.subset.size_exact()]
+                in_count_str = "*".join(dims)
+        
+        return (inbuffer, in_count_str), (outbuffer, out_count_str)

--- a/dace/libraries/mpi/nodes/alltoall.py
+++ b/dace/libraries/mpi/nodes/alltoall.py
@@ -25,12 +25,12 @@ class ExpandAlltoallMPI(ExpandTransformation):
         if node.grid:
             comm = f"__state->{node.grid}_comm"
 
-        # code = f"""
-        #     MPI_Alltoall({buffer}, {count_str}, {mpi_dtype_str}, _outbuffer, {count_str}, {mpi_dtype_str}, {comm});
-        #     """
         code = f"""
-            MPI_Alltoall(_inbuffer, {in_count_str}, {in_mpi_dtype_str}, \
-                        _outbuffer, {out_count_str}, {out_mpi_dtype_str}, \
+            int size;
+            MPI_Comm_size({comm}, &size);
+            int sendrecv_amt = {in_count_str} / size;
+            MPI_Alltoall(_inbuffer, sendrecv_amt, {in_mpi_dtype_str}, \
+                        _outbuffer, sendrecv_amt, {out_mpi_dtype_str}, \
                         {comm});
             """
         tasklet = dace.sdfg.nodes.Tasklet(node.name,

--- a/tests/library/mpi/mpi_allgather_test.py
+++ b/tests/library/mpi/mpi_allgather_test.py
@@ -22,7 +22,10 @@ def make_sdfg(dtype):
     outA = state.add_access("outA")
     allgather_node = mpi.nodes.allgather.Allgather("allgather")
 
-    state.add_memlet_path(inA, allgather_node, dst_conn="_inbuffer", memlet=Memlet.simple(inA, "0:n", num_accesses=n))
+    state.add_memlet_path(inA,
+                          allgather_node,
+                          dst_conn="_inbuffer",
+                          memlet=Memlet.simple(inA, "0:n", num_accesses=n))
     state.add_memlet_path(allgather_node,
                           outA,
                           src_conn="_outbuffer",

--- a/tests/library/mpi/mpi_alltoall_test.py
+++ b/tests/library/mpi/mpi_alltoall_test.py
@@ -59,7 +59,7 @@ def test_mpi(implementation, dtype):
     size_per_proc = int(size/commsize)
     A = np.arange(0, size, dtype=np_dtype)
     B = np.full(size, 0, dtype=np_dtype)
-    mpi_sdfg(inbuf=A, outbuf=B, n=size_per_proc)
+    mpi_sdfg(inbuf=A, outbuf=B, n=size)
 
     # now B should be an array of size,
     # containing (size / size_per_proc) repeated chunked_data

--- a/tests/library/mpi/mpi_alltoall_test.py
+++ b/tests/library/mpi/mpi_alltoall_test.py
@@ -1,0 +1,78 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+from dace.memlet import Memlet
+import dace.libraries.mpi as mpi
+import numpy as np
+import pytest
+
+###############################################################################
+
+
+def make_sdfg(dtype):
+
+    n = dace.symbol("n")
+
+    sdfg = dace.SDFG("mpi_alltoall")
+    state = sdfg.add_state("dataflow")
+
+    sdfg.add_array("inbuf", [n], dtype, transient=False)
+    sdfg.add_array("outbuf", [n], dtype, transient=False)
+    inbuf = state.add_access("inbuf")
+    outbuf = state.add_access("outbuf")
+    alltoall_node = mpi.nodes.alltoall.Alltoall("alltoall")
+
+    state.add_memlet_path(inbuf,
+                          alltoall_node,
+                          dst_conn="_inbuffer",
+                          memlet=Memlet.simple(inbuf, "0:n", num_accesses=n))
+    state.add_memlet_path(alltoall_node,
+                          outbuf,
+                          src_conn="_outbuffer",
+                          memlet=Memlet.simple(outbuf, "0:n", num_accesses=n))
+
+    return sdfg
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize("implementation, dtype", [
+    pytest.param("MPI", dace.float32, marks=pytest.mark.mpi),
+    pytest.param("MPI", dace.float64, marks=pytest.mark.mpi)
+])
+def test_mpi(implementation, dtype):
+    from mpi4py import MPI as MPI4PY
+    np_dtype = getattr(np, dtype.to_string())
+    comm = MPI4PY.COMM_WORLD
+    rank = comm.Get_rank()
+    commsize = comm.Get_size()
+    mpi_sdfg = None
+    if commsize < 2:
+        raise ValueError("This test is supposed to be run with at least two processes!")
+    for r in range(0, commsize):
+        if r == rank:
+            sdfg = make_sdfg(dtype)
+            mpi_sdfg = sdfg.compile()
+        comm.Barrier()
+
+    size = 128
+    size_per_proc = int(size/commsize)
+    A = np.arange(0, size, dtype=np_dtype)
+    B = np.full(size, 0, dtype=np_dtype)
+    mpi_sdfg(inbuf=A, outbuf=B, n=size_per_proc)
+
+    # now B should be an array of size,
+    # containing (size / size_per_proc) repeated chunked_data
+    chunked_data = A[rank * size_per_proc: (rank + 1) * size_per_proc]
+    correct_data = np.tile(chunked_data, int(size / size_per_proc))
+    if (not np.allclose(B, correct_data)):
+        raise (ValueError("The received values are not what I expected on root."))
+
+
+###############################################################################
+
+if __name__ == "__main__":
+    test_mpi("MPI", dace.float32)
+    test_mpi("MPI", dace.float64)
+
+###############################################################################

--- a/tests/library/mpi/mpi_send_recv_test.py
+++ b/tests/library/mpi/mpi_send_recv_test.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
+from dace.sdfg import utils
 from dace.memlet import Memlet
 import dace.libraries.mpi as mpi
 import numpy as np
@@ -75,21 +76,15 @@ def test_mpi():
 
 ###############################################################################
 
-myrank = dace.symbol('myrank', dtype=dace.int32)
-mysize = dace.symbol('mysize', dtype=dace.int32)
-
-
 @dace.program
-def dace_send_recv():
-    tmp1 = np.full([1], myrank, dtype=np.int32)
-    tmp2 = np.zeros([1], dtype=np.int32)
-    if myrank == 0:
-        dace.comm.Send(tmp1, 1, tag=42)
-        dace.comm.Recv(tmp2, mysize - 1, tag=42)
-    else:
-        dace.comm.Recv(tmp2, (myrank - 1) % mysize, tag=42)
-        dace.comm.Send(tmp1, (myrank + 1) % mysize, tag=42)
-    return tmp2
+def dace_send_recv(rank: dace.int32, size: dace.int32):
+    src = np.full([1], (rank - 1) % size, dtype=np.int32)
+    dst = np.full([1], (rank + 1) % size, dtype=np.int32)
+    sbuf = np.full([1], rank, dtype=np.int32)
+    rbuf = np.zeros([1], dtype=np.int32)
+    dace.comm.Recv(rbuf, src, tag=42)
+    dace.comm.Send(sbuf, dst, tag=42)
+    return rbuf
 
 
 @pytest.mark.mpi
@@ -101,14 +96,14 @@ def test_dace_send_recv():
     mpi_sdfg = None
     if commsize < 2:
         raise ValueError("This test is supposed to be run with at least two processes!")
-    for r in range(0, commsize):
-        if r == rank:
-            mpi_sdfg = dace_send_recv.compile()
-        comm.Barrier()
+    sdfg = None
+    if rank == 0:
+        sdfg = dace_send_recv.to_sdfg(simplify=True)
+    mpi_sdfg = utils.distributed_compile(sdfg, comm)
 
-    prv_rank = mpi_sdfg(myrank=rank, mysize=commsize)
+    val = mpi_sdfg(rank=rank, size=commsize)
 
-    assert (prv_rank[0] == (rank - 1) % commsize)
+    assert (val[0] == (rank - 1) % commsize)
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary
Added mpi4py send/recv support and alltoall library node

## Description
Added replacements and unit tests for mpi4py.MPI.COMM_WORLD.Send and mpi4py.MPI.COMM_WORLD.Recv.
Implemented the library node and unit test for the alltoall collective.