### PR TITLE
Test propagation of strides for tasklet indirection (was working on v0.14.4)

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1107,13 +1107,6 @@ class DaCeKeywordRemover(ExtNodeTransformer):
                 ]
 
         if isinstance(visited_slice, ast.Tuple):
-            # If slice is multi-dimensional and writes to array with more than 1 elements, then:
-            # - Assume this is indirection (?)
-            # - Soft-squeeze the slice (remove unit-modes) to match the treatment of the strides above.
-            if target not in self.constants:
-                desc = self.sdfg.arrays[dname]
-                if isinstance(desc, data.Array) and data._prod(desc.shape) != 1:
-                    assert len(desc.shape) - desc.shape.count(1) == len(visited_slice.elts)
             if len(strides) != len(visited_slice.elts):
                 raise SyntaxError('Invalid number of dimensions in expression (expected %d, '
                                   'got %d)' % (len(strides), len(visited_slice.elts)))

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1092,18 +1092,17 @@ class DaCeKeywordRemover(ExtNodeTransformer):
             memlet = self.memlets[target][0]
             dtype = self.memlets[target][3]
             dname = memlet.data
-            strides = self.sdfg.arrays[dname].strides
+            desc = self.sdfg.arrays[dname]
             # Get memlet absolute strides, including tile sizes
-            strides = memlet.subset.absolute_strides(strides)
+            strides = memlet.subset.absolute_strides(desc.strides)
             # Filter ("squeeze") strides w.r.t. scalar dimensions
-            dimlen = dtype.veclen if isinstance(dtype, dtypes.vector) else 1
+            dimlen = dtype.veclen if isinstance(dtype, dtypes.vector) else 0
             subset_size = memlet.subset.size()
-            indexdims = [i for i, s in enumerate(subset_size) if s == 1]
             # Pointer to a single element can use all strides
             is_scalar = not isinstance(dtype, dtypes.pointer)
             if is_scalar or data._prod(subset_size) != 1:
                 strides = [
-                    s for i, s in enumerate(strides) if i not in indexdims and not (s == 1 and subset_size[i] == dimlen)
+                    s for i, s in enumerate(strides) if desc.shape[i] != 1 and not (s == 1 and subset_size[i] == dimlen)
                 ]
 
         if isinstance(visited_slice, ast.Tuple):
@@ -1111,10 +1110,8 @@ class DaCeKeywordRemover(ExtNodeTransformer):
             # - Assume this is indirection (?)
             # - Soft-squeeze the slice (remove unit-modes) to match the treatment of the strides above.
             if target not in self.constants:
-                desc = self.sdfg.arrays[dname]
                 if isinstance(desc, data.Array) and data._prod(desc.shape) != 1:
-                    n = len(desc.shape) - len(visited_slice.elts)
-                    elts = [e for i, e in enumerate(visited_slice.elts) if desc.shape[n + i] != 1]
+                    elts = [e for i, e in enumerate(visited_slice.elts) if desc.shape[i] != 1]
             else:
                 elts = visited_slice.elts
             if len(strides) != len(elts):

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1113,14 +1113,12 @@ class DaCeKeywordRemover(ExtNodeTransformer):
             if target not in self.constants:
                 desc = self.sdfg.arrays[dname]
                 if isinstance(desc, data.Array) and data._prod(desc.shape) != 1:
-                    elts = [e for i, e in enumerate(visited_slice.elts) if desc.shape[i] != 1]
-            else:
-                elts = visited_slice.elts
-            if len(strides) != len(elts):
+                    assert len(desc.shape) - desc.shape.count(1) == len(visited_slice.elts)
+            if len(strides) != len(visited_slice.elts):
                 raise SyntaxError('Invalid number of dimensions in expression (expected %d, '
-                                  'got %d)' % (len(strides), len(elts)))
+                                  'got %d)' % (len(strides), len(visited_slice.elts)))
 
-            return sum(symbolic.pystr_to_symbolic(unparse(elt)) * s for elt, s in zip(elts, strides))
+            return sum(symbolic.pystr_to_symbolic(unparse(elt)) * s for elt, s in zip(visited_slice.elts, strides))
 
         if len(strides) != 1:
             raise SyntaxError('Missing dimensions in expression (expected %d, got one)' % len(strides))

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -1107,11 +1107,21 @@ class DaCeKeywordRemover(ExtNodeTransformer):
                 ]
 
         if isinstance(visited_slice, ast.Tuple):
-            if len(strides) != len(visited_slice.elts):
+            # If slice is multi-dimensional and writes to array with more than 1 elements, then:
+            # - Assume this is indirection (?)
+            # - Soft-squeeze the slice (remove unit-modes) to match the treatment of the strides above.
+            if target not in self.constants:
+                desc = self.sdfg.arrays[dname]
+                if isinstance(desc, data.Array) and data._prod(desc.shape) != 1:
+                    n = len(desc.shape) - len(visited_slice.elts)
+                    elts = [e for i, e in enumerate(visited_slice.elts) if desc.shape[n + i] != 1]
+            else:
+                elts = visited_slice.elts
+            if len(strides) != len(elts):
                 raise SyntaxError('Invalid number of dimensions in expression (expected %d, '
-                                  'got %d)' % (len(strides), len(visited_slice.elts)))
+                                  'got %d)' % (len(strides), len(elts)))
 
-            return sum(symbolic.pystr_to_symbolic(unparse(elt)) * s for elt, s in zip(visited_slice.elts, strides))
+            return sum(symbolic.pystr_to_symbolic(unparse(elt)) * s for elt, s in zip(elts, strides))
 
         if len(strides) != 1:
             raise SyntaxError('Missing dimensions in expression (expected %d, got one)' % len(strides))

--- a/tests/subarray_test.py
+++ b/tests/subarray_test.py
@@ -1,13 +1,13 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-import dace as dp
+import dace as dc
 import numpy as np
 
-W = dp.symbol('W')
+W = dc.symbol('W')
 
 
-@dp.program
+@dc.program
 def subarray(A, B):
-    @dp.map(_[0:W])
+    @dc.map(_[0:W])
     def subarrays(i):
         a << A[:, i, i, i]
         a2 << A(1)[i, i, i, :]
@@ -18,16 +18,148 @@ def subarray(A, B):
 def test():
     W.set(3)
 
-    A = dp.ndarray([W, W, W, W])
-    B = dp.ndarray([W, W, W, W])
+    A = dc.ndarray([W, W, W, W])
+    B = dc.ndarray([W, W, W, W])
 
     A[:] = np.mgrid[0:W.get(), 0:W.get(), 0:W.get()]
     for i in range(W.get()):
         A[i, :] += 10 * (i + 1)
-    B[:] = dp.float32(0.0)
+    B[:] = dc.float32(0.0)
 
     subarray(A, B, W=W)
 
 
+N = 3
+
+
+
+def test1():
+
+    @dc.program(simplify=False)
+    def subarray1b(A: dc.float64[1, N], B: dc.float64[1, N, N]):
+        @dc.tasklet
+        def tlet():
+            a << A[0, :]
+            b >> B[0, :, :]
+            for j in range(N):
+                x = a[j] + dc.float32(1.0)
+                b[j, j] = x
+
+    nsdfg = subarray1b.to_sdfg()
+
+    @dc.program(simplify=False)
+    def subarray1(A: dc.float64[W, N], B: dc.float64[W, N, N]):
+        for i in dc.map[0:W]:
+            @dc.tasklet
+            def tlet():
+                nsdfg(A[i, :], B[i, :, :])
+
+    W.set(2)
+
+    A = np.random.rand(W.get(), N)
+    B = np.random.rand(W.get(), N, N)
+
+    ref = np.ndarray(B.shape)
+    for i in range(ref.shape[0]):
+        ref[i,:,:] = np.diag(A[i,:] + 1) + np.rot90(np.diag(np.diag(np.rot90(B[i,:,:], axes=(1,0)))))
+
+    subarray1(A, B, W=W)
+
+    np.allclose(ref, B)
+
+
+def test_strides_propagation_to_tasklet():
+    N = 2
+    vec_stride_W, vec_stride_d0 = (
+        dc.symbol(s) for s in ['vec_stride_W', 'vec_stride_d0']
+    )
+    mat_stride_W, mat_stride_d0, mat_stride_d1 = (
+        dc.symbol(s) for s in ['mat_stride_W', 'mat_stride_d0', 'mat_stride_d1']
+    )
+
+    def build_nsdfg():
+        sdfg = dc.SDFG('vec_to_mat')
+        sdfg.add_array(
+            'vec_field', (1, N), dc.float64,
+            strides=(vec_stride_W, vec_stride_d0)
+        )
+        sdfg.add_array(
+            'mat_field', (1, N, N), dc.float64,
+            strides=(mat_stride_W, mat_stride_d0, mat_stride_d1)
+        )
+        state = sdfg.add_state()
+        tasklet = state.add_tasklet(
+            'vec_to_mat', {'_vec'}, {'_mat'}, f"\
+for i in range({N}):\
+    _mat[i, i] = _vec[i] + dace.float64(1)\
+        ")
+        state.add_edge(
+            state.add_access('vec_field'), None,
+            tasklet, '_vec',
+            dc.Memlet.from_array('vec_field', sdfg.arrays['vec_field'])
+        )
+        state.add_edge(
+            tasklet, '_mat',
+            state.add_access('mat_field'), None,
+            dc.Memlet.from_array('mat_field', sdfg.arrays['mat_field'])
+        )
+        return sdfg
+
+    sdfg = dc.SDFG('test')
+    sdfg.add_array(
+        'vec_field', (W, N), dc.float64,
+        strides=(vec_stride_W, vec_stride_d0)
+    )
+    sdfg.add_array(
+        'mat_field', (W, N, N), dc.float64,
+        strides=(mat_stride_W, mat_stride_d0, mat_stride_d1)
+    )
+    state = sdfg.add_state()
+    nsdfg_node = state.add_nested_sdfg(
+        build_nsdfg(),
+        sdfg,
+        inputs={'vec_field'},
+        outputs={'mat_field'},
+    )
+    me, mx = state.add_map('map_W', dict(i='0:W'))
+    state.add_memlet_path(
+        state.add_access('vec_field'),
+        me,
+        nsdfg_node,
+        dst_conn='vec_field',
+        memlet=dc.Memlet.simple('vec_field', f"i,0:{N}")
+    )
+    state.add_memlet_path(
+        nsdfg_node,
+        mx,
+        state.add_access('mat_field'),
+        src_conn='mat_field',
+        memlet=dc.Memlet.simple('mat_field', f"i,0:{N},0:{N}")
+    )
+
+    W.set(2)
+    A = np.random.rand(W.get(), N)
+    B = np.random.rand(W.get(), N, N)
+
+    ref = np.ndarray(B.shape)
+    for i in range(ref.shape[0]):
+        ref[i,:,:] = np.diag(A[i,:] + 1) + np.rot90(np.diag(np.diag(np.rot90(B[i,:,:], axes=(1,0)))))
+
+    A_stride_0, A_stride_1 = (s / A.itemsize for s in A.strides)
+    B_stride_0, B_stride_1, B_stride_2 = (s / B.itemsize for s in B.strides)
+    stride_symbols = {
+        'vec_stride_W': A_stride_0,
+        'vec_stride_d0': A_stride_1,
+        'mat_stride_W': B_stride_0,
+        'mat_stride_d0': B_stride_1,
+        'mat_stride_d1': B_stride_2,
+    }
+
+    sdfg(vec_field=A, mat_field=B, W=W, **stride_symbols)
+    np.allclose(ref, B)
+
+
 if __name__ == "__main__":
     test()
+    test1()
+    test_strides_propagation_to_tasklet()

--- a/tests/subarray_test.py
+++ b/tests/subarray_test.py
@@ -12,7 +12,7 @@ def subarray(A, B):
         a << A[:, i, i, i]
         a2 << A(1)[i, i, i, :]
         b >> B[i, :, i, i]
-        b[i] = a[i] + a2[i]
+        b[0, i, 0, 0] = a[i, 0, 0, 0] + a2[0, 0, 0, i]
 
 
 def test():

--- a/tests/subarray_test.py
+++ b/tests/subarray_test.py
@@ -29,45 +29,6 @@ def test():
     subarray(A, B, W=W)
 
 
-N = 3
-
-
-
-def test1():
-
-    @dc.program(simplify=False)
-    def subarray1b(A: dc.float64[1, N], B: dc.float64[1, N, N]):
-        @dc.tasklet
-        def tlet():
-            a << A[0, :]
-            b >> B[0, :, :]
-            for j in range(N):
-                x = a[j] + dc.float32(1.0)
-                b[j, j] = x
-
-    nsdfg = subarray1b.to_sdfg()
-
-    @dc.program(simplify=False)
-    def subarray1(A: dc.float64[W, N], B: dc.float64[W, N, N]):
-        for i in dc.map[0:W]:
-            @dc.tasklet
-            def tlet():
-                nsdfg(A[i, :], B[i, :, :])
-
-    W.set(2)
-
-    A = np.random.rand(W.get(), N)
-    B = np.random.rand(W.get(), N, N)
-
-    ref = np.ndarray(B.shape)
-    for i in range(ref.shape[0]):
-        ref[i,:,:] = np.diag(A[i,:] + 1) + np.rot90(np.diag(np.diag(np.rot90(B[i,:,:], axes=(1,0)))))
-
-    subarray1(A, B, W=W)
-
-    np.allclose(ref, B)
-
-
 def test_strides_propagation_to_tasklet():
     N = 2
     vec_stride_W, vec_stride_d0 = (
@@ -137,7 +98,7 @@ for i in range({N}):\
         memlet=dc.Memlet.simple('mat_field', f"i,0:{N},0:{N}")
     )
 
-    W.set(2)
+    W.set(3)
     A = np.random.rand(W.get(), N)
     B = np.random.rand(W.get(), N, N)
 
@@ -161,5 +122,4 @@ for i in range({N}):\
 
 if __name__ == "__main__":
     test()
-    test1()
     test_strides_propagation_to_tasklet()

--- a/tests/subarray_test.py
+++ b/tests/subarray_test.py
@@ -12,7 +12,7 @@ def subarray(A, B):
         a << A[:, i, i, i]
         a2 << A(1)[i, i, i, :]
         b >> B[i, :, i, i]
-        b[0, i, 0, 0] = a[i, 0, 0, 0] + a2[0, 0, 0, i]
+        b[i] = a[i] + a2[i]
 
 
 def test():
@@ -53,7 +53,7 @@ def test_strides_propagation_to_tasklet():
         tasklet = state.add_tasklet(
             'vec_to_mat', {'_vec'}, {'_mat'}, f"\
 for i in range({N}):\
-    _mat[0, i, i] = _vec[0, i] + dace.float64(1)\
+    _mat[0, i, i] = _vec[i] + dace.float64(1)\
         ")
         state.add_edge(
             state.add_access('vec_field'), None,


### PR DESCRIPTION
I was trying to bump the version of dace in gt4py dependencies from 0.14.4 to 0.15.1. Some tests in gt4py cartesian (the legacy gt4py version) start to fail, because of an exception in cpp code generation. I was able to reproduce the issue in the test case which is added by this PR.

The exception originates from:
```
self = <dace.codegen.targets.cpp.DaCeKeywordRemover object at 0x134060f70>
slicenode = <ast.Tuple object at 0x134060c10>, target = '_mat'

    def _subscript_expr(self, slicenode: ast.AST, target: str) -> symbolic.SymbolicType:
        ...
    
        if isinstance(visited_slice, ast.Tuple):
            # If slice is multi-dimensional and writes to array with more than 1 elements, then:
            # - Assume this is indirection (?)
            # - Soft-squeeze the slice (remove unit-modes) to match the treatment of the strides above.
            if target not in self.constants:
                desc = self.sdfg.arrays[dname]
                if isinstance(desc, data.Array) and data._prod(desc.shape) != 1:
                    elts = [e for i, e in enumerate(visited_slice.elts) if desc.shape[i] != 1]
            else:
                elts = visited_slice.elts
            if len(strides) != len(elts):
>               raise SyntaxError('Invalid number of dimensions in expression (expected %d, '
                                  'got %d)' % (len(strides), len(elts)))
E               SyntaxError: Invalid number of dimensions in expression (expected 2, got 1)
```

This PR proposes a fix, although I do not fully understand this code and there might be a better solution.