### PR TITLE
Fix for VS Code debug console: view opens sdfg in VS Code and not in browser

### DIFF
--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -36,7 +36,7 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
     """
     # If vscode is open, try to open it inside vscode
     if filename is None:
-        if 'VSCODE_IPC_HOOK_CLI' in os.environ or 'VSCODE_GIT_IPC_HANDLE' in os.environ:
+        if 'VSCODE_IPC_HOOK' in os.environ or 'VSCODE_GIT_IPC_HANDLE' in os.environ:
             filename = tempfile.mktemp(suffix='.sdfg')
             sdfg.save(filename)
             os.system(f'code {filename}')

--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -36,7 +36,11 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
     """
     # If vscode is open, try to open it inside vscode
     if filename is None:
-        if 'VSCODE_IPC_HOOK' in os.environ or 'VSCODE_GIT_IPC_HANDLE' in os.environ:
+        if (
+            'VSCODE_IPC_HOOK' in os.environ
+            or 'VSCODE_IPC_HOOK_CLI' in os.environ
+            or 'VSCODE_GIT_IPC_HANDLE' in os.environ
+        ):
             filename = tempfile.mktemp(suffix='.sdfg')
             sdfg.save(filename)
             os.system(f'code {filename}')


### PR DESCRIPTION
Test system Mac OS

This small modification makes sure that in both modes (interactive & debug) the `sdfg.view()` will open the graph in the VS Code env (if present) and not in the available browser.

The `VSCODE_IPC_HOOK_CLI` env var is present in an interactive session from the VS Code termninal, but it is not present in the debug console. In the debugging mode, it is the `VSCODE_IPC_HOOK` env var which is present.
