### PR TITLE
Proposal for resolving benign validation errors when auto-optimizing for non-CPU devices

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -898,6 +898,13 @@ required:
                 title: Undefined Symbol Check
                 description: >
                     Check for undefined symbols in memlets during SDFG validation.
+            
+            check_accessibility:
+                type: bool
+                default: True
+                title: Accessibility Check
+                description: >
+                    Check if data containers can be accessed in the SDFG contexts with corresponding AccessNodes.
 
     #############################################
     # Features for unit testing

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -1,12 +1,12 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 """ Exception classes and methods for validation of SDFGs. """
 import copy
-from dace.dtypes import DebugInfo, StorageType
 import os
-from typing import TYPE_CHECKING, Dict, List, Set, Tuple, Union
 import warnings
-from dace import dtypes, data as dt, subsets
-from dace import symbolic
+
+from dace import config, dtypes, data as dt, subsets, symbolic
+from dace.dtypes import DebugInfo, StorageType
+from typing import TYPE_CHECKING, Dict, List, Set, Tuple, Union
 
 if TYPE_CHECKING:
     import dace
@@ -235,6 +235,10 @@ def _accessible(sdfg: 'dace.sdfg.SDFG', container: str, context: Dict[str, bool]
     """
     Helper function that returns False if a data container cannot be accessed in the current SDFG context.
     """
+
+    if not config.Config.get_bool('experimental', 'check_accessibility'):
+        return True
+
     storage = sdfg.arrays[container].storage
     if storage == dtypes.StorageType.GPU_Global or storage in dtypes.GPU_STORAGES:
         return context.get('in_gpu', False)


### PR DESCRIPTION
A standard workflow for optimizing programs to run on non-CPU devices involves instrumenting smaller kernels assuming that the inputs and output (non-transient data) are already on the device, i.e., no copies from the host to the device and back are needed. This is usually achieved by changing the non-transient data's storage to, e.g., GPU or FPGA global memory and then applying the appropriate device-specific transformation. However, when auto-optimizing, many other transformations are executed before GPU/FPGATransform. During this process, the SDFG is most likely invalid because the non-transient data on the device may appear to be accessed in the host's context, resulting in validation errors. Such errors are benign since the device-specific transformations will appropriately update schedules and storages, and they will introduce any needed copies.

This PR proposes a quick way to address the above issue. It introduces a new configuration parameter, `check_accessibility`, under the `experimental` category, having by default the value `True`. The fix consists of two components:
- The `dace.sdfg.validation._accessible` helper method checks the parameter's value and immediately returns `True` if the parameter is set to `False`.
- The auto-optimizer sets the parameter to `False`, if the selected device is other than CPU. It restores the original value of the parameter (as set by the user) just before applying GPU or FPGATransform.
