### PR TITLE
Support array dimension properties in Fortran frontend

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -615,17 +615,7 @@ class InternalFortranAst:
                 sizes = get_child(get_child(i, ["Dimension_Attr_Spec"]), ["Explicit_Shape_Spec_List"])
                 
                 for shape_spec in get_children(sizes, [f03.Explicit_Shape_Spec]):
-                    print(shape_spec)
                     self.parse_shape_specification(shape_spec, attr_size, attr_offset)
-                print(sizes.children)
-                print(type(sizes))
-                #print(sizes.children)
-
-                #if len(i.children) > 0 and isinstance(i.children[0], f03.Dimension_Attr_Spec):
-                #    print(i, dir(i), type(i.children[0]), dir(i.children[0]))
-
-        #sizes = get_child(attributes, ["Attr_Spec_List"])
-        #print(sizes)
 
         vardecls = []
 
@@ -656,8 +646,6 @@ class InternalFortranAst:
                 raw_init = initialization.children[1]
                 init = self.create_ast(raw_init)
 
-            print('t', symbol, size, attr_size)
-            print(offset, attr_offset)
             if symbol == False:
 
                 if attr_size is None:

--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -610,9 +610,13 @@ class InternalFortranAst:
 
             if isinstance(i, Fortran2008.Attr_Spec_List):
 
+                dimension_spec = get_children(i, "Dimension_Attr_Spec")
+                if len(dimension_spec) == 0:
+                    continue
+
                 attr_size = []
                 attr_offset = []
-                sizes = get_child(get_child(i, ["Dimension_Attr_Spec"]), ["Explicit_Shape_Spec_List"])
+                sizes = get_child(dimension_spec[0], ["Explicit_Shape_Spec_List"])
                 
                 for shape_spec in get_children(sizes, [f03.Explicit_Shape_Spec]):
                     self.parse_shape_specification(shape_spec, attr_size, attr_offset)

--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -695,8 +695,6 @@ class InternalFortranAst:
                                                                     kind=kind,
                                                                     init=init,
                                                                     line_number=node.item.span))
-        #print(vardecls[0].sizes)
-        #print(vardecls[0].offsets)
         return ast_internal_classes.Decl_Stmt_Node(vardecl=vardecls, line_number=node.item.span)
 
     def entity_decl(self, node: FASTNode):

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -199,6 +199,7 @@ class Symbol_Array_Decl_Node(Statement_Node):
     )
     _fields = (
         'sizes',
+        'offsets'
         'typeref',
         'init',
     )

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -214,6 +214,7 @@ class Var_Decl_Node(Statement_Node):
     )
     _fields = (
         'sizes',
+        'offsets',
         'typeref',
         'init',
     )

--- a/tests/fortran/array_attributes_test.py
+++ b/tests/fortran/array_attributes_test.py
@@ -47,16 +47,11 @@ def test_fortran_frontend_array_attribute_offset():
                     PROGRAM index_offset_test
                     implicit none
                     double precision, dimension(50:54) :: d
-                    !double precision, dimension(5) :: d
-                    !double precision d(50:54)
                     CALL index_test_function(d)
                     end
 
                     SUBROUTINE index_test_function(d)
-                    !double precision d(50:54)
-                    !double precision d(5)
                     double precision, dimension(50:54) :: d
-                    !double precision, intent(inout) :: d(50:54)
 
                     do i=50,54
                        d(i) = i * 2.0

--- a/tests/fortran/index_offset_test.py
+++ b/tests/fortran/index_offset_test.py
@@ -18,6 +18,46 @@ import dace.frontend.fortran.ast_transforms as ast_transforms
 import dace.frontend.fortran.ast_utils as ast_utils
 import dace.frontend.fortran.ast_internal_classes as ast_internal_classes
 
+def test_fortran_frontend_index_offset_attributes():
+    """
+    Tests that the Fortran frontend can parse array accesses and that the accessed indices are correct.
+    """
+    test_string = """
+                    PROGRAM index_offset_test
+                    implicit none
+                    double precision, dimension(50:54) :: d
+                    !double precision, dimension(5) :: d
+                    !double precision d(50:54)
+                    CALL index_test_function(d)
+                    end
+
+                    SUBROUTINE index_test_function(d)
+                    !double precision d(50:54)
+                    !double precision d(5)
+                    double precision, dimension(50:54) :: d
+                    !double precision, intent(inout) :: d(50:54)
+
+                    do i=50,54
+                       d(i) = i * 2.0
+                    end do
+
+                    END SUBROUTINE index_test_function
+                    """
+    sdfg = fortran_parser.create_sdfg_from_string(test_string, "index_offset_test")
+    sdfg.simplify(verbose=True)
+    sdfg.compile()
+
+    assert len(sdfg.data('d').shape) == 1
+    assert sdfg.data('d').shape[0] == 5
+    assert len(sdfg.data('d').offset) == 1
+    assert sdfg.data('d').offset[0] == -1
+
+    a = np.full([60], 42, order="F", dtype=np.float64)
+    sdfg(d=a)
+    for i in range(50,54):
+        # offset -1 is already added
+        assert a[i-1] == i * 2
+
 def test_fortran_frontend_index_offset():
     """
     Tests that the Fortran frontend can parse array accesses and that the accessed indices are correct.
@@ -56,5 +96,5 @@ def test_fortran_frontend_index_offset():
 
 if __name__ == "__main__":
 
-    #test_fortran_frontend_index_offset()
-    test_fortran_frontend_index_offset_dimensions()
+    test_fortran_frontend_index_offset()
+    test_fortran_frontend_index_offset_attributes()

--- a/tests/fortran/index_offset_test.py
+++ b/tests/fortran/index_offset_test.py
@@ -1,0 +1,60 @@
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+
+from fparser.common.readfortran import FortranStringReader
+from fparser.common.readfortran import FortranFileReader
+from fparser.two.parser import ParserFactory
+import sys, os
+import numpy as np
+import pytest
+
+import dace
+from dace import SDFG, SDFGState, instrument, nodes, dtypes, data, subsets, symbolic
+from dace.frontend.fortran import fortran_parser
+from fparser.two.symbol_table import SymbolTable
+from dace.sdfg import utils as sdutil
+
+import dace.frontend.fortran.ast_components as ast_components
+import dace.frontend.fortran.ast_transforms as ast_transforms
+import dace.frontend.fortran.ast_utils as ast_utils
+import dace.frontend.fortran.ast_internal_classes as ast_internal_classes
+
+def test_fortran_frontend_index_offset():
+    """
+    Tests that the Fortran frontend can parse array accesses and that the accessed indices are correct.
+    """
+    test_string = """
+                    PROGRAM index_offset_test
+                    implicit none
+                    double precision d(50:54)
+                    CALL index_test_function(d)
+                    end
+
+                    SUBROUTINE index_test_function(d)
+                    double precision d(50:54)
+
+                    do i=50,54
+                       d(i) = i * 2.0
+                    end do
+                    
+                    END SUBROUTINE index_test_function
+                    """
+    sdfg = fortran_parser.create_sdfg_from_string(test_string, "index_offset_test")
+    sdfg.simplify(verbose=True)
+    sdfg.compile()
+
+    assert len(sdfg.data('d').shape) == 1
+    assert sdfg.data('d').shape[0] == 5
+    assert len(sdfg.data('d').offset) == 1
+    assert sdfg.data('d').offset[0] == -1
+
+    a = np.full([60], 42, order="F", dtype=np.float64)
+    sdfg(d=a)
+    for i in range(50,54):
+        # offset -1 is already added
+        assert a[i-1] == i * 2
+
+
+if __name__ == "__main__":
+
+    #test_fortran_frontend_index_offset()
+    test_fortran_frontend_index_offset_dimensions()


### PR DESCRIPTION
Hi!

This PR adds to the Fortran frontend the support for defining array sizes and offset through the `dimension` attribute.