### PR TITLE
Changed default of serialize_all_fields to True

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -945,10 +945,10 @@ required:
 
             serialize_all_fields:
                 type: bool
-                default: false
+                default: true
                 title: Serialize all unmodified fields in SDFG files
                 description: >
-                    If False (default), saving an SDFG keeps only the modified non-default properties. If True,
+                    If False, saving an SDFG keeps only the modified non-default properties. If True,
                     saves all fields.
 
     #############################################


### PR DESCRIPTION
This is in preparation of the `0.15.1` release to avoid introducing potentially breaking changes.