### PR TITLE
state.read_and_write_sets() ignore reads directly after writes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,5 +36,6 @@ Reid Wahl
 Yihang Luo
 Alexandru Calotoiu
 Phillip Lane
+Samuel Martin
 
 and other contributors listed in https://github.com/spcl/dace/graphs/contributors

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -298,11 +298,10 @@ class StateGraphView(object):
 
         # Get scopes
         for node, scopenodes in sdc.items():
-            scope_exit_nodes = [v for v in scopenodes if isinstance(v, nd.ExitNode)]
             if node is None:
                 exit_node = None
             else:
-                exit_node = next(iter(scope_exit_nodes))
+                exit_node = next(v for v in scopenodes if isinstance(v, nd.ExitNode))
             scope = ScopeTree(node, exit_node)
             result[node] = scope
 
@@ -506,10 +505,10 @@ class StateGraphView(object):
                     in_edges = sg.in_edges(n)
                     out_edges = sg.out_edges(n)
                     # Filter out memlets which go out but the same data is written to the AccessNode by another memlet
-                    for out_edge in out_edges:
-                        for in_edge in in_edges:
-                            if in_edge.data.data == out_edge.data.data and \
-                                    in_edge.data.dst_subset.covers(out_edge.data.src_subset):
+                    for out_edge in list(out_edges):
+                        for in_edge in list(in_edges):
+                            if (in_edge.data.data == out_edge.data.data and
+                                    in_edge.data.dst_subset.covers(out_edge.data.src_subset)):
                                 out_edges.remove(out_edge)
 
                     for e in in_edges:

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -298,10 +298,11 @@ class StateGraphView(object):
 
         # Get scopes
         for node, scopenodes in sdc.items():
+            scope_exit_nodes = [v for v in scopenodes if isinstance(v, nd.ExitNode)]
             if node is None:
                 exit_node = None
             else:
-                exit_node = next(v for v in scopenodes if isinstance(v, nd.ExitNode))
+                exit_node = next(iter(scope_exit_nodes))
             scope = ScopeTree(node, exit_node)
             result[node] = scope
 
@@ -502,13 +503,22 @@ class StateGraphView(object):
             # is read is not counted in the read set
             for n in utils.dfs_topological_sort(sg, sources=sg.source_nodes()):
                 if isinstance(n, nd.AccessNode):
-                    for e in sg.in_edges(n):
+                    in_edges = sg.in_edges(n)
+                    out_edges = sg.out_edges(n)
+                    # Filter out memlets which go out but the same data is written to the AccessNode by another memlet
+                    for out_edge in out_edges:
+                        for in_edge in in_edges:
+                            if in_edge.data.data == out_edge.data.data and \
+                                    in_edge.data.dst_subset.covers(out_edge.data.src_subset):
+                                out_edges.remove(out_edge)
+
+                    for e in in_edges:
                         # skip empty memlets
                         if e.data.is_empty():
                             continue
                         # Store all subsets that have been written
                         ws[n.data].append(e.data.subset)
-                    for e in sg.out_edges(n):
+                    for e in out_edges:
                         # skip empty memlets
                         if e.data.is_empty():
                             continue

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -925,7 +925,12 @@ class RefineNestedAccess(transformation.SingleStateTransformation):
                     continue
 
                 # For now we only detect one element
+                read_set, write_set = nstate.read_and_write_sets()
                 for e in nstate.in_edges(dnode):
+                    if e.data.data not in write_set:
+                        # Skip data which is not in the read and write set of the state -> there also won't be a
+                        # connector
+                        continue
                     # If more than one unique element detected, remove from
                     # candidates
                     if e.data.data in out_candidates:
@@ -941,6 +946,10 @@ class RefineNestedAccess(transformation.SingleStateTransformation):
                         continue
                     out_candidates[e.data.data] = (e.data, nstate, set(range(len(e.data.subset))))
                 for e in nstate.out_edges(dnode):
+                    if e.data.data not in read_set:
+                        # Skip data which is not in the read and write set of the state -> there also won't be a
+                        # connector
+                        continue
                     # If more than one unique element detected, remove from
                     # candidates
                     if e.data.data in in_candidates:

--- a/tests/sdfg/state_test.py
+++ b/tests/sdfg/state_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 
 

--- a/tests/sdfg/state_test.py
+++ b/tests/sdfg/state_test.py
@@ -1,0 +1,23 @@
+import dace
+
+
+def test_read_write_set():
+    sdfg = dace.SDFG('graph')
+    A = sdfg.add_array('A', [10], dace.float64)
+    B = sdfg.add_array('B', [10], dace.float64)
+    C = sdfg.add_array('C', [10], dace.float64)
+    state = sdfg.add_state('state')
+    task1 = state.add_tasklet('work1', {'A'}, {'B'}, 'B = A + 1')
+    task2 = state.add_tasklet('work2', {'B'},  {'C'}, 'C = B + 1')
+    read_a = state.add_access('A')
+    rw_b = state.add_access('B')
+    write_c = state.add_access('C')
+    state.add_memlet_path(read_a, task1, dst_conn='A', memlet=dace.Memlet('A[2]'))
+    state.add_memlet_path(task1, rw_b, src_conn='B', memlet=dace.Memlet('B[2]'))
+    state.add_memlet_path(rw_b, task2, dst_conn='B', memlet=dace.Memlet('B[2]'))
+    state.add_memlet_path(task2, write_c, src_conn='C', memlet=dace.Memlet('C[2]'))
+
+    assert 'B' not in state.read_and_write_sets()[0]
+
+if __name__ == '__main__':
+    test_read_write_set()


### PR DESCRIPTION
`read_and_write_sets()` filters out reads which are written directly before to the same AccessNode. Will only work if the read and write memlet go to the same AccessNode