### PR TITLE
Fix issue where multidimensional arrays with a singleton dimension sometimes fail

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -482,6 +482,7 @@ def add_indirection_subgraph(sdfg: SDFG,
         code = "lookup = {arr}[{index}]"
 
     newsubset = [r[0] if isinstance(r, tuple) else r for r in newsubset]
+    newsubset = [s for s, shp in zip(newsubset, array.shape) if shp != 1]
     if ind_entry:  # Amend newsubset when a range is indirected
         for i, idx in enumerate(nonsqz_dims):
             newsubset[idx] = '__i%d' % i


### PR DESCRIPTION
Encountered a bug where multidimensional arrays with a singleton dimension can result in a failing SDFG. @tbennun guided me on the bug fix, and has said he'll write the unit tests. Leaving this as a draft until appropriate unit tests can be written.