### PR TITLE
Update fparser to 0.1.3

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -1,6 +1,5 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
-from fparser.two.Fortran2008 import Fortran2008 as f08
-from fparser.two import Fortran2008
+from fparser.two import Fortran2008 as f08
 from fparser.two import Fortran2003 as f03
 from fparser.two import symbol_table
 
@@ -608,7 +607,7 @@ class InternalFortranAst:
             if i.string.lower() == "parameter":
                 symbol = True
 
-            if isinstance(i, Fortran2008.Attr_Spec_List):
+            if isinstance(i, f08.Attr_Spec_List):
 
                 dimension_spec = get_children(i, "Dimension_Attr_Spec")
                 if len(dimension_spec) == 0:
@@ -1052,7 +1051,7 @@ class InternalFortranAst:
 
         decls = [self.create_ast(i) for i in node.children if isinstance(i, f08.Type_Declaration_Stmt)]
 
-        uses = [self.create_ast(i) for i in node.children if isinstance(i, f08.Use_Stmt)]
+        uses = [self.create_ast(i) for i in node.children if isinstance(i, f03.Use_Stmt)]
         tmp = [self.create_ast(i) for i in node.children]
         typedecls = [i for i in tmp if isinstance(i, ast_internal_classes.Type_Decl_Node)]
         symbols = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 dill==0.3.6
 Flask==2.3.2
-fparser==0.1.2
+fparser==0.1.3
 idna==3.4
 importlib-metadata==6.6.0
 itsdangerous==2.1.2

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(name='dace',
       include_package_data=True,
       install_requires=[
          'numpy', 'networkx >= 2.5', 'astunparse', 'sympy<=1.9', 'pyyaml', 'ply', 'websockets', 'requests', 'flask',
-          'fparser >= 0.1.2', 'aenum >= 3.1', 'dataclasses; python_version < "3.7"', 'dill',
+          'fparser >= 0.1.3', 'aenum >= 3.1', 'dataclasses; python_version < "3.7"', 'dill',
           'pyreadline;platform_system=="Windows"', 'typing-compat; python_version < "3.8"'
       ] + cmake_requires,
       extras_require={


### PR DESCRIPTION
This PR updates the core Fortran dependency and makes our code compatible with the restructurization of this third-party package. Should fix failing tests in #1370 

cc: @tbennun @acalotoiu 