### PR TITLE
This commit addresses issue #1380.

### DIFF
--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -240,6 +240,9 @@ class DaceProgram(pycommon.SDFGConvertible):
             warnings.warn("You are calling to_sdfg() on a dace program that "
                           "has set 'recompile' to False. "
                           "This may not be what you want.")
+        if self.autoopt == True:
+            warnings.warn("You are calling to_sdfg() on a dace program that "
+                          "has set `auto_optimize` to True, which is ignored here.")
 
         if use_cache:
             # Update global variables with current closure


### PR DESCRIPTION
As it was discussed the ignoring of the `auto_optimize` flag in `to_sdfg()` is intentional. To make it clear to the user the function now issues a warning in this case.