### PR TITLE
Evaluate dtype_to_typeclass at use time

### DIFF
--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -746,9 +746,9 @@ class CPPUnparser:
     def _Num(self, t):
         t_n = t.value if sys.version_info >= (3, 8) else t.n
         repr_n = repr(t_n)
-        # For complex values, use DTYPE_TO_TYPECLASS dictionary
+        # For complex values, use ``dtype_to_typeclass``
         if isinstance(t_n, complex):
-            dtype = dtypes.DTYPE_TO_TYPECLASS[complex]
+            dtype = dtypes.dtype_to_typeclass(complex)
 
         # Handle large integer values
         if isinstance(t_n, int):

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3240,7 +3240,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 raise DaceSyntaxError(self, target, 'Variable "{}" used before definition'.format(name))
 
             new_data, rng = None, None
-            dtype_keys = tuple(dtypes.DTYPE_TO_TYPECLASS.keys())
+            dtype_keys = tuple(dtypes.dtype_to_typeclass().keys())
             if not (result in self.sdfg.symbols or symbolic.issymbolic(result) or isinstance(result, dtype_keys) or
                     (isinstance(result, str) and result in self.sdfg.arrays)):
                 raise DaceSyntaxError(
@@ -4653,14 +4653,14 @@ class ProgramVisitor(ExtNodeVisitor):
         if isinstance(node.n, bool):
             return dace.bool_(node.n)
         if isinstance(node.n, (int, float, complex)):
-            return dtypes.DTYPE_TO_TYPECLASS[type(node.n)](node.n)
+            return dtypes.dtype_to_typeclass(type(node.n))(node.n)
         return node.n
 
     def visit_Constant(self, node: ast.Constant):
         if isinstance(node.value, bool):
             return dace.bool_(node.value)
         if isinstance(node.value, (int, float, complex)):
-            return dtypes.DTYPE_TO_TYPECLASS[type(node.value)](node.value)
+            return dtypes.dtype_to_typeclass(type(node.value))(node.value)
         if isinstance(node.value, (str, bytes)):
             return StringLiteral(node.value)
         return node.value
@@ -4745,7 +4745,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 result.append((operand, type(self.sdfg.arrays[operand])))
             elif isinstance(operand, str) and operand in self.scope_arrays:
                 result.append((operand, type(self.scope_arrays[operand])))
-            elif isinstance(operand, tuple(dtypes.DTYPE_TO_TYPECLASS.keys())):
+            elif isinstance(operand, tuple(dtypes.dtype_to_typeclass().keys())):
                 if isinstance(operand, (bool, numpy.bool_)):
                     result.append((operand, 'BoolConstant'))
                 else:

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -30,12 +30,12 @@ def _cast_to_dtype_str(value, dtype: dace.dtypes.typeclass) -> str:
         cast_value = complex(value)
 
         return "dace.{type}({real}, {imag})".format(
-            type=dace.DTYPE_TO_TYPECLASS[dtype].to_string(),
+            type=dace.dtype_to_typeclass(dtype).to_string(),
             real=cast_value.real,
             imag=cast_value.imag,
         )
     else:
-        return "dace.{}({})".format(dace.DTYPE_TO_TYPECLASS[dtype].to_string(), value)
+        return "dace.{}({})".format(dace.dtype_to_typeclass(dtype).to_string(), value)
 
 
 @dace.library.expansion
@@ -52,7 +52,7 @@ class ExpandGemmPure(ExpandTransformation):
 
         dtype_a = outer_array_a.dtype.type
         dtype_b = outer_array_b.dtype.type
-        dtype_c = dace.DTYPE_TO_TYPECLASS[np.result_type(dtype_a, dtype_b).type]
+        dtype_c = dace.dtype_to_typeclass(np.result_type(dtype_a, dtype_b).type)
 
         if node.transA:
             trans_shape_a = list(reversed(shape_a))
@@ -518,7 +518,7 @@ class ExpandGemmFPGA1DSystolic(ExpandTransformation):
 
         dtype_a = outer_array_a.dtype.type
         dtype_b = outer_array_b.dtype.type
-        dtype_c = dace.DTYPE_TO_TYPECLASS[np.result_type(dtype_a, dtype_b).type]
+        dtype_c = dace.dtype_to_typeclass(np.result_type(dtype_a, dtype_b).type)
         shape_c = (shape_a[0], shape_b[1])
         if node.transA:
             raise NotImplementedError("GEMM FPGA expansion not implemented for transposed A.")

--- a/dace/libraries/sparse/nodes/csrmm.py
+++ b/dace/libraries/sparse/nodes/csrmm.py
@@ -28,12 +28,12 @@ def _cast_to_dtype_str(value, dtype: dace.dtypes.typeclass) -> str:
         cast_value = complex(value)
 
         return "dace.{type}({real}, {imag})".format(
-            type=dace.DTYPE_TO_TYPECLASS[dtype].to_string(),
+            type=dace.dtype_to_typeclass(dtype).to_string(),
             real=cast_value.real,
             imag=cast_value.imag,
         )
     else:
-        return "dace.{}({})".format(dace.DTYPE_TO_TYPECLASS[dtype].to_string(), value)
+        return "dace.{}({})".format(dace.dtype_to_typeclass(dtype).to_string(), value)
 
 
 def _get_csrmm_operands(node,

--- a/dace/libraries/sparse/nodes/csrmv.py
+++ b/dace/libraries/sparse/nodes/csrmv.py
@@ -27,12 +27,12 @@ def _cast_to_dtype_str(value, dtype: dace.dtypes.typeclass) -> str:
         cast_value = complex(value)
 
         return "dace.{type}({real}, {imag})".format(
-            type=dace.DTYPE_TO_TYPECLASS[dtype].to_string(),
+            type=dace.dtype_to_typeclass(dtype).to_string(),
             real=cast_value.real,
             imag=cast_value.imag,
         )
     else:
-        return "dace.{}({})".format(dace.DTYPE_TO_TYPECLASS[dtype].to_string(), value)
+        return "dace.{}({})".format(dace.dtype_to_typeclass(dtype).to_string(), value)
 
 
 def _get_csrmv_operands(node: dace.sdfg.nodes.LibraryNode,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -769,7 +769,7 @@ class SDFG(ControlFlowRegion):
         if name in self.symbols:
             raise FileExistsError('Symbol "%s" already exists in SDFG' % name)
         if not isinstance(stype, dtypes.typeclass):
-            stype = dtypes.DTYPE_TO_TYPECLASS[stype]
+            stype = dtypes.dtype_to_typeclass(stype)
         self.symbols[name] = stype
 
     def remove_symbol(self, name):

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -42,7 +42,7 @@ class symbol(sympy.Symbol):
         if not isinstance(dtype, dtypes.typeclass):
             raise TypeError('dtype must be a DaCe type, got %s' % str(dtype))
 
-        dkeys = [k for k, v in dtypes.DTYPE_TO_TYPECLASS.items() if v == dtype]
+        dkeys = [k for k, v in dtypes.dtype_to_typeclass().items() if v == dtype]
         is_integer = [issubclass(k, int) or issubclass(k, numpy.integer) for k in dkeys]
         if 'integer' in assumptions or not numpy.any(is_integer):
             # Using __xnew__ as the regular __new__ is cached, which leads


### PR DESCRIPTION
Prior to this PR, `dtype_to_typeclass` was evaluated at import time. This means that the configuration entry `default_data_types` could not be modified after importing dace in a meaningful way.