### PR TITLE
Relaxed Shape/Size Equality Checks

### DIFF
--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -2133,10 +2133,13 @@ def _matmult(visitor: ProgramVisitor, sdfg: SDFG, state: SDFGState, op1: str, op
     if len(arr1.shape) > 1 and len(arr2.shape) > 1:  # matrix * matrix
 
         if len(arr1.shape) > 3 or len(arr2.shape) > 3:
-            raise SyntaxError('Matrix multiplication of tensors of dimensions > 3 '
-                              'not supported')
+            raise SyntaxError('Matrix multiplication of tensors of dimensions > 3 not supported')
 
-        if arr1.shape[-1] != arr2.shape[-2]:
+        res = symbolic.equal(arr1.shape[-1], arr2.shape[-2])
+        if res is None:
+            warnings.warn(f'Last mode of first tesnsor/matrix {arr1.shape[-1]} and second-last mode of '
+                          f'second tensor/matrix {arr2.shape[-2]} may not match', UserWarning)
+        elif not res:
             raise SyntaxError('Matrix dimension mismatch %s != %s' % (arr1.shape[-1], arr2.shape[-2]))
 
         from dace.libraries.blas.nodes.matmul import _get_batchmm_opts
@@ -2150,7 +2153,11 @@ def _matmult(visitor: ProgramVisitor, sdfg: SDFG, state: SDFGState, op1: str, op
 
     elif len(arr1.shape) == 2 and len(arr2.shape) == 1:  # matrix * vector
 
-        if arr1.shape[1] != arr2.shape[0]:
+        res = symbolic.equal(arr1.shape[-1], arr2.shape[0])
+        if res is None:
+            warnings.warn(f'Number of matrix columns {arr1.shape[-1]} and length of vector {arr2.shape[0]} '
+                          f'may not match', UserWarning)
+        elif not res:
             raise SyntaxError("Number of matrix columns {} must match"
                               "size of vector {}.".format(arr1.shape[1], arr2.shape[0]))
 
@@ -2158,7 +2165,11 @@ def _matmult(visitor: ProgramVisitor, sdfg: SDFG, state: SDFGState, op1: str, op
 
     elif len(arr1.shape) == 1 and len(arr2.shape) == 2:  # vector * matrix
 
-        if arr1.shape[0] != arr2.shape[0]:
+        res = symbolic.equal(arr1.shape[0], arr2.shape[0])
+        if res is None:
+            warnings.warn(f'Length of vector {arr1.shape[0]} and number of matrix rows {arr2.shape[0]} '
+                          f'may not match', UserWarning)
+        elif not res:
             raise SyntaxError("Size of vector {} must match number of matrix "
                               "rows {} must match".format(arr1.shape[0], arr2.shape[0]))
 
@@ -2166,7 +2177,11 @@ def _matmult(visitor: ProgramVisitor, sdfg: SDFG, state: SDFGState, op1: str, op
 
     elif len(arr1.shape) == 1 and len(arr2.shape) == 1:  # vector * vector
 
-        if arr1.shape[0] != arr2.shape[0]:
+        res = symbolic.equal(arr1.shape[0], arr2.shape[0])
+        if res is None:
+            warnings.warn(f'Length of first vector {arr1.shape[0]} and length of second vector {arr2.shape[0]} '
+                          f'may not match', UserWarning)
+        elif not res:
             raise SyntaxError("Vectors in vector product must have same size: "
                               "{} vs. {}".format(arr1.shape[0], arr2.shape[0]))
 

--- a/dace/libraries/blas/nodes/matmul.py
+++ b/dace/libraries/blas/nodes/matmul.py
@@ -1,8 +1,8 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
-from dace import properties
+from dace import properties, symbolic
 from copy import deepcopy as dc
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 import warnings
 
 
@@ -58,8 +58,13 @@ def _get_batchmm_opts(a_shape, a_strides, b_shape, b_strides, c_shape, c_strides
         batch = a_shape[0]
         stride_a = a_strides[0]
     if len(b_shape) == 3:
-        if batch and batch != b_shape[0]:
-            raise ValueError('Batch size mismatch for matrix multiplication')
+        if batch is not None:
+            res = symbolic.equal(batch, b_shape[0])
+            if res is None:
+                warnings.warn(f'Batch size of first tensor ({batch}) may not match second tensor ({b_shape[0]})',
+                              UserWarning)
+            elif not res:
+                raise ValueError('Batch size mismatch for matrix multiplication')
         batch = b_shape[0]
         stride_b = b_strides[0]
     if c_shape and len(c_shape) == 3:

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1337,3 +1337,27 @@ def inequal_symbols(a: Union[sympy.Expr, Any], b: Union[sympy.Expr, Any]) -> boo
         # We subtract and compare to zero according to the SymPy documentation
         # (https://docs.sympy.org/latest/tutorial/gotchas.html).
         return (a - b).simplify() != 0
+
+
+def equal(a: SymbolicType, b: SymbolicType, is_length: bool = True) -> Union[bool, None]:
+    """
+    Compares 2 symbolic expressions and returns True if they are equal, False if they are inequal,
+    and None if the comparison is inconclusive.
+
+    :param a: First symbolic expression.
+    :param b: Second symbolic expression.
+    :param is_length: If True, the assumptions that a, b are integers and positive are made.
+    """
+
+    args = [arg.expr if isinstance(arg, SymExpr) else arg for arg in (a, b)]
+
+    if any([args is None for args in args]):
+        return False
+
+    facts = []
+    if is_length:
+        for arg in args:
+            facts += [sympy.Q.integer(arg), sympy.Q.positive(arg)]
+    
+    with sympy.assuming(*facts):
+        return sympy.ask(sympy.Q.is_true(sympy.Eq(*args)))

--- a/tests/library/gemm_test.py
+++ b/tests/library/gemm_test.py
@@ -12,6 +12,8 @@ from dace.libraries.blas import Gemm
 M = dace.symbol('M')
 K = dace.symbol('K')
 N = dace.symbol('N')
+L = dace.symbol('L')
+O = dace.symbol('O')
 
 
 @pytest.mark.parametrize(
@@ -171,8 +173,55 @@ def test_library_gemm(implementation):
                       "misconfigured, skipping test for {}.".format(implementation))
 
 
+def test_gemm_symbolic():
+    sdfg = dace.SDFG("gemm")
+    state = sdfg.add_state()
+    A, A_arr = sdfg.add_array("A", [M, K], dace.float64)
+    B, B_arr = sdfg.add_array("B", [L, N], dace.float64)
+    C, C_arr = sdfg.add_array("C", [O, N], dace.float64)
+
+    rA = state.add_read("A")
+    rB = state.add_read("B")
+    wC = state.add_write("C")
+
+    libnode = Gemm('_Gemm_', transA=False, transB=False, alpha=1.0, beta=0.0)
+    state.add_node(libnode)
+
+    state.add_edge(rA, None, libnode, '_a', dace.Memlet.from_array(A, A_arr))
+    state.add_edge(rB, None, libnode, '_b', dace.Memlet.from_array(B, B_arr))
+    state.add_edge(libnode, '_c', wC, None, dace.Memlet.from_array(C, C_arr))
+
+    sdfg.validate()
+
+
+def test_gemm_symbolic_1():
+    sdfg = dace.SDFG("gemm")
+    state = sdfg.add_state()
+    A, A_arr = sdfg.add_array("A", [M, K], dace.float64)
+    B, B_arr = sdfg.add_array("B", [K + 2, N], dace.float64)
+    C, C_arr = sdfg.add_array("C", [M, N], dace.float64)
+
+    rA = state.add_read("A")
+    rB = state.add_read("B")
+    wC = state.add_write("C")
+
+    libnode = Gemm('_Gemm_', transA=False, transB=False, alpha=1.0, beta=0.0)
+    state.add_node(libnode)
+
+    state.add_edge(rA, None, libnode, '_a', dace.Memlet.from_array(A, A_arr))
+    state.add_edge(rB, None, libnode, '_b', dace.Memlet.from_array(B, B_arr))
+    state.add_edge(libnode, '_c', wC, None, dace.Memlet.from_array(C, C_arr))
+
+    try:
+        sdfg.validate()
+    except dace.sdfg.InvalidSDFGError:
+        pass
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == 'gpu':
         test_library_gemm('cuBLAS')
-    test_library_gemm('pure')
-    test_library_gemm('MKL')
+    # test_library_gemm('pure')
+    # test_library_gemm('MKL')
+    test_gemm_symbolic()
+    test_gemm_symbolic_1()

--- a/tests/numpy/matrix_multiplication_test.py
+++ b/tests/numpy/matrix_multiplication_test.py
@@ -1,9 +1,9 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import unittest
 import dace
 import numpy as np
 
-B, M, N, K = tuple(dace.symbol(k) for k in 'BMNK')
+B, M, N, K, L, O = tuple(dace.symbol(k) for k in 'BMNKLO')
 
 
 class MatrixMultiplication(unittest.TestCase):
@@ -37,6 +37,28 @@ class MatrixMultiplication(unittest.TestCase):
         a = np.random.rand(34, 32)
         b = np.random.rand(3, 32, 31)
         c = mmmtest(a, b)
+        self.assertEqual(list(c.shape), [3, 34, 31])
+        self.assertTrue(np.allclose(c, a @ b))
+    
+    def test_mm_symbolic(self):
+        @dace.program
+        def mmtest_symbolic(a: dace.float64[M, K], b: dace.float64[O, N]):
+            return a @ b
+
+        a = np.random.rand(32, 33)
+        b = np.random.rand(33, 34)
+        c = mmtest_symbolic(a, b)
+        self.assertEqual(list(c.shape), [32, 34])
+        self.assertTrue(np.allclose(c, a @ b))
+    
+    def test_mmm_batch_symbolic(self):
+        @dace.program
+        def mmmtest_symbolic(a: dace.float64[B, M, K], b: dace.float64[L, O, N]):
+            return a @ b
+
+        a = np.random.rand(3, 34, 32)
+        b = np.random.rand(3, 32, 31)
+        c = mmmtest_symbolic(a, b)
         self.assertEqual(list(c.shape), [3, 34, 31])
         self.assertTrue(np.allclose(c, a @ b))
 


### PR DESCRIPTION
This PR introduces a new equality-check method, mainly aimed at dimension/mode length checks. The new method returns `True` if the two arguments are equal, `False` if they are unequal, and `None` if the result cannot be determined. The PR also introduces example usages in matrix-multiplication-related functionality, utilizing the method to print warnings instead of throwing errors when matrix multiplication could be valid depending on the values symbols take.