### PR TITLE
Pace Fixes 0

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3653,6 +3653,11 @@ class ProgramVisitor(ExtNodeVisitor):
                     # If the symbol is a callback, but is not used in the nested SDFG, skip it
                     continue
 
+                # NOTE: Is it possible that an array in the SDFG's closure is not in the SDFG?
+                # NOTE: Perhaps its use was simplified/optimized away?
+                if aname not in sdfg.arrays:
+                    continue
+
                 # First, we do an inverse lookup on the already added closure arrays for `arr`.
                 is_new_arr = True
                 for k, v in self.nested_closure_arrays.items():
@@ -3739,15 +3744,6 @@ class ProgramVisitor(ExtNodeVisitor):
                 mapping[aname] = arg
         for arg in args_to_remove:
             args.remove(arg)
-
-        # Drop args that are not in the SDFG
-        filtered_args = []
-        for conn, arg in args:
-            if conn not in sdfg.arrays:
-                warnings.warn(f'Connector {conn} not found in SDFG; dropping it')
-            else:
-                filtered_args.append((conn, arg))
-        args = filtered_args
 
         # Change connector names
         updated_args = []

--- a/dace/transformation/passes/array_elimination.py
+++ b/dace/transformation/passes/array_elimination.py
@@ -170,6 +170,9 @@ class ArrayElimination(ppl.Pass):
                 for anode in access_nodes[aname]:
                     if anode in removed_nodes:
                         continue
+                    if anode not in state.nodes():
+                        removed_nodes.add(anode)
+                        continue
 
                     if state.out_degree(anode) == 1:
                         succ = state.successors(anode)[0]


### PR DESCRIPTION
This PR addresses the following:
- [x] Do not add nested program call's arguments closure arrays that do not exist in the corresponding SDFG.
- [x] Ensure access nodes that are candidates for elimination (RedundantArray-kind transformations) exist in the target SDFGState. For example, RedundantSecondArray may remove two AcessNodes: the destination, but also the source, if it has in-degree 0. 

