### PR TITLE
Fix MapFusion with NestedSDFGs

### DIFF
--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -562,6 +562,12 @@ def validate_state(state: 'dace.sdfg.SDFGState',
         src_node = path[0].src
         dst_node = path[-1].dst
 
+        # NestedSDFGs must connect to AccessNodes
+        if isinstance(src_node, nd.NestedSDFG) and not isinstance(dst_node, nd.AccessNode):
+            raise InvalidSDFGEdgeError("Nested SDFG source nodes must be AccessNodes", sdfg, state_id, eid)
+        if isinstance(dst_node, nd.NestedSDFG) and not isinstance(src_node, nd.AccessNode):
+            raise InvalidSDFGEdgeError("Nested SDFG destination nodes must be AccessNodes", sdfg, state_id, eid)
+
         # Set up memlet-specific SDFG context
         memlet_context = copy.copy(context)
         for pe in path:

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -563,10 +563,11 @@ def validate_state(state: 'dace.sdfg.SDFGState',
         dst_node = path[-1].dst
 
         # NestedSDFGs must connect to AccessNodes
-        if isinstance(src_node, nd.NestedSDFG) and not isinstance(dst_node, nd.AccessNode):
-            raise InvalidSDFGEdgeError("Nested SDFG source nodes must be AccessNodes", sdfg, state_id, eid)
-        if isinstance(dst_node, nd.NestedSDFG) and not isinstance(src_node, nd.AccessNode):
-            raise InvalidSDFGEdgeError("Nested SDFG destination nodes must be AccessNodes", sdfg, state_id, eid)
+        if not e.data.is_empty():
+            if isinstance(src_node, nd.NestedSDFG) and not isinstance(dst_node, nd.AccessNode):
+                raise InvalidSDFGEdgeError("Nested SDFG source nodes must be AccessNodes", sdfg, state_id, eid)
+            if isinstance(dst_node, nd.NestedSDFG) and not isinstance(src_node, nd.AccessNode):
+                raise InvalidSDFGEdgeError("Nested SDFG destination nodes must be AccessNodes", sdfg, state_id, eid)
 
         # Set up memlet-specific SDFG context
         memlet_context = copy.copy(context)


### PR DESCRIPTION
This PR:
- Adds a validation check for edges/Memlet paths and NestedSDFGs; if a NestedSDFG is src/dst of a Memlet path, then the dst/src must be an AccessNode.
- Amends MapFusion to create new intermediate data, even when the access is Scalar, when connecting one or more NestedSDFGs.
