### PR TITLE
Fix two issues related to deepcopying elements

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1172,7 +1172,16 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         result = cls.__new__(cls)
         memo[id(self)] = result
         for k, v in self.__dict__.items():
+            if k == '_parent':  # Skip derivative attributes
+                continue
             setattr(result, k, copy.deepcopy(v, memo))
+
+        for k in ('_parent',):
+            if id(getattr(self, k)) in memo:
+                setattr(result, k, memo[id(getattr(self, k))])
+            else:
+                setattr(result, k, None)
+
         for node in result.nodes():
             if isinstance(node, nd.NestedSDFG):
                 try:

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -205,6 +205,7 @@ def _copy_state(sdfg: SDFG,
 
     state_copy = copy.deepcopy(state)
     state_copy._label += '_copy'
+    state_copy.parent = sdfg
     sdfg.add_node(state_copy)
 
     in_conditions = []

--- a/tests/sdfg/state_test.py
+++ b/tests/sdfg/state_test.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
+from dace.transformation.helpers import find_sdfg_control_flow
 
 
 def test_read_write_set():
@@ -42,7 +43,22 @@ def test_read_write_set_y_formation():
 
     assert 'B' not in state.read_and_write_sets()[0]
 
+def test_deepcopy_state():
+    N = dace.symbol('N')
+
+    @dace.program
+    def double_loop(arr: dace.float32[N]):
+        for i in range(N):
+            arr[i] *= 2
+        for i in range(N):
+            arr[i] *= 2
+
+    sdfg = double_loop.to_sdfg()
+    find_sdfg_control_flow(sdfg)
+    sdfg.validate()
+
 
 if __name__ == '__main__':
     test_read_write_set()
     test_read_write_set_y_formation()
+    test_deepcopy_state()


### PR DESCRIPTION
This PR fixes #1439 and #1443 by adapting fields and the deepcopy operation for states:
1. Skips derived field `parent` being set if a state is deepcopied on its own
2. Does not add a new field to AST nodes during preprocessing. That parent-pointing field outlives preprocessing and ends up copying the entire original AST for short codeblocks.