### PR TITLE
Symbol specialization in `auto_optimizer()` never took effect.

### DIFF
--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -647,7 +647,6 @@ def auto_optimize(sdfg: SDFG,
     if symbols:
         # Specialize for all known symbols
         known_symbols = {s: v for (s, v) in symbols.items() if s in sdfg.free_symbols}
-        known_symbols = {}
         for (s, v) in symbols.items():
             if s in sdfg.free_symbols:
                 if isinstance(v, (int, float)):

--- a/dace/transformation/auto/auto_optimize.py
+++ b/dace/transformation/auto/auto_optimize.py
@@ -646,7 +646,7 @@ def auto_optimize(sdfg: SDFG,
 
     if symbols:
         # Specialize for all known symbols
-        known_symbols = {s: v for (s, v) in symbols.items() if s in sdfg.free_symbols}
+        known_symbols = {}
         for (s, v) in symbols.items():
             if s in sdfg.free_symbols:
                 if isinstance(v, (int, float)):


### PR DESCRIPTION
The `dict` that was storing all the symbols, `known_symbols`, was emptied just after its creation. The efect was that the specialization never took effect.