### PR TITLE
Added mpi4py communicator split support

### DIFF
--- a/dace/distr_types.py
+++ b/dace/distr_types.py
@@ -13,6 +13,30 @@ RankType = Union[Integral, str, symbolic.symbol, symbolic.SymExpr, symbolic.symp
 
 
 @make_properties
+class ProcessComm(object):
+    """
+    ProcessComm is the descriptor class for comm world split
+    Real comm creation is implemented in mpi.nodes.comm_split.Comm_split
+    """
+
+    name = Property(dtype=str, desc="The name of new comm world.")
+    def __init__(self,
+                 name: str):
+        self.name = name
+        self._validate()
+
+    def validate(self):
+        """ Validate the correctness of this object.
+            Raises an exception on error. """
+        self._validate()
+
+    # Validation of this class is in a separate function, so that this
+    # class can call `_validate()` without calling the subclasses'
+    # `validate` function.
+    def _validate(self):
+        return True
+
+@make_properties
 class ProcessGrid(object):
     """
     Process-grids implement cartesian topologies similarly to cartesian communicators created with [MPI_Cart_create](https://www.mpich.org/static/docs/latest/www3/MPI_Cart_create.html)

--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -224,6 +224,11 @@ def _bcast(pv: ProgramVisitor,
     desc = sdfg.arrays[buffer]
     in_buffer = state.add_read(buffer)
     out_buffer = state.add_write(buffer)
+    if grid:
+        comm_node = state.add_read(grid)
+        comm_desc = sdfg.arrays[grid]
+        state.add_edge(comm_node, None, libnode, None, Memlet.from_array(grid, comm_desc))
+
     if isinstance(root, str) and root in sdfg.arrays.keys():
         root_node = state.add_read(root)
     else:

--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -44,7 +44,8 @@ def _comm_split(pv: 'ProgramVisitor',
                 sdfg: SDFG,
                 state: SDFGState,
                 color: Union[str, sp.Expr, Number] = 0,
-                key: Union[str, sp.Expr, Number] = 0):
+                key: Union[str, sp.Expr, Number] = 0,
+                grid: str = None):
     """ Splits communicator
     """
 
@@ -53,7 +54,7 @@ def _comm_split(pv: 'ProgramVisitor',
     # fine a new comm world name
     comm_name = sdfg.add_comm()
 
-    comm_split_node = Comm_split(comm_name)
+    comm_split_node = Comm_split(comm_name, grid)
 
     _, color_node = _get_int_arg_node(pv, sdfg, state, color)
     _, key_node = _get_int_arg_node(pv, sdfg, state, key)
@@ -79,12 +80,22 @@ def _intracomm_comm_split(pv: 'ProgramVisitor',
                      color: Union[str, sp.Expr, Number] = 0,
                      key: Union[str, sp.Expr, Number] = 0):
     """ Equivalent to `dace.comm.Bcast(buffer, root)`. """
-    # print("intracomm")
     from mpi4py import MPI
     comm_name, comm_obj = comm
     if comm_obj == MPI.COMM_WORLD:
         return _comm_split(pv, sdfg, state, color, key)
     raise ValueError('Only the mpi4py.MPI.COMM_WORLD Intracomm is supported in DaCe Python programs.')
+
+
+@oprepo.replaces_method('ProcessComm', 'Split')
+def _intracomm_comm_split(pv: 'ProgramVisitor',
+                     sdfg: SDFG,
+                     state: SDFGState,
+                     comm: Tuple[str, 'Comm'],
+                     color: Union[str, sp.Expr, Number] = 0,
+                     key: Union[str, sp.Expr, Number] = 0):
+    """ Equivalent to `dace.comm.Bcast(buffer, root)`. """
+    return _comm_split(pv, sdfg, state, color, key, grid=comm)
 
 
 ##### MPI Cartesian Communicators

--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -22,17 +22,17 @@ ProgramVisitor = 'dace.frontend.python.newast.ProgramVisitor'
 def _get_int_arg_node(pv: ProgramVisitor,
                      sdfg: SDFG,
                      state: SDFGState,
-                     arg_name: Union[str, sp.Expr, Number]
+                     argument: Union[str, sp.Expr, Number]
                     ):
-    if isinstance(arg_name, str) and arg_name in sdfg.arrays.keys():
-        arg_name = arg_name
+    if isinstance(argument, str) and argument in sdfg.arrays.keys():
+        arg_name = argument
         arg_node = state.add_read(arg_name)
     else:
         # create a transient scalar and take its name
         arg_name = _define_local_scalar(pv, sdfg, state, dace.int32)
         arg_node = state.add_access(arg_name)
         # every tasklet is in different scope, no need to worry about name confilct
-        color_tasklet = state.add_tasklet(f'_set_{arg_name}_', {}, {'__out'}, f'__out = {arg_name}')
+        color_tasklet = state.add_tasklet(f'_set_{arg_name}_', {}, {'__out'}, f'__out = {argument}')
         state.add_edge(color_tasklet, '__out', arg_node, None, Memlet.simple(arg_node, '0'))
 
     return arg_name, arg_node

--- a/dace/frontend/common/distr.py
+++ b/dace/frontend/common/distr.py
@@ -88,7 +88,7 @@ def _intracomm_comm_split(pv: 'ProgramVisitor',
 
 
 @oprepo.replaces_method('ProcessComm', 'Split')
-def _intracomm_comm_split(pv: 'ProgramVisitor',
+def processcomm_comm_split(pv: 'ProgramVisitor',
                      sdfg: SDFG,
                      state: SDFGState,
                      comm: Tuple[str, 'Comm'],
@@ -96,6 +96,27 @@ def _intracomm_comm_split(pv: 'ProgramVisitor',
                      key: Union[str, sp.Expr, Number] = 0):
     """ Equivalent to `dace.comm.Bcast(buffer, root)`. """
     return _comm_split(pv, sdfg, state, color, key, grid=comm)
+
+
+@oprepo.replaces_method('ProcessComm', 'Free')
+def _processcomm_comm_free(pv: 'ProgramVisitor',
+                     sdfg: SDFG,
+                     state: SDFGState,
+                     comm: Tuple[str, 'Comm']):
+
+    from dace.libraries.mpi.nodes.comm_free import Comm_free
+
+    print(comm)
+
+    comm_free_node = Comm_free("_Comm_free_", comm)
+
+    # Pseudo-writing for newast.py #3195 check and complete Processcomm creation
+    comm_node = state.add_read(comm)
+    comm_desc = sdfg.arrays[comm]
+    state.add_edge(comm_node, None, comm_free_node, "_in", Memlet.from_array(comm, comm_desc))
+
+    # return value will be the name of this splited communicator
+    return f"{comm}_free"
 
 
 ##### MPI Cartesian Communicators

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1312,6 +1312,7 @@ class ProgramVisitor(ExtNodeVisitor):
 
         # MPI-related stuff
         result.update({k: self.sdfg.process_grids[v] for k, v in self.variables.items() if v in self.sdfg.process_grids})
+        result.update({k: self.sdfg.process_comms[v] for k, v in self.variables.items() if v in self.sdfg.process_comms})
         try:
             from mpi4py import MPI
             result.update({k: v for k, v in self.globals.items() if isinstance(v, MPI.Comm)})
@@ -4682,6 +4683,8 @@ class ProgramVisitor(ExtNodeVisitor):
         for operand in operands:
             if isinstance(operand, str) and operand in self.sdfg.process_grids:
                 result.append((operand, type(self.sdfg.process_grids[operand]).__name__))
+            elif isinstance(operand, str) and operand in self.sdfg.process_comms:
+                result.append((operand, type(self.sdfg.process_comms[operand]).__name__))
             elif isinstance(operand, str) and operand in self.sdfg.arrays:
                 result.append((operand, type(self.sdfg.arrays[operand])))
             elif isinstance(operand, str) and operand in self.scope_arrays:

--- a/dace/libraries/mpi/nodes/__init__.py
+++ b/dace/libraries/mpi/nodes/__init__.py
@@ -13,3 +13,4 @@ from .allgather import Allgather
 from .alltoall import Alltoall
 from .dummy import Dummy
 from .redistribute import Redistribute
+from .comm_split import Comm_split

--- a/dace/libraries/mpi/nodes/__init__.py
+++ b/dace/libraries/mpi/nodes/__init__.py
@@ -14,4 +14,4 @@ from .alltoall import Alltoall
 from .dummy import Dummy
 from .redistribute import Redistribute
 from .comm_split import Comm_split
-from .free import Free
+from .comm_free import Comm_free

--- a/dace/libraries/mpi/nodes/__init__.py
+++ b/dace/libraries/mpi/nodes/__init__.py
@@ -14,3 +14,4 @@ from .alltoall import Alltoall
 from .dummy import Dummy
 from .redistribute import Redistribute
 from .comm_split import Comm_split
+from .free import Free

--- a/dace/libraries/mpi/nodes/comm_free.py
+++ b/dace/libraries/mpi/nodes/comm_free.py
@@ -14,12 +14,8 @@ class ExpandFreeMPI(ExpandTransformation):
 
     @staticmethod
     def expansion(node, parent_state, parent_sdfg, n=None, **kwargs):
-        comm = "MPI_COMM_WORLD"
-        if node.grid:
-            comm = f"__state->{node.grid}_comm"
-
         code = f"""
-            MPI_Comm_free(&{comm});
+            MPI_Comm_free(&__state->{node.grid}_comm);
             """
         tasklet = dace.sdfg.nodes.Tasklet(node.name,
                                           node.in_connectors,
@@ -30,7 +26,7 @@ class ExpandFreeMPI(ExpandTransformation):
 
 
 @dace.library.node
-class Free(MPINode):
+class Comm_free(MPINode):
 
     # Global properties
     implementations = {
@@ -38,10 +34,10 @@ class Free(MPINode):
     }
     default_implementation = "MPI"
 
-    grid = dace.properties.Property(dtype=str, allow_none=True, default=None)
+    grid = dace.properties.Property(dtype=str, allow_none=False, default=None)
 
-    def __init__(self, name, grid=None, *args, **kwargs):
-        super().__init__(name, *args, inputs={}, outputs={}, **kwargs)
+    def __init__(self, name, grid, *args, **kwargs):
+        super().__init__(name, *args, inputs={"_in"}, outputs={}, **kwargs)
         self.grid = grid
 
     def validate(self, sdfg, state):

--- a/dace/libraries/mpi/nodes/comm_split.py
+++ b/dace/libraries/mpi/nodes/comm_split.py
@@ -16,7 +16,11 @@ class ExpandCommSplitMPI(ExpandTransformation):
     def expansion(node, parent_state, parent_sdfg, n=None, **kwargs):
         color, key = node.validate(parent_sdfg, parent_state)
 
-        comm = "MPI_COMM_WORLD"
+        if node.grid is None:
+            comm = "MPI_COMM_WORLD"
+        else:
+            comm = f"__state->{node.grid}_comm"
+
         comm_name = node.name
 
         node.fields = [

--- a/dace/libraries/mpi/nodes/comm_split.py
+++ b/dace/libraries/mpi/nodes/comm_split.py
@@ -69,5 +69,10 @@ class Comm_split(MPINode):
                 color = sdfg.arrays[e.data.data]
             if e.dst_conn == "_key":
                 key = sdfg.arrays[e.data.data]
+
+        if color.dtype.base_type != dace.dtypes.int32:
+            raise ValueError("Source must be an integer!")
+        if key.dtype.base_type != dace.dtypes.int32:
+            raise ValueError("Tag must be an integer!")
         
         return color, key

--- a/dace/libraries/mpi/nodes/comm_split.py
+++ b/dace/libraries/mpi/nodes/comm_split.py
@@ -69,10 +69,5 @@ class Comm_split(MPINode):
                 color = sdfg.arrays[e.data.data]
             if e.dst_conn == "_key":
                 key = sdfg.arrays[e.data.data]
-
-        if color.dtype.base_type != dace.dtypes.int32:
-            raise ValueError("Source must be an integer!")
-        if key.dtype.base_type != dace.dtypes.int32:
-            raise ValueError("Tag must be an integer!")
         
         return color, key

--- a/dace/libraries/mpi/nodes/comm_split.py
+++ b/dace/libraries/mpi/nodes/comm_split.py
@@ -1,0 +1,73 @@
+# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import dace.library
+import dace.properties
+import dace.sdfg.nodes
+from dace.transformation.transformation import ExpandTransformation
+from .. import environments
+from dace.libraries.mpi.nodes.node import MPINode
+
+
+@dace.library.expansion
+class ExpandCommSplitMPI(ExpandTransformation):
+
+    environments = [environments.mpi.MPI]
+
+    @staticmethod
+    def expansion(node, parent_state, parent_sdfg, n=None, **kwargs):
+        color, key = node.validate(parent_sdfg, parent_state)
+
+        comm_name = node.name
+        comm = "MPI_COMM_WORLD"
+
+        node.fields = [
+            f'MPI_Comm {comm_name};',
+            f'int {comm_name}_rank;',
+            f'int {comm_name}_size;',
+        ]
+
+        code = f"""
+            MPI_Comm_split({comm}, _color, _key, &__state->{comm_name});
+            MPI_Comm_rank(__state->{comm_name}, &__state->{comm_name}_rank);
+            MPI_Comm_size(__state->{comm_name}, &__state->{comm_name}_size);
+        """
+
+        tasklet = dace.sdfg.nodes.Tasklet(node.name,
+                                          node.in_connectors,
+                                          node.out_connectors,
+                                          code,
+                                          state_fields=node.fields,
+                                          language=dace.dtypes.Language.CPP,
+                                          side_effects=True)
+        return tasklet
+
+
+@dace.library.node
+class Comm_split(MPINode):
+
+    # Global properties
+    implementations = {
+        "MPI": ExpandCommSplitMPI,
+    }
+    default_implementation = "MPI"
+
+    grid = dace.properties.Property(dtype=str, allow_none=True, default=None)
+
+    def __init__(self, name, grid=None, *args, **kwargs):
+        super().__init__(name, *args, inputs={"_color", "_key"}, outputs={}, **kwargs)
+        self.grid = grid
+
+    def validate(self, sdfg, state):
+        """
+        :return: A three-tuple (buffer, root) of the three data descriptors in the
+                 parent SDFG.
+        """
+
+        color, key = None, None
+
+        for e in state.in_edges(self):
+            if e.dst_conn == "_color":
+                color = sdfg.arrays[e.data.data]
+            if e.dst_conn == "_key":
+                key = sdfg.arrays[e.data.data]
+        
+        return color, key

--- a/tests/library/mpi/comm_free_test.py
+++ b/tests/library/mpi/comm_free_test.py
@@ -1,0 +1,67 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+from dace.sdfg import utils
+import dace.dtypes as dtypes
+from dace.memlet import Memlet
+import dace.libraries.mpi as mpi
+import dace.frontend.common.distr as comm
+import numpy as np
+import pytest
+
+
+@pytest.mark.mpi
+def test_comm_free():
+    from mpi4py import MPI
+    comm_world = MPI.COMM_WORLD
+    comm_rank = comm_world.Get_rank()
+    comm_size = comm_world.Get_size()
+
+    if comm_size < 2:
+        raise ValueError("Please run this test with at least two processes.")
+
+    sdfg = dace.SDFG("mpi_free_test")
+    state = sdfg.add_state("start")
+
+    sdfg.add_scalar("color", dace.dtypes.int32, transient=False)
+    sdfg.add_scalar("key", dace.dtypes.int32, transient=False)
+
+    color = state.add_read("color")
+    key = state.add_read("key")
+
+    # color and key needs to be variable
+    comm_name = sdfg.add_comm()
+    comm_split_node = mpi.nodes.comm_split.Comm_split(comm_name)
+
+    state.add_edge(color, None, comm_split_node, '_color', Memlet.simple(color, "0:1", num_accesses=1))
+    state.add_edge(key, None, comm_split_node, '_key', Memlet.simple(key, "0:1", num_accesses=1))
+
+    # Pseudo-writing for newast.py #3195 check and complete Processcomm creation
+    _, scal = sdfg.add_scalar(comm_name, dace.int32, transient=True)
+    wnode = state.add_write(comm_name)
+    state.add_edge(comm_split_node, "_out", wnode, None, Memlet.from_array(comm_name, scal))
+
+    state2 = sdfg.add_state("main")
+
+    sdfg.add_edge(state, state2, dace.InterstateEdge())
+
+    tasklet = state2.add_tasklet(
+        "comm_free",
+        {},
+        {},
+        f"MPI_Comm_free(&__state->{comm_name}_comm);",
+        dtypes.Language.CPP)
+
+    # comm_free_node = mpi.nodes.free.Free(comm_name)
+    # state2.add_node(comm_free_node)
+
+    func = utils.distributed_compile(sdfg, comm_world)
+
+    # split world
+    color = comm_rank % 2
+    key = comm_rank
+
+    func(color=color, key=key)
+
+
+if __name__ == "__main__":
+    test_comm_free()

--- a/tests/library/mpi/comm_split_test.py
+++ b/tests/library/mpi/comm_split_test.py
@@ -37,6 +37,11 @@ def test_comm_split():
     state.add_edge(color, None, comm_split_node, '_color', Memlet.simple(color, "0:1", num_accesses=1))
     state.add_edge(key, None, comm_split_node, '_key', Memlet.simple(key, "0:1", num_accesses=1))
     
+    # Pseudo-writing for newast.py #3195 check and complete Processcomm creation
+    _, scal = sdfg.add_scalar(comm_name, dace.int32, transient=True)
+    wnode = state.add_write(comm_name)
+    state.add_edge(comm_split_node, "_out", wnode, None, Memlet.from_array(comm_name, scal))
+
     state2 = sdfg.add_state("main")
     
     sdfg.add_edge(state, state2, dace.InterstateEdge())

--- a/tests/library/mpi/comm_split_test.py
+++ b/tests/library/mpi/comm_split_test.py
@@ -21,9 +21,9 @@ def test_comm_split():
     
     sdfg = dace.SDFG("mpi_comm_split")
     state = sdfg.add_state("start")
-    
-    sdfg.add_array("color", [1], dace.dtypes.int32, transient=False)
-    sdfg.add_array("key", [1], dace.dtypes.int32, transient=False)
+
+    sdfg.add_scalar("color", dace.dtypes.int32, transient=False)
+    sdfg.add_scalar("key", dace.dtypes.int32, transient=False)
     sdfg.add_array("new_rank", [1], dtype=dace.int32, transient=False)
     sdfg.add_array("new_size", [1], dtype=dace.int32, transient=False)
 
@@ -57,8 +57,8 @@ def test_comm_split():
     func = utils.distributed_compile(sdfg, comm_world)
 
     # split world
-    color = np.full((1,), comm_rank % 2, dtype=np.int32)
-    key = np.full((1,), comm_rank, dtype=np.int32)
+    color = comm_rank % 2
+    key = comm_rank
     new_rank = np.zeros((1, ), dtype=np.int32)
     new_size = np.zeros((1, ), dtype=np.int32)
 
@@ -68,8 +68,8 @@ def test_comm_split():
     assert (correct_new_rank[comm_rank] == new_rank[0])
 
     # reverse rank order
-    color = np.full((1,), 0, dtype=np.int32)
-    key = np.full((1,), comm_size - comm_rank, dtype=np.int32)
+    color = 0
+    key = comm_size - comm_rank
     new_rank = np.zeros((1, ), dtype=np.int32)
     new_size = np.zeros((1, ), dtype=np.int32)
 

--- a/tests/library/mpi/comm_split_test.py
+++ b/tests/library/mpi/comm_split_test.py
@@ -33,17 +33,9 @@ def test_comm_split():
     # color and key needs to be variable
     comm_name = sdfg.add_comm()
     comm_split_node = mpi.nodes.comm_split.Comm_split(comm_name)
-    # comm_name = comm._comm_split(None, sdfg, state, str(color), str(key))
 
-    state.add_memlet_path(color,
-                          comm_split_node,
-                          dst_conn="_color",
-                          memlet=Memlet.simple(color, "0:1", num_accesses=1))
-    
-    state.add_memlet_path(key,
-                          comm_split_node,
-                          dst_conn="_key",
-                          memlet=Memlet.simple(key, "0:1", num_accesses=1))
+    state.add_edge(color, None, comm_split_node, '_color', Memlet.simple(color, "0:1", num_accesses=1))
+    state.add_edge(key, None, comm_split_node, '_key', Memlet.simple(key, "0:1", num_accesses=1))
     
     state2 = sdfg.add_state("main")
     
@@ -58,6 +50,7 @@ def test_comm_split():
 
     new_rank = state2.add_write("new_rank")
     new_size = state2.add_write("new_size")
+
     state2.add_edge(tasklet, '_rank', new_rank, None, Memlet.simple(new_rank, "0:1", num_accesses=1))
     state2.add_edge(tasklet, '_size', new_size, None, Memlet.simple(new_size, "0:1", num_accesses=1))
 

--- a/tests/library/mpi/comm_split_test.py
+++ b/tests/library/mpi/comm_split_test.py
@@ -1,0 +1,89 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+from dace.sdfg import utils
+import dace.dtypes as dtypes
+from dace.memlet import Memlet
+import dace.libraries.mpi as mpi
+import dace.frontend.common.distr as comm
+import numpy as np
+import pytest
+
+
+@pytest.mark.mpi
+def test_comm_split():
+    from mpi4py import MPI
+    comm_world = MPI.COMM_WORLD
+    comm_rank = comm_world.Get_rank()
+    comm_size = comm_world.Get_size()
+
+    if comm_size < 2:
+        raise ValueError("Please run this test with at least two processes.")
+    
+    sdfg = dace.SDFG("mpi_comm_split")
+    state = sdfg.add_state("start")
+    
+    sdfg.add_array("color", [1], dace.dtypes.int32, transient=False)
+    sdfg.add_array("key", [1], dace.dtypes.int32, transient=False)
+    sdfg.add_array("new_rank", [1], dtype=dace.int32, transient=False)
+    sdfg.add_array("new_size", [1], dtype=dace.int32, transient=False)
+
+    color = state.add_read("color")
+    key = state.add_read("key")
+
+    # color and key needs to be variable
+    comm_name = sdfg.add_comm()
+    comm_split_node = mpi.nodes.comm_split.Comm_split(comm_name)
+    # comm_name = comm._comm_split(None, sdfg, state, str(color), str(key))
+
+    state.add_memlet_path(color,
+                          comm_split_node,
+                          dst_conn="_color",
+                          memlet=Memlet.simple(color, "0:1", num_accesses=1))
+    
+    state.add_memlet_path(key,
+                          comm_split_node,
+                          dst_conn="_key",
+                          memlet=Memlet.simple(key, "0:1", num_accesses=1))
+    
+    state2 = sdfg.add_state("main")
+    
+    sdfg.add_edge(state, state2, dace.InterstateEdge())
+
+    tasklet = state2.add_tasklet(
+        "new_comm_get",
+        {},
+        {'_rank', '_size'},
+        f"_rank = __state->{comm_name}_rank;\n_size = __state->{comm_name}_size;",
+        dtypes.Language.CPP)
+
+    new_rank = state2.add_write("new_rank")
+    new_size = state2.add_write("new_size")
+    state2.add_edge(tasklet, '_rank', new_rank, None, Memlet.simple(new_rank, "0:1", num_accesses=1))
+    state2.add_edge(tasklet, '_size', new_size, None, Memlet.simple(new_size, "0:1", num_accesses=1))
+
+    func = utils.distributed_compile(sdfg, comm_world)
+
+    # split world
+    color = np.full((1,), comm_rank % 2, dtype=np.int32)
+    key = np.full((1,), comm_rank, dtype=np.int32)
+    new_rank = np.zeros((1, ), dtype=np.int32)
+    new_size = np.zeros((1, ), dtype=np.int32)
+
+    func(color=color, key=key, new_rank=new_rank, new_size=new_size)
+
+    correct_new_rank = np.arange(0, comm_size, dtype=np.int32) // 2
+    assert (correct_new_rank[comm_rank] == new_rank[0])
+
+    # reverse rank order
+    color = np.full((1,), 0, dtype=np.int32)
+    key = np.full((1,), comm_size - comm_rank, dtype=np.int32)
+    new_rank = np.zeros((1, ), dtype=np.int32)
+    new_size = np.zeros((1, ), dtype=np.int32)
+
+    func(color=color, key=key, new_rank=new_rank, new_size=new_size)
+
+    correct_new_rank = np.flip(np.arange(0, comm_size, dtype=np.int32), 0)
+    assert (correct_new_rank[comm_rank] == new_rank[0])
+
+if __name__ == "__main__":
+    test_comm_split()

--- a/tests/library/mpi/mpi4py_test.py
+++ b/tests/library/mpi/mpi4py_test.py
@@ -77,6 +77,48 @@ def test_external_comm_bcast():
     assert(np.array_equal(A, A_ref))
 
 
+# @pytest.mark.mpi
+def test_process_comm_split_bcast():
+
+    from mpi4py import MPI
+    commworld = MPI.COMM_WORLD
+    rank = commworld.Get_rank()
+    size = commworld.Get_size()
+
+    @dace.program
+    def comm_split_bcast(rank: dace.int32, A: dace.int32[10]):
+        # new_comm = commworld.Split(rank % 2, 0)
+        color = np.full((1,), rank % 2, dtype=np.int32)
+        key = np.full((1,), 0, dtype=np.int32)
+        new_comm = commworld.Split(color, key)
+        new_comm.Bcast(A)
+
+    if size < 2:
+        raise ValueError("Please run this test with at least two processes.")
+
+    sdfg = None
+    if rank == 0:
+        sdfg = comm_split_bcast.to_sdfg()
+        # disable openMP section for split completeness
+        sdfg.openmp_sections = False
+    func = utils.distributed_compile(sdfg, commworld)
+
+    if rank == 0:
+        A = np.arange(10, dtype=np.int32)
+        A_ref = A.copy()
+    elif rank == 1:
+        A = np.arange(10, 20, dtype=np.int32)
+        A_ref = A.copy()
+    else:
+        A = np.zeros((10, ), dtype=np.int32)
+        A_ref = A.copy()
+
+    func(rank=rank, A=A)
+    comm_split_bcast.f(rank, A_ref)
+
+    assert(np.array_equal(A, A_ref))
+
+
 @pytest.mark.mpi
 def test_process_grid_bcast():
 
@@ -327,12 +369,44 @@ def test_alltoall():
         raise (ValueError("The received values are not what I expected."))
 
 
+@pytest.mark.mpi
+def test_comm_split_alltoall():
+    from mpi4py import MPI
+    commworld = MPI.COMM_WORLD
+    rank = commworld.Get_rank()
+    size = commworld.Get_size()
+
+    @dace.program
+    def mpi4py_comm_split_alltoall(rank: dace.int32, size: dace.compiletime):
+        color = np.full((1,), rank % 2, dtype=np.int32)
+        key = np.full((1,), 0, dtype=np.int32)
+        new_comm = commworld.Split(color, key)
+
+        sbuf = np.full((size // 2,), rank, dtype=np.int32)
+        rbuf = np.zeros((size // 2, ), dtype=np.int32)
+        new_comm.Alltoall(sbuf, rbuf)
+        return rbuf
+
+    sdfg = None
+    if rank == 0:
+        sdfg = mpi4py_comm_split_alltoall.to_sdfg(simplify=True, size=size)
+    func = utils.distributed_compile(sdfg, commworld)
+
+    val = func(rank=rank)
+    ref = mpi4py_comm_split_alltoall.f(rank, size)
+
+    if (not np.allclose(val, ref)):
+        raise (ValueError("The received values are not what I expected."))
+
+
 if __name__ == "__main__":
     test_comm_world_bcast()
     test_external_comm_bcast()
+    test_process_comm_split_bcast()
     test_process_grid_bcast()
     test_sub_grid_bcast()
     test_3mm()
     test_isend_irecv()
     test_send_recv()
     test_alltoall()
+    test_comm_split_alltoall()

--- a/tests/library/mpi/mpi4py_test.py
+++ b/tests/library/mpi/mpi4py_test.py
@@ -89,8 +89,7 @@ def test_process_comm_split_bcast():
     def comm_split_bcast(rank: dace.int32, A: dace.int32[10]):
         # new_comm = commworld.Split(rank % 2, 0)
         color = np.full((1,), rank % 2, dtype=np.int32)
-        key = np.full((1,), 0, dtype=np.int32)
-        new_comm = commworld.Split(color, key)
+        new_comm = commworld.Split(color, 0)
         new_comm.Bcast(A)
 
     if size < 2:

--- a/tests/library/mpi/mpi4py_test.py
+++ b/tests/library/mpi/mpi4py_test.py
@@ -77,7 +77,7 @@ def test_external_comm_bcast():
     assert(np.array_equal(A, A_ref))
 
 
-# @pytest.mark.mpi
+@pytest.mark.mpi
 def test_process_comm_split_bcast():
 
     from mpi4py import MPI


### PR DESCRIPTION
## Summary
Added mpi4py communicator split support by creating a new library node.

## Description
Added comm split library node, test, and replacement in frontend.
In this library node, the pseudo-writing edge can be used to ensure the order of mpi nodes.