### PR TITLE
Fix for DFS edges method

### DIFF
--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -346,11 +346,13 @@ class Graph(Generic[NodeT, EdgeT]):
                 parent, children = stack[-1]
                 try:
                     e = next(children)
+                    to_yield = condition is None or condition(e.src, e.dst, e.data)
                     if e.dst not in visited:
                         visited.add(e.dst)
-                        if condition is None or condition(e.src, e.dst, e.data):
-                            yield e
+                        if to_yield:
                             stack.append((e.dst, self.out_edges(e.dst).__iter__()))
+                    if to_yield:
+                        yield e
                 except StopIteration:
                     stack.pop()
 

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -105,6 +105,15 @@ class TestOrderedGraphs(unittest.TestCase):
         self.assertEqual(next(bfs_edges), e3)
         self.assertEqual(next(bfs_edges), e6)
         self.assertEqual(next(bfs_edges), e7)
+    
+    def test_dfs_edges(self):
+
+        sdfg = dace.SDFG('test_dfs_edges')
+        before, _, _ = sdfg.add_loop(sdfg.add_state(), sdfg.add_state(), sdfg.add_state(), 'i', '0', 'i < 10', 'i + 1')
+        
+        visited_edges = list(sdfg.dfs_edges(before))
+        assert len(visited_edges) == len(set(visited_edges))
+        assert all(e in visited_edges for e in sdfg.edges())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The method `dace.sdfg.graph.Graph.dfs_edges` avoids cycles by keeping track of visited nodes (SDFGStates). While iterating over the out-edges of a node, if the destination has already been visited, it skips it. However, the edge should still be yielded, otherwise, not all of them will be returned. For example, the former algorithm skips the back-edge leading from the body of a for-loop to its guard.

UPDATE: To fix a (newly) failing test, this PR also amends `InterstateEdge.new_symbols` to return only newly defined symbols. For example, if the InterstateEdge consists of the assignment `i = i + 1`, `InterstateEdge.new_symbols` **will not** return `i` any longer. The method uses the same algorithm as `InterstateEdge.free_symbols` to infer which symbols are actually defined.