### PR TITLE
External interaction fixes

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -377,7 +377,8 @@ int __dace_init_cuda({sdfg.name}_t *__state{params}) {{
 
     // Create {backend} streams and events
     for(int i = 0; i < {nstreams}; ++i) {{
-        DACE_GPU_CHECK({backend}StreamCreateWithFlags(&__state->gpu_context->streams[i], {backend}StreamNonBlocking));
+        DACE_GPU_CHECK({backend}StreamCreateWithFlags(&__state->gpu_context->internal_streams[i], {backend}StreamNonBlocking));
+        __state->gpu_context->streams[i] = __state->gpu_context->internal_streams[i]; // Allow for externals to modify streams
     }}
     for(int i = 0; i < {nevents}; ++i) {{
         DACE_GPU_CHECK({backend}EventCreateWithFlags(&__state->gpu_context->events[i], {backend}EventDisableTiming));
@@ -398,7 +399,7 @@ int __dace_exit_cuda({sdfg.name}_t *__state) {{
 
     // Destroy {backend} streams and events
     for(int i = 0; i < {nstreams}; ++i) {{
-        DACE_GPU_CHECK({backend}StreamDestroy(__state->gpu_context->streams[i]));
+        DACE_GPU_CHECK({backend}StreamDestroy(__state->gpu_context->internal_streams[i]));
     }}
     for(int i = 0; i < {nevents}; ++i) {{
         DACE_GPU_CHECK({backend}EventDestroy(__state->gpu_context->events[i]));

--- a/dace/runtime/include/dace/cuda/cudacommon.cuh
+++ b/dace/runtime/include/dace/cuda/cudacommon.cuh
@@ -47,11 +47,13 @@ struct Context {
   int num_streams;
   int num_events;
   gpuStream_t *streams;
+  gpuStream_t *internal_streams;
   gpuEvent_t *events;
   gpuError_t lasterror;
   Context(int nstreams, int nevents)
       : num_streams(nstreams), num_events(nevents), lasterror((gpuError_t)0) {
     streams = new gpuStream_t[nstreams];
+    internal_streams = new gpuStream_t[nstreams];
     events = new gpuEvent_t[nevents];
   }
   ~Context() {

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -494,6 +494,10 @@ def make_transients_persistent(sdfg: SDFG,
                         not_persistent.add(dnode.data)
                         continue
 
+                if desc.lifetime == dtypes.AllocationLifetime.External:
+                    not_persistent.add(dnode.data)
+                    continue
+
                 persistent.add(dnode.data)
 
         for aname in (persistent - not_persistent):


### PR DESCRIPTION
Two minor fixes in this PR:
* Fix for double-free of external streams if `__dace_gpu_set_stream` was called
* Fix auto-optimize removing `External` lifetimes