### PR TITLE
Fix for #1308

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2352,6 +2352,8 @@ class ProgramVisitor(ExtNodeVisitor):
         # Visit test-condition
         if not is_test_simple:
             parsed_node = self.visit(node)
+            if isinstance(parsed_node, (list, tuple)) and len(parsed_node) == 1:
+                parsed_node = parsed_node[0]
             if isinstance(parsed_node, str) and parsed_node in self.sdfg.arrays:
                 datadesc = self.sdfg.arrays[parsed_node]
                 if isinstance(datadesc, data.Array):

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -4370,6 +4370,8 @@ def _datatype_converter(sdfg: SDFG, state: SDFGState, arg: UfuncInput, dtype: dt
         'outputs': ['__out'],
         'code': "__out = dace.{}(__inp)".format(dtype.to_string())
     }
+    if dtype in (dace.bool, dace.bool_):
+        impl['code'] = "__out = dace.bool_(__inp)"
     tasklet_params = _set_tasklet_params(impl, [arg])
 
     # Visitor input only needed when `has_where == True`.

--- a/tests/python_frontend/conditionals_test.py
+++ b/tests/python_frontend/conditionals_test.py
@@ -161,6 +161,19 @@ def test_if_return_chain():
     assert if_return_chain(15)[0] == 4
 
 
+def test_if_test_call():
+
+    @dace.program
+    def if_test_call(a, b):
+        if bool(a):
+            return a
+        else:
+            return b
+
+    assert if_test_call(0, 2)[0] == if_test_call.f(0, 2)
+    assert if_test_call(1, 2)[0] == if_test_call.f(1, 2)
+
+
 if __name__ == "__main__":
     test_simple_if()
     test_call_if()
@@ -169,3 +182,4 @@ if __name__ == "__main__":
     test_call_while()
     test_if_return_both()
     test_if_return_chain()
+    test_if_test_call()


### PR DESCRIPTION
Fixes the case where the result of visiting a condition's/while's test is a list/tuple of size 1 and isn't unpacked correctly. It also adds a special case when converting data to bool because we do not/cannot define `dace::bool`.