### PR TITLE
Fix IndexError in memlet propagation

### DIFF
--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1073,7 +1073,8 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
                 # range that only exists inside the nested SDFG. If that's the
                 # case, use the entire range.
                 if border_memlet.src_subset is not None:
-                    fallback_subset = iter(subsets.Range.from_array(sdfg.arrays[border_memlet.data]))
+                    fallback_subset = subsets.Range.from_array(sdfg.arrays[border_memlet.data])
+                    fallback_offset = len(border_memlet.src_subset) - len(fallback_subset)
                     for i, rng in enumerate(border_memlet.src_subset):
                         fall_back = False
                         for item in rng:
@@ -1081,7 +1082,7 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
                                 fall_back = True
                                 break
                         if fall_back:
-                            border_memlet.src_subset[i] = next(fallback_subset)
+                            border_memlet.src_subset[i] = fallback_subset[i - fallback_offset]
                 if border_memlet.dst_subset is not None:
                     fallback_subset = subsets.Range.from_array(sdfg.arrays[border_memlet.data])
                     for i, rng in enumerate(border_memlet.dst_subset):

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1073,7 +1073,7 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
                 # range that only exists inside the nested SDFG. If that's the
                 # case, use the entire range.
                 if border_memlet.src_subset is not None:
-                    fallback_subset = subsets.Range.from_array(sdfg.arrays[border_memlet.data])
+                    fallback_subset = iter(subsets.Range.from_array(sdfg.arrays[border_memlet.data]))
                     for i, rng in enumerate(border_memlet.src_subset):
                         fall_back = False
                         for item in rng:
@@ -1081,7 +1081,7 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
                                 fall_back = True
                                 break
                         if fall_back:
-                            border_memlet.src_subset[i] = fallback_subset[i]
+                            border_memlet.src_subset[i] = next(fallback_subset)
                 if border_memlet.dst_subset is not None:
                     fallback_subset = subsets.Range.from_array(sdfg.arrays[border_memlet.data])
                     for i, rng in enumerate(border_memlet.dst_subset):

--- a/tests/memlet_propagation_test.py
+++ b/tests/memlet_propagation_test.py
@@ -104,8 +104,85 @@ def test_nsdfg_memlet_propagation_with_one_sparse_dimension():
             str(outer_out.subset))
 
 
+def test_nsdfg_memlet_propagation_with_slicing():
+    
+    dim_X, dim_Y = (dace.symbol(s) for s in ('dim_X', 'dim_Y'))
+
+    def build_nsdfg():
+        sdfg = dace.SDFG('mat_to_vec')
+        sdfg.add_array('_inp', (dim_X, dim_Y), dace.float64)
+        sdfg.add_array('_out', (dim_X,), dace.float64)
+        sdfg.add_scalar('_inp_idx', dace.int32)
+        state1 = sdfg.add_state()
+        state2 = sdfg.add_state()
+        sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments={'y':'_inp_idx'}))
+        state2.add_edge(
+            state2.add_access('_inp'), None,
+            state2.add_access('_out'), None,
+            dace.Memlet(data='_out', subset='0:dim_X', other_subset='0:dim_X, y')
+        )
+        return sdfg
+
+    sdfg = dace.SDFG('memlet_propagation_with_slicing')
+    sdfg.add_array('mat', (dim_X, dim_Y), dace.float64)
+    sdfg.add_array('vec', (dim_X,), dace.float64)
+    sdfg.add_symbol('idx_Y', dace.int32)
+    sdfg.add_scalar('idx', dace.int32, transient=True)
+
+    state = sdfg.add_state()
+    nsdfg_node = state.add_nested_sdfg(
+        build_nsdfg(),
+        sdfg,
+        inputs={'_inp', '_inp_idx'},
+        outputs={'_out'},
+    )
+    idx_node = state.add_access('idx')
+    state.add_edge(
+        state.add_tasklet('get_idx_Y', {}, {'x'}, 'x = idx_Y'),
+        'x',
+        idx_node,
+        None,
+        dace.Memlet.simple('idx', '0')
+    )
+    state.add_edge(
+        idx_node,
+        None,
+        nsdfg_node,
+        '_inp_idx',
+        dace.Memlet.simple('idx', '0')
+    )
+    state.add_edge(
+        state.add_access('mat'),
+        None,
+        nsdfg_node,
+        '_inp',
+        dace.Memlet.from_array('mat', sdfg.arrays['mat'])
+    )
+    state.add_edge(
+        nsdfg_node,
+        '_out',
+        state.add_access('vec'),
+        None,
+        dace.Memlet.from_array('vec', sdfg.arrays['vec'])
+    )
+
+    propagate_memlets_sdfg(sdfg)
+
+    dim_X.set(10)
+    dim_Y.set(20)
+    idx_Y = 3
+    
+    A = np.random.rand(dim_X.get(), dim_Y.get())
+    B = np.random.rand(dim_X.get())
+    ref = A[:, idx_Y]
+
+    sdfg(mat=A, vec=B, idx_Y=idx_Y, dim_X=dim_X, dim_Y=dim_Y)
+    np.allclose(ref, B)
+
+
 if __name__ == '__main__':
     test_conditional()
     test_conditional_nested()
     test_runtime_conditional()
     test_nsdfg_memlet_propagation_with_one_sparse_dimension()
+    test_nsdfg_memlet_propagation_with_slicing()


### PR DESCRIPTION
During integration of dace v0.15.1 into icon4py, the following exception was raised in SDFG auto-optimize step:
```
../edopao/gt4py/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py:233: in build_sdfg_from_itir
    sdfg = autoopt.auto_optimize(sdfg, device, symbols=symbols, use_gpu_storage=on_gpu)
../edopao/dace/dace/transformation/auto/auto_optimize.py:575: in auto_optimize
    l2ms = sdfg.apply_transformations_repeated((LoopToMap, RefineNestedAccess),
../edopao/dace/dace/sdfg/sdfg.py:2484: in apply_transformations_repeated
    results = pazz.apply_pass(self, {})
../edopao/dace/dace/transformation/passes/pattern_matching.py:253: in apply_pass
    return self._apply_pass(sdfg, pipeline_results, apply_once=False)
../edopao/dace/dace/transformation/passes/pattern_matching.py:211: in _apply_pass
    self._apply_and_validate(match, sdfg, start, pipeline_results, applied_transformations)
../edopao/dace/dace/transformation/passes/pattern_matching.py:168: in _apply_and_validate
    applied_transformations[type(match).__name__].append(match.apply(graph, tsdfg))
../edopao/dace/dace/transformation/interstate/sdfg_nesting.py:1101: in apply
    propagation.propagate_memlets_state(sdfg, state)
../edopao/dace/dace/sdfg/propagation.py:1202: in propagate_memlets_state
    propagate_memlets_sdfg(node.sdfg)
../edopao/dace/dace/sdfg/propagation.py:1162: in propagate_memlets_sdfg
    propagate_memlets_state(sdfg, state)
../edopao/dace/dace/sdfg/propagation.py:1205: in propagate_memlets_state
    propagate_memlets_nested_sdfg(sdfg, state, node)
../edopao/dace/dace/sdfg/propagation.py:1084: in propagate_memlets_nested_sdfg
    border_memlet.src_subset[i] = fallback_subset[i]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Range (0:geofac_n2s_shape0_6730), key = 1

    def __getitem__(self, key):
>       return self.ranges.__getitem__(key)
E       IndexError: list index out of range

../edopao/dace/dace/subsets.py:624: IndexError
```


This error is probably the same as one of the issues reported in #1468. The testcase in this PR allows to reproduce this issue.

This PR is applying a workaround in `dace/sdfg/propagation.py`, to make the test pass. However, this does not seem to be the proper the solution. This code change is rather a placeholder to highlight where the issue originates.