### PR TITLE
Generalize container views

### DIFF
--- a/dace/codegen/dispatcher.py
+++ b/dace/codegen/dispatcher.py
@@ -505,11 +505,11 @@ class TargetDispatcher(object):
             dst_is_data = True
 
         # Skip copies to/from views where edge matches
-        if src_is_data and isinstance(src_node.desc(sdfg), (dt.StructureView, dt.View)):
+        if src_is_data and isinstance(src_node.desc(sdfg), dt.IView):
             e = sdutil.get_view_edge(state, src_node)
             if e is edge:
                 return None
-        if dst_is_data and isinstance(dst_node.desc(sdfg), (dt.StructureView, dt.View)):
+        if dst_is_data and isinstance(dst_node.desc(sdfg), dt.IView):
             e = sdutil.get_view_edge(state, dst_node)
             if e is edge:
                 return None

--- a/dace/codegen/dispatcher.py
+++ b/dace/codegen/dispatcher.py
@@ -505,11 +505,11 @@ class TargetDispatcher(object):
             dst_is_data = True
 
         # Skip copies to/from views where edge matches
-        if src_is_data and isinstance(src_node.desc(sdfg), dt.IView):
+        if src_is_data and isinstance(src_node.desc(sdfg), dt.View):
             e = sdutil.get_view_edge(state, src_node)
             if e is edge:
                 return None
-        if dst_is_data and isinstance(dst_node.desc(sdfg), dt.IView):
+        if dst_is_data and isinstance(dst_node.desc(sdfg), dt.View):
             e = sdutil.get_view_edge(state, dst_node)
             if e is edge:
                 return None

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -527,8 +527,7 @@ class CPUCodeGen(TargetCodeGenerator):
                                               dtypes.AllocationLifetime.External)
             self._dispatcher.declared_arrays.remove(alloc_name, is_global=is_global)
 
-        if isinstance(nodedesc,
-                      (data.Scalar, data.View, data.Stream, data.Reference)):
+        if isinstance(nodedesc, (data.Scalar, data.View, data.Stream, data.Reference)):
             return
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or (nodedesc.storage == dtypes.StorageType.Register and symbolic.issymbolic(arrsize, sdfg.constants))):

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -362,7 +362,7 @@ class CPUCodeGen(TargetCodeGenerator):
                     self.allocate_array(sdfg, dfg, state_id, nodes.AccessNode(f"{name}.{k}"), v, function_stream,
                                         declaration_stream, allocation_stream)
             return
-        if isinstance(nodedesc, data.IView):
+        if isinstance(nodedesc, data.View):
             return self.allocate_view(sdfg, dfg, state_id, node, function_stream, declaration_stream, allocation_stream)
         if isinstance(nodedesc, data.Reference):
             return self.allocate_reference(sdfg, dfg, state_id, node, function_stream, declaration_stream,
@@ -528,7 +528,7 @@ class CPUCodeGen(TargetCodeGenerator):
             self._dispatcher.declared_arrays.remove(alloc_name, is_global=is_global)
 
         if isinstance(nodedesc,
-                      (data.Scalar, data.IView, data.Stream, data.Reference)):
+                      (data.Scalar, data.View, data.Stream, data.Reference)):
             return
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or (nodedesc.storage == dtypes.StorageType.Register and symbolic.issymbolic(arrsize, sdfg.constants))):

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -216,7 +216,7 @@ class CPUCodeGen(TargetCodeGenerator):
                                                         is_write=is_write)
 
         # Test for views of container arrays and structs
-        if isinstance(sdfg.arrays[viewed_dnode.data], (data.Structure, data.ContainerArray)):
+        if isinstance(sdfg.arrays[viewed_dnode.data], (data.Structure, data.ContainerArray, data.ContainerView)):
             vdesc = sdfg.arrays[viewed_dnode.data]
             ptrname = cpp.ptr(memlet.data, vdesc, sdfg, self._dispatcher.frame)
             field_name = None
@@ -362,7 +362,7 @@ class CPUCodeGen(TargetCodeGenerator):
                     self.allocate_array(sdfg, dfg, state_id, nodes.AccessNode(f"{name}.{k}"), v, function_stream,
                                         declaration_stream, allocation_stream)
             return
-        if isinstance(nodedesc, (data.StructureView, data.View)):
+        if isinstance(nodedesc, data.IView):
             return self.allocate_view(sdfg, dfg, state_id, node, function_stream, declaration_stream, allocation_stream)
         if isinstance(nodedesc, data.Reference):
             return self.allocate_reference(sdfg, dfg, state_id, node, function_stream, declaration_stream,
@@ -527,7 +527,8 @@ class CPUCodeGen(TargetCodeGenerator):
                                               dtypes.AllocationLifetime.External)
             self._dispatcher.declared_arrays.remove(alloc_name, is_global=is_global)
 
-        if isinstance(nodedesc, (data.Scalar, data.StructureView, data.View, data.Stream, data.Reference)):
+        if isinstance(nodedesc,
+                      (data.Scalar, data.IView, data.Stream, data.Reference)):
             return
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or (nodedesc.storage == dtypes.StorageType.Register and symbolic.issymbolic(arrsize, sdfg.constants))):

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -751,7 +751,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
                     instances = access_instances[sdfg.sdfg_id][name]
 
                     # A view gets "allocated" everywhere it appears
-                    if isinstance(desc, (data.StructureView, data.View)):
+                    if isinstance(desc, data.IView):
                         for s, n in instances:
                             self.to_allocate[s].append((sdfg, s, n, False, True, False))
                             self.to_allocate[s].append((sdfg, s, n, False, False, True))

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -751,7 +751,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
                     instances = access_instances[sdfg.sdfg_id][name]
 
                     # A view gets "allocated" everywhere it appears
-                    if isinstance(desc, data.IView):
+                    if isinstance(desc, data.View):
                         for s, n in instances:
                             self.to_allocate[s].append((sdfg, s, n, False, True, False))
                             self.to_allocate[s].append((sdfg, s, n, False, False, True))

--- a/dace/data.py
+++ b/dace/data.py
@@ -1592,15 +1592,6 @@ class Array(Data):
         self._set_shape_dependent_properties(new_shape, strides, total_size, offset)
         self.validate()
 
-    def __getitem__(self, s):
-        """ This is syntactic sugar that allows us to define a container array type
-            with the following syntax: ``dace.float64[N][M]``
-            :return: A ``data.ContainerArray`` data descriptor.
-        """
-        if isinstance(s, list) or isinstance(s, tuple):
-            return ContainerArray(self, tuple(s))
-        return ContainerArray(self, (s, ))
-
 
 @make_properties
 class Stream(Data):
@@ -1817,6 +1808,7 @@ class ContainerArray(Array):
 
         return ret
 
+
 class IView:
     """
     Interface that specifies the data container views another data container.
@@ -1824,6 +1816,7 @@ class IView:
     on another data container.
     """
     pass
+
 
 @make_properties
 class View(Array, IView):
@@ -1914,14 +1907,39 @@ class StructureView(Structure, IView):
         if self.lifetime != dtypes.AllocationLifetime.Scope:
             raise ValueError('Only Scope allocation lifetime is supported for Views')
 
+    def as_structure(self):
+        copy = cp.deepcopy(self)
+        copy.__class__ = Structure
+        return copy
 
 
 @make_properties
 class ContainerView(ContainerArray, IView):
     """ 
-    Data descriptor that acts as a reference (or view) of another container array. Can
+    Data descriptor that acts as a view of another container array. Can
     be used to access nested container types without a copy.
     """
+
+    def __init__(self,
+                 stype: Data,
+                 shape=None,
+                 transient=True,
+                 allow_conflicts=False,
+                 storage=dtypes.StorageType.Default,
+                 location=None,
+                 strides=None,
+                 offset=None,
+                 may_alias=False,
+                 lifetime=dtypes.AllocationLifetime.Scope,
+                 alignment=0,
+                 debuginfo=None,
+                 total_size=None,
+                 start_offset=None,
+                 optional=None,
+                 pool=False):
+        shape = [1] if shape is None else shape
+        super().__init__(stype, shape, transient, allow_conflicts, storage, location, strides, offset, may_alias,
+                         lifetime, alignment, debuginfo, total_size, start_offset, optional, pool)
 
     def validate(self):
         super().validate()

--- a/dace/data.py
+++ b/dace/data.py
@@ -2085,6 +2085,9 @@ class StructureReference(Structure, Reference):
         if self.lifetime != dtypes.AllocationLifetime.Scope:
             raise ValueError('Only Scope allocation lifetime is supported for References')
 
+        if 'set' in self.members:
+            raise NameError('A structure that is referenced may not contain a member called "set" (reserved keyword).')
+
     def as_structure(self):
         copy = cp.deepcopy(self)
         copy.__class__ = Structure

--- a/dace/data.py
+++ b/dace/data.py
@@ -266,7 +266,7 @@ class Data:
                  rather than a set of strings.
         """
         result = set()
-        if (self.transient and not isinstance(self, (IView, Reference))) or all_symbols:
+        if (self.transient and not isinstance(self, (View, Reference))) or all_symbols:
             for s in self.shape:
                 if isinstance(s, sp.Basic):
                     result |= set(s.free_symbols)
@@ -1544,7 +1544,7 @@ class Array(Data):
         for o in self.offset:
             if isinstance(o, sp.Expr):
                 result |= set(o.free_symbols)
-        if (self.transient and not isinstance(self, (IView, Reference))) or all_symbols:
+        if (self.transient and not isinstance(self, (View, Reference))) or all_symbols:
             if isinstance(self.total_size, sp.Expr):
                 result |= set(self.total_size.free_symbols)
         return result
@@ -1831,7 +1831,8 @@ class View:
     Other cases are ambiguous and will fail SDFG validation.
     """
 
-    def __new__(self, viewed_container: Data, debuginfo=None):
+    @staticmethod
+    def view(viewed_container: Data, debuginfo=None):
         """
         Create a new View of the specified data container.
 

--- a/dace/data.py
+++ b/dace/data.py
@@ -1228,6 +1228,10 @@ class Scalar(Data):
         return 0
 
     @property
+    def alignment(self):
+        return 0
+
+    @property
     def optional(self) -> bool:
         return False
 
@@ -1867,7 +1871,7 @@ class View:
                                    start_offset=viewed_container.start_offset,
                                    optional=viewed_container.optional,
                                    pool=viewed_container.pool)
-        elif isinstance(viewed_container, Array):
+        elif isinstance(viewed_container, (Array, Scalar)):
             result = ArrayView(dtype=viewed_container.dtype,
                                shape=viewed_container.shape,
                                allow_conflicts=viewed_container.allow_conflicts,
@@ -1917,12 +1921,24 @@ class Reference:
         # Assign the right kind of reference from the input data container
         # NOTE: The class assignment below is OK since the Reference class is a subclass of the instance,
         # and those should not have additional fields.
-        if isinstance(viewed_container, Array):
-            result.__class__ = ArrayReference
+        if isinstance(viewed_container, ContainerArray):
+            result.__class__ = ContainerArrayReference
         elif isinstance(viewed_container, Structure):
             result.__class__ = StructureReference
-        elif isinstance(viewed_container, ContainerArray):
-            result.__class__ = ContainerArrayReference
+        elif isinstance(viewed_container, Array):
+            result.__class__ = ArrayReference
+        elif isinstance(viewed_container, Scalar):
+            result = ArrayReference(dtype=viewed_container.dtype,
+                                    shape=[1],
+                                    storage=viewed_container.storage,
+                                    lifetime=viewed_container.lifetime,
+                                    alignment=viewed_container.alignment,
+                                    debuginfo=viewed_container.debuginfo,
+                                    total_size=1,
+                                    start_offset=0,
+                                    optional=viewed_container.optional,
+                                    pool=False,
+                                    byval=False)
         else:  # In undefined cases, make a container array reference of size 1
             result = ContainerArrayReference(result, [1], debuginfo=debuginfo)
 

--- a/dace/data.py
+++ b/dace/data.py
@@ -1844,23 +1844,7 @@ class View:
         """
         debuginfo = debuginfo or viewed_container.debuginfo
         # Construct the right kind of view from the input data container
-        if isinstance(viewed_container, Array):
-            result = ArrayView(dtype=viewed_container.dtype,
-                               shape=viewed_container.shape,
-                               allow_conflicts=viewed_container.allow_conflicts,
-                               storage=viewed_container.storage,
-                               location=viewed_container.location,
-                               strides=viewed_container.strides,
-                               offset=viewed_container.offset,
-                               may_alias=viewed_container.may_alias,
-                               lifetime=viewed_container.lifetime,
-                               alignment=viewed_container.alignment,
-                               debuginfo=debuginfo,
-                               total_size=viewed_container.total_size,
-                               start_offset=viewed_container.start_offset,
-                               optional=viewed_container.optional,
-                               pool=viewed_container.pool)
-        elif isinstance(viewed_container, Structure):
+        if isinstance(viewed_container, Structure):
             result = StructureView(members=cp.deepcopy(viewed_container.members),
                                    name=viewed_container.name,
                                    storage=viewed_container.storage,
@@ -1883,6 +1867,22 @@ class View:
                                    start_offset=viewed_container.start_offset,
                                    optional=viewed_container.optional,
                                    pool=viewed_container.pool)
+        elif isinstance(viewed_container, Array):
+            result = ArrayView(dtype=viewed_container.dtype,
+                               shape=viewed_container.shape,
+                               allow_conflicts=viewed_container.allow_conflicts,
+                               storage=viewed_container.storage,
+                               location=viewed_container.location,
+                               strides=viewed_container.strides,
+                               offset=viewed_container.offset,
+                               may_alias=viewed_container.may_alias,
+                               lifetime=viewed_container.lifetime,
+                               alignment=viewed_container.alignment,
+                               debuginfo=debuginfo,
+                               total_size=viewed_container.total_size,
+                               start_offset=viewed_container.start_offset,
+                               optional=viewed_container.optional,
+                               pool=viewed_container.pool)
         else:
             # In undefined cases, make a container array view of size 1
             result = ContainerView(cp.deepcopy(viewed_container), [1], debuginfo=debuginfo)

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -402,7 +402,7 @@ def prepare_schedule_tree_edges(state: SDFGState) -> Dict[gr.MultiConnectorEdge[
             # 1. Check for views
             if isinstance(e.src, dace.nodes.AccessNode):
                 desc = e.src.desc(sdfg)
-                if isinstance(desc, (dace.data.View, dace.data.StructureView)):
+                if isinstance(desc, dace.data.IView):
                     vedge = sdutil.get_view_edge(state, e.src)
                     if e is vedge:
                         viewed_node = sdutil.get_view_node(state, e.src)
@@ -412,7 +412,7 @@ def prepare_schedule_tree_edges(state: SDFGState) -> Dict[gr.MultiConnectorEdge[
                         continue
             if isinstance(e.dst, dace.nodes.AccessNode):
                 desc = e.dst.desc(sdfg)
-                if isinstance(desc, (dace.data.View, dace.data.StructureView)):
+                if isinstance(desc, dace.data.IView):
                     vedge = sdutil.get_view_edge(state, e.dst)
                     if e is vedge:
                         viewed_node = sdutil.get_view_node(state, e.dst)

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -397,7 +397,7 @@ def prepare_schedule_tree_edges(state: SDFGState) -> Dict[gr.MultiConnectorEdge[
             # 1. Check for views
             if isinstance(e.src, dace.nodes.AccessNode):
                 desc = e.src.desc(sdfg)
-                if isinstance(desc, dace.data.IView):
+                if isinstance(desc, dace.data.View):
                     vedge = sdutil.get_view_edge(state, e.src)
                     if e is vedge:
                         viewed_node = sdutil.get_view_node(state, e.src)
@@ -407,7 +407,7 @@ def prepare_schedule_tree_edges(state: SDFGState) -> Dict[gr.MultiConnectorEdge[
                         continue
             if isinstance(e.dst, dace.nodes.AccessNode):
                 desc = e.dst.desc(sdfg)
-                if isinstance(desc, dace.data.IView):
+                if isinstance(desc, dace.data.View):
                     vedge = sdutil.get_view_edge(state, e.dst)
                     if e is vedge:
                         viewed_node = sdutil.get_view_node(state, e.dst)

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -71,16 +71,11 @@ def dealias_sdfg(sdfg: SDFG):
             for parent_name in to_unsqueeze:
                 parent_arr = parent_sdfg.arrays[parent_name]
                 if isinstance(parent_arr, data.View):
-                    parent_arr = data.Array(parent_arr.dtype, parent_arr.shape, parent_arr.transient,
-                                            parent_arr.allow_conflicts, parent_arr.storage, parent_arr.location,
-                                            parent_arr.strides, parent_arr.offset, parent_arr.may_alias,
-                                            parent_arr.lifetime, parent_arr.alignment, parent_arr.debuginfo,
-                                            parent_arr.total_size, parent_arr.start_offset, parent_arr.optional,
-                                            parent_arr.pool)
+                    parent_arr = parent_arr.as_array()
                 elif isinstance(parent_arr, data.StructureView):
-                    parent_arr = data.Structure(parent_arr.members, parent_arr.name, parent_arr.transient,
-                                                parent_arr.storage, parent_arr.location, parent_arr.lifetime,
-                                                parent_arr.debuginfo)
+                    parent_arr = parent_arr.as_structure()
+                elif isinstance(parent_arr, data.ContainerView):
+                    parent_arr = copy.deepcopy(parent_arr.stype)
                 child_names = inv_replacements[parent_name]
                 for name in child_names:
                     child_arr = copy.deepcopy(parent_arr)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1723,18 +1723,18 @@ class SDFG(ControlFlowRegion):
         if isinstance(dtype, type) and dtype in dtypes._CONSTANT_TYPES[:-1]:
             dtype = dtypes.typeclass(dtype)
 
-        desc = dt.Reference(dtype,
-                            shape,
-                            storage=storage,
-                            allow_conflicts=allow_conflicts,
-                            transient=True,
-                            strides=strides,
-                            offset=offset,
-                            lifetime=dtypes.AllocationLifetime.Scope,
-                            alignment=alignment,
-                            debuginfo=debuginfo,
-                            total_size=total_size,
-                            may_alias=may_alias)
+        desc = dt.ArrayReference(dtype,
+                                 shape,
+                                 storage=storage,
+                                 allow_conflicts=allow_conflicts,
+                                 transient=True,
+                                 strides=strides,
+                                 offset=offset,
+                                 lifetime=dtypes.AllocationLifetime.Scope,
+                                 alignment=alignment,
+                                 debuginfo=debuginfo,
+                                 total_size=total_size,
+                                 may_alias=may_alias)
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
 
@@ -1926,17 +1926,19 @@ class SDFG(ControlFlowRegion):
                                   exists, finds a new name to add.
             :return: Name of the new data descriptor
         """
-        vdesc = copy.deepcopy(datadesc)
-        if isinstance(datadesc, dt.ContainerArray):
-            vdesc.__class__ = dt.ContainerView
-        elif isinstance(datadesc, dt.Structure):
-            vdesc.__class__ = dt.StructureView
-        elif isinstance(datadesc, dt.Array):
-            vdesc.__class__ = dt.ArrayView
-        else:
-            raise TypeError(f'Cannot natively create a view of a {type(vdesc)} data descriptor')
+        vdesc = dt.View.view(datadesc)
+        return self.add_datadesc(name, vdesc, find_new_name)
 
-        vdesc.transient = True
+    def add_datadesc_reference(self, name: str, datadesc: dt.Data, find_new_name=False) -> str:
+        """ Adds a reference of a given data descriptor to the SDFG array store.
+
+            :param name: Name to use.
+            :param datadesc: Data descriptor to view.
+            :param find_new_name: If True and data descriptor with this name
+                                  exists, finds a new name to add.
+            :return: Name of the new data descriptor
+        """
+        vdesc = dt.Reference.view(datadesc)
         return self.add_datadesc(name, vdesc, find_new_name)
 
     def add_pgrid(self,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -610,9 +610,7 @@ class SDFG(ControlFlowRegion):
         else:
             constants_prop = None
 
-        ret = SDFG(name=attrs['name'],
-                   constants=constants_prop,
-                   parent=context_info['sdfg'])
+        ret = SDFG(name=attrs['name'], constants=constants_prop, parent=context_info['sdfg'])
 
         dace.serialize.set_properties_from_json(ret,
                                                 json_obj,
@@ -1239,10 +1237,10 @@ class SDFG(ControlFlowRegion):
 
     def _used_symbols_internal(self,
                                all_symbols: bool,
-                               defined_syms: Optional[Set]=None,
-                               free_syms: Optional[Set]=None,
-                               used_before_assignment: Optional[Set]=None,
-                               keep_defined_in_mapping: bool=False) -> Tuple[Set[str], Set[str], Set[str]]:
+                               defined_syms: Optional[Set] = None,
+                               free_syms: Optional[Set] = None,
+                               used_before_assignment: Optional[Set] = None,
+                               keep_defined_in_mapping: bool = False) -> Tuple[Set[str], Set[str], Set[str]]:
         defined_syms = set() if defined_syms is None else defined_syms
         free_syms = set() if free_syms is None else free_syms
         used_before_assignment = set() if used_before_assignment is None else used_before_assignment
@@ -1259,10 +1257,11 @@ class SDFG(ControlFlowRegion):
         for code in self.exit_code.values():
             free_syms |= symbolic.symbols_in_code(code.as_string, self.symbols.keys())
 
-        return super()._used_symbols_internal(
-            all_symbols=all_symbols, keep_defined_in_mapping=keep_defined_in_mapping,
-            defined_syms=defined_syms, free_syms=free_syms, used_before_assignment=used_before_assignment
-        )
+        return super()._used_symbols_internal(all_symbols=all_symbols,
+                                              keep_defined_in_mapping=keep_defined_in_mapping,
+                                              defined_syms=defined_syms,
+                                              free_syms=free_syms,
+                                              used_before_assignment=used_before_assignment)
 
     def get_all_toplevel_symbols(self) -> Set[str]:
         """
@@ -1917,6 +1916,25 @@ class SDFG(ControlFlowRegion):
         _add_symbols(datadesc)
 
         return name
+
+    def add_datadesc_view(self, name: str, datadesc: dt.Data, find_new_name=False) -> str:
+        """ Adds a view of a given data descriptor to the SDFG array store.
+
+            :param name: Name to use.
+            :param datadesc: Data descriptor to view.
+            :param find_new_name: If True and data descriptor with this name
+                                  exists, finds a new name to add.
+            :return: Name of the new data descriptor
+        """
+        vdesc = copy.deepcopy(datadesc)
+        if isinstance(datadesc, dt.ContainerArray):
+            vdesc.__class__ = dt.ContainerView
+        elif isinstance(datadesc, dt.Structure):
+            vdesc.__class__ = dt.StructureView
+        elif isinstance(datadesc, dt.Array):
+            vdesc.__class__ = dt.View
+        vdesc.transient = True
+        return self.add_datadesc(name, vdesc, find_new_name)
 
     def add_pgrid(self,
                   shape: ShapeType = None,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1666,7 +1666,7 @@ class SDFG(ControlFlowRegion):
                  total_size=None,
                  find_new_name=False,
                  alignment=0,
-                 may_alias=False) -> Tuple[str, dt.View]:
+                 may_alias=False) -> Tuple[str, dt.ArrayView]:
         """ Adds a view to the SDFG data descriptor store. """
 
         # convert strings to int if possible
@@ -1681,18 +1681,18 @@ class SDFG(ControlFlowRegion):
         if isinstance(dtype, type) and dtype in dtypes._CONSTANT_TYPES[:-1]:
             dtype = dtypes.typeclass(dtype)
 
-        desc = dt.View(dtype,
-                       shape,
-                       storage=storage,
-                       allow_conflicts=allow_conflicts,
-                       transient=True,
-                       strides=strides,
-                       offset=offset,
-                       lifetime=dtypes.AllocationLifetime.Scope,
-                       alignment=alignment,
-                       debuginfo=debuginfo,
-                       total_size=total_size,
-                       may_alias=may_alias)
+        desc = dt.ArrayView(dtype,
+                            shape,
+                            storage=storage,
+                            allow_conflicts=allow_conflicts,
+                            transient=True,
+                            strides=strides,
+                            offset=offset,
+                            lifetime=dtypes.AllocationLifetime.Scope,
+                            alignment=alignment,
+                            debuginfo=debuginfo,
+                            total_size=total_size,
+                            may_alias=may_alias)
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1932,7 +1932,10 @@ class SDFG(ControlFlowRegion):
         elif isinstance(datadesc, dt.Structure):
             vdesc.__class__ = dt.StructureView
         elif isinstance(datadesc, dt.Array):
-            vdesc.__class__ = dt.View
+            vdesc.__class__ = dt.ArrayView
+        else:
+            raise TypeError(f'Cannot natively create a view of a {type(vdesc)} data descriptor')
+
         vdesc.transient = True
         return self.add_datadesc(name, vdesc, find_new_name)
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1426,7 +1426,7 @@ def is_nonfree_sym_dependent(node: nd.AccessNode, desc: dt.Data, state: SDFGStat
     :param state: the state that contains the node
     :param fsymbols: the free symbols to check against
     """
-    if isinstance(desc, (dt.StructureView, dt.View)):
+    if isinstance(desc, (dt.IView)):
         # Views can be non-free symbol dependent due to the adjacent edges.
         e = get_view_edge(state, node)
         if e.data:

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1426,7 +1426,7 @@ def is_nonfree_sym_dependent(node: nd.AccessNode, desc: dt.Data, state: SDFGStat
     :param state: the state that contains the node
     :param fsymbols: the free symbols to check against
     """
-    if isinstance(desc, (dt.IView)):
+    if isinstance(desc, (dt.View)):
         # Views can be non-free symbol dependent due to the adjacent edges.
         e = get_view_edge(state, node)
         if e.data:

--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -452,10 +452,10 @@ class RedundantArray(pm.SingleStateTransformation):
         view_strides = in_desc.strides
         if (b_dims_to_pop and len(b_dims_to_pop) == len(out_desc.shape) - len(in_desc.shape)):
             view_strides = [s for i, s in enumerate(out_desc.strides) if i not in b_dims_to_pop]
-        sdfg.arrays[in_array.data] = data.View(in_desc.dtype, in_desc.shape, True, in_desc.allow_conflicts,
-                                               out_desc.storage, out_desc.location, view_strides, in_desc.offset,
-                                               out_desc.may_alias, dtypes.AllocationLifetime.Scope, in_desc.alignment,
-                                               in_desc.debuginfo, in_desc.total_size)
+        sdfg.arrays[in_array.data] = data.ArrayView(in_desc.dtype, in_desc.shape, True, in_desc.allow_conflicts,
+                                                    out_desc.storage, out_desc.location, view_strides, in_desc.offset,
+                                                    out_desc.may_alias, dtypes.AllocationLifetime.Scope,
+                                                    in_desc.alignment, in_desc.debuginfo, in_desc.total_size)
         in_array.add_out_connector('views', force=True)
         e1._src_conn = 'views'
 
@@ -926,10 +926,11 @@ class RedundantSecondArray(pm.SingleStateTransformation):
             view_strides = out_desc.strides
             if (a_dims_to_pop and len(a_dims_to_pop) == len(in_desc.shape) - len(out_desc.shape)):
                 view_strides = [s for i, s in enumerate(in_desc.strides) if i not in a_dims_to_pop]
-            sdfg.arrays[out_array.data] = data.View(out_desc.dtype, out_desc.shape, True, out_desc.allow_conflicts,
-                                                    in_desc.storage, in_desc.location, view_strides, out_desc.offset,
-                                                    in_desc.may_alias, dtypes.AllocationLifetime.Scope,
-                                                    out_desc.alignment, out_desc.debuginfo, out_desc.total_size)
+            sdfg.arrays[out_array.data] = data.ArrayView(out_desc.dtype, out_desc.shape, True, out_desc.allow_conflicts,
+                                                         in_desc.storage, in_desc.location, view_strides,
+                                                         out_desc.offset, in_desc.may_alias,
+                                                         dtypes.AllocationLifetime.Scope, out_desc.alignment,
+                                                         out_desc.debuginfo, out_desc.total_size)
             out_array.add_in_connector('views', force=True)
             e1._dst_conn = 'views'
             return out_array
@@ -1572,7 +1573,7 @@ class RemoveSliceView(pm.SingleStateTransformation):
                     elif subset is not None:
                         # Fill in the subset from the original memlet
                         e.data.subset = copy.deepcopy(subset)
-                        
+
                 else:  # The memlet points to the other side, use ``other_subset``
                     if e.data.other_subset is not None:
                         e.data.other_subset = self._offset_subset(mapping, subset, e.data.other_subset)
@@ -1582,7 +1583,6 @@ class RemoveSliceView(pm.SingleStateTransformation):
 
                 # NOTE: It's only necessary to modify one subset of the memlet, as the space of the other differs from
                 #       the view space.
-
 
             # Remove edge directly adjacent to view and reconnect
             state.remove_edge(edge)
@@ -1619,7 +1619,6 @@ class RemoveIntermediateWrite(pm.SingleStateTransformation):
     write = pm.PatternNode(nodes.AccessNode)
     map_exit = pm.PatternNode(nodes.MapExit)
 
-
     @classmethod
     def expressions(cls):
         return [sdutil.node_path_graph(cls.write, cls.map_exit)]
@@ -1630,7 +1629,7 @@ class RemoveIntermediateWrite(pm.SingleStateTransformation):
         edges = state.edges_between(self.write, self.map_exit)
         if any(not e.data.is_empty() for e in edges):
             return False
-        
+
         # The input edges must either depend on all the Map parameters or have WCR.
         for edge in state.in_edges(self.write):
             if edge.data.wcr:
@@ -1645,7 +1644,7 @@ class RemoveIntermediateWrite(pm.SingleStateTransformation):
 
         entry_node = state.entry_node(self.map_exit)
         scope_dict = state.scope_dict()
-        
+
         outer_write = state.add_access(self.write.data)
         for edge in state.in_edges(self.write):
             state.add_memlet_path(edge.src, self.map_exit, outer_write, memlet=edge.data, src_conn=edge.src_conn)

--- a/dace/transformation/passes/reference_reduction.py
+++ b/dace/transformation/passes/reference_reduction.py
@@ -241,8 +241,5 @@ class ReferenceToView(ppl.Pass):
             state.add_edge(node, None, view, 'views', copy.deepcopy(refsource))
 
     def change_ref_descriptors_to_views(self, sdfg: SDFG, names: Set[str]):
-        # A slightly hacky way to replace a reference class with a view.
-        # Since both classes have the same superclass, and all the fields
-        # are the same, this is safe to perform.
         for name in names:
-            sdfg.arrays[name].__class__ = data.View
+            sdfg.arrays[name] = data.View.view(sdfg.arrays[name])

--- a/tests/sdfg/data/container_array_test.py
+++ b/tests/sdfg/data/container_array_test.py
@@ -224,7 +224,51 @@ def test_jagged_container_array():
     assert np.allclose(ref, B[0])
 
 
+def test_two_levels():
+    N = dace.symbol('N')
+    M = dace.symbol('M')
+    K = dace.symbol('K')
+    sdfg = dace.SDFG('tester')
+    sdfg.add_datadesc('A', dace.float64[N][M][K])
+    desc = dace.data.ContainerView(dace.float64[N], [M], True)
+    sdfg.add_datadesc('v', desc)
+    sdfg.add_view('vv', [N], dace.float64)
+    sdfg.add_array('B', [1], dace.float64)
+
+    # Make a state where the container is viewed twice in a row
+    state = sdfg.add_state()
+    r = state.add_read('A')
+    v = state.add_access('v')
+    v.add_in_connector('views')
+    vv = state.add_access('vv')
+    vv.add_in_connector('views')
+    w = state.add_write('B')
+    state.add_edge(r, None, v, 'views', dace.Memlet('A[1]'))
+    state.add_edge(v, None, vv, 'views', dace.Memlet('v[2]'))
+    state.add_edge(vv, None, w, None, dace.Memlet('vv[3]'))
+
+    # Create a ctypes array of arrays
+    jagged_array = (ctypes.POINTER(ctypes.POINTER(ctypes.c_double)) * 5)(
+        *[
+            #
+            (ctypes.POINTER(ctypes.c_double) * 5)(
+                *[
+                    #
+                    (ctypes.c_double * 5)(*np.random.rand(5)) for _ in range(5)
+                    #
+                ]) for _ in range(5)
+            #
+        ])
+
+    ref = jagged_array[1][2][3]
+
+    B = np.zeros([1])
+    sdfg(A=jagged_array, B=B)
+    assert np.allclose(ref, B[0])
+
+
 if __name__ == '__main__':
     test_read_struct_array()
     test_write_struct_array()
     test_jagged_container_array()
+    test_two_levels()

--- a/tests/sdfg/data/container_array_test.py
+++ b/tests/sdfg/data/container_array_test.py
@@ -11,17 +11,13 @@ def test_read_struct_array():
     L, M, N, nnz = (dace.symbol(s) for s in ('L', 'M', 'N', 'nnz'))
     csr_obj = dace.data.Structure(dict(indptr=dace.int32[M + 1], indices=dace.int32[nnz], data=dace.float32[nnz]),
                                   name='CSRMatrix')
-    csr_obj_view = dace.data.StructureView([('indptr', dace.int32[M + 1]), ('indices', dace.int32[nnz]),
-                                            ('data', dace.float32[nnz])],
-                                           name='CSRMatrix',
-                                           transient=True)
 
     sdfg = dace.SDFG('array_of_csr_to_dense')
 
     sdfg.add_datadesc('A', csr_obj[L])
     sdfg.add_array('B', [L, M, N], dace.float32)
 
-    sdfg.add_datadesc('vcsr', csr_obj_view)
+    sdfg.add_datadesc_view('vcsr', csr_obj)
     sdfg.add_view('vindptr', csr_obj.members['indptr'].shape, csr_obj.members['indptr'].dtype)
     sdfg.add_view('vindices', csr_obj.members['indices'].shape, csr_obj.members['indices'].dtype)
     sdfg.add_view('vdata', csr_obj.members['data'].shape, csr_obj.members['data'].dtype)
@@ -96,18 +92,13 @@ def test_write_struct_array():
     csr_obj = dace.data.Structure([('indptr', dace.int32[M + 1]), ('indices', dace.int32[nnz]),
                                    ('data', dace.float32[nnz])],
                                   name='CSRMatrix')
-    csr_obj_view = dace.data.StructureView(dict(indptr=dace.int32[M + 1],
-                                                indices=dace.int32[nnz],
-                                                data=dace.float32[nnz]),
-                                           name='CSRMatrix',
-                                           transient=True)
 
     sdfg = dace.SDFG('array_dense_to_csr')
 
     sdfg.add_array('A', [L, M, N], dace.float32)
     sdfg.add_datadesc('B', csr_obj[L])
 
-    sdfg.add_datadesc('vcsr', csr_obj_view)
+    sdfg.add_datadesc_view('vcsr', csr_obj)
     sdfg.add_view('vindptr', csr_obj.members['indptr'].shape, csr_obj.members['indptr'].dtype)
     sdfg.add_view('vindices', csr_obj.members['indices'].shape, csr_obj.members['indices'].dtype)
     sdfg.add_view('vdata', csr_obj.members['data'].shape, csr_obj.members['data'].dtype)
@@ -229,9 +220,9 @@ def test_two_levels():
     M = dace.symbol('M')
     K = dace.symbol('K')
     sdfg = dace.SDFG('tester')
-    sdfg.add_datadesc('A', dace.float64[N][M][K])
-    desc = dace.data.ContainerView(dace.float64[N], [M], True)
-    sdfg.add_datadesc('v', desc)
+    desc = dace.data.ContainerArray(dace.data.ContainerArray(dace.float64[N], [M]), [K])
+    sdfg.add_datadesc('A', desc)
+    sdfg.add_datadesc_view('v', desc.stype)
     sdfg.add_view('vv', [N], dace.float64)
     sdfg.add_array('B', [1], dace.float64)
 

--- a/tests/transformations/redundant_slices_test.py
+++ b/tests/transformations/redundant_slices_test.py
@@ -94,7 +94,7 @@ def test_write_slice2():
 @pytest.mark.parametrize('with_subset', (False, True))
 def test_view_slice_detect_simple(with_subset):
     adesc = dace.float64[1, 1]
-    vdesc = dace.data.View(dace.float64[1])
+    vdesc = dace.data.View.view(dace.float64[1])
 
     if with_subset:
         subset = dace.Memlet('A[0, 0]').subset
@@ -115,7 +115,7 @@ def test_view_slice_detect_complex(with_subset):
 
     adesc = dace.float64[2, 2, 1, 1, N]
     adesc.strides = [5 * M * N * K, M * N * K, M * N, 1, N]
-    vdesc = dace.data.View(
+    vdesc = dace.data.View.view(
         dace.data.Array(dace.float64, [2, 1, 2, 1, N, 1], strides=[5 * M * N * K, M * N * K, M * N * K, M * N, N, N]))
 
     if with_subset:

--- a/tests/transformations/redundant_slices_test.py
+++ b/tests/transformations/redundant_slices_test.py
@@ -94,7 +94,7 @@ def test_write_slice2():
 @pytest.mark.parametrize('with_subset', (False, True))
 def test_view_slice_detect_simple(with_subset):
     adesc = dace.float64[1, 1]
-    vdesc = dace.data.View(dace.float64, [1])
+    vdesc = dace.data.View(dace.float64[1])
 
     if with_subset:
         subset = dace.Memlet('A[0, 0]').subset
@@ -115,7 +115,7 @@ def test_view_slice_detect_complex(with_subset):
 
     adesc = dace.float64[2, 2, 1, 1, N]
     adesc.strides = [5 * M * N * K, M * N * K, M * N, 1, N]
-    vdesc = dace.data.View(dace.float64, [2, 1, 2, 1, N, 1], strides=[5 * M * N * K, M * N * K, M * N * K, M * N, N, N])
+    vdesc = dace.data.View(dace.data.Array(dace.float64, [2, 1, 2, 1, N, 1], strides=[5 * M * N * K, M * N * K, M * N * K, M * N, N, N]))
 
     if with_subset:
         subset = dace.Memlet('A[0:2, 3:5, i, j, 0:M]').subset

--- a/tests/transformations/redundant_slices_test.py
+++ b/tests/transformations/redundant_slices_test.py
@@ -115,7 +115,8 @@ def test_view_slice_detect_complex(with_subset):
 
     adesc = dace.float64[2, 2, 1, 1, N]
     adesc.strides = [5 * M * N * K, M * N * K, M * N, 1, N]
-    vdesc = dace.data.View(dace.data.Array(dace.float64, [2, 1, 2, 1, N, 1], strides=[5 * M * N * K, M * N * K, M * N * K, M * N, N, N]))
+    vdesc = dace.data.View(
+        dace.data.Array(dace.float64, [2, 1, 2, 1, N, 1], strides=[5 * M * N * K, M * N * K, M * N * K, M * N, N, N]))
 
     if with_subset:
         subset = dace.Memlet('A[0:2, 3:5, i, j, 0:M]').subset


### PR DESCRIPTION
This PR refactors the notion of views to a `View` interface, and provides views to arrays, structures, and container arrays. It also adds a syntactic-sugar/helper API to define a view of an existing data descriptor. Depends on merging #1504