### PR TITLE
Fortran fix memlet indices

### DIFF
--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -463,6 +463,7 @@ class AST_translator:
                                 if i.type == "ALL":
                                     shape.append(array.shape[indices])
                                     mysize = mysize * array.shape[indices]
+                                    index_list.append(None)
                                 else:
                                     raise NotImplementedError("Index in ParDecl should be ALL")
                             else:


### PR DESCRIPTION
Fixes error with memlet indices. Parser made implicit assumption about position of index a loop iterations over. Also added a testcase.