### PR TITLE
Fix transient bug in test with `array_equal` of empty arrays

### DIFF
--- a/tests/numpy/ufunc_support_test.py
+++ b/tests/numpy/ufunc_support_test.py
@@ -122,6 +122,7 @@ def ufunc_add_where(A: dace.int32[10], B: dace.int32[10], W: dace.bool_[10]):
 
 
 def test_ufunc_add_where():
+    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
     B = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
     W = np.random.randint(2, size=(10, ), dtype=np.bool_)
@@ -140,18 +141,6 @@ def test_ufunc_add_where_true():
     B = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
     C = ufunc_add_where_true(A, B)
     assert (np.array_equal(np.add(A, B, where=True), C))
-
-
-@dace.program
-def ufunc_add_where_false(A: dace.int32[10], B: dace.int32[10]):
-    return np.add(A, B, where=False)
-
-
-def test_ufunc_add_where_false():
-    A = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
-    B = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
-    C = ufunc_add_where_false(A, B)
-    assert (not np.array_equal(A + B, C))
 
 
 @dace.program
@@ -188,6 +177,7 @@ def ufunc_add_where1(A: dace.int32[1], B: dace.int32[1], W: dace.bool_[1]):
 
 
 def test_ufunc_add_where1():
+    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(1, ), dtype=np.int32)
     B = np.random.randint(1, 10, size=(1, ), dtype=np.int32)
     W = np.random.randint(2, size=(1, ), dtype=np.bool_)
@@ -452,6 +442,7 @@ def ufunc_add_outer_where(A: dace.int32[2, 2, 2, 2, 2], B: dace.int32[2, 2, 2, 2
 
 
 def test_ufunc_add_outer_where():
+    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     B = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     W = np.random.randint(2, size=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), dtype=np.bool_)
@@ -465,6 +456,7 @@ def ufunc_add_outer_where2(A: dace.int32[2, 2, 2, 2, 2], B: dace.int32[2, 2, 2, 
 
 
 def test_ufunc_add_outer_where2():
+    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     B = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     W = np.random.randint(2, size=(2, 1, 2), dtype=np.bool_)

--- a/tests/numpy/ufunc_support_test.py
+++ b/tests/numpy/ufunc_support_test.py
@@ -122,13 +122,13 @@ def ufunc_add_where(A: dace.int32[10], B: dace.int32[10], W: dace.bool_[10]):
 
 
 def test_ufunc_add_where():
-    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
     B = np.random.randint(1, 10, size=(10, ), dtype=np.int32)
     W = np.random.randint(2, size=(10, ), dtype=np.bool_)
     C = ufunc_add_where(A, B, W)
     assert (np.array_equal(np.add(A, B, where=W)[W], C[W]))
-    assert (not np.array_equal((A + B)[np.logical_not(W)], C[np.logical_not(W)]))
+    if not np.all(W):  # If all of W is True, np.logical_not(W) would result in empty arrays
+        assert (not np.array_equal((A + B)[np.logical_not(W)], C[np.logical_not(W)]))
 
 
 @dace.program
@@ -177,7 +177,6 @@ def ufunc_add_where1(A: dace.int32[1], B: dace.int32[1], W: dace.bool_[1]):
 
 
 def test_ufunc_add_where1():
-    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(1, ), dtype=np.int32)
     B = np.random.randint(1, 10, size=(1, ), dtype=np.int32)
     W = np.random.randint(2, size=(1, ), dtype=np.bool_)
@@ -442,12 +441,11 @@ def ufunc_add_outer_where(A: dace.int32[2, 2, 2, 2, 2], B: dace.int32[2, 2, 2, 2
 
 
 def test_ufunc_add_outer_where():
-    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     B = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     W = np.random.randint(2, size=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), dtype=np.bool_)
     s = ufunc_add_outer_where(A, B, W)
-    assert (np.array_equal(np.add.outer(A, B, where=W)[W], s[W]))
+    assert np.array_equal(np.add.outer(A, B, where=W)[W], s[W])
 
 
 @dace.program
@@ -456,7 +454,6 @@ def ufunc_add_outer_where2(A: dace.int32[2, 2, 2, 2, 2], B: dace.int32[2, 2, 2, 
 
 
 def test_ufunc_add_outer_where2():
-    np.random.seed(1234)
     A = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     B = np.random.randint(1, 10, size=(2, 2, 2, 2, 2), dtype=np.int32)
     W = np.random.randint(2, size=(2, 1, 2), dtype=np.bool_)
@@ -464,7 +461,7 @@ def test_ufunc_add_outer_where2():
     C = ufunc_add_outer_where2(A, B, W)
     where = np.empty((2, 2, 2, 2, 2, 2, 2, 2, 2, 2), dtype=np.bool_)
     where[:] = W
-    assert (np.array_equal(np.add.outer(A, B, where=W)[where], C[where]))
+    assert np.array_equal(np.add.outer(A, B, where=W)[where], C[where])
 
 
 @compare_numpy_output()


### PR DESCRIPTION
In some specific random seeds, the following error occurs:
```
tests/numpy/ufunc_support_test.py:130: in test_ufunc_add_where
    assert (not np.array_equal((A + B)[np.logical_not(W)], C[np.logical_not(W)]))
E   assert not True
E    +  where True = <function array_equal at 0x7f64de13d730>(array([], dtype=int32), array([], dtype=int32))
E    +    where <function array_equal at 0x7f64de13d730> = np.array_equal
```

This PR patches it by freezing the random seed.