### PR TITLE
Fix ROCm issue where target ID is set to gfxgfx***

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,5 +35,6 @@ Tiancheng Chen
 Reid Wahl
 Yihang Luo
 Alexandru Calotoiu
+Phillip Lane
 
 and other contributors listed in https://github.com/spcl/dace/graphs/contributors

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -497,7 +497,7 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg.name}_t *__state, gpuStream_
             hip_arch = [ha for ha in hip_arch if ha is not None and len(ha) > 0]
 
             flags = Config.get("compiler", "cuda", "hip_args")
-            flags += ' ' + ' '.join('--offload-arch={arch}'.format(arch=arch if "gfx" in arch else "gfx" + arch) for arch in hip_arch)
+            flags += ' ' + ' '.join('--offload-arch={arch}'.format(arch=arch if arch.startswith("gfx") else "gfx" + arch) for arch in hip_arch)
             options.append("-DEXTRA_HIP_FLAGS=\"{}\"".format(flags))
 
         if Config.get('compiler', 'cpu', 'executable'):

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -497,7 +497,7 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg.name}_t *__state, gpuStream_
             hip_arch = [ha for ha in hip_arch if ha is not None and len(ha) > 0]
 
             flags = Config.get("compiler", "cuda", "hip_args")
-            flags += ' ' + ' '.join('--offload-arch=gfx{arch}'.format(arch=arch) for arch in hip_arch)
+            flags += ' ' + ' '.join('--offload-arch={arch}'.format(arch=arch if "gfx" in arch else "gfx" + arch) for arch in hip_arch)
             options.append("-DEXTRA_HIP_FLAGS=\"{}\"".format(flags))
 
         if Config.get('compiler', 'cpu', 'executable'):


### PR DESCRIPTION
I've encountered an error on ROCm systems where the target ID has "gfx" set twice (e.g., "gfxgfx906" instead of "gfx906"), which causes compile-time issues. I have fixed this issue by adding a check if "gfx" is already part of the architecture, and only prepending "gfx" if it isn't.