### PR TITLE
Adds InterstateEdge check to RefinedNestedAccess

### DIFF
--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -956,7 +956,7 @@ class RefineNestedAccess(transformation.SingleStateTransformation):
                         continue
                     in_candidates[e.data.data] = (e.data, nstate, set(range(len(e.data.subset))))
 
-        # Check interstate edges for candidates
+        # Check read memlets in interstate edges for candidates
         for e in nsdfg.sdfg.edges():
             for m in e.data.get_read_memlets(nsdfg.sdfg.arrays):
                 # If more than one unique element detected, remove from candidates

--- a/tests/transformations/refine_nested_access_test.py
+++ b/tests/transformations/refine_nested_access_test.py
@@ -23,7 +23,7 @@ def test_refine_dataflow():
     A = state.add_access('A')
     B = state.add_access('B')
     me, mx = state.add_map('m', dict(i='0:5', j='0:5'))
-    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(), sdfg, {'A'}, {'B'}, {'i': 'i', 'j': 'j'})
+    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), sdfg, {'A'}, {'B'}, {'i': 'i', 'j': 'j'})
     state.add_memlet_path(A, me, nsdfg, dst_conn='A', memlet=dace.Memlet.from_array('A', sdfg.arrays['A']))
     state.add_memlet_path(nsdfg, mx, B, src_conn='B', memlet=dace.Memlet.from_array('B', sdfg.arrays['B']))
 
@@ -63,7 +63,10 @@ def test_refine_interstate():
     B = state.add_access('B')
     select = state.add_access('select')
     me, mx = state.add_map('m', dict(i='0:5', j='0:5'))
-    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(), sdfg, {'A', 'select'}, {'B'}, {'i': 'i', 'j': 'j'})
+    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), sdfg, {'A', 'select'}, {'B'}, {
+        'i': 'i',
+        'j': 'j'
+    })
     state.add_memlet_path(A, me, nsdfg, dst_conn='A', memlet=dace.Memlet.from_array('A', sdfg.arrays['A']))
     state.add_memlet_path(select,
                           me,

--- a/tests/transformations/refine_nested_access_test.py
+++ b/tests/transformations/refine_nested_access_test.py
@@ -1,6 +1,5 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 """ Tests for the RefineNestedAccess transformation. """
-
 import dace
 import numpy as np
 


### PR DESCRIPTION
This PR adds InterstateEdge support to RefinedNestedAccess, i.e., data accesses appearing in InterstateEdges will be recorded to the candidate registries.