### PR TITLE
Fix some underlying issues with tensor core sample

### DIFF
--- a/samples/codegen/tensor_cores.py
+++ b/samples/codegen/tensor_cores.py
@@ -96,6 +96,8 @@ class TensorCoreCodegen(TargetCodeGenerator):
                 mat=('a' if 'A' in nodedesc.storage.name else 'b'), maj=maj)
             declaration_stream.write(f'{ctype} {name};', sdfg, state_id, node)
             
+        # Add the ctype to defined_vars so that the codegen can properly pass
+        # fragments to functions as an object reference.
         self._dispatcher.defined_vars.add(name, DefinedType.Stream, ctype)
 
     def deallocate_array(self, sdfg: dace.SDFG, dfg: StateSubgraphView, state_id: int, node: nodes.AccessNode,


### PR DESCRIPTION
After messing with the tensor core example some, myself and @tbennun noticed some issues with the sample. This PR fixes a few issues.

1. The storage types (e.g., `Accumulator`, `TensorCore_*`) have been added to `defined_vars`. In some cases not demonstrated in `hgemm`, the codegen generates improper passes to functions. By setting the type to `DefinedType.Stream`, we ensure that the WMMA fragments are always passed as an object reference.
2. The frontend is greatly redone and simplified, changing the use of `@replaces` to simple `dace.tasklet`s. As with 1, certain situations not exposed with `hgemm` showed that memlets are not always properly generated with the `frag_fill` and `wmma` functions. Changing their implementation to `dace.tasklet` ensures that memlets are now properly generated in all use cases, along with simplifying their implementation to a large degree.