### PR TITLE
Fix two regressions in 0.15

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1460,6 +1460,7 @@ class CPUCodeGen(TargetCodeGenerator):
         callsite_stream.write('}', sdfg, state_id, node)
         callsite_stream.write(outer_stream_end.getvalue(), sdfg, state_id, node)
 
+        self._locals.clear_scope(self._ldepth + 1)
         self._dispatcher.defined_vars.exit_scope(node)
 
     def unparse_tasklet(self, sdfg, state_id, dfg, node, function_stream, inner_stream, locals, ldepth,

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -88,6 +88,8 @@ def dealias_sdfg(sdfg: SDFG):
                     nsdfg.arrays[name] = child_arr
                 for state in nsdfg.states():
                     for e in state.edges():
+                        if e.data.is_empty():
+                            continue
                         if not state.is_leaf_memlet(e):
                             continue
 
@@ -129,7 +131,10 @@ def dealias_sdfg(sdfg: SDFG):
                                 syms.remove(memlet.data)
                     for s in syms:
                         if s in parent_edges:
-                            repl_dict[s] = str(parent_edges[s].data)
+                            if s in nsdfg.arrays:
+                                repl_dict[s] = parent_edges[s].data.data
+                            else:
+                                repl_dict[s] = str(parent_edges[s].data)
                     e.data.replace_dict(repl_dict)
                 for name in child_names:
                     edge = parent_edges[name]


### PR DESCRIPTION
* Schedule tree: Fix support for empty memlets and array use in interstate edges
* Move clearing local scope to tasklet processing due to shift in call stacks in v0.15 that may skip said clearing