### PR TITLE
Fixes Intemediate Node Removal in SubgraphFusion

### DIFF
--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -841,21 +841,21 @@ def get_view_edge(state: SDFGState, view: nd.AccessNode) -> gr.MultiConnectorEdg
         return out_edge
     if not src_is_data and not dst_is_data:
         return None
+    
+    # Check if there is a 'views' connector
+    if in_edge.dst_conn and in_edge.dst_conn == 'views':
+        return in_edge
+    if out_edge.src_conn and out_edge.src_conn == 'views':
+        return out_edge
 
-    # If both sides lead to access nodes, if one memlet's data points to the
-    # view it cannot point to the viewed node.
+    # TODO: This sounds arbitrary and is not well communicated to the frontends. Revisit in the future.
+    # If both sides lead to access nodes, if one memlet's data points to the view it cannot point to the viewed node.
     if in_edge.data.data == view.data and out_edge.data.data != view.data:
         return out_edge
     if in_edge.data.data != view.data and out_edge.data.data == view.data:
         return in_edge
     if in_edge.data.data == view.data and out_edge.data.data == view.data:
         return None
-
-    # Check if there is a 'views' connector
-    if in_edge.dst_conn and in_edge.dst_conn == 'views':
-        return in_edge
-    if out_edge.src_conn and out_edge.src_conn == 'views':
-        return out_edge
 
     # If both memlets' data are the respective access nodes, the access
     # node at the highest scope is the one that is viewed.

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -1154,7 +1154,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                 intermediate_data[acc.data].append(acc)
             else:
                 intermediate_data[acc.data] = [acc]
-        
+
         filtered_intermediate_data = dict()
         intermediate_sources = dict()
         intermediate_sinks = dict()
@@ -1189,7 +1189,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
             intermediate_sinks[dname] = sinks
 
         edges_to_remove = set()
-             
+
         for dname, accesses in filtered_intermediate_data.items():
 
             # Checking if data are contained in the subgraph
@@ -1214,7 +1214,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                         if in_subset:
                             in_subset = subsets.union(in_subset, ie.data.dst_subset)
                         else:
-                            in_subset = ie.data.dst_subset 
+                            in_subset = ie.data.dst_subset
                             first_subset = ie.data.dst_subset
 
                 # Create transient data corresponding to the union of the incoming subsets.
@@ -1225,11 +1225,11 @@ class SubgraphFusion(transformation.SubgraphTransformation):
 
                     acc.data = new_name
 
-                     # Reconnect incoming edges through the transient data.
+                    # Reconnect incoming edges through the transient data.
                     for ie in graph.in_edges(acc):
                         mem = Memlet(data=new_name,
-                                    subset=ie.data.dst_subset.offset_new(in_subset, True),
-                                    other_subset=ie.data.src_subset)
+                                     subset=ie.data.dst_subset.offset_new(in_subset, True),
+                                     other_subset=ie.data.src_subset)
                         # new_edge = graph.add_edge(ie.src, ie.src_conn, new_node, None, mem)
                         ie.data = mem
                         # Update memlet paths.
@@ -1242,8 +1242,8 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                     for oe in graph.out_edges(acc):
                         if in_subset.covers(oe.data.src_subset):
                             mem = Memlet(data=new_name,
-                                        subset=oe.data.src_subset.offset_new(in_subset, True),
-                                        other_subset=oe.data.dst_subset)
+                                         subset=oe.data.src_subset.offset_new(in_subset, True),
+                                         other_subset=oe.data.dst_subset)
                             # new_edge = graph.add_edge(new_node, None, oe.dst, oe.dst_conn, mem)
                             oe.data = mem
                             # Update memlet paths.
@@ -1264,16 +1264,15 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                             graph.add_memlet_path(inode, global_map_entry, oe.dst, memlet=oe.data, dst_conn=oe.dst_conn)
                             edges_to_remove.add(oe)
 
-
                     # Connect transient data to the outer output node.
                     if acc in intermediate_sinks[dname]:
                         if not onode:
                             onode = graph.add_access(dname)
                         graph.add_memlet_path(acc,
-                                            global_map_exit,
-                                            onode,
-                                            memlet=Memlet(data=dname, subset=in_subset),
-                                            src_conn=None)
+                                              global_map_exit,
+                                              onode,
+                                              memlet=Memlet(data=dname, subset=in_subset),
+                                              src_conn=None)
 
         for e in edges_to_remove:
             graph.remove_edge(e)

--- a/tests/transformations/subgraph_fusion/intermediate_mimo_test.py
+++ b/tests/transformations/subgraph_fusion/intermediate_mimo_test.py
@@ -123,6 +123,19 @@ def test_single_data_multiple_intermediate_accesses():
     sdfg = sdmi_accesses.to_sdfg(simplify=True)
     assert len(sdfg.states()) == 1
 
+    rng = np.random.default_rng(42)
+    ZSOLQA = rng.random((1, 5, 5))
+    ZEPSEC = rng.random()
+    ZQX = rng.random((1, 137, 5))
+    ref_LLINDEX3 = rng.random((1, 5, 5)) > 0.5
+    ref_ZRATIO = rng.random((1, 5))
+    ref_ZSINKSUM = rng.random((1, 5))
+    val_LLINDEX3 = ref_LLINDEX3.copy()
+    val_ZRATIO = ref_ZRATIO.copy()
+    val_ZSINKSUM = ref_ZSINKSUM.copy()
+
+    sdfg(ZSOLQA=ZSOLQA, ZEPSEC=ZEPSEC, ZQX=ZQX, LLINDEX3=ref_LLINDEX3, ZRATIO=ref_ZRATIO, ZSINKSUM=ref_ZSINKSUM)
+
     graph = sdfg.states()[0]
     subgraph = SubgraphView(graph, [node for node in graph.nodes()])
 
@@ -136,9 +149,13 @@ def test_single_data_multiple_intermediate_accesses():
     assert sf.can_be_applied(sdfg, subgraph) == True
     sf.apply(sdfg)
 
-    sdfg.view()
+    sdfg(ZSOLQA=ZSOLQA, ZEPSEC=ZEPSEC, ZQX=ZQX, LLINDEX3=val_LLINDEX3, ZRATIO=val_ZRATIO, ZSINKSUM=val_ZSINKSUM)
+
+    assert np.allclose(ref_LLINDEX3, val_LLINDEX3)
+    assert np.allclose(ref_ZRATIO, val_ZRATIO)
+    assert np.allclose(ref_ZSINKSUM, val_ZSINKSUM)
 
 
 if __name__ == '__main__':
-    # test_mimo()
+    test_mimo()
     test_single_data_multiple_intermediate_accesses()


### PR DESCRIPTION
The PR fixes removal of intermediate nodes to non-local data in SubgraphFusion, taking into account dependencies among those nodes.