### PR TITLE
Remove erroneous file creation in test

### DIFF
--- a/tests/sdfg/data/tensor_test.py
+++ b/tests/sdfg/data/tensor_test.py
@@ -63,8 +63,6 @@ def test_read_csr_tensor():
     func(A=inpA, B=B, M=A.shape[0], N=A.shape[1], nnz=A.nnz)
     ref = A.toarray()
 
-    sdfg.save("./tensor.json")
-
     assert np.allclose(B, ref)
 
 


### PR DESCRIPTION
I left a save statement in one of the tests, which was just for debugging purposes. This creates the file `tests/tensor.json` every time the tests are run, which is a bit messy. This PR removes that.