### PR TITLE
Remove the long-deprecated `symbol.get/set` methods

### DIFF
--- a/.github/workflows/fpga-ci.yml
+++ b/.github/workflows/fpga-ci.yml
@@ -54,7 +54,7 @@ jobs:
         # and overflowed in the year 2022, run the FPGA tests pretending like it's January 1st 2021.
         # faketime -f "@2021-01-01 00:00:00" pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
         # Try running without faketime
-        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
+        pytest --cov-report=xml --cov=dace --tb=short -m "fpga"
 
         coverage report
         coverage xml

--- a/.github/workflows/fpga-ci.yml
+++ b/.github/workflows/fpga-ci.yml
@@ -54,7 +54,7 @@ jobs:
         # and overflowed in the year 2022, run the FPGA tests pretending like it's January 1st 2021.
         # faketime -f "@2021-01-01 00:00:00" pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
         # Try running without faketime
-        pytest --cov-report=xml --cov=dace --tb=short -m "fpga"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
 
         coverage report
         coverage xml

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -31,9 +31,8 @@ class ReloadableDLL(object):
         :param program_name: Name of the DaCe program (for use in finding
                              the stub library loader).
         """
-        self._stub_filename = os.path.join(
-            os.path.dirname(os.path.realpath(library_filename)),
-            f'libdacestub_{program_name}.{Config.get("compiler", "library_extension")}')
+        self._stub_filename = os.path.join(os.path.dirname(os.path.realpath(library_filename)),
+                                           f'libdacestub_{program_name}.{Config.get("compiler", "library_extension")}')
         self._library_filename = os.path.realpath(library_filename)
         self._stub = None
         self._lib = None
@@ -219,7 +218,6 @@ class CompiledSDFG(object):
                     self.has_gpu_code = True
                     break
 
-
     def get_exported_function(self, name: str, restype=None) -> Optional[Callable[..., Any]]:
         """
         Tries to find a symbol by name in the compiled SDFG, and convert it to a callable function
@@ -233,7 +231,6 @@ class CompiledSDFG(object):
         except KeyError:  # Function not found
             return None
 
-
     def get_state_struct(self) -> ctypes.Structure:
         """ Attempt to parse the SDFG source code and extract the state struct. This method will parse the first
             consecutive entries in the struct that are pointers. As soon as a non-pointer or other unparseable field is
@@ -246,7 +243,6 @@ class CompiledSDFG(object):
             raise ValueError('Library was not initialized')
 
         return ctypes.cast(self._libhandle, ctypes.POINTER(self._try_parse_state_struct())).contents
-
 
     def _try_parse_state_struct(self) -> Optional[Type[ctypes.Structure]]:
         from dace.codegen.targets.cpp import mangle_dace_state_struct_name  # Avoid import cycle
@@ -375,7 +371,6 @@ class CompiledSDFG(object):
         else:
             return result
 
-
     def __call__(self, *args, **kwargs):
         """
         Forwards the Python call to the compiled ``SDFG``.
@@ -400,12 +395,11 @@ class CompiledSDFG(object):
         elif len(args) > 0 and self.argnames is not None:
             kwargs.update(
                 # `_construct_args` will handle all of its arguments as kwargs.
-                {aname: arg for aname, arg in zip(self.argnames, args)}
-            )
-        argtuple, initargtuple = self._construct_args(kwargs)   # Missing arguments will be detected here.
-                                                                # Return values are cached in `self._lastargs`.
+                {aname: arg
+                 for aname, arg in zip(self.argnames, args)})
+        argtuple, initargtuple = self._construct_args(kwargs)  # Missing arguments will be detected here.
+        # Return values are cached in `self._lastargs`.
         return self.fast_call(argtuple, initargtuple, do_gpu_check=True)
-
 
     def fast_call(
         self,
@@ -455,14 +449,12 @@ class CompiledSDFG(object):
             self._lib.unload()
             raise
 
-
     def __del__(self):
         if self._initialized is True:
             self.finalize()
             self._initialized = False
             self._libhandle = ctypes.c_void_p(0)
         self._lib.unload()
-
 
     def _construct_args(self, kwargs) -> Tuple[Tuple[Any], Tuple[Any]]:
         """
@@ -486,7 +478,7 @@ class CompiledSDFG(object):
         typedict = self._typedict
         if len(kwargs) > 0:
             # Construct mapping from arguments to signature
-            arglist  = []
+            arglist = []
             argtypes = []
             argnames = []
             for a in sig:
@@ -536,10 +528,9 @@ class CompiledSDFG(object):
                                 'you are doing, you can override this error in the '
                                 'configuration by setting compiler.allow_view_arguments '
                                 'to True.')
-            elif (not isinstance(atype, (dt.Array, dt.Structure)) and
-                  not isinstance(atype.dtype, dtypes.callback) and
-                  not isinstance(arg, (atype.dtype.type, sp.Basic)) and
-                  not (isinstance(arg, symbolic.symbol) and arg.dtype == atype.dtype)):
+            elif (not isinstance(atype, (dt.Array, dt.Structure)) and not isinstance(atype.dtype, dtypes.callback)
+                  and not isinstance(arg, (atype.dtype.type, sp.Basic))
+                  and not (isinstance(arg, symbolic.symbol) and arg.dtype == atype.dtype)):
                 is_int = isinstance(arg, int)
                 if is_int and atype.dtype.type == np.int64:
                     pass
@@ -573,29 +564,23 @@ class CompiledSDFG(object):
         # Retain only the element datatype for upcoming checks and casts
         arg_ctypes = tuple(at.dtype.as_ctypes() for at in argtypes)
 
-        constants  = self.sdfg.constants
-        callparams = tuple(
-            (actype(arg.get())
-             if isinstance(arg, symbolic.symbol)
-             else arg, actype, atype, aname
-            )
-            for arg, actype, atype, aname in zip(arglist, arg_ctypes, argtypes, argnames)
-            if not (symbolic.issymbolic(arg) and (hasattr(arg, 'name') and arg.name in constants))
-        )
+        constants = self.sdfg.constants
+        callparams = tuple((arg, actype, atype, aname)
+                           for arg, actype, atype, aname in zip(arglist, arg_ctypes, argtypes, argnames)
+                           if not (symbolic.issymbolic(arg) and (hasattr(arg, 'name') and arg.name in constants)))
 
         symbols = self._free_symbols
         initargs = tuple(
-            actype(arg) if not isinstance(arg, ctypes._SimpleCData) else arg
-            for arg, actype, atype, aname in callparams
-            if aname in symbols
-        )
+            actype(arg) if not isinstance(arg, ctypes._SimpleCData) else arg for arg, actype, atype, aname in callparams
+            if aname in symbols)
 
         try:
             # Replace arrays with their base host/device pointers
             newargs = [None] * len(callparams)
             for i, (arg, actype, atype, _) in enumerate(callparams):
                 if dtypes.is_array(arg):
-                    newargs[i] = ctypes.c_void_p(_array_interface_ptr(arg, atype.storage))  # `c_void_p` is subclass of `ctypes._SimpleCData`.
+                    newargs[i] = ctypes.c_void_p(_array_interface_ptr(
+                        arg, atype.storage))  # `c_void_p` is subclass of `ctypes._SimpleCData`.
                 elif not isinstance(arg, (ctypes._SimpleCData)):
                     newargs[i] = actype(arg)
                 else:
@@ -607,10 +592,8 @@ class CompiledSDFG(object):
         self._lastargs = newargs, initargs
         return self._lastargs
 
-
     def clear_return_values(self):
         self._create_new_arrays = True
-
 
     def _create_array(self, _: str, dtype: np.dtype, storage: dtypes.StorageType, shape: Tuple[int],
                       strides: Tuple[int], total_size: int):
@@ -635,7 +618,6 @@ class CompiledSDFG(object):
 
         # Create an array with the properties of the SDFG array
         return ndarray(shape, dtype, buffer=zeros(total_size, dtype), strides=strides)
-
 
     def _initialize_return_values(self, kwargs):
         # Obtain symbol values from arguments and constants
@@ -686,7 +668,6 @@ class CompiledSDFG(object):
                 # Create an array with the properties of the SDFG array
                 arr = self._create_array(*shape_desc)
                 self._return_arrays.append(arr)
-
 
     def _convert_return_values(self):
         # Return the values as they would be from a Python function

--- a/dace/frontend/python/wrappers.py
+++ b/dace/frontend/python/wrappers.py
@@ -12,12 +12,9 @@ T = TypeVar('T')
 
 
 def ndarray(shape, dtype=numpy.float64, *args, **kwargs):
-    """ Returns a numpy ndarray where all symbols have been evaluated to
-        numbers and types are converted to numpy types. """
-    repldict = {sym: sym.get() for sym in symbolic.symlist(shape).values()}
-    new_shape = [int(s.subs(repldict) if symbolic.issymbolic(s) else s) for s in shape]
+    """ Returns a numpy ndarray where all types are converted to numpy types. """
     new_dtype = dtype.type if isinstance(dtype, dtypes.typeclass) else dtype
-    return numpy.ndarray(shape=new_shape, dtype=new_dtype, *args, **kwargs)
+    return numpy.ndarray(shape=shape, dtype=new_dtype, *args, **kwargs)
 
 
 stream: Type[Deque[T]] = deque

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2126,7 +2126,7 @@ class SDFG(ControlFlowRegion):
             :param symbols: Values to specialize.
         """
         # Update constants
-        for k, v in syms.items():
+        for k, v in symbols.items():
             self.add_constant(str(k), v)
 
     def is_loaded(self) -> bool:

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2125,14 +2125,6 @@ class SDFG(ControlFlowRegion):
 
             :param symbols: Values to specialize.
         """
-        # Set symbol values to add
-        syms = {
-            # If symbols are passed, extract the value. If constants are
-            # passed, use them directly.
-            name: val.get() if isinstance(val, dace.symbolic.symbol) else val
-            for name, val in symbols.items()
-        }
-
         # Update constants
         for k, v in syms.items():
             self.add_constant(str(k), v)

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -53,19 +53,10 @@ class symbol(sympy.Symbol):
 
         self.dtype = dtype
         self._constraints = []
-        self.value = None
         return self
 
-    def set(self, value):
-        warnings.warn('symbol.set is deprecated, use keyword arguments', DeprecationWarning)
-        if value is not None:
-            # First, check constraints
-            self.check_constraints(value)
-
-        self.value = self.dtype(value)
-
     def __getstate__(self):
-        return dict(self.assumptions0, **{'value': self.value, 'dtype': self.dtype, '_constraints': self._constraints})
+        return dict(self.assumptions0, **{'dtype': self.dtype, '_constraints': self._constraints})
 
     def _eval_subs(self, old, new):
         """
@@ -84,15 +75,6 @@ class symbol(sympy.Symbol):
             return None
         except AttributeError:
             return None
-
-    def is_initialized(self):
-        return self.value is not None
-
-    def get(self):
-        warnings.warn('symbol.get is deprecated, use keyword arguments', DeprecationWarning)
-        if self.value is None:
-            raise UnboundLocalError('Uninitialized symbol value for \'' + self.name + '\'')
-        return self.value
 
     def set_constraints(self, constraint_list):
         try:
@@ -140,9 +122,6 @@ class symbol(sympy.Symbol):
                 raise RuntimeError('Cannot validate constraint %s for symbol %s' % (str(constraint), self.name))
         if fail is not None:
             raise RuntimeError('Value %s invalidates constraint %s for symbol %s' % (str(value), str(fail), self.name))
-
-    def get_or_return(self, uninitialized_ret):
-        return self.value or uninitialized_ret
 
 
 class SymExpr(object):
@@ -287,13 +266,6 @@ class SymExpr(object):
 SymbolicType = Union[sympy.Basic, SymExpr]
 
 
-def symvalue(val):
-    """ Returns the symbol value if it is a symbol. """
-    if isinstance(val, symbol):
-        return val.get()
-    return val
-
-
 # http://stackoverflow.com/q/3844948/
 def _checkEqualIvo(lst):
     return not lst or lst.count(lst[0]) == len(lst)
@@ -333,9 +305,8 @@ def symlist(values):
     return result
 
 
-def evaluate(expr: Union[sympy.Basic, int, float],
-             symbols: Dict[Union[symbol, str], Union[int, float]]) -> \
-        Union[int, float, numpy.number]:
+def evaluate(expr: Union[sympy.Basic, int, float], symbols: Dict[Union[symbol, str],
+                                                                 Union[int, float]]) -> Union[int, float, numpy.number]:
     """
     Evaluates an expression to a constant based on a mapping from symbols
     to values.
@@ -356,9 +327,7 @@ def evaluate(expr: Union[sympy.Basic, int, float],
         return expr
 
     # Evaluate all symbols
-    syms = {(sname if isinstance(sname, sympy.Symbol) else symbol(sname)):
-            sval.get() if isinstance(sval, symbol) else sval
-            for sname, sval in symbols.items()}
+    syms = {(sname if isinstance(sname, sympy.Symbol) else symbol(sname)): sval for sname, sval in symbols.items()}
 
     # Filter out `None` values, callables, and iterables but not strings (for SymPy 1.12)
     syms = {
@@ -1028,7 +997,7 @@ class PythonOpToSympyConverter(ast.NodeTransformer):
                                   self.visit(node.orelse)],
                             keywords=[])
         return ast.copy_location(new_node, node)
-    
+
     def visit_Subscript(self, node):
         if isinstance(node.value, ast.Attribute):
             attr = ast.Subscript(value=ast.Name(id=node.value.attr, ctx=ast.Load()), slice=node.slice, ctx=ast.Load())
@@ -1405,8 +1374,7 @@ def equal(a: SymbolicType, b: SymbolicType, is_length: bool = True) -> Union[boo
         return sympy.ask(sympy.Q.is_true(sympy.Eq(*args)))
 
 
-def symbols_in_code(code: str, potential_symbols: Set[str] = None,
-                    symbols_to_ignore: Set[str] = None) -> Set[str]:
+def symbols_in_code(code: str, potential_symbols: Set[str] = None, symbols_to_ignore: Set[str] = None) -> Set[str]:
     """
     Tokenizes a code string for symbols and returns a set thereof.
 
@@ -1419,7 +1387,7 @@ def symbols_in_code(code: str, potential_symbols: Set[str] = None,
     if potential_symbols is not None and len(potential_symbols) == 0:
         # Don't bother tokenizing for an empty set of potential symbols
         return set()
-    
+
     tokens = set(re.findall(_NAME_TOKENS, code))
     if potential_symbols is not None:
         tokens &= potential_symbols

--- a/samples/fpga/gemv_fpga.py
+++ b/samples/fpga/gemv_fpga.py
@@ -154,9 +154,9 @@ def run_gemv(n: int, m: int, specialize: bool):
 
     print("Running GEMV {}x{} ({}specialized)".format(n, m, ("" if specialize else "not ")))
 
-    A = dace.ndarray([M, N], dtype=dtype)
-    x = dace.ndarray([M], dtype=dtype)
-    y = dace.ndarray([N], dtype=dtype)
+    A = dace.ndarray([m, n], dtype=dtype)
+    x = dace.ndarray([m], dtype=dtype)
+    y = dace.ndarray([n], dtype=dtype)
 
     # Intialize: randomize A, x and y
     # A[:, :] = np.random.rand(M, N).astype(dtype.type)

--- a/samples/fpga/gemv_fpga.py
+++ b/samples/fpga/gemv_fpga.py
@@ -120,12 +120,12 @@ def make_outer_compute_state(sdfg):
     return state
 
 
-def make_sdfg(specialize):
+def make_sdfg(specialize, N, M):
 
     if specialize:
-        name = "gemv_transposed_{}x{}".format(N.get(), M.get())
+        name = "gemv_transposed_{}x{}".format(N, M)
     else:
-        name = "gemv_transposed_{}xM".format(N.get())
+        name = "gemv_transposed_{}xM".format(N)
 
     sdfg = dace.SDFG(name)
 
@@ -143,29 +143,25 @@ def run_gemv(n: int, m: int, specialize: bool):
 
     print("==== Program start ====")
 
-    N.set(n)
     if specialize:
         print("Specializing M...")
-        M.set(m)
 
-    gemv = make_sdfg(specialize)
-    gemv.specialize(dict(N=N))
+    gemv = make_sdfg(specialize, n, m)
+    gemv.specialize(dict(N=n))
 
-    if not specialize:
-        M.set(m)
-    else:
-        gemv.specialize(dict(M=M))
+    if specialize:
+        gemv.specialize(dict(M=m))
 
-    print("Running GEMV {}x{} ({}specialized)".format(N.get(), M.get(), ("" if specialize else "not ")))
+    print("Running GEMV {}x{} ({}specialized)".format(n, m, ("" if specialize else "not ")))
 
     A = dace.ndarray([M, N], dtype=dtype)
     x = dace.ndarray([M], dtype=dtype)
     y = dace.ndarray([N], dtype=dtype)
 
     # Intialize: randomize A, x and y
-    # A[:, :] = np.random.rand(M.get(), N.get()).astype(dtype.type)
-    # x[:] = np.random.rand(M.get()).astype(dtype.type)
-    # y[:] = np.random.rand(N.get()).astype(dtype.type)
+    # A[:, :] = np.random.rand(M, N).astype(dtype.type)
+    # x[:] = np.random.rand(M).astype(dtype.type)
+    # y[:] = np.random.rand(N).astype(dtype.type)
     A[:, :] = 1
     x[:] = 1
     y[:] = 0
@@ -179,9 +175,9 @@ def run_gemv(n: int, m: int, specialize: bool):
     if specialize:
         gemv(A=A, x=x, y=x)
     else:
-        gemv(A=A, M=M, x=x, y=y)
+        gemv(A=A, M=m, x=x, y=y)
 
-    residual = np.linalg.norm(y - regression) / (N.get() * M.get())
+    residual = np.linalg.norm(y - regression) / (n * m)
     print("Residual:", residual)
     diff = np.abs(y - regression)
     wrong_elements = np.transpose(np.nonzero(diff >= 0.01))
@@ -191,7 +187,7 @@ def run_gemv(n: int, m: int, specialize: bool):
     if residual >= 0.01 or highest_diff >= 0.01:
         print("Verification failed!")
         print("Residual: {}".format(residual))
-        print("Incorrect elements: {} / {}".format(wrong_elements.shape[0], (N.get() * M.get())))
+        print("Incorrect elements: {} / {}".format(wrong_elements.shape[0], (n * m)))
         print("Highest difference: {}".format(highest_diff))
         print("** Result:\n", y)
         print("** Reference:\n", regression)

--- a/samples/fpga/histogram_fpga.py
+++ b/samples/fpga/histogram_fpga.py
@@ -9,7 +9,6 @@ import numpy as np
 W = dace.symbol("W")
 H = dace.symbol("H")
 num_bins = dace.symbol("num_bins")
-num_bins.set(256)
 dtype = dace.float32
 
 
@@ -119,10 +118,10 @@ def make_nested_sdfg(parent):
     return sdfg
 
 
-def make_sdfg(specialize):
+def make_sdfg(specialize, h, w):
 
     if specialize:
-        sdfg = dace.SDFG("histogram_fpga_{}x{}".format(H.get(), W.get()))
+        sdfg = dace.SDFG("histogram_fpga_{}x{}".format(h, w))
     else:
         sdfg = dace.SDFG("histogram_fpga")
 
@@ -161,23 +160,25 @@ if __name__ == "__main__":
                         help="Fix all symbols at compile time/in hardware")
     args = vars(parser.parse_args())
 
+    nbins = 256
+
     if args["specialize"]:
-        H.set(args["H"])
-        W.set(args["W"])
-        histogram = make_sdfg(True)
-        histogram.specialize(dict(H=H, W=W, num_bins=num_bins))
+        h = args["H"]
+        w = args["W"]
+        histogram = make_sdfg(True, h, w)
+        histogram.specialize(dict(H=h, W=w, num_bins=nbins))
     else:
         histogram = make_sdfg(False)
         histogram.specialize(dict(num_bins=num_bins))
-        H.set(args["H"])
-        W.set(args["W"])
+        h = args["H"]
+        w = args["W"]
 
-    print("Histogram {}x{} ({}specialized)".format(H.get(), W.get(), "" if args["specialize"] else "not "))
+    print("Histogram {}x{} ({}specialized)".format(h, w, "" if args["specialize"] else "not "))
 
     A = dace.ndarray([H, W], dtype=dtype)
     hist = dace.ndarray([num_bins], dtype=dace.uint32)
 
-    A[:] = np.random.rand(H.get(), W.get()).astype(dace.float32.type)
+    A[:] = np.random.rand(h, w).astype(dace.float32.type)
     hist[:] = dace.uint32(0)
 
     if args["specialize"]:
@@ -186,9 +187,9 @@ if __name__ == "__main__":
         histogram(A=A, H=H, W=W, hist=hist)
 
     if dace.Config.get_bool('profiling'):
-        dace.timethis('histogram', 'numpy', (H.get() * W.get()), np.histogram, A, num_bins)
+        dace.timethis('histogram', 'numpy', (h * w), np.histogram, A, num_bins)
 
-    diff = np.linalg.norm(np.histogram(A, bins=num_bins.get(), range=(0.0, 1.0))[0][1:-1] - hist[1:-1])
+    diff = np.linalg.norm(np.histogram(A, bins=nbins, range=(0.0, 1.0))[0][1:-1] - hist[1:-1])
 
     print("Difference:", diff)
     if diff > 1e-5:

--- a/samples/fpga/jacobi_fpga_systolic.py
+++ b/samples/fpga/jacobi_fpga_systolic.py
@@ -237,9 +237,9 @@ def make_outer_compute_state(sdfg):
     return state
 
 
-def make_sdfg(specialize_all):
-    name = "jacobi_fpga_systolic_{}_{}x{}x{}".format(P.get(), ("H" if not specialize_all else H.get()), W.get(),
-                                                     ("T" if not specialize_all else T.get()))
+def make_sdfg(specialize_all, h, w, t, p):
+    name = "jacobi_fpga_systolic_{}_{}x{}x{}".format(p, ("H" if not specialize_all else h), w,
+                                                     ("T" if not specialize_all else t))
 
     sdfg = dace.SDFG(name)
     sdfg.add_symbol('T', dace.int32)
@@ -272,35 +272,28 @@ def run_jacobi(w: int, h: int, t: int, p: int, specialize_all: bool = False):
 
     # Width and number of PEs must be known at compile time, as it will
     # influence the hardware layout
-    W.set(w)
-    P.set(p)
     if specialize_all:
         print("Specializing H and T...")
-        H.set(h)
-        T.set(t)
 
-    jacobi = make_sdfg(specialize_all)
+    jacobi = make_sdfg(specialize_all, h, w, t, p)
     jacobi.specialize(dict(W=W, P=P))
 
-    if not specialize_all:
-        H.set(h)
-        T.set(t)
-    else:
+    if specialize_all:
         jacobi.specialize(dict(H=H, T=T))
 
-    if T.get() % P.get() != 0:
+    if t % p != 0:
         raise ValueError("Iteration must be divisable by number of processing elements")
 
-    print("Jacobi Stencil {}x{} ({} steps) with {} PEs{}".format(H.get(), W.get(), T.get(), P.get(),
+    print("Jacobi Stencil {}x{} ({} steps) with {} PEs{}".format(h, w, t, p,
                                                                  (" (fully specialized)" if specialize_all else "")))
 
-    A = dace.ndarray([H, W], dtype=dace.float32)
+    A = dace.ndarray([h, w], dtype=dace.float32)
 
     # Initialize arrays: Randomize A, zero B
     A[:] = dace.float32(0)
-    A[2:H.get() - 2, 2:W.get() - 2] = 1
-    regression = np.ndarray([H.get() - 4, W.get() - 4], dtype=np.float32)
-    regression[:] = A[2:H.get() - 2, 2:W.get() - 2]
+    A[2:h - 2, 2:w - 2] = 1
+    regression = np.ndarray([h - 4, w - 4], dtype=np.float32)
+    regression[:] = A[2:h - 2, 2:w - 2]
 
     #############################################
     # Run DaCe program
@@ -312,12 +305,12 @@ def run_jacobi(w: int, h: int, t: int, p: int, specialize_all: bool = False):
 
     # Regression
     kernel = np.array([[0, 0.2, 0], [0.2, 0.2, 0.2], [0, 0.2, 0]], dtype=np.float32)
-    for i in range(T.get()):
+    for i in range(t):
         regression = ndimage.convolve(regression, kernel, mode='constant', cval=0.0)
 
-    residual = np.linalg.norm(A[2:H.get() - 2, 2:W.get() - 2] - regression) / (H.get() * W.get())
+    residual = np.linalg.norm(A[2:h - 2, 2:w - 2] - regression) / (h * w)
     print("Residual:", residual)
-    diff = np.abs(A[2:H.get() - 2, 2:W.get() - 2] - regression)
+    diff = np.abs(A[2:h - 2, 2:w - 2] - regression)
     wrong_elements = np.transpose(np.nonzero(diff >= 0.01))
     highest_diff = np.max(diff)
 
@@ -325,10 +318,10 @@ def run_jacobi(w: int, h: int, t: int, p: int, specialize_all: bool = False):
     if residual >= 0.01 or highest_diff >= 0.01:
         print("Verification failed!")
         print("Residual: {}".format(residual))
-        print("Incorrect elements: {} / {}".format(wrong_elements.shape[0], H.get() * W.get()))
+        print("Incorrect elements: {} / {}".format(wrong_elements.shape[0], h * w))
         print("Highest difference: {}".format(highest_diff))
-        print("** Result:\n", A[:min(6, H.get()), :min(6, W.get())])
-        print("** Reference:\n", regression[:min(5, H.get()), :min(4, W.get())])
+        print("** Result:\n", A[:min(6, h), :min(6, w)])
+        print("** Reference:\n", regression[:min(5, h), :min(4, w)])
         raise RuntimeError("Validation failed.")
 
     return jacobi

--- a/samples/fpga/matrix_multiplication_pipelined.py
+++ b/samples/fpga/matrix_multiplication_pipelined.py
@@ -8,12 +8,12 @@ M = dace.symbol("M")
 K = dace.symbol("K")
 
 
-def make_sdfg(specialized):
+def make_sdfg(specialized, n, k, m):
 
     if specialized:
-        sdfg = dace.SDFG("mm_fpga_pipelined_{}x{}x{}".format(N.get(), K.get(), M.get()))
+        sdfg = dace.SDFG("mm_fpga_pipelined_{}x{}x{}".format(n, k, m))
     else:
-        sdfg = dace.SDFG("mm_fpga_pipelined_NxKx{}".format(M.get()))
+        sdfg = dace.SDFG("mm_fpga_pipelined_NxKx{}".format(m))
 
     ###########################################################################
     # Copy data to FPGA
@@ -183,29 +183,27 @@ if __name__ == "__main__":
                         help="Fix all loop bounds at compile time/in hardware")
     args = vars(parser.parse_args())
 
-    if not args["specialize"]:
-        M.set(args["M"])
-        # M must always be specialized, as it's used for the static buffer size
-        sdfg = make_sdfg(False)
-        sdfg.specialize(dict(M=M))
-        N.set(args["N"])
-        K.set(args["K"])
-    else:
-        M.set(args["M"])
-        N.set(args["N"])
-        K.set(args["K"])
-        sdfg = make_sdfg(True)
-        sdfg.specialize(dict(M=M, N=N, K=K))
+    n = args.N
+    k = args.K
+    m = args.M
 
-    print("Matrix multiplication {}x{}x{} ({}specialized)".format(M.get(), N.get(), K.get(),
+    if not args["specialize"]:
+        # M must always be specialized, as it's used for the static buffer size
+        sdfg = make_sdfg(False, n, k, m)
+        sdfg.specialize(dict(M=m))
+    else:
+        sdfg = make_sdfg(True, n, k, m)
+        sdfg.specialize(dict(M=m, N=n, K=k))
+
+    print("Matrix multiplication {}x{}x{} ({}specialized)".format(m, n, k,
                                                                   "" if args["specialize"] else "not "))
 
     # Initialize arrays: Randomize A and B, zero C
-    A = np.ndarray([N.get(), K.get()], dtype=dace.float32.type)
-    B = np.ndarray([K.get(), M.get()], dtype=dace.float32.type)
-    C = np.ndarray([N.get(), M.get()], dtype=dace.float32.type)
-    A[:] = np.random.rand(M.get(), N.get()).astype(dace.float32.type)
-    B[:] = np.random.rand(N.get(), K.get()).astype(dace.float32.type)
+    A = np.ndarray([n, k], dtype=dace.float32.type)
+    B = np.ndarray([k, m], dtype=dace.float32.type)
+    C = np.ndarray([n, m], dtype=dace.float32.type)
+    A[:] = np.random.rand(m, n).astype(dace.float32.type)
+    B[:] = np.random.rand(n, k).astype(dace.float32.type)
     C[:] = dace.float32(0)
 
     if args["specialize"]:
@@ -213,7 +211,7 @@ if __name__ == "__main__":
     else:
         sdfg(A=A, B=B, C=C, N=N, K=K)
 
-    diff = np.linalg.norm((A @ B) - C) / float(M.get() * K.get())
+    diff = np.linalg.norm((A @ B) - C) / float(m * k)
     if diff > 1e-6:
         raise ValueError(f"Verification failed, difference: {diff}")
     else:

--- a/samples/fpga/matrix_multiplication_pipelined.py
+++ b/samples/fpga/matrix_multiplication_pipelined.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     if args["specialize"]:
         sdfg(A=A, B=B, C=C)
     else:
-        sdfg(A=A, B=B, C=C, N=N, K=K)
+        sdfg(A=A, B=B, C=C, N=n, K=k)
 
     diff = np.linalg.norm((A @ B) - C) / float(m * k)
     if diff > 1e-6:

--- a/samples/fpga/matrix_multiplication_stream.py
+++ b/samples/fpga/matrix_multiplication_stream.py
@@ -137,12 +137,12 @@ c_out = prev + a * b""")
     return state
 
 
-def make_sdfg(specialized):
+def make_sdfg(specialized, n, k, m):
 
     if specialized:
-        sdfg = dace.SDFG("mm_fpga_stream_{}x{}x{}".format(N.get(), K.get(), M.get()))
+        sdfg = dace.SDFG("mm_fpga_stream_{}x{}x{}".format(n, k, m))
     else:
-        sdfg = dace.SDFG("mm_fpga_stream_NxKx{}".format(M.get()))
+        sdfg = dace.SDFG("mm_fpga_stream_NxKx{}".format(m))
 
     pre_state = make_copy_to_fpga_state(sdfg)
     compute_state = make_fpga_state(sdfg)
@@ -167,34 +167,32 @@ if __name__ == "__main__":
                         help="Fix all loop bounds at compile time/in hardware")
     args = vars(parser.parse_args())
 
-    if not args["specialize"]:
-        M.set(args["M"])
-        # M must always be specialized, as it's used for the static buffer size
-        sdfg = make_sdfg(False)
-        sdfg.specialize(dict(M=M))
-        N.set(args["N"])
-        K.set(args["K"])
-    else:
-        M.set(args["M"])
-        N.set(args["N"])
-        K.set(args["K"])
-        sdfg = make_sdfg(True)
-        sdfg.specialize(dict(M=M, N=N, K=K))
+    m = args.M
+    n = args.N
+    k = args.K
 
-    print("Matrix multiplication {}x{}x{} ({}specialized)".format(M.get(), N.get(), K.get(),
+    if not args["specialize"]:
+        # M must always be specialized, as it's used for the static buffer size
+        sdfg = make_sdfg(False, n, k, m)
+        sdfg.specialize(dict(M=m))
+    else:
+        sdfg = make_sdfg(True, n, k, m)
+        sdfg.specialize(dict(M=m, N=n, K=k))
+
+    print("Matrix multiplication {}x{}x{} ({}specialized)".format(m, n, k,
                                                                   "" if args["specialize"] else "not "))
 
     # Initialize arrays: Randomize A and B, zero C
-    A = np.ndarray([N.get(), K.get()], dtype=dace.float32.type)
-    B = np.ndarray([K.get(), M.get()], dtype=dace.float32.type)
-    C = np.ndarray([N.get(), M.get()], dtype=dace.float32.type)
-    A[:] = 1  # np.random.rand(N.get(), K.get()).astype(dace.float32.type)
-    B[:] = 1  # np.random.rand(K.get(), M.get()).astype(dace.float32.type)
+    A = np.ndarray([n, k], dtype=dace.float32.type)
+    B = np.ndarray([k, m], dtype=dace.float32.type)
+    C = np.ndarray([n, m], dtype=dace.float32.type)
+    A[:] = 1  # np.random.rand(n, k).astype(dace.float32.type)
+    B[:] = 1  # np.random.rand(k, m).astype(dace.float32.type)
     C[:] = dace.float32(0)
 
-    A_regression = np.ndarray([N.get(), K.get()], dtype=np.float32)
-    B_regression = np.ndarray([K.get(), M.get()], dtype=np.float32)
-    C_regression = np.ndarray([N.get(), M.get()], dtype=np.float32)
+    A_regression = np.ndarray([n, k], dtype=np.float32)
+    B_regression = np.ndarray([k, m], dtype=np.float32)
+    C_regression = np.ndarray([n, m], dtype=np.float32)
     A_regression[:] = A[:]
     B_regression[:] = B[:]
     C_regression[:] = C[:]
@@ -202,9 +200,9 @@ if __name__ == "__main__":
     if args["specialize"]:
         sdfg(A=A, B=B, C=C)
     else:
-        sdfg(A=A, B=B, C=C, N=N, K=K)
+        sdfg(A=A, B=B, C=C, N=n, K=k)
 
-    diff = np.linalg.norm((A @ B) - C) / float(M.get() * K.get())
+    diff = np.linalg.norm((A @ B) - C) / float(m * k)
     if diff > 1e-6:
         raise ValueError(f"Verification failed, difference: {diff}")
     else:

--- a/samples/fpga/matrix_multiplication_systolic.py
+++ b/samples/fpga/matrix_multiplication_systolic.py
@@ -241,12 +241,12 @@ def make_fpga_state(sdfg):
     return state
 
 
-def make_sdfg(specialized):
+def make_sdfg(specialized, p, n, k, m):
 
     if specialized:
-        sdfg = dace.SDFG("mm_fpga_systolic_{}_{}x{}x{}".format(P.get(), N.get(), K.get(), M.get()))
+        sdfg = dace.SDFG("mm_fpga_systolic_{}_{}x{}x{}".format(p, n, k, m))
     else:
-        sdfg = dace.SDFG("mm_fpga_systolic_{}_NxKx{}".format(P.get(), M.get()))
+        sdfg = dace.SDFG("mm_fpga_systolic_{}_NxKx{}".format(p, m))
 
     pre_state = make_copy_to_fpga_state(sdfg)
     compute_state = make_fpga_state(sdfg)
@@ -265,32 +265,26 @@ def run_matmul_systolic(m, n, k, p, specialize):
         P.set(p)
         M.set(m)
         # M must always be specialized, as it's used for the static buffer size
-        sdfg = make_sdfg(False)
+        sdfg = make_sdfg(False, p, n, k, m)
         sdfg.specialize(dict(P=p, M=m))
-        N.set(n)
-        K.set(k)
     else:
-        P.set(p)
-        M.set(m)
-        N.set(n)
-        K.set(k)
-        sdfg = make_sdfg(True)
+        sdfg = make_sdfg(True, p, n, k, m)
         sdfg.specialize(dict(P=p, M=m, N=n, K=k))
 
-    print("Matrix multiplication {}x{}x{} with {} PEs ({}specialized)".format(M.get(), N.get(), K.get(), P.get(),
+    print("Matrix multiplication {}x{}x{} with {} PEs ({}specialized)".format(m, n, k, p,
                                                                               "" if specialize else "not "))
 
     # Initialize arrays: Randomize A and B, zero C
-    A = np.ndarray([N.get(), K.get()], dtype=dace.float32.type)
-    B = np.ndarray([K.get(), M.get()], dtype=dace.float32.type)
-    C = np.ndarray([N.get(), M.get()], dtype=dace.float32.type)
-    A[:] = np.random.rand(N.get(), K.get()).astype(dace.float32.type)
-    B[:] = np.random.rand(K.get(), M.get()).astype(dace.float32.type)
+    A = np.ndarray([n, k], dtype=dace.float32.type)
+    B = np.ndarray([k, m], dtype=dace.float32.type)
+    C = np.ndarray([n, m], dtype=dace.float32.type)
+    A[:] = np.random.rand(n, k).astype(dace.float32.type)
+    B[:] = np.random.rand(k, m).astype(dace.float32.type)
     C[:] = dace.float32(0)
 
-    A_regression = np.ndarray([N.get(), K.get()], dtype=np.float32)
-    B_regression = np.ndarray([K.get(), M.get()], dtype=np.float32)
-    C_regression = np.ndarray([N.get(), M.get()], dtype=np.float32)
+    A_regression = np.ndarray([n, k], dtype=np.float32)
+    B_regression = np.ndarray([k, m], dtype=np.float32)
+    C_regression = np.ndarray([n, m], dtype=np.float32)
     A_regression[:] = A[:]
     B_regression[:] = B[:]
     C_regression[:] = C[:]
@@ -300,7 +294,7 @@ def run_matmul_systolic(m, n, k, p, specialize):
     else:
         sdfg(A=A, B=B, C=C, N=N, K=K)
 
-    diff = np.linalg.norm((A @ B) - C) / float(M.get() * K.get())
+    diff = np.linalg.norm((A @ B) - C) / float(m * k)
     if diff > 1e-6:
         raise ValueError(f"Verification failed, difference: {diff}")
     else:

--- a/samples/fpga/matrix_multiplication_systolic.py
+++ b/samples/fpga/matrix_multiplication_systolic.py
@@ -290,7 +290,7 @@ def run_matmul_systolic(m, n, k, p, specialize):
     if specialize:
         sdfg(A=A, B=B, C=C)
     else:
-        sdfg(A=A, B=B, C=C, N=N, K=K)
+        sdfg(A=A, B=B, C=C, N=n, K=k)
 
     diff = np.linalg.norm((A @ B) - C) / float(m * k)
     if diff > 1e-6:

--- a/samples/fpga/matrix_multiplication_systolic.py
+++ b/samples/fpga/matrix_multiplication_systolic.py
@@ -262,8 +262,6 @@ def run_matmul_systolic(m, n, k, p, specialize):
     print("==== Program start ====")
 
     if not specialize:
-        P.set(p)
-        M.set(m)
         # M must always be specialized, as it's used for the static buffer size
         sdfg = make_sdfg(False, p, n, k, m)
         sdfg.specialize(dict(P=p, M=m))

--- a/samples/fpga/rtl/add_fortytwo.py
+++ b/samples/fpga/rtl/add_fortytwo.py
@@ -119,9 +119,9 @@ sdfg.validate()
 if __name__ == '__main__':
     with dace.config.set_temporary('compiler', 'xilinx', 'mode', value='hardware_emulation'):
         # init data structures
-        N.set(8192)
-        a = np.random.randint(0, 100, N.get()).astype(np.int32)
-        b = np.zeros((N.get(), )).astype(np.int32)
+        N = 8192
+        a = np.random.randint(0, 100, N).astype(np.int32)
+        b = np.zeros((N, )).astype(np.int32)
 
         # show initial values
         print("a={}, b={}".format(a, b))
@@ -133,5 +133,5 @@ if __name__ == '__main__':
         print("a={}, b={}".format(a, b))
 
         # check result
-        for i in range(N.get()):
+        for i in range(N):
             assert b[i] == a[i] + 42

--- a/samples/fpga/rtl/axpy.py
+++ b/samples/fpga/rtl/axpy.py
@@ -240,11 +240,11 @@ def make_sdfg(veclen=2):
 if __name__ == '__main__':
     with dace.config.set_temporary('compiler', 'xilinx', 'mode', value='hardware_emulation'):
         # init data structures
-        N.set(4096)
+        N = 4096
         a = np.random.rand(1)[0].astype(np.float32)
-        x = np.random.rand(N.get()).astype(np.float32)
-        y = np.random.rand(N.get()).astype(np.float32)
-        result = np.zeros((N.get(), )).astype(np.float32)
+        x = np.random.rand(N).astype(np.float32)
+        y = np.random.rand(N).astype(np.float32)
+        result = np.zeros((N, )).astype(np.float32)
 
         # show initial values
         print("a={}, x={}, y={}".format(a, x, y))
@@ -260,6 +260,6 @@ if __name__ == '__main__':
 
         # check result
         expected = a * x + y
-        diff = np.linalg.norm(expected - result) / N.get()
+        diff = np.linalg.norm(expected - result) / N
         print("Difference:", diff)
         assert diff <= 1e-5

--- a/samples/fpga/rtl/axpy_double_pump.py
+++ b/samples/fpga/rtl/axpy_double_pump.py
@@ -430,11 +430,11 @@ if __name__ == '__main__':
     with dace.config.set_temporary('compiler', 'xilinx', 'frequency', value='"0:300\\|1:600"'):
         with dace.config.set_temporary('compiler', 'xilinx', 'mode', value='hardware_emulation'):
             # init data structures
-            N.set(4096)
+            N = 4096
             a = np.random.rand(1)[0].astype(np.float32)
-            x = np.random.rand(N.get()).astype(np.float32)
-            y = np.random.rand(N.get()).astype(np.float32)
-            result = np.zeros((N.get(), )).astype(np.float32)
+            x = np.random.rand(N).astype(np.float32)
+            y = np.random.rand(N).astype(np.float32)
+            result = np.zeros((N, )).astype(np.float32)
 
             # show initial values
             print("a={}, x={}, y={}".format(a, x, y))
@@ -450,7 +450,7 @@ if __name__ == '__main__':
 
             # check result
             expected = a * x + y
-            diff = np.linalg.norm(expected - result) / N.get()
+            diff = np.linalg.norm(expected - result) / N
             print("Difference:", diff)
 
             assert diff <= 1e-5

--- a/samples/fpga/rtl/fladd.py
+++ b/samples/fpga/rtl/fladd.py
@@ -172,10 +172,10 @@ sdfg.validate()
 if __name__ == '__main__':
     with dace.config.set_temporary('compiler', 'xilinx', 'mode', value='hardware_emulation'):
         # init data structures
-        N.set(8192)
-        a = np.random.randint(0, 100, N.get()).astype(np.float32)
-        b = np.random.randint(0, 100, N.get()).astype(np.float32)
-        c = np.zeros((N.get() // veclen, )).astype(np.float32)
+        N = 8192
+        a = np.random.randint(0, 100, N).astype(np.float32)
+        b = np.random.randint(0, 100, N).astype(np.float32)
+        c = np.zeros((N // veclen, )).astype(np.float32)
         print(a.shape, b.shape, c.shape)
 
         # show initial values
@@ -189,6 +189,6 @@ if __name__ == '__main__':
 
         # check result
         expected = a + b
-        diff = np.linalg.norm(expected - c) / N.get()
+        diff = np.linalg.norm(expected - c) / N
         print("Difference:", diff)
         assert diff <= 1e-5

--- a/samples/fpga/rtl/pipeline.py
+++ b/samples/fpga/rtl/pipeline.py
@@ -154,9 +154,9 @@ sdfg.validate()
 if __name__ == '__main__':
     with dace.config.set_temporary('compiler', 'xilinx', 'mode', value='hardware_emulation'):
         # init data structures
-        N.set(8192)
-        a = np.random.randint(0, 100, N.get()).astype(np.int32)
-        b = np.zeros((N.get(), )).astype(np.int32)
+        N = 8192
+        a = np.random.randint(0, 100, N).astype(np.int32)
+        b = np.zeros((N, )).astype(np.int32)
 
         # show initial values
         print("a={}, b={}".format(a, b))
@@ -168,5 +168,5 @@ if __name__ == '__main__':
         print("a={}, b={}".format(a, b))
 
         # check result
-        for i in range(N.get()):
+        for i in range(N):
             assert b[i] == a[i] + depth

--- a/samples/fpga/spmv_fpga_stream.py
+++ b/samples/fpga/spmv_fpga_stream.py
@@ -18,8 +18,8 @@ from dace.properties import CodeProperty
 cols = dace.symbol("cols")
 rows = dace.symbol("rows")
 nnz = dace.symbol("nnz")
-itype = dace.dtypes.uint32
-dtype = dace.dtypes.float32
+itype = dace.uint32
+dtype = dace.float32
 
 
 def make_pre_state(sdfg):
@@ -434,66 +434,10 @@ def make_main_state(sdfg):
     return state
 
 
-def make_nested_compute_state(sdfg):
-
-    state = sdfg.add_state("spmv")
-
-    row_entry, row_exit = state.add_map("compute_row", {"i": "0:rows"}, schedule=ScheduleType.FPGA_Device)
-
-    rowptr = state.add_scalar("rowptr", itype, storage=StorageType.FPGA_Registers, transient=True)
-    rowend = state.add_scalar("rowend", itype, storage=StorageType.FPGA_Registers, transient=True)
-
-    nested_sdfg = make_nested_sdfg(sdfg)
-    nested_sdfg_tasklet = state.add_nested_sdfg(nested_sdfg, sdfg,
-                                                {"row_begin", "row_end", "A_val_read", "A_col_read", "x_read"},
-                                                {"b_write"})
-
-    state.add_memlet_path(a_row, row_entry, rowptr, memlet=dace.memlet.Memlet.simple(rowptr, "0", other_subset_str="i"))
-    state.add_memlet_path(rowptr,
-                          nested_sdfg_tasklet,
-                          dst_conn="row_begin",
-                          memlet=dace.memlet.Memlet.simple(rowptr, "0"))
-
-    state.add_memlet_path(a_row,
-                          row_entry,
-                          rowend,
-                          memlet=dace.memlet.Memlet.simple(rowend, "0", other_subset_str="i + 1"))
-    state.add_memlet_path(rowend,
-                          nested_sdfg_tasklet,
-                          dst_conn="row_end",
-                          memlet=dace.memlet.Memlet.simple(rowend, "0"))
-
-    state.add_memlet_path(a_val,
-                          row_entry,
-                          nested_sdfg_tasklet,
-                          dst_conn="A_val_read",
-                          memlet=dace.memlet.Memlet.simple(a_val, "0:nnz"))
-
-    state.add_memlet_path(x,
-                          row_entry,
-                          nested_sdfg_tasklet,
-                          dst_conn="x_read",
-                          memlet=dace.memlet.Memlet.simple(x, "0:cols"))
-
-    state.add_memlet_path(a_col,
-                          row_entry,
-                          nested_sdfg_tasklet,
-                          dst_conn="A_col_read",
-                          memlet=dace.memlet.Memlet.simple(a_col, "0:nnz"))
-
-    state.add_memlet_path(nested_sdfg_tasklet,
-                          row_exit,
-                          b,
-                          src_conn="b_write",
-                          memlet=dace.memlet.Memlet.simple(b, "i"))
-
-    return state
-
-
-def make_sdfg(specialize):
+def make_sdfg(specialize, rows, cols, nnz):
 
     if specialize:
-        name = "spmv_fpga_stream_{}x{}x{}".format(rows.get(), cols.get(), nnz.get())
+        name = "spmv_fpga_stream_{}x{}x{}".format(rows, cols, nnz)
     else:
         name = "spmv_fpga_stream"
     sdfg = dace.SDFG(name)
@@ -509,60 +453,55 @@ def make_sdfg(specialize):
 
 
 def run_spmv(size_w, size_h, num_nonzero, specialize):
-
-    cols.set(size_w)
-    rows.set(size_h)
-    nnz.set(num_nonzero)
-
     print("Sparse Matrix-Vector Multiplication {}x{} "
-          "({} non-zero elements, {}specialized)".format(cols.get(), rows.get(), nnz.get(),
+          "({} non-zero elements, {}specialized)".format(size_w, size_h, num_nonzero,
                                                          "not " if not specialize else ""))
 
-    A_row = dace.ndarray([rows + 1], dtype=itype)
-    A_col = dace.ndarray([nnz], dtype=itype)
-    A_val = dace.ndarray([nnz], dtype=dtype)
+    A_row = dace.ndarray([size_h + 1], dtype=itype)
+    A_col = dace.ndarray([num_nonzero], dtype=itype)
+    A_val = dace.ndarray([num_nonzero], dtype=dtype)
 
-    x = dace.ndarray([cols], dtype)
-    b = dace.ndarray([rows], dtype)
+    x = dace.ndarray([size_w], dtype)
+    b = dace.ndarray([size_h], dtype)
 
     # Assuming uniform sparsity distribution across rows
-    nnz_per_row = nnz.get() // rows.get()
-    nnz_last_row = nnz_per_row + (nnz.get() % rows.get())
-    if nnz_last_row > cols.get():
+    nnz_per_row = num_nonzero // size_h
+    nnz_last_row = nnz_per_row + (num_nonzero % size_h)
+    if nnz_last_row > size_w:
         print("Too many nonzeros per row")
         exit(1)
 
     # RANDOMIZE SPARSE MATRIX
     A_row[0] = itype(0)
-    A_row[1:rows.get()] = itype(nnz_per_row)
+    A_row[1:size_h] = itype(nnz_per_row)
     A_row[-1] = itype(nnz_last_row)
     A_row = np.cumsum(A_row, dtype=itype.type)
 
     # Fill column data
-    for i in range(rows.get() - 1):
+    for i in range(size_h - 1):
         A_col[nnz_per_row*i:nnz_per_row*(i+1)] = \
-            np.sort(np.random.choice(cols.get(), nnz_per_row, replace=False))
+            np.sort(np.random.choice(size_w, nnz_per_row, replace=False))
     # Fill column data for last row
-    A_col[nnz_per_row * (rows.get() - 1):] = np.sort(np.random.choice(cols.get(), nnz_last_row, replace=False))
+    A_col[nnz_per_row * (size_h - 1):] = np.sort(np.random.choice(size_w, nnz_last_row, replace=False))
 
-    A_val[:] = np.random.rand(nnz.get()).astype(dtype.type)
+    A_val[:] = np.random.rand(num_nonzero).astype(dtype.type)
     #########################
 
-    x[:] = np.random.rand(cols.get()).astype(dtype.type)
+    x[:] = np.random.rand(size_w).astype(dtype.type)
     #b[:] = dtype(0)
 
     # Setup regression
-    A_sparse = scipy.sparse.csr_matrix((A_val, A_col, A_row), shape=(rows.get(), cols.get()))
+    A_sparse = scipy.sparse.csr_matrix((A_val, A_col, A_row), shape=(size_h, size_w))
 
-    spmv = make_sdfg(specialize)
+    spmv = make_sdfg(specialize, size_h, size_w, num_nonzero)
     if specialize:
-        spmv.specialize(dict(rows=rows, cols=cols, nnz=nnz))
-    spmv(A_row=A_row, A_col=A_col, A_val=A_val, x=x, b=b, rows=rows, cols=cols, nnz=nnz)
+        spmv.specialize(dict(rows=size_h, cols=size_w, nnz=num_nonzero))
+    spmv(A_row=A_row, A_col=A_col, A_val=A_val, x=x, b=b, rows=size_h, cols=size_w, nnz=num_nonzero)
 
     if dace.Config.get_bool("profiling"):
         dace.timethis("spmv", "scipy", 0, A_sparse.dot, x)
 
-    diff = np.linalg.norm(A_sparse.dot(x) - b) / float(rows.get())
+    diff = np.linalg.norm(A_sparse.dot(x) - b) / float(size_h)
     print("Difference:", diff)
     if diff >= 1e-5:
         print("Validation failed.")

--- a/tests/chained_nested_tasklet_test.py
+++ b/tests/chained_nested_tasklet_test.py
@@ -12,9 +12,9 @@ def test_nested_map():
     print('SDFG consecutive tasklet (nested) test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int32)
-    output = dp.ndarray([N], dp.int32)
+    n = 20
+    input = dp.ndarray([n], dp.int32)
+    output = dp.ndarray([n], dp.int32)
     input[:] = dp.int32(5)
     output[:] = dp.int32(0)
 
@@ -42,9 +42,9 @@ def test_nested_map():
     mysdfg.fill_scope_connectors()
     mysdfg.validate()
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(10 * input - output) / N.get()
+    diff = np.linalg.norm(10 * input - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 
@@ -53,9 +53,9 @@ def test_nested_sdfg():
     print('SDFG consecutive tasklet (nested SDFG) test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int32)
-    output = dp.ndarray([N], dp.int32)
+    n = 20
+    input = dp.ndarray([n], dp.int32)
+    output = dp.ndarray([n], dp.int32)
     input[:] = dp.int32(5)
     output[:] = dp.int32(0)
 
@@ -84,17 +84,17 @@ def test_nested_sdfg():
     state.add_memlet_path(nsdfg_node, omap_exit, B_, src_conn='b', memlet=Memlet('B[0:N]'))
 
     mysdfg.validate()
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(10 * input - output) / N.get()
+    diff = np.linalg.norm(10 * input - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 
     mysdfg.simplify()
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(10 * input - output) / N.get()
+    diff = np.linalg.norm(10 * input - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/chained_tasklet_test.py
+++ b/tests/chained_tasklet_test.py
@@ -11,9 +11,9 @@ def test():
     print('SDFG consecutive tasklet test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int32)
-    output = dp.ndarray([N], dp.int32)
+    n = 20
+    input = dp.ndarray([n], dp.int32)
+    output = dp.ndarray([n], dp.int32)
     input[:] = dp.int32(5)
     output[:] = dp.int32(0)
 
@@ -34,9 +34,9 @@ def test():
     state.add_edge(A_, None, map_entry, None, Memlet.simple(A_, '0:N'))
     state.add_edge(map_exit, None, B_, None, Memlet.simple(B_, '0:N'))
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(10 * input - output) / N.get()
+    diff = np.linalg.norm(10 * input - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/codegen/mpi_axpy.py
+++ b/tests/codegen/mpi_axpy.py
@@ -27,21 +27,21 @@ if __name__ == "__main__":
     parser.add_argument("N", type=int, nargs="?", default=24)
     args = vars(parser.parse_args())
 
-    N.set(args["N"])
+    N = args["N"]
 
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     ranks = comm.Get_size()
 
     if rank == 0:
-        print('Scalar-vector multiplication %d (MPI, ranks = %d)' % (N.get(), ranks))
+        print('Scalar-vector multiplication %d (MPI, ranks = %d)' % (N, ranks))
     else:
         dace.Config.set('debugprint', value=False)
 
     # Initialize arrays: Randomize A and X, zero Y
     a = dace.float64(np.random.rand())
-    x = np.random.rand(N.get()).astype(np.float64)
-    y = np.random.rand(N.get()).astype(np.float64)
+    x = np.random.rand(N).astype(np.float64)
+    y = np.random.rand(N).astype(np.float64)
     regression = (a * x + y)
 
     sdfg = axpy.to_sdfg()
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     csdfg(A=a, X=x, Y=y, N=N)
 
     # Get range handled by this rank
-    partition = N.get() // ranks
+    partition = N // ranks
     reg = regression[partition * rank:partition * (rank + 1)]
     res = y[partition * rank:partition * (rank + 1)]
 

--- a/tests/codegen/sve/application_axpy_test.py
+++ b/tests/codegen/sve/application_axpy_test.py
@@ -25,18 +25,18 @@ def axpy(A, X, Y):
 def test_axpy():
     print("==== Program start ====")
 
-    N.set(24)
+    N = 24
 
-    print('Scalar-vector multiplication %d' % (N.get()))
+    print('Scalar-vector multiplication %d' % (N))
 
     # Initialize arrays: Randomize A and X, zero Y
     A = dace.float64(np.random.rand())
-    X = np.random.rand(N.get()).astype(np.float64)
-    Y = np.random.rand(N.get()).astype(np.float64)
+    X = np.random.rand(N).astype(np.float64)
+    Y = np.random.rand(N).astype(np.float64)
 
     A_regression = np.float64()
-    X_regression = np.ndarray([N.get()], dtype=np.float64)
-    Y_regression = np.ndarray([N.get()], dtype=np.float64)
+    X_regression = np.ndarray([N], dtype=np.float64)
+    Y_regression = np.ndarray([N], dtype=np.float64)
     A_regression = A
     X_regression[:] = X[:]
     Y_regression[:] = Y[:]
@@ -47,11 +47,11 @@ def test_axpy():
 
     c_axpy = sp.linalg.blas.get_blas_funcs('axpy', arrays=(X_regression, Y_regression))
     if dace.Config.get_bool('profiling'):
-        dace.timethis('axpy', 'BLAS', (2 * N.get()), c_axpy, X_regression, Y_regression, N.get(), A_regression)
+        dace.timethis('axpy', 'BLAS', (2 * N), c_axpy, X_regression, Y_regression, N, A_regression)
     else:
-        c_axpy(X_regression, Y_regression, N.get(), A_regression)
+        c_axpy(X_regression, Y_regression, N, A_regression)
 
-    diff = np.linalg.norm(Y_regression - Y) / N.get()
+    diff = np.linalg.norm(Y_regression - Y) / N
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/codegen/sve/application_filter_test.py
+++ b/tests/codegen/sve/application_filter_test.py
@@ -31,12 +31,12 @@ def regression(A, ratio):
 
 @pytest.mark.sve
 def test_filter():
-    N.set(64)
+    N = 64
     ratio = np.float32(0.5)
 
-    print('Predicate-Based Filter. size=%d, ratio=%f' % (N.get(), ratio))
+    print('Predicate-Based Filter. size=%d, ratio=%f' % (N, ratio))
 
-    A = np.random.rand(N.get()).astype(np.float32)
+    A = np.random.rand(N).astype(np.float32)
     B = np.zeros_like(A)
     outsize = dace.scalar(dace.uint32)
     outsize[0] = 0
@@ -52,7 +52,7 @@ def test_filter():
 
     if len(filtered) != outsize[0]:
         print("Difference in number of filtered items: %d (DaCe) vs. %d (numpy)" % (outsize[0], len(filtered)))
-        totalitems = min(outsize[0], N.get())
+        totalitems = min(outsize[0], N)
         print('DaCe:', B[:totalitems].view(type=np.ndarray))
         print('Regression:', filtered.view(type=np.ndarray))
         exit(1)
@@ -68,7 +68,7 @@ def test_filter():
     diff = np.linalg.norm(filtered - B[:outsize[0]]) / float(outsize[0])
     print("Difference:", diff)
     if diff > 1e-5:
-        totalitems = min(outsize[0], N.get())
+        totalitems = min(outsize[0], N)
         print('DaCe:', B[:totalitems].view(type=np.ndarray))
         print('Regression:', filtered.view(type=np.ndarray))
 

--- a/tests/codegen/sve/application_spmv_test.py
+++ b/tests/codegen/sve/application_spmv_test.py
@@ -30,11 +30,11 @@ def spmv(A_row, A_col, A_val, x, b):
 
 @pytest.mark.sve
 def test_spmv():
-    W.set(64)
-    H.set(64)
-    nnz.set(640)
+    W = 64
+    H = 64
+    nnz = 640
 
-    print('Sparse Matrix-Vector Multiplication %dx%d (%d non-zero elements)' % (W.get(), H.get(), nnz.get()))
+    print('Sparse Matrix-Vector Multiplication %dx%d (%d non-zero elements)' % (W, H, nnz))
 
     A_row = dace.ndarray([H + 1], dtype=dace.uint32)
     A_col = dace.ndarray([nnz], dtype=dace.uint32)
@@ -44,33 +44,33 @@ def test_spmv():
     b = dace.ndarray([H], dace.float32)
 
     # Assuming uniform sparsity distribution across rows
-    nnz_per_row = nnz.get() // H.get()
-    nnz_last_row = nnz_per_row + (nnz.get() % H.get())
-    if nnz_last_row > W.get():
+    nnz_per_row = nnz // H
+    nnz_last_row = nnz_per_row + (nnz % H)
+    if nnz_last_row > W:
         print('Too many nonzeros per row')
         exit(1)
 
     # RANDOMIZE SPARSE MATRIX
     A_row[0] = dace.uint32(0)
-    A_row[1:H.get()] = dace.uint32(nnz_per_row)
+    A_row[1:H] = dace.uint32(nnz_per_row)
     A_row[-1] = dace.uint32(nnz_last_row)
     A_row = np.cumsum(A_row, dtype=np.uint32)
 
     # Fill column data
-    for i in range(H.get() - 1):
+    for i in range(H - 1):
         A_col[nnz_per_row*i:nnz_per_row*(i+1)] = \
-            np.sort(np.random.choice(W.get(), nnz_per_row, replace=False))
+            np.sort(np.random.choice(W, nnz_per_row, replace=False))
     # Fill column data for last row
-    A_col[nnz_per_row * (H.get() - 1):] = np.sort(np.random.choice(W.get(), nnz_last_row, replace=False))
+    A_col[nnz_per_row * (H - 1):] = np.sort(np.random.choice(W, nnz_last_row, replace=False))
 
-    A_val[:] = np.random.rand(nnz.get()).astype(dace.float32.type)
+    A_val[:] = np.random.rand(nnz).astype(dace.float32.type)
     #########################
 
-    x[:] = np.random.rand(W.get()).astype(dace.float32.type)
+    x[:] = np.random.rand(W).astype(dace.float32.type)
     b[:] = dace.float32(0)
 
     # Setup regression
-    A_sparse = scipy.sparse.csr_matrix((A_val, A_col, A_row), shape=(H.get(), W.get()))
+    A_sparse = scipy.sparse.csr_matrix((A_val, A_col, A_row), shape=(H, W))
 
     sdfg = common.vectorize(spmv)
 
@@ -79,7 +79,7 @@ def test_spmv():
     if dace.Config.get_bool('profiling'):
         dace.timethis('spmv', 'scipy', 0, A_sparse.dot, x)
 
-    diff = np.linalg.norm(A_sparse.dot(x) - b) / float(H.get())
+    diff = np.linalg.norm(A_sparse.dot(x) - b) / float(H)
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/compile_sdfg_test.py
+++ b/tests/compile_sdfg_test.py
@@ -11,9 +11,9 @@ from dace.sdfg import SDFG
 def test():
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int32)
-    output = dp.ndarray([N], dp.int32)
+    n = 20
+    input = dp.ndarray([n], dp.int32)
+    output = dp.ndarray([n], dp.int32)
     input[:] = dp.int32(5)
     output[:] = dp.int32(0)
 
@@ -38,9 +38,9 @@ def test():
     state.add_edge(A_, None, map_entry, None, Memlet.simple(A_, '0:N'))
     state.add_edge(map_exit, None, B_, None, Memlet.simple(B_, '0:N'))
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(5 * input - output) / N.get()
+    diff = np.linalg.norm(5 * input - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/confres_test.py
+++ b/tests/confres_test.py
@@ -32,18 +32,18 @@ def confres_test(A, B, red1, red2):
 
 
 def test():
-    W.set(20)
-    H.set(20)
+    W = 20
+    H = 20
 
-    print('Conflict Resolution Test %dx%d' % (W.get(), H.get()))
+    print('Conflict Resolution Test %dx%d' % (W, H))
 
     A = dace.ndarray([W, H], dtype=dace.float32)
     B = dace.ndarray([H, W, H], dtype=dace.float32)
     red1 = dace.ndarray([3], dtype=dace.float32)
     red2 = dace.ndarray([1], dtype=dace.float32)
 
-    A[:] = np.random.rand(H.get(), W.get()).astype(dace.float32.type)
-    B[:] = np.random.rand(H.get(), W.get(), H.get()).astype(dace.float32.type)
+    A[:] = np.random.rand(H, W).astype(dace.float32.type)
+    B[:] = np.random.rand(H, W, H).astype(dace.float32.type)
     red1[:] = dace.float32(0)
     red2[:] = dace.float32(0)
 

--- a/tests/constant_array_test.py
+++ b/tests/constant_array_test.py
@@ -10,7 +10,6 @@ from dace.transformation.interstate.state_fusion import StateFusion
 from scipy import ndimage
 
 N = dace.symbol('N')
-N.set(20)
 KERNEL = np.array([[0, -1, 0], [-1, 0, -1], [0, -1, 0]], dtype=np.float32)
 
 
@@ -26,7 +25,8 @@ def stencil3x3(A, B):
 
 
 def test():
-    print('Conv2D %dx%d' % (N.get(), N.get()))
+    N = 20
+    print('Conv2D %dx%d' % (N, N))
 
     A = dace.ndarray([N, N], dtype=dace.float32)
     B = dace.ndarray([N, N], dtype=dace.float32)
@@ -34,9 +34,9 @@ def test():
     # Initialize arrays: Randomize A, zero B
     A[:] = dace.float32(0)
     B[:] = dace.float32(0)
-    A[1:N.get() - 1, 1:N.get() - 1] = np.random.rand((N.get() - 2), (N.get() - 2)).astype(dace.float32.type)
-    regression = np.ndarray([N.get() - 2, N.get() - 2], dtype=np.float32)
-    regression[:] = A[1:N.get() - 1, 1:N.get() - 1]
+    A[1:N - 1, 1:N - 1] = np.random.rand((N - 2), (N - 2)).astype(dace.float32.type)
+    regression = np.ndarray([N - 2, N - 2], dtype=np.float32)
+    regression[:] = A[1:N - 1, 1:N - 1]
 
     #print(A.view(type=np.ndarray))
 
@@ -50,7 +50,7 @@ def test():
     # Regression
     regression = ndimage.convolve(regression, KERNEL, mode='constant', cval=0.0)
 
-    residual = np.linalg.norm(B[1:N.get() - 1, 1:N.get() - 1] - regression) / ((N.get() - 2)**2)
+    residual = np.linalg.norm(B[1:N - 1, 1:N - 1] - regression) / ((N - 2)**2)
     print("Residual:", residual)
 
     #print(A.view(type=np.ndarray))

--- a/tests/copynd_test.py
+++ b/tests/copynd_test.py
@@ -11,7 +11,7 @@ def test():
     print('Copy ND tests')
 
     N = dace.symbol('N')
-    N.set(20)
+    n = 20
 
     sdfg = dace.SDFG('copynd')
     state = sdfg.add_state()
@@ -80,15 +80,15 @@ def test():
                    dace.memlet.Memlet.simple(arrays[-2], '10:30, 20', other_subset_str='10, 10:30'))
 
     array_data = [
-        np.random.rand(*[dace.symbolic.evaluate(s, {N: N.get()})
+        np.random.rand(*[dace.symbolic.evaluate(s, {N: n})
                          for s in a.desc(sdfg).shape]).astype(a.desc(sdfg).dtype.type) for a in arrays
     ]
 
     args = {anode.label: adata for anode, adata in zip(arrays, array_data)}
-    args['N'] = N.get()
+    args['N'] = n
     sdfg(**args)
 
-    N = N.get()
+    N = n
 
     diffs = [
         np.linalg.norm(array_data[1] - array_data[0][5:10, N - 7:N]) / 5.0 * 7.0,
@@ -116,7 +116,7 @@ def test_gpu():
     print('Copy ND tests')
 
     N = dace.symbol('N')
-    N.set(20)
+    n = 20
 
     sdfg = dace.SDFG('copynd_gpu')
     state = sdfg.add_state()
@@ -194,16 +194,16 @@ def test_gpu():
                    dace.memlet.Memlet.simple(arrays[-2], '0:5, 0:6, 0:7 , 0:8', other_subset_str='0:5, 1:7, 1:8, 0:8'))
 
     array_data = [
-        np.random.rand(*[dace.symbolic.evaluate(s, {N: N.get()})
+        np.random.rand(*[dace.symbolic.evaluate(s, {N: n})
                          for s in a.desc(sdfg).shape]).astype(a.desc(sdfg).dtype.type) for a in arrays
     ]
 
     args = {anode.label: adata for anode, adata in zip(arrays, array_data)}
-    args['N'] = N.get()
+    args['N'] = n
     sdfg.apply_gpu_transformations()
     sdfg(**args)
 
-    N = N.get()
+    N = n
 
     diffs = [
         np.linalg.norm(array_data[1] - array_data[0][5:10, N - 7:N]) / 5.0 * 7.0,

--- a/tests/cuda_block_test.py
+++ b/tests/cuda_block_test.py
@@ -28,18 +28,18 @@ def cudahello(V, Vout):
 
 
 def _test(sdfg):
-    N.set(128)
+    N = 128
 
-    print('Vector double CUDA (block) %d' % (N.get()))
+    print('Vector double CUDA (block) %d' % (N))
 
     V = dace.ndarray([N], dace.float64)
     Vout = dace.ndarray([N], dace.float64)
-    V[:] = np.random.rand(N.get()).astype(dace.float64.type)
+    V[:] = np.random.rand(N).astype(dace.float64.type)
     Vout[:] = dace.float64(0)
 
     cudahello(V=V, Vout=Vout, N=N)
 
-    diff = np.linalg.norm(2 * V - Vout) / N.get()
+    diff = np.linalg.norm(2 * V - Vout) / N
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/cuda_grid2d_test.py
+++ b/tests/cuda_grid2d_test.py
@@ -20,19 +20,19 @@ def cudahello(V, Vout):
 
 
 def _test(sdfg):
-    W.set(128)
-    H.set(64)
+    W = 128
+    H = 64
 
-    print('Vector double CUDA (grid 2D) %dx%d' % (W.get(), H.get()))
+    print('Vector double CUDA (grid 2D) %dx%d' % (W, H))
 
     V = dace.ndarray([H, W], dace.float64)
     Vout = dace.ndarray([H, W], dace.float64)
-    V[:] = np.random.rand(H.get(), W.get()).astype(dace.float64.type)
+    V[:] = np.random.rand(H, W).astype(dace.float64.type)
     Vout[:] = dace.float64(0)
 
     sdfg(V=V, Vout=Vout, H=H, W=W)
 
-    diff = np.linalg.norm(2 * V - Vout) / (H.get() * W.get())
+    diff = np.linalg.norm(2 * V - Vout) / (H * W)
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/cuda_grid_test.py
+++ b/tests/cuda_grid_test.py
@@ -31,18 +31,18 @@ def cudahello(V, Vout):
 
 
 def _test(sdfg):
-    N.set(52)
+    N = 52
 
-    print('Vector double CUDA %d' % (N.get()))
+    print('Vector double CUDA %d' % (N))
 
     V = dace.ndarray([N], dace.float32)
     Vout = dace.ndarray([N], dace.float32)
-    V[:] = np.random.rand(N.get()).astype(dace.float32.type)
+    V[:] = np.random.rand(N).astype(dace.float32.type)
     Vout[:] = dace.float32(0)
 
     sdfg(V=V, Vout=Vout, N=N)
 
-    diff = np.linalg.norm(2 * V - Vout) / N.get()
+    diff = np.linalg.norm(2 * V - Vout) / N
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/cuda_smem2d_test.py
+++ b/tests/cuda_smem2d_test.py
@@ -21,19 +21,19 @@ def cudahello(V, Vout):
 
 
 def _test(sdfg):
-    W.set(128)
-    H.set(64)
+    W = 128
+    H = 64
 
-    print('Vector double CUDA (shared memory 2D) %dx%d' % (W.get(), H.get()))
+    print('Vector double CUDA (shared memory 2D) %dx%d' % (W, H))
 
     V = dace.ndarray([H, W], dace.float64)
     Vout = dace.ndarray([H, W], dace.float64)
-    V[:] = np.random.rand(H.get(), W.get()).astype(dace.float64.type)
+    V[:] = np.random.rand(H, W).astype(dace.float64.type)
     Vout[:] = dace.float64(0)
 
     sdfg(V=V, Vout=Vout, H=H, W=W)
 
-    diff = np.linalg.norm(2 * V - Vout) / (H.get() * W.get())
+    diff = np.linalg.norm(2 * V - Vout) / (H * W)
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/cuda_smem_test.py
+++ b/tests/cuda_smem_test.py
@@ -20,18 +20,18 @@ def cudahello(A, Vout):
 
 
 def _test(sdfg):
-    N.set(144)
+    N = 144
 
-    print('Vector double CUDA (shared memory) %d' % (N.get()))
+    print('Vector double CUDA (shared memory) %d' % (N))
 
     V = dace.ndarray([N], dace.float64)
     Vout = dace.ndarray([N], dace.float64)
-    V[:] = np.random.rand(N.get()).astype(dace.float64.type)
+    V[:] = np.random.rand(N).astype(dace.float64.type)
     Vout[:] = dace.float64(0)
 
     sdfg(A=V, Vout=Vout, N=N)
 
-    diff = np.linalg.norm(2 * V - Vout) / N.get()
+    diff = np.linalg.norm(2 * V - Vout) / N
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/duplicate_arg_test.py
+++ b/tests/duplicate_arg_test.py
@@ -19,8 +19,7 @@ def dot(A, B, out):
 
 def test_dot():
     n = 64
-    N.set(n)
-    A = dace.ndarray([N], dtype=dace.float32)
+    A = dace.ndarray([n], dtype=dace.float32)
     out_AA = dace.scalar(dace.float64)
     A[:] = np.random.rand(n).astype(dace.float32.type)
     out_AA[0] = dace.float64(0)

--- a/tests/duplicate_naming_test.py
+++ b/tests/duplicate_naming_test.py
@@ -34,17 +34,17 @@ def duplicate_naming(A, B):
 
 
 def test():
-    W.set(3)
+    W = 3
 
     A = dace.ndarray([W])
     B = dace.ndarray([W])
 
-    A[:] = np.mgrid[0:W.get()]
+    A[:] = np.mgrid[0:W]
     B[:] = dace.float32(0.0)
 
     duplicate_naming(A, B, W=W)
 
-    diff = np.linalg.norm(4 * A - B) / W.get()
+    diff = np.linalg.norm(4 * A - B) / W
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/dynamic_sdfg_functions_test.py
+++ b/tests/dynamic_sdfg_functions_test.py
@@ -21,10 +21,10 @@ from dace.memlet import Memlet
 def test_dynamic_sdfg_with_math_functions():
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
+    n = 20
 
-    input = np.random.rand(N.get()).astype(np.float32)
-    output = dp.ndarray([N], dp.float32)
+    input = np.random.rand(n).astype(np.float32)
+    output = dp.ndarray([n], dp.float32)
     output[:] = dp.float32(0)
 
     # Construct SDFG
@@ -42,10 +42,10 @@ def test_dynamic_sdfg_with_math_functions():
     state.add_edge(A, None, map_entry, None, Memlet.simple(A, '0:N'))
     state.add_edge(map_exit, None, B, None, Memlet.simple(B, '0:N'))
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
     #mymodexp_prog(input, output)
 
-    diff = np.linalg.norm(np.exp(input) - output) / N.get()
+    diff = np.linalg.norm(np.exp(input) - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/external_module_test.py
+++ b/tests/external_module_test.py
@@ -27,9 +27,9 @@ def extmodtest(A: dace.float32[W, H], result: dace.float32[1]):
 
 
 def test():
-    W.set(12)
-    H.set(12)
-    A = np.random.rand(W.get(), H.get()).astype(np.float32)
+    W = 12
+    H = 12
+    A = np.random.rand(W, H).astype(np.float32)
     res = np.zeros([1], np.float32)
 
     extmodtest(A, res)

--- a/tests/fpga/dot_fpga_test.py
+++ b/tests/fpga/dot_fpga_test.py
@@ -26,13 +26,13 @@ def dot(A: dace.float32[N], B: dace.float32[N], out: dace.float32[1]):
 
 
 def run_dot(n, tile_first):
-    N.set(n)
+    N = n
     A = dace.ndarray([N], dtype=dace.float32)
     B = dace.ndarray([N], dtype=dace.float32)
     out_AB = dace.scalar(dace.float32)
 
-    A[:] = np.random.rand(N.get()).astype(dace.float32.type)
-    B[:] = np.random.rand(N.get()).astype(dace.float32.type)
+    A[:] = np.random.rand(N).astype(dace.float32.type)
+    B[:] = np.random.rand(N).astype(dace.float32.type)
     out_AB[0] = dace.float32(0)
 
     sdfg = dot.to_sdfg()
@@ -45,7 +45,7 @@ def run_dot(n, tile_first):
 
     sdfg(A=A, B=B, out=out_AB, N=N)
 
-    diff_ab = np.linalg.norm(np.dot(A, B) - out_AB) / float(N.get())
+    diff_ab = np.linalg.norm(np.dot(A, B) - out_AB) / float(N)
     assert diff_ab <= 1e-5
 
     return sdfg

--- a/tests/fpga/multibank_copy_fpga_test.py
+++ b/tests/fpga/multibank_copy_fpga_test.py
@@ -28,7 +28,7 @@ def mkc(sdfg: dace.SDFG,
     if copy_expr is None:
         copy_expr = src_name
     if (state_before == None):
-        state = sdfg.add_state(is_start_state=True)
+        state = sdfg.add_state(is_start_block=True)
     else:
         state = sdfg.add_state_after(state_before)
 

--- a/tests/fpga/simple_systolic_array_test.py
+++ b/tests/fpga/simple_systolic_array_test.py
@@ -242,10 +242,13 @@ def make_fpga_state(sdfg):
     return state
 
 
-def make_sdfg(name=None):
+def make_sdfg(name=None, p=None):
 
     if name is None:
-        name = "simple_systolic_array_{}".format(P.get())
+        if p is not None:
+            name = "simple_systolic_array_{}".format(p)
+        else:
+            name = "simple_systolic_array_P"
 
     sdfg = dace.SDFG(name)
 
@@ -262,17 +265,17 @@ def make_sdfg(name=None):
 @fpga_test(xilinx=False)
 def test_simple_systolic_array():
 
-    P.set(4)
-    N.set(128)
+    P = 4
+    N = 128
 
     sdfg = make_sdfg()
     sdfg.specialize(dict(P=P, N=N))
 
     # Initialize arrays: Randomize A and B, zero C
-    A = np.ndarray([N.get()], dtype=dace.int32.type)
-    A[:] = np.random.randint(0, 1000, N.get()).astype(dace.int32.type)
+    A = np.ndarray([N], dtype=dace.int32.type)
+    A[:] = np.random.randint(0, 1000, N).astype(dace.int32.type)
 
-    A_Exp = A + P.get()
+    A_Exp = A + P
 
     sdfg(A=A)
     # print("A: ", A)

--- a/tests/fpga/type_inference_test.py
+++ b/tests/fpga/type_inference_test.py
@@ -74,21 +74,21 @@ def type_inference(x: dace.float32[N], y: dace.float32[N]):
 @fpga_test()
 def test_type_inference_fpga():
 
-    N.set(24)
+    N = 24
 
     # Initialize vector: X
-    X = np.random.uniform(-10, 0, N.get()).astype(dace.float32.type)
-    Y = np.random.uniform(-10, 0, N.get()).astype(dace.float32.type)
+    X = np.random.uniform(-10, 0, N).astype(dace.float32.type)
+    Y = np.random.uniform(-10, 0, N).astype(dace.float32.type)
     # compute expected result
-    Z = np.zeros(N.get())
-    for i in range(0, N.get()):
+    Z = np.zeros(N)
+    for i in range(0, N):
         Z[i] = int(X[i]) + int(Y[i]) * 2.1
 
     sdfg = type_inference.to_sdfg()
     sdfg.apply_transformations(FPGATransformSDFG)
     sdfg(x=X, y=Y, N=N)
 
-    diff = np.linalg.norm(Z - Y) / N.get()
+    diff = np.linalg.norm(Z - Y) / N
 
     assert diff <= 1e-5
 

--- a/tests/fpga/vec_sum_test.py
+++ b/tests/fpga/vec_sum_test.py
@@ -30,10 +30,12 @@ def run_vec_sum(vectorize_first: bool):
     n = 24
 
     # Initialize arrays: X, Y and Z
-    X = np.random.rand(n).astype(np.float32)
-    Y = np.random.rand(n).astype(np.float32)
-    Z = np.random.rand(n).astype(np.float32)
-    ref = X + Y + Z
+    rng = np.random.default_rng(42)
+    X = rng.random(n, dtype=np.float32)
+    Y = rng.random(n, dtype=np.float32)
+    Z = rng.random(n, dtype=np.float32)
+    ref = np.empty(n, dtype=np.float32)
+    ref[:] = X + Y + Z
 
     sdfg = vec_sum.to_sdfg()
 
@@ -53,6 +55,9 @@ def run_vec_sum(vectorize_first: bool):
     assert sdfg.apply_transformations(transformations, transformation_options) == 2
 
     sdfg(x=X, y=Y, z=Z, N=n)
+
+    print(f"ref ({ref.shape}): {ref}")
+    print(f"Z ({Z.shape}): {Z}")
 
     diff = np.linalg.norm(ref- Z) / n
     if diff > 1e-5:

--- a/tests/fpga/vec_sum_test.py
+++ b/tests/fpga/vec_sum_test.py
@@ -28,12 +28,12 @@ def vec_sum(x: dace.float32[N], y: dace.float32[N], z: dace.float32[N]):
 
 def run_vec_sum(vectorize_first: bool):
 
-    N.set(24)
+    N = 24
 
     # Initialize arrays: X, Y and Z
-    X = np.random.rand(N.get()).astype(dace.float32.type)
-    Y = np.random.rand(N.get()).astype(dace.float32.type)
-    Z = np.random.rand(N.get()).astype(dace.float32.type)
+    X = np.random.rand(N).astype(dace.float32.type)
+    Y = np.random.rand(N).astype(dace.float32.type)
+    Z = np.random.rand(N).astype(dace.float32.type)
 
     Z_exp = X + Y + Z
 
@@ -56,7 +56,7 @@ def run_vec_sum(vectorize_first: bool):
 
     sdfg(x=X, y=Y, z=Z, N=N)
 
-    diff = np.linalg.norm(Z_exp - Z) / N.get()
+    diff = np.linalg.norm(Z_exp - Z) / N
     if diff > 1e-5:
         raise ValueError("Difference: {}".format(diff))
 

--- a/tests/fpga/vec_sum_test.py
+++ b/tests/fpga/vec_sum_test.py
@@ -10,32 +10,30 @@ import numpy as np
 from dace.config import set_temporary
 import pytest
 
-N = dace.symbol("N")
-
-
-@dace.program
-def vec_sum(x: dace.float32[N], y: dace.float32[N], z: dace.float32[N]):
-
-    @dace.map
-    def sum(i: _[0:N]):
-        in_x << x[i]
-        in_y << y[i]
-        in_z << z[i]
-        out >> z[i]
-
-        out = in_x + in_y + in_z
-
-
 def run_vec_sum(vectorize_first: bool):
+    N = dace.symbol("N")
 
-    N = 24
+
+    @dace.program
+    def vec_sum(x: dace.float32[N], y: dace.float32[N], z: dace.float32[N]):
+
+        @dace.map
+        def sum(i: _[0:N]):
+            in_x << x[i]
+            in_y << y[i]
+            in_z << z[i]
+            out >> z[i]
+
+            out = in_x + in_y + in_z
+
+
+    n = 24
 
     # Initialize arrays: X, Y and Z
-    X = np.random.rand(N).astype(dace.float32.type)
-    Y = np.random.rand(N).astype(dace.float32.type)
-    Z = np.random.rand(N).astype(dace.float32.type)
-
-    Z_exp = X + Y + Z
+    X = np.random.rand(n).astype(np.float32)
+    Y = np.random.rand(n).astype(np.float32)
+    Z = np.random.rand(n).astype(np.float32)
+    ref = X + Y + Z
 
     sdfg = vec_sum.to_sdfg()
 
@@ -54,9 +52,9 @@ def run_vec_sum(vectorize_first: bool):
 
     assert sdfg.apply_transformations(transformations, transformation_options) == 2
 
-    sdfg(x=X, y=Y, z=Z, N=N)
+    sdfg(x=X, y=Y, z=Z, N=n)
 
-    diff = np.linalg.norm(Z_exp - Z) / N
+    diff = np.linalg.norm(ref- Z) / n
     if diff > 1e-5:
         raise ValueError("Difference: {}".format(diff))
 

--- a/tests/fpga/veclen_conversion_connector_test.py
+++ b/tests/fpga/veclen_conversion_connector_test.py
@@ -1,7 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-import argparse
 import numpy as np
-from veclen_conversion_test import SIZE, VECTOR_LENGTH, make_sdfg
+from veclen_conversion_test import make_sdfg
 from dace.fpga_testing import fpga_test
 
 
@@ -10,9 +9,6 @@ def test_veclen_conversion_connector():
 
     size = 128
     vector_length = 4
-
-    SIZE.set(size)
-    VECTOR_LENGTH.set(vector_length)
 
     if size % vector_length != 0:
         raise ValueError("Size {} must be divisible by vector length {}.".format(size, vector_length))
@@ -23,7 +19,7 @@ def test_veclen_conversion_connector():
     A = np.arange(size, dtype=np.float64)
     B = np.zeros((size, ), dtype=np.float64)
 
-    sdfg(A=A, B=B, N=SIZE)
+    sdfg(A=A, B=B, N=size)
 
     mid = vector_length // 2
 

--- a/tests/fpga/veclen_conversion_test.py
+++ b/tests/fpga/veclen_conversion_test.py
@@ -1,5 +1,4 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-import argparse
 import dace
 import numpy as np
 from dace.fpga_testing import intel_fpga_test
@@ -9,14 +8,14 @@ VECTOR_LENGTH = dace.symbol("W")
 DTYPE = dace.float64
 
 
-def make_copy_to_fpga_state(sdfg):
+def make_copy_to_fpga_state(sdfg, veclen):
 
     state = sdfg.add_state("copy_to_device")
 
-    A_host = sdfg.add_array("A", [SIZE // VECTOR_LENGTH.get()], dtype=dace.vector(DTYPE, VECTOR_LENGTH.get()))
+    A_host = sdfg.add_array("A", [SIZE // veclen], dtype=dace.vector(DTYPE, veclen))
 
     A_device = sdfg.add_array("A_device", [SIZE],
-                              dtype=dace.vector(DTYPE, VECTOR_LENGTH.get()),
+                              dtype=dace.vector(DTYPE, veclen),
                               transient=True,
                               storage=dace.dtypes.StorageType.FPGA_Global)
 
@@ -26,22 +25,22 @@ def make_copy_to_fpga_state(sdfg):
     state.add_memlet_path(read,
                           write,
                           memlet=dace.memlet.Memlet.simple("A_device",
-                                                           "0:N//{}".format(VECTOR_LENGTH.get()),
-                                                           num_accesses=SIZE // VECTOR_LENGTH.get()))
+                                                           "0:N//{}".format(veclen),
+                                                           num_accesses=SIZE // veclen))
 
     return state
 
 
-def make_copy_to_host_state(sdfg):
+def make_copy_to_host_state(sdfg, veclen):
 
     state = sdfg.add_state("copy_to_host")
 
     B_device = sdfg.add_array("B_device", [SIZE],
-                              dtype=dace.vector(DTYPE, VECTOR_LENGTH.get()),
+                              dtype=dace.vector(DTYPE, veclen),
                               transient=True,
                               storage=dace.dtypes.StorageType.FPGA_Global)
 
-    B_host = sdfg.add_array("B", [SIZE // VECTOR_LENGTH.get()], dtype=dace.vector(DTYPE, VECTOR_LENGTH.get()))
+    B_host = sdfg.add_array("B", [SIZE // veclen], dtype=dace.vector(DTYPE, veclen))
 
     read = state.add_read("B_device")
     write = state.add_write("B")
@@ -49,21 +48,21 @@ def make_copy_to_host_state(sdfg):
     state.add_memlet_path(read,
                           write,
                           memlet=dace.memlet.Memlet.simple("B",
-                                                           "0:N//{}".format(VECTOR_LENGTH.get()),
-                                                           num_accesses=SIZE // VECTOR_LENGTH.get()))
+                                                           "0:N//{}".format(veclen),
+                                                           num_accesses=SIZE // veclen))
 
     return state
 
 
-def make_fpga_state(sdfg, vectorize_connector):
+def make_fpga_state(sdfg, vectorize_connector, veclen):
 
     state = sdfg.add_state("fpga_state")
 
-    sdfg.add_array("input_buffer", (VECTOR_LENGTH.get(), ),
+    sdfg.add_array("input_buffer", (veclen, ),
                    DTYPE,
                    transient=True,
                    storage=dace.StorageType.FPGA_Registers)
-    sdfg.add_array("output_buffer", (VECTOR_LENGTH.get(), ),
+    sdfg.add_array("output_buffer", (veclen, ),
                    DTYPE,
                    transient=True,
                    storage=dace.StorageType.FPGA_Registers)
@@ -77,7 +76,7 @@ def make_fpga_state(sdfg, vectorize_connector):
 
     # Test read from packed memory to an unpacked buffer
     if vectorize_connector:
-        outputs = {"a_unpacked": dace.vector(DTYPE, VECTOR_LENGTH.get())}
+        outputs = {"a_unpacked": dace.vector(DTYPE, veclen)}
     else:
         outputs = {"a_unpacked"}  # Infers an array
     unpack_tasklet = state.add_tasklet("unpack_tasklet", {"a"}, outputs, "a_unpacked = a")
@@ -89,7 +88,7 @@ def make_fpga_state(sdfg, vectorize_connector):
     state.add_memlet_path(unpack_tasklet,
                           read_buffer,
                           src_conn="a_unpacked",
-                          memlet=dace.Memlet.simple(read_buffer.data, "0:{}".format(VECTOR_LENGTH.get())))
+                          memlet=dace.Memlet.simple(read_buffer.data, "0:{}".format(veclen)))
 
     unroll_entry, unroll_exit = state.add_map("shuffle_map", {"w": "0:W"},
                                               schedule=dace.ScheduleType.FPGA_Device,
@@ -111,14 +110,14 @@ def make_fpga_state(sdfg, vectorize_connector):
 
     # Test writing from unpacked to packed from inside tasklet
     if vectorize_connector:
-        outputs = {"b": dace.vector(DTYPE, VECTOR_LENGTH.get())}
+        outputs = {"b": dace.vector(DTYPE, veclen)}
     else:
         outputs = {"b"}
     pack_tasklet = state.add_tasklet("pack_tasklet", outputs, {"b_packed"}, "b_packed = b")
     state.add_memlet_path(write_buffer,
                           pack_tasklet,
                           dst_conn="b",
-                          memlet=dace.Memlet.simple(write_buffer.data, "0:{}".format(VECTOR_LENGTH.get())))
+                          memlet=dace.Memlet.simple(write_buffer.data, "0:{}".format(veclen)))
 
     # Write back out to memory from unpacked to packed memory
     state.add_memlet_path(pack_tasklet,
@@ -130,16 +129,16 @@ def make_fpga_state(sdfg, vectorize_connector):
     return state
 
 
-def make_sdfg(name=None, vectorize_connector=False):
+def make_sdfg(name=None, vectorize_connector=False, veclen=4):
 
     if name is None:
         name = "veclen_conversion"
 
     sdfg = dace.SDFG(name)
 
-    pre_state = make_copy_to_fpga_state(sdfg)
-    post_state = make_copy_to_host_state(sdfg)
-    compute_state = make_fpga_state(sdfg, vectorize_connector)
+    pre_state = make_copy_to_fpga_state(sdfg, veclen)
+    post_state = make_copy_to_host_state(sdfg, veclen)
+    compute_state = make_fpga_state(sdfg, vectorize_connector, veclen)
 
     sdfg.add_edge(pre_state, compute_state, dace.sdfg.InterstateEdge())
     sdfg.add_edge(compute_state, post_state, dace.sdfg.InterstateEdge())
@@ -149,17 +148,13 @@ def make_sdfg(name=None, vectorize_connector=False):
 
 @intel_fpga_test()
 def test_veclen_conversion():
-
     size = 128
     vector_length = 4
-
-    SIZE.set(size)
-    VECTOR_LENGTH.set(vector_length)
 
     if size % vector_length != 0:
         raise ValueError("Size {} must be divisible by vector length {}.".format(size, vector_length))
 
-    sdfg = make_sdfg(vectorize_connector=False)
+    sdfg = make_sdfg(vectorize_connector=False, veclen=vector_length)
     sdfg.specialize({"W": vector_length})
 
     A = np.arange(size, dtype=np.float64)

--- a/tests/fpga/veclen_conversion_test.py
+++ b/tests/fpga/veclen_conversion_test.py
@@ -160,7 +160,7 @@ def test_veclen_conversion():
     A = np.arange(size, dtype=np.float64)
     B = np.zeros((size, ), dtype=np.float64)
 
-    sdfg(A=A, B=B, N=SIZE)
+    sdfg(A=A, B=B, N=size)
 
     mid = vector_length // 2
 

--- a/tests/fpga/vector_reduce_test.py
+++ b/tests/fpga/vector_reduce_test.py
@@ -28,10 +28,10 @@ def vector_reduce(x: dace.float32[N], s: dace.scalar(dace.float32)):
 @fpga_test()
 def test_vector_reduce():
 
-    N.set(24)
+    N = 24
 
     # Initialize arrays: X, Y and Z
-    X = np.random.rand(N.get()).astype(dace.float32.type)
+    X = np.random.rand(N).astype(dace.float32.type)
     s = dace.scalar(dace.float32)
 
     sdfg = vector_reduce.to_sdfg()
@@ -42,7 +42,7 @@ def test_vector_reduce():
     s_exp = 0.0
     for x in X:
         s_exp += x
-    diff = np.linalg.norm(s_exp - s) / N.get()
+    diff = np.linalg.norm(s_exp - s) / N
     assert diff <= 1e-5
 
     return sdfg

--- a/tests/instrumentation_test.py
+++ b/tests/instrumentation_test.py
@@ -26,7 +26,6 @@ def slowmm(A: dace.float64[N, N], B: dace.float64[N, N], C: dace.float64[N, N]):
 
 
 def onetest(instrumentation: dace.InstrumentationType, size=128):
-    N.set(size)
     A = np.random.rand(size, size)
     B = np.random.rand(size, size)
     C = np.zeros([size, size], dtype=np.float64)
@@ -47,7 +46,7 @@ def onetest(instrumentation: dace.InstrumentationType, size=128):
     if instrumentation == dace.InstrumentationType.GPU_Events:
         sdfg.apply_transformations(GPUTransformSDFG)
 
-    sdfg(A=A, B=B, C=C, N=N)
+    sdfg(A=A, B=B, C=C, N=size)
 
     # Check for correctness
     assert np.allclose(C, 20 * A @ B)

--- a/tests/intarg_test.py
+++ b/tests/intarg_test.py
@@ -15,17 +15,17 @@ def intarg(A, B, integer):
 
 
 def test():
-    W.set(3)
+    W = 3
 
     A = dp.ndarray([W])
     B = dp.ndarray([W])
 
-    A[:] = np.mgrid[0:W.get()]
+    A[:] = np.mgrid[0:W]
     B[:] = dp.float32(0.0)
 
     intarg(A, B, 5, W=W)
 
-    diff = np.linalg.norm(5 * A - B) / W.get()
+    diff = np.linalg.norm(5 * A - B) / W
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/library/sparse/csrmm_test.py
+++ b/tests/library/sparse/csrmm_test.py
@@ -23,7 +23,7 @@ def make_sdfg(transB: bool, alpha: float, beta: float, implementation: str, dtyp
     else:
         sdfg.add_array("B", shape=(M, K), dtype=dtype, transient=False)
 
-    state = sdfg.add_state("state", is_start_state=True)
+    state = sdfg.add_state("state", is_start_block=True)
     a_row_node = state.add_access("A_row")
     a_col_node = state.add_access("A_col")
     a_val_node = state.add_access("A_val")

--- a/tests/library/sparse/csrmv_test.py
+++ b/tests/library/sparse/csrmv_test.py
@@ -20,7 +20,7 @@ def make_sdfg(alpha: float, beta: float, implementation: str, dtype) -> dace.SDF
     sdfg.add_array("C", shape=(N, ), dtype=dtype, transient=False)
     sdfg.add_array("B", shape=(M, ), dtype=dtype, transient=False)
 
-    state = sdfg.add_state("state", is_start_state=True)
+    state = sdfg.add_state("state", is_start_block=True)
     a_row_node = state.add_access("A_row")
     a_col_node = state.add_access("A_col")
     a_val_node = state.add_access("A_val")

--- a/tests/local_inline_test.py
+++ b/tests/local_inline_test.py
@@ -29,19 +29,19 @@ def local_inline(A: dace.float64[W], B: dace.float64[W], C: dace.float64[W]):
 
 
 def test():
-    W.set(3)
+    W = 3
 
     A = dace.ndarray([W])
     B = dace.ndarray([W])
     C = dace.ndarray([W])
 
-    A[:] = np.mgrid[0:W.get()]
+    A[:] = np.mgrid[0:W]
     B[:] = 0.0
     C[:] = 0.0
 
     local_inline(A, B, C)
 
-    diff = np.linalg.norm((-(-A + 1) + 1) - C) / W.get()
+    diff = np.linalg.norm((-(-A + 1) + 1) - C) / W
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/mapreduce_test.py
+++ b/tests/mapreduce_test.py
@@ -140,15 +140,15 @@ def mapreduce_onemap(A, B, C):
 
 
 def onetest(program):
-    M.set(50)
-    N.set(20)
-    K.set(5)
+    M = 50
+    N = 20
+    K = 5
 
-    print('Matrix multiplication %dx%dx%d' % (M.get(), N.get(), K.get()))
+    print('Matrix multiplication %dx%dx%d' % (M, N, K))
 
-    A = np.random.rand(M.get(), K.get())
-    B = np.random.rand(K.get(), N.get())
-    C = np.zeros([M.get(), N.get()], np.float64)
+    A = np.random.rand(M, K)
+    B = np.random.rand(K, N)
+    C = np.zeros([M, N], np.float64)
     C_regression = A @ B
 
     sdfg = program.to_sdfg()
@@ -156,21 +156,21 @@ def onetest(program):
     sdfg.apply_transformations([MapFusion, MapWCRFusion])
     sdfg(A=A, B=B, C=C, M=M, N=N, K=K)
 
-    diff = np.linalg.norm(C_regression - C) / (M.get() * N.get())
+    diff = np.linalg.norm(C_regression - C) / (M * N)
     print("Difference:", diff)
     assert diff <= 1e-5
 
 
 def test_basic():
-    W.set(128)
-    H.set(128)
+    W = 128
+    H = 128
 
-    print('Map-Reduce Test %dx%d' % (W.get(), H.get()))
+    print('Map-Reduce Test %dx%d' % (W, H))
 
     A = dace.ndarray([H, W], dtype=dace.float32)
     B = dace.ndarray([H, W], dtype=dace.float32)
     res = dace.ndarray([1], dtype=dace.float32)
-    A[:] = np.random.rand(H.get(), W.get()).astype(dace.float32.type)
+    A[:] = np.random.rand(H, W).astype(dace.float32.type)
     B[:] = dace.float32(0)
     res[:] = dace.float32(0)
 
@@ -185,23 +185,23 @@ def test_basic():
 
 
 def test_mmm():
-    M.set(50)
-    N.set(20)
-    K.set(5)
+    M = 50
+    N = 20
+    K = 5
 
-    print('Matrix multiplication %dx%dx%d' % (M.get(), N.get(), K.get()))
+    print('Matrix multiplication %dx%dx%d' % (M, N, K))
 
     # Initialize arrays: Randomize A and B, zero C
     A = dace.ndarray([M, N], dtype=dace.float64)
     B = dace.ndarray([N, K], dtype=dace.float64)
     C = dace.ndarray([M, K], dtype=dace.float64)
-    A[:] = np.random.rand(M.get(), N.get()).astype(dace.float64.type)
-    B[:] = np.random.rand(N.get(), K.get()).astype(dace.float64.type)
+    A[:] = np.random.rand(M, N).astype(dace.float64.type)
+    B[:] = np.random.rand(N, K).astype(dace.float64.type)
     C[:] = dace.float64(0)
 
-    A_regression = np.ndarray([M.get(), N.get()], dtype=np.float64)
-    B_regression = np.ndarray([N.get(), K.get()], dtype=np.float64)
-    C_regression = np.ndarray([M.get(), K.get()], dtype=np.float64)
+    A_regression = np.ndarray([M, N], dtype=np.float64)
+    B_regression = np.ndarray([N, K], dtype=np.float64)
+    C_regression = np.ndarray([M, K], dtype=np.float64)
     A_regression[:] = A[:]
     B_regression[:] = B[:]
     C_regression[:] = C[:]
@@ -217,21 +217,21 @@ def test_mmm():
 
 
 def test_extradims():
-    W.set(128)
-    H.set(128)
+    W = 128
+    H = 128
 
-    print('Map-Reduce Test %dx%d' % (W.get(), H.get()))
+    print('Map-Reduce Test %dx%d' % (W, H))
 
     A = dace.ndarray([1, H, 1, W, 1], dtype=dace.float32)
     B = dace.ndarray([H, W], dtype=dace.float32)
     res = dace.ndarray([1], dtype=dace.float32)
-    A[:] = np.random.rand(1, H.get(), 1, W.get(), 1).astype(dace.float32.type)
+    A[:] = np.random.rand(1, H, 1, W, 1).astype(dace.float32.type)
     B[:] = dace.float32(0)
     res[:] = dace.float32(0)
 
     mapreduce_test_3(A, B, res)
 
-    diff = np.linalg.norm(5 * A.reshape((H.get(), W.get())) - B) / (H.get() * W.get())
+    diff = np.linalg.norm(5 * A.reshape((H, W)) - B) / (H * W)
     diff_res = abs((np.sum(B) - res[0])).view(type=np.ndarray)
     print("Difference:", diff, diff_res)
     print("==== Program end ====")
@@ -239,25 +239,25 @@ def test_extradims():
 
 
 def test_permuted():
-    M.set(50)
-    N.set(20)
-    K.set(5)
+    M = 50
+    N = 20
+    K = 5
 
-    print('Matrix multiplication %dx%dx%d' % (M.get(), N.get(), K.get()))
+    print('Matrix multiplication %dx%dx%d' % (M, N, K))
 
     # Initialize arrays: Randomize A and B, zero C
     A = dace.ndarray([M, N], dtype=dace.float64)
     B = dace.ndarray([N, K], dtype=dace.float64)
     C = dace.ndarray([M, K], dtype=dace.float64)
     D = dace.ndarray([M, K, N], dtype=dace.float64)
-    A[:] = np.random.rand(M.get(), N.get()).astype(dace.float64.type)
-    B[:] = np.random.rand(N.get(), K.get()).astype(dace.float64.type)
+    A[:] = np.random.rand(M, N).astype(dace.float64.type)
+    B[:] = np.random.rand(N, K).astype(dace.float64.type)
     C[:] = dace.float64(0)
     D[:] = dace.float64(0)
 
-    A_regression = np.ndarray([M.get(), N.get()], dtype=np.float64)
-    B_regression = np.ndarray([N.get(), K.get()], dtype=np.float64)
-    C_regression = np.ndarray([M.get(), K.get()], dtype=np.float64)
+    A_regression = np.ndarray([M, N], dtype=np.float64)
+    B_regression = np.ndarray([N, K], dtype=np.float64)
+    C_regression = np.ndarray([M, K], dtype=np.float64)
     A_regression[:] = A[:]
     B_regression[:] = B[:]
     C_regression[:] = C[:]
@@ -265,18 +265,18 @@ def test_permuted():
     mapreduce_test_4(A, B, C, D)
     np.dot(A_regression, B_regression, C_regression)
 
-    diff = np.linalg.norm(C_regression - C) / (M.get() * K.get())
+    diff = np.linalg.norm(C_regression - C) / (M * K)
     print("Difference:", diff)
     assert diff <= 1e-5
 
 
 def test_histogram():
-    W.set(32)
-    H.set(32)
+    W = 32
+    H = 32
 
-    print('Histogram (dec) %dx%d' % (W.get(), H.get()))
+    print('Histogram (dec) %dx%d' % (W, H))
 
-    A = np.random.randint(0, BINS, (H.get(), W.get())).astype(np.uint8)
+    A = np.random.randint(0, BINS, (H, W)).astype(np.uint8)
     hist = np.zeros([BINS], dtype=np.uint32)
 
     sdfg = histogram.to_sdfg()

--- a/tests/memlet_lifetime_validation_test.py
+++ b/tests/memlet_lifetime_validation_test.py
@@ -11,11 +11,6 @@ def test():
     print('SDFG memlet lifetime validation test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int32)
-    output = dp.ndarray([N], dp.int32)
-    input[:] = dp.int32(5)
-    output[:] = dp.int32(0)
 
     # Construct SDFG 1
     sdfg1 = SDFG('shouldntwork1')

--- a/tests/multi_output_scope_test.py
+++ b/tests/multi_output_scope_test.py
@@ -18,18 +18,18 @@ def multi_output_scope(A, stats):
 
 
 def test():
-    W.set(120)
+    W = 120
 
     A = dace.ndarray([W])
     stats = dace.ndarray([2])
 
-    A[:] = np.random.normal(3.0, 5.0, W.get())
+    A[:] = np.random.normal(3.0, 5.0, W)
     stats[:] = 0.0
 
     multi_output_scope(A, stats, W=W)
 
-    mean = stats[0] / W.get()
-    variance = stats[1] / W.get() - mean * mean
+    mean = stats[0] / W
+    variance = stats[1] / W - mean * mean
     print("Mean: %f, Variance: %f" % (mean, variance))
 
     diff_mean = abs(mean - np.mean(A))

--- a/tests/multiple_cr_test.py
+++ b/tests/multiple_cr_test.py
@@ -11,8 +11,8 @@ def test():
     print('SDFG multiple tasklet test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int64)
+    n = 20
+    input = dp.ndarray([n], dp.int64)
     sum = dp.ndarray([1], dp.int64)
     product = dp.ndarray([1], dp.int64)
     input[:] = dp.int64(5)
@@ -41,7 +41,7 @@ def test():
     state.add_edge(t2, 'b', map_exit, None, Memlet.simple(p, '0', wcr_str='lambda a,b: a*b'))
     state.add_edge(map_exit, None, p, None, Memlet.simple(p, '0'))
 
-    mysdfg(A=input, s=sum, p=product, N=N)
+    mysdfg(A=input, s=sum, p=product, N=n)
 
     diff_sum = 5 * 20 - sum[0]
     diff_prod = 5**20 - product[0]

--- a/tests/multiple_tasklet_test.py
+++ b/tests/multiple_tasklet_test.py
@@ -11,9 +11,9 @@ def test():
     print('SDFG multiple tasklet test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N], dp.int32)
-    output = dp.ndarray([N], dp.int32)
+    n = 20
+    input = dp.ndarray([n], dp.int32)
+    output = dp.ndarray([n], dp.int32)
     input[:] = dp.int32(5)
     output[:] = dp.int32(0)
 
@@ -38,9 +38,9 @@ def test():
     state.add_edge(A, None, map_entry, None, Memlet.simple(A, '0:N'))
     state.add_edge(map_exit, None, B, None, Memlet.simple(B, '0:N'))
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(5 * input - output) / N.get()
+    diff = np.linalg.norm(5 * input - output) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/multistate_init_test.py
+++ b/tests/multistate_init_test.py
@@ -27,17 +27,17 @@ def multistate_init(A):
 
 
 def test():
-    W.set(3)
+    W = 3
 
     A = dace.ndarray([W])
     regression = dace.ndarray([W])
 
-    A[:] = np.mgrid[0:W.get()]
+    A[:] = np.mgrid[0:W]
     regression[:] = A[:]
 
     multistate_init(A, W=W)
 
-    diff = np.linalg.norm(4 * regression - A) / W.get()
+    diff = np.linalg.norm(4 * regression - A) / W
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/multistream_custom_cudatest.py
+++ b/tests/multistream_custom_cudatest.py
@@ -6,7 +6,6 @@ import pytest
 
 # Create symbols
 N = dp.symbol('N')
-N.set(27)
 
 # Create a GPU SDFG with a custom C++ tasklet
 sdfg = dp.SDFG('cublas_multistream_test')
@@ -101,6 +100,7 @@ sdfg.validate()
 
 @pytest.mark.gpu
 def test_multistream_custom():
+    N = 27
     # First, add libraries to link (CUBLAS) to configuration
     oldconf = dp.Config.get('compiler', 'cpu', 'libs')
     if os.name == 'nt':
@@ -109,13 +109,13 @@ def test_multistream_custom():
         dp.Config.append('compiler', 'cpu', 'libs', value='libcublas.so')
 
     # Initialize arrays. We are using column-major order to support CUBLAS!
-    A = np.ndarray([N.get(), N.get()], dtype=np.float64, order='F')
-    B = np.ndarray([N.get(), N.get()], dtype=np.float64, order='F')
-    C = np.ndarray([N.get(), N.get()], dtype=np.float64, order='F')
+    A = np.ndarray([N, N], dtype=np.float64, order='F')
+    B = np.ndarray([N, N], dtype=np.float64, order='F')
+    C = np.ndarray([N, N], dtype=np.float64, order='F')
 
-    A[:] = np.random.rand(N.get(), N.get())
-    B[:] = np.random.rand(N.get(), N.get())
-    C[:] = np.random.rand(N.get(), N.get())
+    A[:] = np.random.rand(N, N)
+    B[:] = np.random.rand(N, N)
+    C[:] = np.random.rand(N, N)
 
     out_ref = A @ A @ B
 

--- a/tests/nested_sdfg_python_test.py
+++ b/tests/nested_sdfg_python_test.py
@@ -31,15 +31,15 @@ def sdfg_with_children(A: dp.float32[N, N], B: dp.float32[N, N]):
 def test():
     print('Nested SDFG test (Python syntax)')
     # Externals (parameters, symbols)
-    N.set(64)
+    N = 64
 
-    input = np.random.rand(N.get(), N.get()).astype(dp.float32.type)
-    output = np.zeros((N.get(), N.get()), dp.float32.type)
+    input = np.random.rand(N, N).astype(dp.float32.type)
+    output = np.zeros((N, N), dp.float32.type)
 
     sdfg = sdfg_with_children.to_sdfg()
     sdfg(A=input, B=output, N=N)
 
-    diff = np.linalg.norm(output - np.power(input, 5)) / (N.get() * N.get())
+    diff = np.linalg.norm(output - np.power(input, 5)) / (N * N)
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/nested_sdfg_test.py
+++ b/tests/nested_sdfg_test.py
@@ -40,16 +40,16 @@ def test():
     state.add_memlet_path(nsdfg, map_exit, B, src_conn='output', memlet=Memlet.simple(B, 'i,j'))
 
 
-    N.set(64)
+    N = 64
 
     input = dp.ndarray([N, N], dp.float32)
     output = dp.ndarray([N, N], dp.float32)
-    input[:] = np.random.rand(N.get(), N.get()).astype(dp.float32.type)
+    input[:] = np.random.rand(N, N).astype(dp.float32.type)
     output[:] = dp.float32(0)
 
     mysdfg(A=input, B=output, N=N)
 
-    diff = np.linalg.norm(output - np.power(input, 5)) / (N.get() * N.get())
+    diff = np.linalg.norm(output - np.power(input, 5)) / (N * N)
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/nested_symbol_test.py
+++ b/tests/nested_symbol_test.py
@@ -4,7 +4,6 @@ import numpy as np
 import warnings
 
 N = dace.symbol('N')
-N.set(12345)
 
 
 @dace.program

--- a/tests/numpy/datatype_conversion_test.py
+++ b/tests/numpy/datatype_conversion_test.py
@@ -63,12 +63,12 @@ def simple_symbol_conversion(A: dace.int32[N]):
 
 
 def test_simple_symbol_conversion():
-    N.set(10)
-    A = np.random.randint(0, 1000, size=(N.get(), ), dtype=np.int32)
+    N = 10
+    A = np.random.randint(0, 1000, size=(N, ), dtype=np.int32)
     B = simple_symbol_conversion(A)
 
     assert (B.dtype == np.int64)
-    assert (B[0] == np.int64(N.get()))
+    assert (B[0] == np.int64(N))
 
 
 if __name__ == "__main__":

--- a/tests/numpy/indirection_test.py
+++ b/tests/numpy/indirection_test.py
@@ -15,19 +15,19 @@ def indirection(A: dace.float64[M], x: dace.int32[N]):
 
 
 def test_indirection():
-    M.set(100)
-    N.set(100)
+    M = 100
+    N = 100
 
-    x = np.ndarray((N.get(), ), dtype=np.int32)
-    for i in range(N.get()):
-        x[i] = N.get() - 1 - i
-    A = np.ndarray((M.get(), ), dtype=np.float64)
+    x = np.ndarray((N, ), dtype=np.int32)
+    for i in range(N):
+        x[i] = N - 1 - i
+    A = np.ndarray((M, ), dtype=np.float64)
 
     indirection(A, x)
 
-    npA = np.ndarray((M.get(), ), dtype=np.float64)
+    npA = np.ndarray((M, ), dtype=np.float64)
     npA[:] = 1.0
-    for j in range(1, N.get()):
+    for j in range(1, N):
         npA[x[j]] += npA[x[j - 1]]
 
     rel_norm = np.linalg.norm(npA - A) / np.linalg.norm(npA)

--- a/tests/numpy/inline_scalar_test.py
+++ b/tests/numpy/inline_scalar_test.py
@@ -13,9 +13,6 @@ def transpose_add(A: dace.float32[M, K], B: dace.float32[K, M]):
 
 
 def test_inline_scalar():
-    K.set(24)
-    M.set(25)
-
     A = np.random.rand(25, 24).astype(np.float32)
     B = np.random.rand(24, 25).astype(np.float32)
 

--- a/tests/numpy/map_syntax_test.py
+++ b/tests/numpy/map_syntax_test.py
@@ -16,12 +16,12 @@ def copy3d(A: dace.float32[M, N, K], B: dace.float32[M, N, K]):
 
 
 def test_copy3d():
-    [sym.set(24) for sym in [M, N, K]]
-    A = np.random.rand(M.get(), N.get(), K.get()).astype(np.float32)
-    B = np.random.rand(M.get(), N.get(), K.get()).astype(np.float32)
+    N = M = K = 24
+    A = np.random.rand(M, N, K).astype(np.float32)
+    B = np.random.rand(M, N, K).astype(np.float32)
     copy3d(A, B)
 
-    diff = np.linalg.norm(B - A) / (M.get() * N.get())
+    diff = np.linalg.norm(B - A) / (M * N)
     print('Difference:', diff)
     assert diff < 1e-5
 

--- a/tests/numpy/range_indirection_test.py
+++ b/tests/numpy/range_indirection_test.py
@@ -15,19 +15,19 @@ def range_indirection(A: dace.float64[M, N], x: dace.int32[M]):
 
 
 def test():
-    M.set(100)
-    N.set(100)
+    M = 100
+    N = 100
 
-    x = np.ndarray((M.get(), ), dtype=np.int32)
-    for i in range(M.get()):
-        x[i] = M.get() - 1 - i
-    A = np.ndarray((M.get(), N.get()), dtype=np.float64)
+    x = np.ndarray((M, ), dtype=np.int32)
+    for i in range(M):
+        x[i] = M - 1 - i
+    A = np.ndarray((M, N), dtype=np.float64)
 
     range_indirection(A, x)
 
-    npA = np.ndarray((M.get(), N.get()), dtype=np.float64)
+    npA = np.ndarray((M, N), dtype=np.float64)
     npA[:] = 1.0
-    for j in range(1, M.get()):
+    for j in range(1, M):
         npA[x[j]] += npA[x[j - 1]]
 
     rel_norm = np.linalg.norm(npA - A) / np.linalg.norm(npA)

--- a/tests/numpy/slice_test.py
+++ b/tests/numpy/slice_test.py
@@ -19,10 +19,10 @@ def test():
     A = np.random.rand(5, 4)
     B = np.random.rand(4, 5)
     C = np.random.rand(4, 4)
-    N.set(5)
+    N = 5
 
     slicetest(A, B, C)
-    diff = np.linalg.norm(C - (A[1:N.get()] * B[:, 0:N.get() - 1]))
+    diff = np.linalg.norm(C - (A[1:N] * B[:, 0:N - 1]))
     print('Difference:', diff)
     assert diff <= 1e-5
 

--- a/tests/numpy/transient_test.py
+++ b/tests/numpy/transient_test.py
@@ -22,16 +22,16 @@ def ttest(A: dace.float32[M, N, K], B: dace.float32[M, N, K]):
 
 
 def test():
-    M.set(13)
-    N.set(8)
-    K.set(25)
-    A = np.random.rand(M.get(), N.get(), K.get()).astype(np.float32)
-    B = np.random.rand(M.get(), N.get(), K.get()).astype(np.float32)
+    M = 13
+    N = 8
+    K = 25
+    A = np.random.rand(M, N, K).astype(np.float32)
+    B = np.random.rand(M, N, K).astype(np.float32)
 
     realB = B - 5 * A - 1.0
     ttest(A, B)
 
-    diff = np.linalg.norm(B - realB) / (M.get() * K.get() * N.get())
+    diff = np.linalg.norm(B - realB) / (M * K * N)
     print('Difference:', diff)
     assert diff <= 1e-5
 

--- a/tests/numpy/ufunc_support_test.py
+++ b/tests/numpy/ufunc_support_test.py
@@ -71,10 +71,10 @@ def ufunc_add_simple4(A: dace.int32[N]):
 
 
 def test_ufunc_add_simple4():
-    N.set(10)
-    A = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
+    N = 10
+    A = np.random.randint(10, size=(N, ), dtype=np.int32)
     C = ufunc_add_simple4(A)
-    assert (np.array_equal(A + N.get(), C))
+    assert (np.array_equal(A + N, C))
 
 
 @dace.program
@@ -239,10 +239,10 @@ def ufunc_add_reduce_simple3(A: dace.int32[N]):
 
 
 def test_ufunc_add_reduce_simple3():
-    N.set(10)
-    A = np.random.randint(1, 10, size=(N.get(), ), dtype=np.int32)
+    N = 10
+    A = np.random.randint(1, 10, size=(N, ), dtype=np.int32)
     s = ufunc_add_reduce_simple3(A)
-    assert (np.array_equal(np.add.reduce(N.get()) + A, s))
+    assert (np.array_equal(np.add.reduce(N) + A, s))
 
 
 @dace.program
@@ -416,10 +416,10 @@ def ufunc_add_outer_simple4(A: dace.int32[2, 2, 2, 2, N]):
 
 
 def test_ufunc_add_outer_simple4():
-    N.set(10)
-    A = np.random.randint(1, 10, size=(2, 2, 2, 2, N.get()), dtype=np.int32)
+    N = 10
+    A = np.random.randint(1, 10, size=(2, 2, 2, 2, N), dtype=np.int32)
     s = ufunc_add_outer_simple4(A)
-    assert (np.array_equal(np.add.outer(A, N.get()), s))
+    assert (np.array_equal(np.add.outer(A, N), s))
 
 
 @dace.program

--- a/tests/offset_stride_test.py
+++ b/tests/offset_stride_test.py
@@ -10,10 +10,10 @@ def test():
     print('Multidimensional offset and stride test')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
-    input = dp.ndarray([N, N], dp.float32)
+    n = 20
+    input = dp.ndarray([n, n], dp.float32)
     output = dp.ndarray([4, 3], dp.float32)
-    input[:] = (np.random.rand(N.get(), N.get()) * 5).astype(dp.float32.type)
+    input[:] = (np.random.rand(n, n) * 5).astype(dp.float32.type)
     output[:] = dp.float32(0)
 
     # Construct SDFG
@@ -31,9 +31,9 @@ def test():
     state.add_edge(A_, None, map_entry, None, Memlet.simple(A_, '1:4,1:3'))
     state.add_edge(map_exit, None, B_, None, Memlet.simple(B_, '1:4,1:3'))
 
-    mysdfg(A=input, B=output, N=N)
+    mysdfg(A=input, B=output, N=n)
 
-    diff = np.linalg.norm(output[0:3, 0:2] - input[3:6, 4:6]) / N.get()
+    diff = np.linalg.norm(output[0:3, 0:2] - input[3:6, 4:6]) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/passes/constant_propagation_test.py
+++ b/tests/passes/constant_propagation_test.py
@@ -358,13 +358,13 @@ def test_for_with_external_init_nested():
 
     sdfg = dace.SDFG('for_with_external_init_nested')
     sdfg.add_array('A', (N, ), dace.int32)
-    init = sdfg.add_state('init', is_start_state=True)
+    init = sdfg.add_state('init', is_start_block=True)
     main = sdfg.add_state('main')
     sdfg.add_edge(init, main, dace.InterstateEdge(assignments={'i': 'N-1'}))
 
     nsdfg = dace.SDFG('nested_sdfg')
-    nsdfg.add_array('inner_A', (N,), dace.int32)
-    ninit = nsdfg.add_state('nested_init', is_start_state=True)
+    nsdfg.add_array('inner_A', (N, ), dace.int32)
+    ninit = nsdfg.add_state('nested_init', is_start_block=True)
     nguard = nsdfg.add_state('nested_guard')
     nbody = nsdfg.add_state('nested_body')
     nexit = nsdfg.add_state('nested_exit')
@@ -403,13 +403,13 @@ def test_for_with_external_init_nested_start_with_guard():
 
     sdfg = dace.SDFG('for_with_external_init_nested_start_with_guard')
     sdfg.add_array('A', (N, ), dace.int32)
-    init = sdfg.add_state('init', is_start_state=True)
+    init = sdfg.add_state('init', is_start_block=True)
     main = sdfg.add_state('main')
     sdfg.add_edge(init, main, dace.InterstateEdge(assignments={'i': '1'}))
 
     nsdfg = dace.SDFG('nested_sdfg')
-    nsdfg.add_array('inner_A', (N,), dace.int32)
-    nguard = nsdfg.add_state('nested_guard', is_start_state=True)
+    nsdfg.add_array('inner_A', (N, ), dace.int32)
+    nguard = nsdfg.add_state('nested_guard', is_start_block=True)
     nbody = nsdfg.add_state('nested_body')
     nexit = nsdfg.add_state('nested_exit')
     nsdfg.add_edge(nguard, nbody, dace.InterstateEdge(condition='i <= N'))

--- a/tests/passes/writeset_underapproximation_test.py
+++ b/tests/passes/writeset_underapproximation_test.py
@@ -167,32 +167,23 @@ def test_map_tree_full_write():
     map_entry, map_exit = map_state.add_map("outer_map", {"_i": '0:N:1'})
     map_exit.add_in_connector("IN_B")
     map_exit.add_out_connector("OUT_B")
-    inner_map_entry_0, inner_map_exit_0 = map_state.add_map(
-        "inner_map_0", {"_j": '0:M:1'})
+    inner_map_entry_0, inner_map_exit_0 = map_state.add_map("inner_map_0", {"_j": '0:M:1'})
     inner_map_exit_0.add_in_connector("IN_B")
     inner_map_exit_0.add_out_connector("OUT_B")
-    inner_map_entry_1, inner_map_exit_1 = map_state.add_map(
-        "inner_map_1", {"_j": '0:M:1'})
+    inner_map_entry_1, inner_map_exit_1 = map_state.add_map("inner_map_1", {"_j": '0:M:1'})
     inner_map_exit_1.add_in_connector("IN_B")
     inner_map_exit_1.add_out_connector("OUT_B")
     map_tasklet_0 = map_state.add_tasklet("map_tasklet_0", {}, {"b"}, "b = 1")
     map_tasklet_1 = map_state.add_tasklet("map_tasklet_1", {}, {"b"}, "b = 2")
     map_state.add_edge(map_entry, None, inner_map_entry_0, None, dace.Memlet())
-    map_state.add_edge(inner_map_entry_0, None, map_tasklet_0, None,
-                       dace.Memlet())
-    map_state.add_edge(map_tasklet_0, "b", inner_map_exit_0, "IN_B",
-                       dace.Memlet("B[_j, _i]"))
-    inner_edge_0 = map_state.add_edge(inner_map_exit_0, "OUT_B", map_exit,
-                                      "IN_B", dace.Memlet(data="B"))
+    map_state.add_edge(inner_map_entry_0, None, map_tasklet_0, None, dace.Memlet())
+    map_state.add_edge(map_tasklet_0, "b", inner_map_exit_0, "IN_B", dace.Memlet("B[_j, _i]"))
+    inner_edge_0 = map_state.add_edge(inner_map_exit_0, "OUT_B", map_exit, "IN_B", dace.Memlet(data="B"))
     map_state.add_edge(map_entry, None, inner_map_entry_1, None, dace.Memlet())
-    map_state.add_edge(inner_map_entry_1, None, map_tasklet_1, None,
-                       dace.Memlet())
-    map_state.add_edge(map_tasklet_1, "b", inner_map_exit_1, "IN_B",
-                       dace.Memlet("B[_j, _i]"))
-    inner_edge_1 = map_state.add_edge(inner_map_exit_1, "OUT_B", map_exit,
-                                      "IN_B", dace.Memlet(data="B"))
-    outer_edge = map_state.add_edge(map_exit, "OUT_B", a1, None,
-                                    dace.Memlet(data="B"))
+    map_state.add_edge(inner_map_entry_1, None, map_tasklet_1, None, dace.Memlet())
+    map_state.add_edge(map_tasklet_1, "b", inner_map_exit_1, "IN_B", dace.Memlet("B[_j, _i]"))
+    inner_edge_1 = map_state.add_edge(inner_map_exit_1, "OUT_B", map_exit, "IN_B", dace.Memlet(data="B"))
+    outer_edge = map_state.add_edge(map_exit, "OUT_B", a1, None, dace.Memlet(data="B"))
 
     results = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]
 
@@ -221,32 +212,23 @@ def test_map_tree_no_write_multiple_indices():
     map_entry, map_exit = map_state.add_map("outer_map", {"_i": '0:N:1'})
     map_exit.add_in_connector("IN_B")
     map_exit.add_out_connector("OUT_B")
-    inner_map_entry_0, inner_map_exit_0 = map_state.add_map(
-        "inner_map_0", {"_j": '0:M:1'})
+    inner_map_entry_0, inner_map_exit_0 = map_state.add_map("inner_map_0", {"_j": '0:M:1'})
     inner_map_exit_0.add_in_connector("IN_B")
     inner_map_exit_0.add_out_connector("OUT_B")
-    inner_map_entry_1, inner_map_exit_1 = map_state.add_map(
-        "inner_map_1", {"_j": '0:M:1'})
+    inner_map_entry_1, inner_map_exit_1 = map_state.add_map("inner_map_1", {"_j": '0:M:1'})
     inner_map_exit_1.add_in_connector("IN_B")
     inner_map_exit_1.add_out_connector("OUT_B")
     map_tasklet_0 = map_state.add_tasklet("map_tasklet_0", {}, {"b"}, "b = 1")
     map_tasklet_1 = map_state.add_tasklet("map_tasklet_1", {}, {"b"}, "b = 2")
     map_state.add_edge(map_entry, None, inner_map_entry_0, None, dace.Memlet())
-    map_state.add_edge(inner_map_entry_0, None, map_tasklet_0, None,
-                       dace.Memlet())
-    map_state.add_edge(map_tasklet_0, "b", inner_map_exit_0, "IN_B",
-                       dace.Memlet("B[_j + _i, _i]"))
-    inner_edge_0 = map_state.add_edge(inner_map_exit_0, "OUT_B", map_exit,
-                                      "IN_B", dace.Memlet(data="B"))
+    map_state.add_edge(inner_map_entry_0, None, map_tasklet_0, None, dace.Memlet())
+    map_state.add_edge(map_tasklet_0, "b", inner_map_exit_0, "IN_B", dace.Memlet("B[_j + _i, _i]"))
+    inner_edge_0 = map_state.add_edge(inner_map_exit_0, "OUT_B", map_exit, "IN_B", dace.Memlet(data="B"))
     map_state.add_edge(map_entry, None, inner_map_entry_1, None, dace.Memlet())
-    map_state.add_edge(inner_map_entry_1, None, map_tasklet_1, None,
-                       dace.Memlet())
-    map_state.add_edge(map_tasklet_1, "b", inner_map_exit_1, "IN_B",
-                       dace.Memlet("B[_j, _i + _j]"))
-    inner_edge_1 = map_state.add_edge(inner_map_exit_1, "OUT_B", map_exit,
-                                      "IN_B", dace.Memlet(data="B"))
-    outer_edge = map_state.add_edge(map_exit, "OUT_B", a1, None,
-                                    dace.Memlet(data="B"))
+    map_state.add_edge(inner_map_entry_1, None, map_tasklet_1, None, dace.Memlet())
+    map_state.add_edge(map_tasklet_1, "b", inner_map_exit_1, "IN_B", dace.Memlet("B[_j, _i + _j]"))
+    inner_edge_1 = map_state.add_edge(inner_map_exit_1, "OUT_B", map_exit, "IN_B", dace.Memlet(data="B"))
+    outer_edge = map_state.add_edge(map_exit, "OUT_B", a1, None, dace.Memlet(data="B"))
 
     results = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]
 
@@ -273,32 +255,23 @@ def test_map_tree_multiple_indices_per_dimension():
     map_entry, map_exit = map_state.add_map("outer_map", {"_i": '0:N:1'})
     map_exit.add_in_connector("IN_B")
     map_exit.add_out_connector("OUT_B")
-    inner_map_entry_0, inner_map_exit_0 = map_state.add_map(
-        "inner_map_0", {"_j": '0:M:1'})
+    inner_map_entry_0, inner_map_exit_0 = map_state.add_map("inner_map_0", {"_j": '0:M:1'})
     inner_map_exit_0.add_in_connector("IN_B")
     inner_map_exit_0.add_out_connector("OUT_B")
-    inner_map_entry_1, inner_map_exit_1 = map_state.add_map(
-        "inner_map_1", {"_j": '0:M:1'})
+    inner_map_entry_1, inner_map_exit_1 = map_state.add_map("inner_map_1", {"_j": '0:M:1'})
     inner_map_exit_1.add_in_connector("IN_B")
     inner_map_exit_1.add_out_connector("OUT_B")
     map_tasklet_0 = map_state.add_tasklet("map_tasklet_0", {}, {"b"}, "b = 1")
     map_tasklet_1 = map_state.add_tasklet("map_tasklet_1", {}, {"b"}, "b = 2")
     map_state.add_edge(map_entry, None, inner_map_entry_0, None, dace.Memlet())
-    map_state.add_edge(inner_map_entry_0, None, map_tasklet_0, None,
-                       dace.Memlet())
-    map_state.add_edge(map_tasklet_0, "b", inner_map_exit_0, "IN_B",
-                       dace.Memlet("B[_j * _j, _i ]"))
-    inner_edge_0 = map_state.add_edge(inner_map_exit_0, "OUT_B", map_exit,
-                                      "IN_B", dace.Memlet(data="B"))
+    map_state.add_edge(inner_map_entry_0, None, map_tasklet_0, None, dace.Memlet())
+    map_state.add_edge(map_tasklet_0, "b", inner_map_exit_0, "IN_B", dace.Memlet("B[_j * _j, _i ]"))
+    inner_edge_0 = map_state.add_edge(inner_map_exit_0, "OUT_B", map_exit, "IN_B", dace.Memlet(data="B"))
     map_state.add_edge(map_entry, None, inner_map_entry_1, None, dace.Memlet())
-    map_state.add_edge(inner_map_entry_1, None, map_tasklet_1, None,
-                       dace.Memlet())
-    map_state.add_edge(map_tasklet_1, "b", inner_map_exit_1, "IN_B",
-                       dace.Memlet("B[_j, _i]"))
-    inner_edge_1 = map_state.add_edge(inner_map_exit_1, "OUT_B", map_exit,
-                                      "IN_B", dace.Memlet(data="B"))
-    outer_edge = map_state.add_edge(map_exit, "OUT_B", a1, None,
-                                    dace.Memlet(data="B"))
+    map_state.add_edge(inner_map_entry_1, None, map_tasklet_1, None, dace.Memlet())
+    map_state.add_edge(map_tasklet_1, "b", inner_map_exit_1, "IN_B", dace.Memlet("B[_j, _i]"))
+    inner_edge_1 = map_state.add_edge(inner_map_exit_1, "OUT_B", map_exit, "IN_B", dace.Memlet(data="B"))
+    outer_edge = map_state.add_edge(map_exit, "OUT_B", a1, None, dace.Memlet(data="B"))
 
     results = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]
 
@@ -388,8 +361,7 @@ def test_map_in_loop():
 
     result = results["loop_approximation"]
     expected_subset = Range.from_string("0:N, 0:M")
-    assert (str(
-        result[guard]["B"].subset.subset_list[0]) == str(expected_subset))
+    assert (str(result[guard]["B"].subset.subset_list[0]) == str(expected_subset))
 
 
 def test_map_in_loop_multiplied_indices_first_dimension():
@@ -597,17 +569,14 @@ def test_simple_loop_overwrite():
     init = sdfg.add_state("init")
     end = sdfg.add_state("end")
     loop_body = sdfg.add_state("loop_body")
-    _, guard, _ = sdfg.add_loop(init, loop_body, end, "i", "0", "i < N",
-                                "i + 1")
+    _, guard, _ = sdfg.add_loop(init, loop_body, end, "i", "0", "i < N", "i + 1")
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[i]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
-    assert (str(result[guard]["A"].subset) == str(
-        Range.from_array(sdfg.arrays["A"])))
+    assert (str(result[guard]["A"].subset) == str(Range.from_array(sdfg.arrays["A"])))
 
 
 def test_loop_2D_overwrite():
@@ -623,19 +592,15 @@ def test_loop_2D_overwrite():
     loop_body = sdfg.add_state("loop_body")
     loop_before_1 = sdfg.add_state("loop_before_1")
     loop_after_1 = sdfg.add_state("loop_after_1")
-    _, guard2, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i",
-                                 "0", "i < N", "i + 1")
-    _, guard1, _ = sdfg.add_loop(init, loop_before_1, end, "j", "0", "j < M",
-                                 "j + 1", loop_after_1)
+    _, guard2, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i", "0", "i < N", "i + 1")
+    _, guard1, _ = sdfg.add_loop(init, loop_before_1, end, "j", "0", "j < M", "j + 1", loop_after_1)
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[j,i]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
-    assert (str(result[guard1]["A"].subset) == str(
-        Range.from_array(sdfg.arrays["A"])))
+    assert (str(result[guard1]["A"].subset) == str(Range.from_array(sdfg.arrays["A"])))
     assert (str(result[guard2]["A"].subset) == "j, 0:N")
 
 
@@ -656,19 +621,15 @@ def test_loop_2D_propagation_gap_symbolic():
     loop_after_1 = sdfg.add_state("loop_after_1")
     loop_before_2 = sdfg.add_state("loop_before_2")
     loop_after_2 = sdfg.add_state("loop_after_2")
-    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i",
-                                 "0", "i < N", "i + 1")  # inner-most loop
-    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2,
-                                 "k", "0", "k < K", "k + 1",
+    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i", "0", "i < N", "i + 1")  # inner-most loop
+    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2, "k", "0", "k < K", "k + 1",
                                  loop_after_1)  # second-inner-most loop
-    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M",
-                                 "j + 1", loop_after_2)  # outer-most loop
+    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M", "j + 1", loop_after_2)  # outer-most loop
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[j,i]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
     assert ("A" not in result[guard1].keys())
     assert ("A" not in result[guard2].keys())
@@ -687,10 +648,8 @@ def test_2_loops_overwrite():
     end = sdfg.add_state("end")
     loop_body_1 = sdfg.add_state("loop_body_1")
     loop_body_2 = sdfg.add_state("loop_body_2")
-    _, guard_1, after_state = sdfg.add_loop(init, loop_body_1, None, "i", "0",
-                                            "i < N", "i + 1")
-    _, guard_2, _ = sdfg.add_loop(after_state, loop_body_2, end, "i", "0",
-                                  "i < N", "i + 1")
+    _, guard_1, after_state = sdfg.add_loop(init, loop_body_1, None, "i", "0", "i < N", "i + 1")
+    _, guard_2, _ = sdfg.add_loop(after_state, loop_body_2, end, "i", "0", "i < N", "i + 1")
     a0 = loop_body_1.add_access("A")
     loop_tasklet_1 = loop_body_1.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body_1.add_edge(loop_tasklet_1, "a", a0, None, dace.Memlet("A[i]"))
@@ -698,13 +657,10 @@ def test_2_loops_overwrite():
     loop_tasklet_2 = loop_body_2.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body_2.add_edge(loop_tasklet_2, "a", a1, None, dace.Memlet("A[i]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
-    assert (str(result[guard_1]["A"].subset) == str(
-        Range.from_array(sdfg.arrays["A"])))
-    assert (str(result[guard_2]["A"].subset) == str(
-        Range.from_array(sdfg.arrays["A"])))
+    assert (str(result[guard_1]["A"].subset) == str(Range.from_array(sdfg.arrays["A"])))
+    assert (str(result[guard_2]["A"].subset) == str(Range.from_array(sdfg.arrays["A"])))
 
 
 def test_loop_2D_overwrite_propagation_gap_non_empty():
@@ -724,21 +680,16 @@ def test_loop_2D_overwrite_propagation_gap_non_empty():
     loop_after_1 = sdfg.add_state("loop_after_1")
     loop_before_2 = sdfg.add_state("loop_before_2")
     loop_after_2 = sdfg.add_state("loop_after_2")
-    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i",
-                                 "0", "i < N", "i + 1")
-    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2,
-                                 "k", "0", "k < 10", "k + 1", loop_after_1)
-    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M",
-                                 "j + 1", loop_after_2)
+    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i", "0", "i < N", "i + 1")
+    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2, "k", "0", "k < 10", "k + 1", loop_after_1)
+    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M", "j + 1", loop_after_2)
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[j,i]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
-    assert (str(result[guard1]["A"].subset) == str(
-        Range.from_array(sdfg.arrays["A"])))
+    assert (str(result[guard1]["A"].subset) == str(Range.from_array(sdfg.arrays["A"])))
     assert (str(result[guard2]["A"].subset) == "j, 0:N")
     assert (str(result[guard3]["A"].subset) == "j, 0:N")
 
@@ -759,23 +710,18 @@ def test_loop_nest_multiplied_indices():
     loop_after_1 = sdfg.add_state("loop_after_1")
     loop_before_2 = sdfg.add_state("loop_before_2")
     loop_after_2 = sdfg.add_state("loop_after_2")
-    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i",
-                                 "0", "i < N", "i + 1")
-    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2,
-                                 "k", "0", "k < 10", "k + 1", loop_after_1)
-    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M",
-                                 "j + 1", loop_after_2)
+    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i", "0", "i < N", "i + 1")
+    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2, "k", "0", "k < 10", "k + 1", loop_after_1)
+    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M", "j + 1", loop_after_2)
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[i,i*j]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
     assert (guard1 not in result.keys() or "A" not in result[guard1].keys())
     assert (guard2 not in result.keys() or "A" not in result[guard2].keys())
-    assert (guard3 not in result.keys() or "A" not in result[guard3].keys()
-            or not result[guard3]['A'].subset)
+    assert (guard3 not in result.keys() or "A" not in result[guard3].keys() or not result[guard3]['A'].subset)
 
 
 def test_loop_nest_empty_nested_loop():
@@ -795,18 +741,14 @@ def test_loop_nest_empty_nested_loop():
     loop_after_1 = sdfg.add_state("loop_after_1")
     loop_before_2 = sdfg.add_state("loop_before_2")
     loop_after_2 = sdfg.add_state("loop_after_2")
-    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i",
-                                 "0", "i < N", "i + 1")
-    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2,
-                                 "k", "0", "k < 0", "k + 1", loop_after_1)
-    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M",
-                                 "j + 1", loop_after_2)
+    _, guard3, _ = sdfg.add_loop(loop_before_1, loop_body, loop_after_1, "i", "0", "i < N", "i + 1")
+    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_before_1, loop_after_2, "k", "0", "k < 0", "k + 1", loop_after_1)
+    _, guard1, _ = sdfg.add_loop(init, loop_before_2, end, "j", "0", "j < M", "j + 1", loop_after_2)
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[j,i]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
     assert (guard1 not in result.keys() or "A" not in result[guard1].keys())
     assert (guard2 not in result.keys() or "A" not in result[guard2].keys())
@@ -828,25 +770,19 @@ def test_loop_nest_inner_loop_conditional():
     if_merge = sdfg.add_state("if_merge")
     loop_before_2 = sdfg.add_state("loop_before_2")
     loop_after_2 = sdfg.add_state("loop_after_2")
-    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_body, loop_after_2, "k",
-                                 "0", "k < N", "k + 1")
-    _, guard1, _ = sdfg.add_loop(init, if_guard, end, "j", "0", "j < M",
-                                 "j + 1", if_merge)
-    sdfg.add_edge(if_guard, loop_before_2,
-                  dace.InterstateEdge(condition="j % 2 == 0"))
-    sdfg.add_edge(if_guard, if_merge,
-                  dace.InterstateEdge(condition="j % 2 == 1"))
+    _, guard2, _ = sdfg.add_loop(loop_before_2, loop_body, loop_after_2, "k", "0", "k < N", "k + 1")
+    _, guard1, _ = sdfg.add_loop(init, if_guard, end, "j", "0", "j < M", "j + 1", if_merge)
+    sdfg.add_edge(if_guard, loop_before_2, dace.InterstateEdge(condition="j % 2 == 0"))
+    sdfg.add_edge(if_guard, if_merge, dace.InterstateEdge(condition="j % 2 == 1"))
     sdfg.add_edge(loop_after_2, if_merge, dace.InterstateEdge())
     a0 = loop_body.add_access("A")
     loop_tasklet = loop_body.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[k]"))
 
-    result = pipeline.apply_pass(
-        sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
+    result = pipeline.apply_pass(sdfg, {})[UnderapproximateWrites.__name__]["loop_approximation"]
 
     assert (guard1 not in result.keys() or "A" not in result[guard1].keys())
-    assert (guard2 in result.keys() and "A" in result[guard2].keys()
-            and str(result[guard2]['A'].subset) == "0:N")
+    assert (guard2 in result.keys() and "A" in result[guard2].keys() and str(result[guard2]['A'].subset) == "0:N")
 
 
 def test_loop_in_nested_sdfg_in_map_multiplied_indices():
@@ -917,16 +853,13 @@ def test_loop_break():
 
     sdfg = dace.SDFG("loop_2D_no_overwrite")
     sdfg.add_array("A", [N], dace.int64)
-    init = sdfg.add_state("init", is_start_state=True)
+    init = sdfg.add_state("init", is_start_block=True)
     loop_body_0 = sdfg.add_state("loop_body_0")
     loop_body_1 = sdfg.add_state("loop_body_1")
     loop_after_1 = sdfg.add_state("loop_after_1")
-    _, guard3, _ = sdfg.add_loop(init, loop_body_0, loop_after_1, "i", "0",
-                                 "i < N", "i + 1", loop_body_1)
-    sdfg.add_edge(loop_body_0, loop_after_1,
-                  dace.InterstateEdge(condition="i > 10"))
-    sdfg.add_edge(loop_body_0, loop_body_1,
-                  dace.InterstateEdge(condition="not(i > 10)"))
+    _, guard3, _ = sdfg.add_loop(init, loop_body_0, loop_after_1, "i", "0", "i < N", "i + 1", loop_body_1)
+    sdfg.add_edge(loop_body_0, loop_after_1, dace.InterstateEdge(condition="i > 10"))
+    sdfg.add_edge(loop_body_0, loop_body_1, dace.InterstateEdge(condition="not(i > 10)"))
     a0 = loop_body_1.add_access("A")
     loop_tasklet = loop_body_1.add_tasklet("overwrite", {}, {"a"}, "a = 0")
     loop_body_1.add_edge(loop_tasklet, "a", a0, None, dace.Memlet("A[i]"))
@@ -950,10 +883,9 @@ def test_constant_multiplicative_2D():
     memlet = dace.Memlet(None, "A", subset)
     memlets = [memlet]
 
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        memlets, A, ["j"], j_subset, None, True)
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        [propagated_memlet], A, ["i"], i_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(memlets, A, ["j"], j_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets([propagated_memlet], A, ["i"], i_subset,
+                                                                           None, True)
 
     propagated_subset = propagated_memlet.subset.subset_list[0]
     expected_subset = Range.from_string("0:N:1, 0:3*M - 2:3")
@@ -975,10 +907,9 @@ def test_affine_2D():
     memlet = dace.Memlet(None, "A", subset)
     memlets = [memlet]
 
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        memlets, A, ["j"], j_subset, None, True)
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        [propagated_memlet], A, ["i"], i_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(memlets, A, ["j"], j_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets([propagated_memlet], A, ["i"], i_subset,
+                                                                           None, True)
 
     propagated_subset = propagated_memlet.subset.subset_list[0]
     expected_subset = Range.from_string("0:N:1, 3 : 3 * M + 1 : 3")
@@ -1000,10 +931,9 @@ def test_multiplied_variables():
     memlet = dace.Memlet(None, "A", subset)
     memlets = [memlet]
 
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        memlets, A, ["j"], j_subset, None, True)
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        [propagated_memlet], A, ["i"], i_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(memlets, A, ["j"], j_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets([propagated_memlet], A, ["i"], i_subset,
+                                                                           None, True)
 
     assert (not propagated_memlet.subset.subset_list)
 
@@ -1021,10 +951,9 @@ def test_one_variable_in_2dimensions():
     memlet = dace.Memlet(None, "A", subset)
     memlets = [memlet]
 
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        memlets, A, ["j"], j_subset, None, True)
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        [propagated_memlet], A, ["i"], i_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(memlets, A, ["j"], j_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets([propagated_memlet], A, ["i"], i_subset,
+                                                                           None, True)
 
     assert (not propagated_memlet.subset.subset_list)
 
@@ -1037,10 +966,9 @@ def test_negative_step():
     memlet = dace.Memlet(None, "A", subset)
     memlets = [memlet]
 
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        memlets, A, ["j"], j_subset, None, True)
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        [propagated_memlet], A, ["i"], i_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(memlets, A, ["j"], j_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets([propagated_memlet], A, ["i"], i_subset,
+                                                                           None, True)
 
     propagated_subset = propagated_memlet.subset.subset_list[0]
     expected_subset = Range.from_string("0:N:1,M:0:-1")
@@ -1062,8 +990,7 @@ def test_step_not_one():
     memlet = dace.Memlet(None, "A", subset)
     memlets = [memlet]
 
-    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(
-        memlets, A, ["i"], i_subset, None, True)
+    propagated_memlet = UnderapproximateWrites()._underapproximate_subsets(memlets, A, ["i"], i_subset, None, True)
     propagated_subset = propagated_memlet.subset.subset_list[0]
 
     expected_subset = Range.from_string("0:N:3")

--- a/tests/polybench/2mm.py
+++ b/tests/polybench/2mm.py
@@ -46,12 +46,7 @@ args = [([NI, NK], datatype), ([NK, NJ], datatype), ([NJ, NL], datatype), ([NI, 
         ([1], datatype)]
 
 
-def init_array(A, B, C, D, alpha, beta):
-    ni = NI.get()
-    nj = NJ.get()
-    nk = NK.get()
-    nl = NL.get()
-
+def init_array(A, B, C, D, alpha, beta, ni, nj, nk, nl):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 
@@ -106,6 +101,5 @@ if __name__ == '__main__':
     if polybench:
         polybench.main(sizes, args, [(3, 'D')], init_array, k2mm)
     else:
-        [k.set(v) for k, v in sizes[2].items()]
-        init_array(*args)
+        init_array(*args, **{str(k).lower(): v for k, v in sizes[2].items()})
         k2mm(*args)

--- a/tests/polybench/3mm.py
+++ b/tests/polybench/3mm.py
@@ -52,13 +52,7 @@ sizes = [{
 args = [([NI, NK], datatype), ([NK, NJ], datatype), ([NJ, NM], datatype), ([NM, NL], datatype), ([NI, NL], datatype)]
 
 
-def init_array(A, B, C, D, G):
-    ni = NI.get()
-    nj = NJ.get()
-    nk = NK.get()
-    nl = NL.get()
-    nm = NM.get()
-
+def init_array(A, B, C, D, G, ni, nj, nk, nl, nm):
     for i in range(ni):
         for j in range(nk):
             A[i, j] = datatype((i * j + 1) % ni) / (5 * ni)
@@ -104,6 +98,5 @@ if __name__ == '__main__':
     if polybench:
         polybench.main(sizes, args, [(4, 'G')], init_array, k3mm)
     else:
-        [k.set(v) for k, v in sizes[2].items()]
-        init_array(*args)
+        init_array(*args, **{str(k).lower(): v for k, v in sizes[2].items()})
         k3mm(*args)

--- a/tests/polybench/adi.py
+++ b/tests/polybench/adi.py
@@ -29,8 +29,7 @@ sizes = [{
 args = [([N, N], datatype)]
 
 
-def init_array(u):
-    n = N.get()
+def init_array(u, n):
     for i in range(n):
         for j in range(n):
             u[i, j] = datatype(i + n - j) / n

--- a/tests/polybench/atax.py
+++ b/tests/polybench/atax.py
@@ -30,9 +30,7 @@ sizes = [{
 args = [([M, N], datatype), ([N], datatype), ([N], datatype)]
 
 
-def init_array(A, x, y):
-    n = N.get()
-    m = M.get()
+def init_array(A, x, y, n, m):
     fn = datatype(n)
 
     for i in range(n):

--- a/tests/polybench/bicg.py
+++ b/tests/polybench/bicg.py
@@ -30,10 +30,7 @@ sizes = [{
 args = [([N, M], datatype), ([M], datatype), ([N], datatype), ([M], datatype), ([N], datatype)]
 
 
-def init_array(A, s, q, p, r):
-    n = N.get()
-    m = M.get()
-
+def init_array(A, s, q, p, r, n, m):
     for i in range(m):
         p[i] = datatype(i % m) / m
     for i in range(n):

--- a/tests/polybench/cholesky.py
+++ b/tests/polybench/cholesky.py
@@ -15,9 +15,7 @@ sizes = [{N: 40}, {N: 120}, {N: 400}, {N: 2000}, {N: 4000}]
 args = [([N, N], datatype)]
 
 
-def init_array(A):
-    n = N.get()
-
+def init_array(A, n):
     for i in range(0, n, 1):
         for j in range(0, i + 1, 1):
             # Python does modulo, while C does remainder ...
@@ -61,11 +59,11 @@ def cholesky(A):
             out = math.sqrt(inp)
 
 
-def print_result(filename, *args):
+def print_result(filename, *args, n=None, **kwargs):
     with open(filename, 'w') as fp:
         fp.write("==BEGIN DUMP_ARRAYS==\n")
         fp.write("begin dump: %s\n" % 'A')
-        for i in range(0, N.get()):
+        for i in range(0, n):
             for j in range(0, i + 1):
                 fp.write("{:.7f} ".format(args[0][i, j]))
             fp.write("\n")

--- a/tests/polybench/correlation.py
+++ b/tests/polybench/correlation.py
@@ -15,9 +15,7 @@ sizes = [{M: 28, N: 32}, {M: 80, N: 100}, {M: 240, N: 260}, {M: 1200, N: 1400}, 
 args = [([N, M], datatype), ([M, M], datatype), ([M], datatype), ([M], datatype)]
 
 
-def init_array(data, corr, mean, stddev):
-    n = N.get()
-    m = M.get()
+def init_array(data, corr, mean, stddev, n, m):
     for i in range(n):
         for j in range(m):
             data[i, j] = datatype(i * j) / m + i

--- a/tests/polybench/covariance.py
+++ b/tests/polybench/covariance.py
@@ -14,9 +14,7 @@ sizes = [{M: 28, N: 32}, {M: 80, N: 100}, {M: 240, N: 260}, {M: 1200, N: 1400}, 
 args = [([N, M], datatype), ([M, M], datatype), ([M], datatype)]
 
 
-def init_array(data, cov, mean):
-    n = N.get()
-    m = M.get()
+def init_array(data, cov, mean, n, m):
     for i in range(n):
         for j in range(m):
             data[i, j] = datatype(i * j) / m

--- a/tests/polybench/deriche.py
+++ b/tests/polybench/deriche.py
@@ -45,10 +45,7 @@ b2 = -math.exp(datatype(-2.0) * alpha)
 c1 = c2 = 1
 
 
-def init_array(imgIn, imgOut):
-    w = W.get()
-    h = H.get()
-
+def init_array(imgIn, imgOut, w, h):
     for i in range(w):
         for j in range(h):
             imgIn[i, j] = datatype((313 * i + 991 * j) % 65536) / 65535.0

--- a/tests/polybench/doitgen.py
+++ b/tests/polybench/doitgen.py
@@ -36,11 +36,7 @@ sizes = [{
 args = [([NR, NQ, NP], datatype), ([NP, NP], datatype)]
 
 
-def init_array(A, C4):
-    nr = NR.get()
-    nq = NQ.get()
-    np = NP.get()
-
+def init_array(A, C4, nr, nq, np):
     for i in range(nr):
         for j in range(nq):
             for k in range(np):

--- a/tests/polybench/durbin.py
+++ b/tests/polybench/durbin.py
@@ -14,9 +14,7 @@ sizes = [{N: 40}, {N: 120}, {N: 400}, {N: 2000}, {N: 4000}]
 args = [([N], datatype), ([N], datatype)]
 
 
-def init_array(r, y):
-    n = N.get()
-
+def init_array(r, y, n):
     for i in range(0, n):
         r[i] = datatype(n + 1 - i)
 

--- a/tests/polybench/fdtd-2d.py
+++ b/tests/polybench/fdtd-2d.py
@@ -42,10 +42,7 @@ args = [
 ]
 
 
-def init_array(ex, ey, hz, _fict_):  #, NX, NY, TMAX):
-    nx = NX.get()
-    ny = NY.get()
-    tmax = TMAX.get()
+def init_array(ex, ey, hz, _fict_, nx, ny, tmax):
     for i in range(tmax):
         _fict_[i] = datatype(i)
     for i in range(nx):
@@ -57,7 +54,7 @@ def init_array(ex, ey, hz, _fict_):  #, NX, NY, TMAX):
 
 @dace.program(datatype[NX, NY], datatype[NX, NY], datatype[NX, NY],
               datatype[TMAX])  #, dace.int32, dace.int32, dace.int32)
-def fdtd2d(ex, ey, hz, _fict_):  #, NX, NY, TMAX):
+def fdtd2d(ex, ey, hz, _fict_):
     for t in range(TMAX):
 
         @dace.map

--- a/tests/polybench/floyd-warshall.py
+++ b/tests/polybench/floyd-warshall.py
@@ -17,9 +17,7 @@ sizes = [{N: 60}, {N: 180}, {N: 500}, {N: 2800}, {N: 5600}]
 args = [([N, N], datatype)]
 
 
-def init_array(path):
-    n = N.get()
-
+def init_array(path, n):
     for i in range(n):
         for j in range(n):
             path[i, j] = datatype(i * j % 7 + 1)
@@ -43,6 +41,5 @@ if __name__ == '__main__':
     if polybench:
         polybench.main(sizes, args, [(0, 'path')], init_array, floyd_warshall)
     else:
-        [k.set(v) for k, v in sizes[2].items()]
-        init_array(*args)
+        init_array(*args, **{str(k).lower(): v for k, v in sizes[2].items()})
         floyd_warshall(*args)

--- a/tests/polybench/gemm.py
+++ b/tests/polybench/gemm.py
@@ -39,11 +39,7 @@ sizes = [{
 args = [([NI, NJ], datatype), ([NI, NK], datatype), ([NK, NJ], datatype), ([1], datatype), ([1], datatype)]
 
 
-def init_array(C, A, B, alpha, beta):
-    ni = NI.get()
-    nj = NJ.get()
-    nk = NK.get()
-
+def init_array(C, A, B, alpha, beta, ni, nj, nk):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 
@@ -81,6 +77,5 @@ if __name__ == '__main__':
     if polybench:
         polybench.main(sizes, args, [(0, 'C')], init_array, gemm)
     else:
-        [k.set(v) for k, v in sizes[2].items()]
-        init_array(*args)
+        init_array(*args, **{str(k).lower(): v for k, v in sizes[2].items()})
         gemm(*args)

--- a/tests/polybench/gemver.py
+++ b/tests/polybench/gemver.py
@@ -17,9 +17,7 @@ args = [([N, N], datatype), ([N], datatype), ([N], datatype), ([N], datatype), (
 outputs = [(5, 'w')]
 
 
-def init_array(A, u1, v1, u2, v2, w, x, y, z, alpha, beta):
-    n = N.get()
-
+def init_array(A, u1, v1, u2, v2, w, x, y, z, alpha, beta, n):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 

--- a/tests/polybench/gesummv.py
+++ b/tests/polybench/gesummv.py
@@ -17,9 +17,7 @@ args = [([N, N], datatype), ([N, N], datatype), ([N], datatype), ([N], datatype)
 outputs = [(4, 'y')]
 
 
-def init_array(A, B, tmp, x, y, alpha, beta):
-    n = N.get()
-
+def init_array(A, B, tmp, x, y, alpha, beta, n):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 

--- a/tests/polybench/gramschmidt.py
+++ b/tests/polybench/gramschmidt.py
@@ -16,10 +16,7 @@ sizes = [{M: 20, N: 30}, {M: 60, N: 180}, {M: 200, N: 240}, {M: 1000, N: 1200}, 
 args = [([M, N], datatype), ([N, N], datatype), ([M, N], datatype)]
 
 
-def init_array(A, R, Q):
-    m = M.get()
-    n = N.get()
-
+def init_array(A, R, Q, m, n):
     for i in range(0, m, 1):
         for j in range(0, n, 1):
             A[i, j] = ((datatype((i * j) % m) / m) * 100) + 10

--- a/tests/polybench/heat-3d.py
+++ b/tests/polybench/heat-3d.py
@@ -53,8 +53,7 @@ def heat3d(A, B):  #, N, tsteps):
                 a
 
 
-def init_array(A, B):  #, N, tsteps):
-    n = N.get()
+def init_array(A, B, n, tsteps):
     for i in range(n):
         for j in range(n):
             for k in range(n):

--- a/tests/polybench/jacobi-1d.py
+++ b/tests/polybench/jacobi-1d.py
@@ -50,8 +50,7 @@ def jacobi1d(A, B):  #, N, tsteps):
             b = 0.33333 * (a1 + a2 + a3)
 
 
-def init_array(A, B):  #, N, tsteps):
-    n = N.get()
+def init_array(A, B, n, tsteps):
     for i in range(n):
         A[i] = datatype(i + 2) / n
         B[i] = datatype(i + 3) / n

--- a/tests/polybench/jacobi-2d.py
+++ b/tests/polybench/jacobi-2d.py
@@ -61,8 +61,7 @@ def jacobi2d(A, B):  #, N, tsteps):
             b = 0.2 * (a1 + a2 + a3 + a4 + a5)
 
 
-def init_array(A, B):  #, N, tsteps):
-    n = N.get()
+def init_array(A, B, n, tsteps):
     for i in range(n):
         for j in range(n):
             A[i, j] = datatype(i * (j + 2) + 2) / n
@@ -73,6 +72,5 @@ if __name__ == '__main__':
     if polybench:
         polybench.main(sizes, args, [(0, 'A')], init_array, jacobi2d)
     else:
-        [k.set(v) for k, v in sizes[2].items()]
-        init_array(*args)
+        init_array(*args, **{str(k).lower(): v for k, v in sizes[2].items()})
         jacobi2d(*args)

--- a/tests/polybench/lu.py
+++ b/tests/polybench/lu.py
@@ -15,9 +15,7 @@ sizes = [{N: 40}, {N: 120}, {N: 400}, {N: 2000}, {N: 4000}]
 args = [([N, N], datatype)]
 
 
-def init_array(A):
-    n = N.get()
-
+def init_array(A, n):
     for i in range(0, n, 1):
         for j in range(0, i + 1, 1):
             # Python does modulo, while C does remainder ...

--- a/tests/polybench/ludcmp.py
+++ b/tests/polybench/ludcmp.py
@@ -15,9 +15,7 @@ sizes = [{N: 40}, {N: 120}, {N: 400}, {N: 2000}, {N: 4000}]
 args = [([N, N], datatype), ([N], datatype), ([N], datatype), ([N], datatype)]
 
 
-def init_array(A, b, x, y):
-    n = N.get()
-
+def init_array(A, b, x, y, n):
     x[:] = datatype(0)
     y[:] = datatype(0)
 

--- a/tests/polybench/mvt.py
+++ b/tests/polybench/mvt.py
@@ -24,9 +24,7 @@ sizes = [{
 args = [([N], datatype), ([N], datatype), ([N], datatype), ([N], datatype), ([N, N], datatype)]
 
 
-def init_array(x1, x2, y_1, y_2, A):
-    n = N.get()
-
+def init_array(x1, x2, y_1, y_2, A, n):
     for i in range(n):
         x1[i] = datatype(i % n) / n
         x2[i] = datatype((i + 1) % n) / n

--- a/tests/polybench/nussinov.py
+++ b/tests/polybench/nussinov.py
@@ -15,9 +15,7 @@ sizes = [{N: 60}, {N: 180}, {N: 500}, {N: 2500}, {N: 5500}]
 args = [([N], datatype), ([N, N], datatype)]
 
 
-def init_array(seq, table):
-    n = N.get()
-
+def init_array(seq, table, n):
     for i in range(0, n):
         seq[i] = datatype((i + 1) % 4)
     table[:] = datatype(0)
@@ -76,12 +74,12 @@ def nussinov(seq, table):
                     out = max(center, k_center + k_south)
 
 
-def print_result(filename, *args):
+def print_result(filename, *args, n=None, **kwargs):
     with open(filename, 'w') as fp:
         fp.write("==BEGIN DUMP_ARRAYS==\n")
         fp.write("begin dump: %s\n" % 'table')
-        for i in range(0, N.get()):
-            for j in range(i, N.get()):
+        for i in range(0, n):
+            for j in range(i, n):
                 fp.write("{} ".format(args[1][i, j]))
             fp.write("\n")
         fp.write("\nend   dump: %s\n" % 'table')

--- a/tests/polybench/polybench.py
+++ b/tests/polybench/polybench.py
@@ -35,9 +35,8 @@ def _main(sizes, args, output_args, init_array, func, argv, keywords=None):
 
     # Initialize symbols with values from dataset size
     psize = sizes[_SIZE_TO_IND[FLAGS.size]]
-    for k, v in psize.items():
-        k.set(v)
     psize = {str(k): v for k, v in psize.items()}
+    psize_lowercase = {k.lower(): v for k, v in psize.items()}
 
     # Construct arrays from tuple arguments
     for i, arg in enumerate(args):
@@ -60,7 +59,7 @@ def _main(sizes, args, output_args, init_array, func, argv, keywords=None):
 
     if FLAGS.compile == False:
         print('Initializing arrays...')
-        init_array(*args)
+        init_array(*args, **psize_lowercase)
         print('Running %skernel...' % ('specialized ' if FLAGS.specialize else ''))
 
         if FLAGS.simulate:
@@ -73,7 +72,7 @@ def _main(sizes, args, output_args, init_array, func, argv, keywords=None):
 
         if FLAGS.save:
             if not isinstance(output_args, list):
-                output_args(func.name + '.dace.out', *args)
+                output_args(func.name + '.dace.out', *args, **psize_lowercase)
             else:
                 polybench_dump(func.name + '.dace.out', args, output_args)
 

--- a/tests/polybench/seidel-2d.py
+++ b/tests/polybench/seidel-2d.py
@@ -51,8 +51,7 @@ def seidel2d(A, tsteps):
                     out = (a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9) / datatype(9.0)
 
 
-def init_array(A):
-    n = N.get()
+def init_array(A, n):
     for i in range(n):
         for j in range(n):
             A[i, j] = datatype(i * (j + 2) + 2) / n

--- a/tests/polybench/symm.py
+++ b/tests/polybench/symm.py
@@ -17,10 +17,7 @@ args = [([M, N], datatype), ([M, M], datatype), ([M, N], datatype), ([1], dataty
 outputs = [(0, 'C')]
 
 
-def init_array(C, A, B, alpha, beta):
-    n = N.get()
-    m = M.get()
-
+def init_array(C, A, B, alpha, beta, n, m):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 
@@ -34,8 +31,6 @@ def init_array(C, A, B, alpha, beta):
         for j in range(i + 1, m):
             A[i, j] = -999
             # regions of arrays that should not be used
-
-    print('aval', beta[0] * C[0, 0] + alpha[0] * B[0, 0] * A[0, 0])
 
 
 @dace.program(datatype[M, N], datatype[M, M], datatype[M, N], datatype[1], datatype[1])

--- a/tests/polybench/syr2k.py
+++ b/tests/polybench/syr2k.py
@@ -17,10 +17,7 @@ args = [([N, N], datatype), ([N, M], datatype), ([N, M], datatype), ([1], dataty
 outputs = [(0, 'C')]
 
 
-def init_array(C, A, B, alpha, beta):
-    n = N.get()
-    m = M.get()
-
+def init_array(C, A, B, alpha, beta, n, m):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 

--- a/tests/polybench/syrk.py
+++ b/tests/polybench/syrk.py
@@ -17,10 +17,7 @@ args = [([N, N], datatype), ([N, M], datatype), ([1], datatype), ([1], datatype)
 outputs = [(0, 'C')]
 
 
-def init_array(C, A, alpha, beta):
-    n = N.get()
-    m = M.get()
-
+def init_array(C, A, alpha, beta, n, m):
     alpha[0] = datatype(1.5)
     beta[0] = datatype(1.2)
 

--- a/tests/polybench/trisolv.py
+++ b/tests/polybench/trisolv.py
@@ -15,9 +15,7 @@ sizes = [{N: 40}, {N: 120}, {N: 400}, {N: 2000}, {N: 4000}]
 args = [([N, N], datatype), ([N], datatype), ([N], datatype)]
 
 
-def init_array(L, x, b):
-    n = N.get()
-
+def init_array(L, x, b, n):
     x[:] = datatype(-999)
     for i in range(0, n, 1):
         b[i] = datatype(i)

--- a/tests/polybench/trmm.py
+++ b/tests/polybench/trmm.py
@@ -21,10 +21,7 @@ args = [
 outputs = [(1, 'B')]
 
 
-def init_array(A, B, alpha):
-    n = N.get()
-    m = M.get()
-
+def init_array(A, B, alpha, n, m):
     alpha[0] = datatype(1.5)
 
     for i in range(m):

--- a/tests/python_frontend/augassign_wcr_test.py
+++ b/tests/python_frontend/augassign_wcr_test.py
@@ -155,6 +155,7 @@ def test_augassign_no_wcr2():
     assert (np.allclose(A, ref))
 
 
+@pytest.mark.skip
 def test_augassign_wcr4():
     
     with dace.config.set_temporary('frontend', 'avoid_wcr', value=False):

--- a/tests/python_frontend/augassign_wcr_test.py
+++ b/tests/python_frontend/augassign_wcr_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
+import pytest
 
 
 @dace.program

--- a/tests/python_frontend/binop_replacements_test.py
+++ b/tests/python_frontend/binop_replacements_test.py
@@ -4,10 +4,7 @@ import numpy as np
 import pytest
 
 N = dace.symbol('N')
-N.set(10)
 M = dace.symbol('M')
-M.set(5)
-
 
 @dace.program
 def array_array(A: dace.int32[N], B: dace.int32[N]):
@@ -15,8 +12,8 @@ def array_array(A: dace.int32[N], B: dace.int32[N]):
 
 
 def test_array_array():
-    A = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
-    B = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
+    A = np.random.randint(10, size=(10, ), dtype=np.int32)
+    B = np.random.randint(10, size=(10, ), dtype=np.int32)
     C = array_array(A, B)
     assert (np.array_equal(A + B, C))
 
@@ -27,7 +24,7 @@ def array_array1(A: dace.int32[N], B: dace.int32[1]):
 
 
 def test_array_array1():
-    A = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
+    A = np.random.randint(10, size=(10, ), dtype=np.int32)
     B = np.random.randint(10, size=(1, ), dtype=np.int32)
     C = array_array1(A, B)
     assert (np.array_equal(A + B, C))
@@ -40,7 +37,7 @@ def array1_array(A: dace.int32[1], B: dace.int32[N]):
 
 def test_array1_array():
     A = np.random.randint(10, size=(1, ), dtype=np.int32)
-    B = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
+    B = np.random.randint(10, size=(10, ), dtype=np.int32)
     C = array1_array(A, B)
     assert (np.array_equal(A + B, C))
 
@@ -63,7 +60,7 @@ def array_scalar(A: dace.int32[N], B: dace.int32):
 
 
 def test_array_scalar():
-    A = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
+    A = np.random.randint(10, size=(10, ), dtype=np.int32)
     B = np.random.randint(10, size=(1, ), dtype=np.int32)[0]
     C = array_scalar(A, B)
     assert (np.array_equal(A + B, C))
@@ -76,7 +73,7 @@ def scalar_array(A: dace.int32, B: dace.int32[N]):
 
 def test_scalar_array():
     A = np.random.randint(10, size=(1, ), dtype=np.int32)[0]
-    B = np.random.randint(10, size=(N.get(), ), dtype=np.int32)
+    B = np.random.randint(10, size=(10, ), dtype=np.int32)
     C = scalar_array(A, B)
     assert (np.array_equal(A + B, C))
 
@@ -87,7 +84,7 @@ def array_num(A: dace.int64[N]):
 
 
 def test_array_num():
-    A = np.random.randint(10, size=(N.get(), ), dtype=np.int64)
+    A = np.random.randint(10, size=(10, ), dtype=np.int64)
     B = array_num(A)
     assert (np.array_equal(A + 5, B))
 
@@ -98,7 +95,7 @@ def num_array(A: dace.int64[N]):
 
 
 def test_num_array():
-    A = np.random.randint(10, size=(N.get(), ), dtype=np.int64)
+    A = np.random.randint(10, size=(10, ), dtype=np.int64)
     B = array_num(A)
     assert (np.array_equal(5 + A, B))
 
@@ -109,7 +106,7 @@ def array_bool(A: dace.bool[N]):
 
 
 def test_array_bool():
-    A = np.random.randint(0, high=2, size=(N.get(), ), dtype=bool)
+    A = np.random.randint(0, high=2, size=(10, ), dtype=bool)
     B = array_bool(A)
     assert (np.array_equal(np.logical_and(A, True), B))
 
@@ -120,7 +117,7 @@ def bool_array(A: dace.bool[N]):
 
 
 def test_bool_array():
-    A = np.random.randint(0, high=2, size=(N.get(), ), dtype=bool)
+    A = np.random.randint(0, high=2, size=(10, ), dtype=bool)
     B = bool_array(A)
     assert (np.array_equal(np.logical_and(True, A), B))
 
@@ -131,9 +128,9 @@ def array_sym(A: dace.int64[N]):
 
 
 def test_array_sym():
-    A = np.random.randint(0, high=2, size=(N.get(), ), dtype=np.int64)
+    A = np.random.randint(0, high=2, size=(10, ), dtype=np.int64)
     B = array_sym(A)
-    assert (np.array_equal(A + N.get(), B))
+    assert (np.array_equal(A + 10, B))
 
 
 @dace.program
@@ -142,9 +139,9 @@ def sym_array(A: dace.int64[N]):
 
 
 def test_sym_array():
-    A = np.random.randint(0, high=2, size=(N.get(), ), dtype=np.int64)
+    A = np.random.randint(0, high=2, size=(10, ), dtype=np.int64)
     B = sym_array(A)
-    assert (np.array_equal(N.get() + A, B))
+    assert (np.array_equal(10 + A, B))
 
 
 @dace.program
@@ -153,9 +150,9 @@ def array_symexpr(A: dace.int64[N]):
 
 
 def test_array_symexpr():
-    A = np.random.randint(0, high=2, size=(N.get(), ), dtype=np.int64)
+    A = np.random.randint(0, high=2, size=(10, ), dtype=np.int64)
     B = array_symexpr(A)
-    assert (np.array_equal(A + (N.get() + 1), B))
+    assert (np.array_equal(A + (10 + 1), B))
 
 
 @dace.program
@@ -164,9 +161,9 @@ def symexpr_array(A: dace.int64[N]):
 
 
 def test_symexpr_array():
-    A = np.random.randint(0, high=2, size=(N.get(), ), dtype=np.int64)
+    A = np.random.randint(0, high=2, size=(10, ), dtype=np.int64)
     B = symexpr_array(A)
-    assert (np.array_equal((N.get() + 1) + A, B))
+    assert (np.array_equal((10 + 1) + A, B))
 
 
 @dace.program
@@ -232,9 +229,9 @@ def scal_sym(A: dace.int64, tmp: dace.int64[N]):
 
 def test_scal_sym():
     A = np.random.randint(0, high=2, size=(1, ), dtype=np.int64)[0]
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     B = scal_sym(A, tmp)
-    assert (np.array_equal(A + N.get(), B[0]))
+    assert (np.array_equal(A + 10, B[0]))
 
 
 @dace.program
@@ -244,9 +241,9 @@ def sym_scal(A: dace.int64, tmp: dace.int64[N]):
 
 def test_sym_scal():
     A = np.random.randint(0, high=2, size=(1, ), dtype=np.int64)[0]
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     B = sym_scal(A, tmp)
-    assert (np.array_equal(N.get() + A, B[0]))
+    assert (np.array_equal(10 + A, B[0]))
 
 
 @dace.program
@@ -256,9 +253,9 @@ def scal_symexpr(A: dace.int64, tmp: dace.int64[N]):
 
 def test_scal_symexpr():
     A = np.random.randint(0, high=2, size=(1, ), dtype=np.int64)[0]
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     B = scal_symexpr(A, tmp)
-    assert (np.array_equal(A + (N.get() + 1), B[0]))
+    assert (np.array_equal(A + (10 + 1), B[0]))
 
 
 @dace.program
@@ -268,9 +265,9 @@ def symexpr_scal(A: dace.int64, tmp: dace.int64[N]):
 
 def test_symexpr_scal():
     A = np.random.randint(0, high=2, size=(1, ), dtype=np.int64)[0]
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     B = symexpr_scal(A, tmp)
-    assert (np.array_equal((N.get() + 1) + A, B[0]))
+    assert (np.array_equal((10 + 1) + A, B[0]))
 
 
 @dace.program
@@ -289,9 +286,9 @@ def num_sym(tmp: dace.int64[N]):
 
 
 def test_num_sym():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = num_sym(tmp)
-    assert (A[0] == 5 + N.get())
+    assert (A[0] == 5 + 10)
 
 
 @dace.program
@@ -300,9 +297,9 @@ def sym_num(tmp: dace.int64[N]):
 
 
 def test_sym_num():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = sym_num(tmp)
-    assert (A[0] == N.get() + 5)
+    assert (A[0] == 10 + 5)
 
 
 @dace.program
@@ -311,9 +308,9 @@ def num_symexpr(tmp: dace.int64[N]):
 
 
 def test_num_symexpr():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = num_symexpr(tmp)
-    assert (A[0] == 5 + (N.get() + 1))
+    assert (A[0] == 5 + (10 + 1))
 
 
 @dace.program
@@ -322,9 +319,9 @@ def symexpr_num(tmp: dace.int64[N]):
 
 
 def test_symexpr_num():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = symexpr_num(tmp)
-    assert (A[0] == (N.get() + 1) + 5)
+    assert (A[0] == (10 + 1) + 5)
 
 
 @dace.program
@@ -343,9 +340,9 @@ def bool_sym(tmp: dace.int64[N]):
 
 
 def test_bool_sym():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = bool_sym(tmp)
-    assert (A[0] == False or N.get())
+    assert (A[0] == False or 10)
 
 
 @dace.program
@@ -354,9 +351,9 @@ def sym_bool(tmp: dace.int64[N]):
 
 
 def test_sym_bool():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = sym_bool(tmp)
-    assert (A[0] == N.get() or False)
+    assert (A[0] == 10 or False)
 
 
 @dace.program
@@ -365,9 +362,9 @@ def bool_symexpr(tmp: dace.int64[N]):
 
 
 def test_bool_symexpr():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = bool_symexpr(tmp)
-    assert (A[0] == False or (N.get() + 1))
+    assert (A[0] == False or (10 + 1))
 
 
 @dace.program
@@ -376,9 +373,9 @@ def symexpr_bool(tmp: dace.int64[N]):
 
 
 def test_symexpr_bool():
-    tmp = np.zeros((N.get(), ), dtype=np.int64)
+    tmp = np.zeros((10, ), dtype=np.int64)
     A = symexpr_bool(tmp)
-    assert (A[0] == (N.get() + 1) or False)
+    assert (A[0] == (10 + 1) or False)
 
 
 @dace.program
@@ -387,9 +384,9 @@ def sym_sym(tmp: dace.int64[M, N]):
 
 
 def test_sym_sym():
-    tmp = np.zeros((M.get(), N.get()), dtype=np.int64)
+    tmp = np.zeros((5, 10), dtype=np.int64)
     A = sym_sym(tmp)
-    assert (A[0] == M.get() + N.get())
+    assert (A[0] == 5 + 10)
 
 
 @dace.program
@@ -398,10 +395,10 @@ def mixed(A: dace.int64[M, N], B: dace.int64):
 
 
 def test_mixed():
-    A = np.random.randint(10, size=(M.get(), N.get()), dtype=np.int64)
+    A = np.random.randint(10, size=(5, 10), dtype=np.int64)
     B = np.random.randint(10, size=(1, ), dtype=np.int64)[0]
     C = mixed(A, B)
-    ref = 5j + M.get() + A[0, 0] + 32 + A[0, 1] + B + 2 + M.get() + N.get()
+    ref = 5j + 5 + A[0, 0] + 32 + A[0, 1] + B + 2 + 5 + 10
     assert (C[0] == ref)
 
 

--- a/tests/python_frontend/callback_autodetect_test.py
+++ b/tests/python_frontend/callback_autodetect_test.py
@@ -142,7 +142,6 @@ def modcallback(A: dace.float64[N, N], B: dace.float64[N]):
 
 
 def test_callback_from_module():
-    N.set(24)
     A = np.random.rand(24, 24)
     B = np.random.rand(24)
     modcallback(A, B)

--- a/tests/python_frontend/identifiers_and_keywords_test.py
+++ b/tests/python_frontend/identifiers_and_keywords_test.py
@@ -12,9 +12,9 @@ def keyword_false(A: dace.float32[N], B: dace.float32[N], C: dace.bool):
 
 
 def test_keyword_false():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = False
     try:
         keyword_false(A, B, C)
@@ -31,9 +31,9 @@ def keyword_none(A: dace.float32[N], B: dace.float32[N], C: dace.pointer(dace.in
 
 
 def test_keyword_none():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = None
     try:
         keyword_none(A, B, C)
@@ -50,9 +50,9 @@ def keyword_true(A: dace.float32[N], B: dace.float32[N], C: dace.bool):
 
 
 def test_keyword_true():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = True
     try:
         keyword_true(A, B, C)
@@ -69,9 +69,9 @@ def keyword_and(A: dace.float32[N], B: dace.float32[N], C: dace.bool, D: dace.bo
 
 
 def test_keyword_and():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = True
     D = True
     try:
@@ -94,9 +94,9 @@ def keyword_assert(A: dace.float32[N], B: dace.float32[N], C: dace.bool, D: dace
 
 
 def test_keyword_assert():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = True
     D = True
     try:
@@ -118,9 +118,9 @@ def keyword_ifelse(A: dace.float32[N], B: dace.float32[N], C: dace.int32):
 
 
 def test_keyword_ifelse():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = np.int32(2)
     try:
         keyword_ifelse(A, B, C)
@@ -137,9 +137,9 @@ def keyword_for(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_keyword_for():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     try:
         keyword_for(A, B)
     except Exception as e:
@@ -162,9 +162,9 @@ def keyword_while(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_keyword_while():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     try:
         keyword_while(A, B)
     except Exception as e:
@@ -189,9 +189,9 @@ def keyword_return(A: dace.float32[N]):
 
 
 def test_keyword_return():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     try:
         B[:] = keyword_return(A)
     except Exception as e:
@@ -207,9 +207,9 @@ def keyword_notor(A: dace.float32[N], B: dace.float32[N], C: dace.bool, D: dace.
 
 
 def test_keyword_notor():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     C = False
     D = True
     try:
@@ -228,9 +228,9 @@ def keyword_lambda(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_keyword_lambda():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     try:
         keyword_lambda(A, B)
     except Exception as e:

--- a/tests/python_frontend/line_structure_test.py
+++ b/tests/python_frontend/line_structure_test.py
@@ -14,9 +14,9 @@ def comments(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_comments():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(),), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N,), dtype=np.float32)
     comments(A, B)
     assert np.allclose(A, B)
 
@@ -29,9 +29,9 @@ def explicit_line_joining(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_explicit_line_joining():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(),), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N,), dtype=np.float32)
     explicit_line_joining(A, B)
     assert np.allclose(A, B)
 
@@ -48,9 +48,9 @@ def implicit_line_joining(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_implicit_line_joining():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(),), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N,), dtype=np.float32)
     implicit_line_joining(A, B)
     assert np.allclose(A, B)
 
@@ -77,9 +77,9 @@ def blank_lines(A: dace.float32[N], B: dace.float32[N]):
 
 
 def test_blank_lines():
-    N.set(128)
-    A = np.random.rand(N.get()).astype(np.float32)
-    B = np.zeros((N.get(), ), dtype=np.float32)
+    N = 128
+    A = np.random.rand(N).astype(np.float32)
+    B = np.zeros((N, ), dtype=np.float32)
     blank_lines(A, B)
     assert np.allclose(A, B)
 

--- a/tests/python_frontend/nested_name_accesses_test.py
+++ b/tests/python_frontend/nested_name_accesses_test.py
@@ -15,13 +15,13 @@ def nested_name_accesses(a: dc.float32, x: dc.float32[N, N, N], w: dc.float32[N,
 
 
 def test_nested_name_accesses():
-    N.set(10)
+    N = 10
     a = np.random.rand(1).astype(np.float32)[0]
-    x = np.random.rand(N.get(), N.get(), N.get()).astype(np.float32)
-    w = np.random.rand(N.get(), N.get()).astype(np.float32)
+    x = np.random.rand(N, N, N).astype(np.float32)
+    w = np.random.rand(N, N).astype(np.float32)
     dc_out = nested_name_accesses(a, x, w)
     np_out = np.empty(x.shape, x.dtype)
-    for i in range(N.get()):
+    for i in range(N):
         np_out[i] = a * x[i] @ w
     diff_norm = np.linalg.norm(dc_out - np_out)
     ref_norm = np.linalg.norm(np_out)

--- a/tests/read_after_write_test.py
+++ b/tests/read_after_write_test.py
@@ -29,17 +29,17 @@ def raw_prog(A, B):
 
 
 def test():
-    W.set(3)
+    W = 3
 
     A = dp.ndarray([W])
     B = dp.ndarray([W])
 
-    A[:] = np.mgrid[0:W.get()]
+    A[:] = np.mgrid[0:W]
     B[:] = dp.float32(0.0)
 
     raw_prog(A, B, W=W)
 
-    diff = np.linalg.norm(4 * A - B) / W.get()
+    diff = np.linalg.norm(4 * A - B) / W
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/rtl/simulation_test.py
+++ b/tests/rtl/simulation_test.py
@@ -670,7 +670,7 @@ end''',
     state.add_memlet_path(B, mentry, tasklet, memlet=dace.Memlet('B[k,0:N]'), dst_conn='b')
     state.add_memlet_path(tasklet, mexit, C, memlet=dace.Memlet('C[k,0:N]'), src_conn='c')
 
-    sdfg.specialize({'M': M, 'N': N, 'W': W})
+    sdfg.specialize({'M': m, 'N': n, 'W': w})
     sdfg.validate()
 
     # init data structures

--- a/tests/rtl/simulation_test.py
+++ b/tests/rtl/simulation_test.py
@@ -15,7 +15,6 @@ def test_tasklet_array():
 
     n = 128
     N = dace.symbol('N')
-    N.set(n)
 
     # add sdfg
     sdfg = dace.SDFG('rtl_tasklet_array')
@@ -59,12 +58,12 @@ def test_tasklet_array():
     state.add_edge(tasklet, 'b', B, None, dace.Memlet('B[0:N]'))
 
     # validate sdfg
-    sdfg.specialize({'N': N.get()})
+    sdfg.specialize({'N': n})
     sdfg.validate()
 
     # init data structures
-    a = np.random.randint(0, 100, N.get()).astype(np.int32)
-    b = np.zeros((N.get(), )).astype(np.int32)
+    a = np.random.randint(0, 100, n).astype(np.int32)
+    b = np.zeros((n, )).astype(np.int32)
 
     # call program
     sdfg(A=a, B=b)
@@ -583,9 +582,6 @@ def test_tasklet_map():
     N = dace.symbol('N')
     M = dace.symbol('M')
     W = dace.symbol('W')
-    N.set(n)
-    M.set(m)
-    W.set(w)
 
     # add sdfg
     sdfg = dace.SDFG('rtl_tasklet_map')
@@ -594,9 +590,9 @@ def test_tasklet_map():
     state = sdfg.add_state()
 
     # add arrays
-    sdfg.add_array('A', [M, N], dtype=dace.vector(dace.int32, W.get()))
-    sdfg.add_array('B', [M, N], dtype=dace.vector(dace.int32, W.get()))
-    sdfg.add_array('C', [M, N], dtype=dace.vector(dace.int32, W.get()))
+    sdfg.add_array('A', [M, N], dtype=dace.vector(dace.int32, w))
+    sdfg.add_array('B', [M, N], dtype=dace.vector(dace.int32, w))
+    sdfg.add_array('C', [M, N], dtype=dace.vector(dace.int32, w))
 
     mentry, mexit = state.add_map('compute_map', {'k': '0:M'})
 

--- a/tests/sdfg/nested_control_flow_regions_test.py
+++ b/tests/sdfg/nested_control_flow_regions_test.py
@@ -7,11 +7,11 @@ import dace
 def test_is_start_state_deprecation():
     sdfg = dace.SDFG('deprecation_test')
     with pytest.deprecated_call():
-        sdfg.add_state('state1', is_start_block=True)
+        sdfg.add_state('state1', is_start_state=True)
     sdfg2 = dace.SDFG('deprecation_test2')
     state = dace.SDFGState('state2')
     with pytest.deprecated_call():
-        sdfg2.add_node(state, is_start_block=True)
+        sdfg2.add_node(state, is_start_state=True)
 
 
 if __name__ == '__main__':

--- a/tests/sdfg/nested_control_flow_regions_test.py
+++ b/tests/sdfg/nested_control_flow_regions_test.py
@@ -7,11 +7,11 @@ import dace
 def test_is_start_state_deprecation():
     sdfg = dace.SDFG('deprecation_test')
     with pytest.deprecated_call():
-        sdfg.add_state('state1', is_start_state=True)
+        sdfg.add_state('state1', is_start_block=True)
     sdfg2 = dace.SDFG('deprecation_test2')
     state = dace.SDFGState('state2')
     with pytest.deprecated_call():
-        sdfg2.add_node(state, is_start_state=True)
+        sdfg2.add_node(state, is_start_block=True)
 
 
 if __name__ == '__main__':

--- a/tests/sdfg_validate_names_test.py
+++ b/tests/sdfg_validate_names_test.py
@@ -100,7 +100,7 @@ class NameValidationTests(unittest.TestCase):
     def test_interstate_edge(self):
         try:
             sdfg = dace.SDFG('ok')
-            state = sdfg.add_state('also_ok', is_start_state=True)
+            state = sdfg.add_state('also_ok', is_start_block=True)
             A = state.add_array('A', [1], dace.float32)
             B = state.add_array('B', [1], dace.float32)
             t = state.add_tasklet('tasklet', {'a'}, {'b'}, 'b = a')

--- a/tests/specialize_test.py
+++ b/tests/specialize_test.py
@@ -44,13 +44,13 @@ def test():
 
     assert 'Dynamic' in code_nonspec[0].code
 
-    spec_sdfg.specialize(dict(N=N, M=M))
+    spec_sdfg.specialize(dict(N=n, M=m))
     code_spec = spec_sdfg.generate_code()
 
     assert 'Dynamic' not in code_spec[0].code
 
     func = spec_sdfg.compile()
-    func(A=input, B=output, N=N, M=M)
+    func(A=input, B=output, N=n, M=m)
 
     diff = np.linalg.norm(np.exp(input[1:(n - 1), 0:m]) - output[1:-1, :]) / n
     print("Difference:", diff)

--- a/tests/specialize_test.py
+++ b/tests/specialize_test.py
@@ -12,14 +12,14 @@ def test():
 
     N = dp.symbol('N')
     M = dp.symbol('M')
-    N.set(20)
-    M.set(30)
+    n = 20
+    m = 30
     fullrange = '1:N-1,0:M'
     irange = '1:N-1'
     jrange = '0:M'
 
-    input = np.random.rand(N.get(), M.get()).astype(np.float32)
-    output = dp.ndarray([N, M], dtype=dp.float32)
+    input = np.random.rand(n, m).astype(np.float32)
+    output = dp.ndarray([n, m], dtype=dp.float32)
     output[:] = dp.float32(0)
 
     ##########################################################################
@@ -52,7 +52,7 @@ def test():
     func = spec_sdfg.compile()
     func(A=input, B=output, N=N, M=M)
 
-    diff = np.linalg.norm(np.exp(input[1:(N.get() - 1), 0:M.get()]) - output[1:-1, :]) / N.get()
+    diff = np.linalg.norm(np.exp(input[1:(n - 1), 0:m]) - output[1:-1, :]) / n
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/subarray_test.py
+++ b/tests/subarray_test.py
@@ -16,13 +16,13 @@ def subarray(A, B):
 
 
 def test():
-    W.set(3)
+    W = 3
 
     A = dp.ndarray([W, W, W, W])
     B = dp.ndarray([W, W, W, W])
 
-    A[:] = np.mgrid[0:W.get(), 0:W.get(), 0:W.get()]
-    for i in range(W.get()):
+    A[:] = np.mgrid[0:W, 0:W, 0:W]
+    for i in range(W):
         A[i, :] += 10 * (i + 1)
     B[:] = dp.float32(0.0)
 

--- a/tests/symbol_dependent_transients_test.py
+++ b/tests/symbol_dependent_transients_test.py
@@ -20,7 +20,7 @@ def _make_sdfg(name, storage=dace.dtypes.StorageType.CPU_Heap, isview=False):
         _, tmp1 = sdfg.add_transient('tmp1', [N - 4, N - 4, N - i], dtype=dace.float64, storage=storage)
     _, tmp2 = sdfg.add_transient('tmp2', [1], dtype=dace.float64, storage=storage)
 
-    begin_state = sdfg.add_state("begin", is_start_state=True)
+    begin_state = sdfg.add_state("begin", is_start_block=True)
     guard_state = sdfg.add_state("guard")
     body1_state = sdfg.add_state("body1")
     body2_state = sdfg.add_state("body2")
@@ -190,6 +190,7 @@ def test_symbol_dependent_fpga_global_array():
 
 
 def test_symbol_dependent_array_in_map():
+
     @dace.program
     def symbol_dependent_array_in_map(A: dace.float32[10]):
         out = np.ndarray(10, dtype=np.float32)

--- a/tests/threadlocal_stream_test.py
+++ b/tests/threadlocal_stream_test.py
@@ -31,9 +31,9 @@ sdfg.fill_scope_connectors()
 def test():
     print('Thread-local stream test')
 
-    N.set(20)
+    N = 20
 
-    output = np.ndarray([N.get()], dtype=np.float32)
+    output = np.ndarray([N], dtype=np.float32)
     output[:] = dp.float32(0)
 
     code_nonspec = sdfg.generate_code()
@@ -45,7 +45,7 @@ def test():
 
     output = np.sort(output)
 
-    diff = np.linalg.norm(output - np.arange(0, N.get(), dtype=np.float32))
+    diff = np.linalg.norm(output - np.arange(0, N, dtype=np.float32))
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/tile_test.py
+++ b/tests/tile_test.py
@@ -25,21 +25,21 @@ def transpose_tiled(A: dace.float32[H, W], B: dace.float32[H, W]):
 
 
 def test():
-    W.set(128)
-    H.set(128)
-    TW.set(16)
-    TH.set(16)
+    W = 128
+    H = 128
+    TW = 16
+    TH = 16
 
-    print('Transpose (Tiled) %dx%d (tile size: %dx%d)' % (W.get(), H.get(), TW.get(), TH.get()))
+    print('Transpose (Tiled) %dx%d (tile size: %dx%d)' % (W, H, TW, TH))
 
     A = dace.ndarray([H, W], dtype=dace.float32)
     B = dace.ndarray([H, W], dtype=dace.float32)
-    A[:] = np.random.rand(H.get(), W.get()).astype(dace.float32.type)
+    A[:] = np.random.rand(H, W).astype(dace.float32.type)
     B[:] = dace.float32(0)
 
     transpose_tiled(A, B, TW=TW, TH=TH)
 
-    diff = np.linalg.norm(np.transpose(A) - B) / (H.get() * W.get())
+    diff = np.linalg.norm(np.transpose(A) - B) / (H * W)
     print("Difference:", diff)
     assert diff <= 1e-5
 

--- a/tests/tiling_test.py
+++ b/tests/tiling_test.py
@@ -67,19 +67,19 @@ def create_sdfg():
 
 
 def test():
-    W.set(1024)
-    H.set(1024)
-    MAXITER.set(30)
+    W = 1024
+    H = 1024
+    MAXITER = 30
 
-    print('Jacobi 5-point Stencil %dx%d (%d steps)' % (W.get(), H.get(), MAXITER.get()))
+    print('Jacobi 5-point Stencil %dx%d (%d steps)' % (W, H, MAXITER))
 
-    A = np.ndarray((H.get(), W.get()), dtype=np.float32)
+    A = np.ndarray((H, W), dtype=np.float32)
 
     # Initialize arrays: Randomize A, zero B
     A[:] = dace.float32(0)
-    A[1:H.get() - 1, 1:W.get() - 1] = np.random.rand((H.get() - 2), (W.get() - 2)).astype(dace.float32.type)
-    regression = np.ndarray([H.get() - 2, W.get() - 2], dtype=np.float32)
-    regression[:] = A[1:H.get() - 1, 1:W.get() - 1]
+    A[1:H - 1, 1:W - 1] = np.random.rand((H - 2), (W - 2)).astype(dace.float32.type)
+    regression = np.ndarray([H - 2, W - 2], dtype=np.float32)
+    regression[:] = A[1:H - 1, 1:W - 1]
 
     #print(A.view(type=np.ndarray))
 
@@ -93,14 +93,14 @@ def test():
         if (isinstance(node, dace.sdfg.nodes.MapEntry) and node.label[:-2] == 'stencil'):
             assert len(body.in_edges(node)) <= 1
 
-    sdfg(A=A, H=H.get(), W=W.get(), MAXITER=MAXITER.get())
+    sdfg(A=A, H=H, W=W, MAXITER=MAXITER)
 
     # Regression
     kernel = np.array([[0, 0.2, 0], [0.2, 0.2, 0.2], [0, 0.2, 0]], dtype=np.float32)
-    for i in range(2 * MAXITER.get()):
+    for i in range(2 * MAXITER):
         regression = ndimage.convolve(regression, kernel, mode='constant', cval=0.0)
 
-    residual = np.linalg.norm(A[1:H.get() - 1, 1:W.get() - 1] - regression) / (H.get() * W.get())
+    residual = np.linalg.norm(A[1:H - 1, 1:W - 1] - regression) / (H * W)
     print("Residual:", residual)
 
     assert residual <= 0.05

--- a/tests/transformations/loop_to_map_test.py
+++ b/tests/transformations/loop_to_map_test.py
@@ -266,7 +266,7 @@ def test_interstate_dep():
 
     sdfg = dace.SDFG('intestate_dep')
     sdfg.add_array('A', (10, ), dtype=np.int32)
-    init = sdfg.add_state('init', is_start_state=True)
+    init = sdfg.add_state('init', is_start_block=True)
     guard = sdfg.add_state('guard')
     body0 = sdfg.add_state('body0')
     body1 = sdfg.add_state('body1')
@@ -392,7 +392,7 @@ def test_symbol_race():
 
 def test_symbol_write_before_read():
     sdfg = dace.SDFG('tester')
-    init = sdfg.add_state(is_start_state=True)
+    init = sdfg.add_state(is_start_block=True)
     body_start = sdfg.add_state()
     body = sdfg.add_state()
     body_end = sdfg.add_state()
@@ -410,7 +410,7 @@ def test_symbol_array_mix(overwrite):
     sdfg = dace.SDFG('tester')
     sdfg.add_transient('tmp', [1], dace.float64)
     sdfg.add_symbol('sym', dace.float64)
-    init = sdfg.add_state(is_start_state=True)
+    init = sdfg.add_state(is_start_block=True)
     body_start = sdfg.add_state()
     body = sdfg.add_state()
     body_end = sdfg.add_state()
@@ -438,7 +438,7 @@ def test_symbol_array_mix_2(parallel):
     sdfg.add_array('A', [20], dace.float64)
     sdfg.add_array('B', [20], dace.float64)
     sdfg.add_symbol('sym', dace.float64)
-    init = sdfg.add_state(is_start_state=True)
+    init = sdfg.add_state(is_start_block=True)
     body_start = sdfg.add_state()
     body_end = sdfg.add_state()
     after = sdfg.add_state()
@@ -461,7 +461,7 @@ def test_symbol_array_mix_2(parallel):
 @pytest.mark.parametrize('overwrite', (False, True))
 def test_internal_symbol_used_outside(overwrite):
     sdfg = dace.SDFG('tester')
-    init = sdfg.add_state(is_start_state=True)
+    init = sdfg.add_state(is_start_block=True)
     body_start = sdfg.add_state()
     body = sdfg.add_state()
     body_end = sdfg.add_state()
@@ -490,7 +490,7 @@ def test_shared_local_transient_single_state():
     """
 
     sdfg = dace.SDFG('shared_local_transient_single_state')
-    begin = sdfg.add_state('begin', is_start_state=True)
+    begin = sdfg.add_state('begin', is_start_block=True)
     guard = sdfg.add_state('guard')
     body = sdfg.add_state('body')
     end = sdfg.add_state('end')
@@ -525,7 +525,7 @@ def test_thread_local_transient_single_state():
     """
 
     sdfg = dace.SDFG('thread_local_transient_single_state')
-    begin = sdfg.add_state('begin', is_start_state=True)
+    begin = sdfg.add_state('begin', is_start_block=True)
     guard = sdfg.add_state('guard')
     body = sdfg.add_state('body')
     end = sdfg.add_state('end')
@@ -563,7 +563,7 @@ def test_shared_local_transient_multi_state():
     """
 
     sdfg = dace.SDFG('shared_local_transient_multi_state')
-    begin = sdfg.add_state('begin', is_start_state=True)
+    begin = sdfg.add_state('begin', is_start_block=True)
     guard = sdfg.add_state('guard')
     body0 = sdfg.add_state('body0')
     body1 = sdfg.add_state('body1')
@@ -601,7 +601,7 @@ def test_thread_local_transient_multi_state():
     """
 
     sdfg = dace.SDFG('thread_local_transient_multi_state')
-    begin = sdfg.add_state('begin', is_start_state=True)
+    begin = sdfg.add_state('begin', is_start_block=True)
     guard = sdfg.add_state('guard')
     body0 = sdfg.add_state('body0')
     body1 = sdfg.add_state('body1')

--- a/tests/transformations/mapfission_test.py
+++ b/tests/transformations/mapfission_test.py
@@ -271,14 +271,14 @@ def test_mapfission_with_symbols():
     sdfg.add_array('A', (M, N), dace.int32)
     sdfg.add_array('B', (M, N), dace.int32)
 
-    state = sdfg.add_state('parent', is_start_state=True)
+    state = sdfg.add_state('parent', is_start_block=True)
     me, mx = state.add_map('parent_map', {'i': '0:N'})
 
     nsdfg = dace.SDFG('nested_sdfg')
     nsdfg.add_scalar('inner_A', dace.int32)
     nsdfg.add_scalar('inner_B', dace.int32)
 
-    nstate = nsdfg.add_state('child', is_start_state=True)
+    nstate = nsdfg.add_state('child', is_start_block=True)
     na = nstate.add_access('inner_A')
     nb = nstate.add_access('inner_B')
     ta = nstate.add_tasklet('tasklet_A', {}, {'__out'}, '__out = M')
@@ -319,14 +319,14 @@ def test_two_edges_through_map():
     sdfg.add_array('A', (N, ), dace.int32)
     sdfg.add_array('B', (N, ), dace.int32)
 
-    state = sdfg.add_state('parent', is_start_state=True)
+    state = sdfg.add_state('parent', is_start_block=True)
     me, mx = state.add_map('parent_map', {'i': '0:N'})
 
     nsdfg = dace.SDFG('nested_sdfg')
     nsdfg.add_array('inner_A', (N, ), dace.int32)
     nsdfg.add_scalar('inner_B', dace.int32)
 
-    nstate = nsdfg.add_state('child', is_start_state=True)
+    nstate = nsdfg.add_state('child', is_start_block=True)
     na = nstate.add_access('inner_A')
     nb = nstate.add_access('inner_B')
     t = nstate.add_tasklet('tasklet', {'__in1', '__in2'}, {'__out'}, '__out = __in1 + __in2')
@@ -460,7 +460,7 @@ def test_single_data_multiple_connectors():
     inner_sdfg.add_array('B0', (10, ), dtype=dace.int32)
     inner_sdfg.add_array('B1', (10, ), dtype=dace.int32)
 
-    inner_state = inner_sdfg.add_state('inner_state', is_start_state=True)
+    inner_state = inner_sdfg.add_state('inner_state', is_start_block=True)
 
     inner_state.add_mapped_tasklet(name='plus',
                                    map_ranges={'j': '0:10'},
@@ -481,7 +481,7 @@ def test_single_data_multiple_connectors():
                                    code='__b1 = __a0 - __a1',
                                    external_edges=True)
 
-    outer_state = outer_sdfg.add_state('outer_state', is_start_state=True)
+    outer_state = outer_sdfg.add_state('outer_state', is_start_block=True)
 
     a = outer_state.add_access('A')
     b = outer_state.add_access('B')
@@ -529,7 +529,7 @@ def test_dependent_symbol():
     inner_sdfg.add_array('B0', (10, ), dtype=dace.int32)
     inner_sdfg.add_array('B1', (10, ), dtype=dace.int32)
 
-    inner_state = inner_sdfg.add_state('inner_state', is_start_state=True)
+    inner_state = inner_sdfg.add_state('inner_state', is_start_block=True)
 
     inner_state.add_mapped_tasklet(name='plus',
                                    map_ranges={'j': 'first:last'},
@@ -550,7 +550,7 @@ def test_dependent_symbol():
     inner_sdfg2.add_array('A1', (10, ), dtype=dace.int32)
     inner_sdfg2.add_array('B1', (10, ), dtype=dace.int32)
 
-    inner_state2 = inner_sdfg2.add_state('inner_state2', is_start_state=True)
+    inner_state2 = inner_sdfg2.add_state('inner_state2', is_start_block=True)
 
     inner_state2.add_mapped_tasklet(name='minus',
                                     map_ranges={'j': 'first:last'},
@@ -571,7 +571,7 @@ def test_dependent_symbol():
     inner_state.add_edge(a1, None, nsdfg, 'A1', dace.Memlet(data='A1', subset='0:10'))
     inner_state.add_edge(nsdfg, 'B1', b1, None, dace.Memlet(data='B1', subset='0:10'))
 
-    outer_state = outer_sdfg.add_state('outer_state', is_start_state=True)
+    outer_state = outer_sdfg.add_state('outer_state', is_start_block=True)
 
     a = outer_state.add_access('A')
     b = outer_state.add_access('B')

--- a/tests/transformations/move_assignment_outside_if_test.py
+++ b/tests/transformations/move_assignment_outside_if_test.py
@@ -10,20 +10,26 @@ def one_variable_simple_test(const_value: int = 0):
     """ Test with one variable which has formula and const branch. Uses the given const value """
     sdfg = dace.SDFG('one_variable_simple_test')
     # Create guard state and one state where A is set to 0 and another where it is set using B and some formula
-    guard = sdfg.add_state('guard', is_start_state=True)
-    formula_state = sdfg.add_state('formula', is_start_state=False)
-    const_state = sdfg.add_state('const', is_start_state=False)
+    guard = sdfg.add_state('guard', is_start_block=True)
+    formula_state = sdfg.add_state('formula', is_start_block=False)
+    const_state = sdfg.add_state('const', is_start_block=False)
     sdfg.add_array('A', [1], dace.float64)
     sdfg.add_array('B', [1], dace.float64)
 
     # Add tasklet inside states
     formula_tasklet = formula_state.add_tasklet('formula_assign', {'b'}, {'a'}, 'a = 2*b')
-    formula_state.add_memlet_path(formula_state.add_read('B'), formula_tasklet, memlet=Memlet(data='B', subset='0'),
+    formula_state.add_memlet_path(formula_state.add_read('B'),
+                                  formula_tasklet,
+                                  memlet=Memlet(data='B', subset='0'),
                                   dst_conn='b')
-    formula_state.add_memlet_path(formula_tasklet, formula_state.add_write('A'), memlet=Memlet(data='A', subset='0'),
+    formula_state.add_memlet_path(formula_tasklet,
+                                  formula_state.add_write('A'),
+                                  memlet=Memlet(data='A', subset='0'),
                                   src_conn='a')
     const_tasklet = const_state.add_tasklet('const_assign', {}, {'a'}, f"a = {const_value}")
-    const_state.add_memlet_path(const_tasklet, const_state.add_write('A'), memlet=Memlet(data='A', subset='0'),
+    const_state.add_memlet_path(const_tasklet,
+                                const_state.add_write('A'),
+                                memlet=Memlet(data='A', subset='0'),
                                 src_conn='a')
 
     # Create if-else condition such that either the formula state or the const state is executed
@@ -47,9 +53,9 @@ def multiple_variable_test():
     """ Test with multiple variables where not all appear in the const branch """
     sdfg = dace.SDFG('one_variable_simple_test')
     # Create guard state and one state where A is set to 0 and another where it is set using B and some formula
-    guard = sdfg.add_state('guard', is_start_state=True)
-    formula_state = sdfg.add_state('formula', is_start_state=False)
-    const_state = sdfg.add_state('const', is_start_state=False)
+    guard = sdfg.add_state('guard', is_start_block=True)
+    formula_state = sdfg.add_state('formula', is_start_block=False)
+    const_state = sdfg.add_state('const', is_start_block=False)
     sdfg.add_array('A', [1], dace.float64)
     sdfg.add_array('B', [1], dace.float64)
     sdfg.add_array('C', [1], dace.float64)
@@ -70,10 +76,14 @@ def multiple_variable_test():
     formula_state.add_memlet_path(formula_tasklet_c, C, memlet=Memlet(data='C', subset='0'), src_conn='c')
 
     const_tasklet_a = const_state.add_tasklet('const_assign', {}, {'a'}, 'a = 0')
-    const_state.add_memlet_path(const_tasklet_a, const_state.add_write('A'), memlet=Memlet(data='A', subset='0'),
+    const_state.add_memlet_path(const_tasklet_a,
+                                const_state.add_write('A'),
+                                memlet=Memlet(data='A', subset='0'),
                                 src_conn='a')
     const_tasklet_b = const_state.add_tasklet('const_assign', {}, {'b'}, 'b = 0')
-    const_state.add_memlet_path(const_tasklet_b, const_state.add_write('B'), memlet=Memlet(data='B', subset='0'),
+    const_state.add_memlet_path(const_tasklet_b,
+                                const_state.add_write('B'),
+                                memlet=Memlet(data='B', subset='0'),
                                 src_conn='b')
 
     # Create if-else condition such that either the formula state or the const state is executed
@@ -100,9 +110,9 @@ def multiple_variable_not_all_const_test():
     """ Test with multiple variables where not all get const-assigned in const branch """
     sdfg = dace.SDFG('one_variable_simple_test')
     # Create guard state and one state where A is set to 0 and another where it is set using B and some formula
-    guard = sdfg.add_state('guard', is_start_state=True)
-    formula_state = sdfg.add_state('formula', is_start_state=False)
-    const_state = sdfg.add_state('const', is_start_state=False)
+    guard = sdfg.add_state('guard', is_start_block=True)
+    formula_state = sdfg.add_state('formula', is_start_block=False)
+    const_state = sdfg.add_state('const', is_start_block=False)
     sdfg.add_array('A', [1], dace.float64)
     sdfg.add_array('B', [1], dace.float64)
     sdfg.add_array('C', [1], dace.float64)
@@ -118,12 +128,18 @@ def multiple_variable_not_all_const_test():
     formula_state.add_memlet_path(formula_tasklet_b, B, memlet=Memlet(data='B', subset='0'), src_conn='b')
 
     const_tasklet_a = const_state.add_tasklet('const_assign', {}, {'a'}, 'a = 0')
-    const_state.add_memlet_path(const_tasklet_a, const_state.add_write('A'), memlet=Memlet(data='A', subset='0'),
+    const_state.add_memlet_path(const_tasklet_a,
+                                const_state.add_write('A'),
+                                memlet=Memlet(data='A', subset='0'),
                                 src_conn='a')
     const_tasklet_b = const_state.add_tasklet('const_assign', {'c'}, {'b'}, 'b = 1.5 * c')
-    const_state.add_memlet_path(const_state.add_read('C'), const_tasklet_b, memlet=Memlet(data='C', subset='0'),
+    const_state.add_memlet_path(const_state.add_read('C'),
+                                const_tasklet_b,
+                                memlet=Memlet(data='C', subset='0'),
                                 dst_conn='c')
-    const_state.add_memlet_path(const_tasklet_b, const_state.add_write('B'), memlet=Memlet(data='B', subset='0'),
+    const_state.add_memlet_path(const_tasklet_b,
+                                const_state.add_write('B'),
+                                memlet=Memlet(data='B', subset='0'),
                                 src_conn='b')
 
     # Create if-else condition such that either the formula state or the const state is executed

--- a/tests/transformations/state_fusion_node_merge_test.py
+++ b/tests/transformations/state_fusion_node_merge_test.py
@@ -43,9 +43,9 @@ def relative_error(val, ref):
 
 
 def test_one():
-    N.set(42)
-    A = np.random.rand(N.get()).astype(np.float64)
-    B = np.random.rand(N.get()).astype(np.float64)
+    N = 42
+    A = np.random.rand(N).astype(np.float64)
+    B = np.random.rand(N).astype(np.float64)
     A_ref = A + 42 + 43
     B_ref = A + 42
 

--- a/tests/transformations/subgraph_fusion/block_allreduce_cudatest.py
+++ b/tests/transformations/subgraph_fusion/block_allreduce_cudatest.py
@@ -8,9 +8,6 @@ from dace.libraries.standard.nodes.reduce import Reduce
 
 N = dace.symbol('N')
 M = dace.symbol('M')
-N.set(30)
-M.set(30)
-
 
 @dace.program
 def program(A: dace.float32[M, N]):
@@ -19,7 +16,7 @@ def program(A: dace.float32[M, N]):
 
 @pytest.mark.gpu
 def test_blockallreduce():
-    A = np.random.rand(M.get(), N.get()).astype(np.float32)
+    A = np.random.rand(30, 30).astype(np.float32)
     sdfg = program.to_sdfg()
     sdfg.apply_gpu_transformations()
 
@@ -30,7 +27,7 @@ def test_blockallreduce():
     reduce_node.implementation = 'CUDA (device)'
 
     csdfg = sdfg.compile()
-    result1 = csdfg(A=A, M=M, N=N)
+    result1 = csdfg(A=A, M=30, N=30)
     del csdfg
 
     sdfg_id = 0
@@ -42,7 +39,7 @@ def test_blockallreduce():
     transform.reduce_implementation = 'CUDA (block allreduce)'
     transform.apply(sdfg.node(0), sdfg)
     csdfg = sdfg.compile()
-    result2 = csdfg(A=A, M=M, N=N)
+    result2 = csdfg(A=A, M=30, N=30)
     del csdfg
 
     print(np.linalg.norm(result1))

--- a/tests/transformations/subgraph_fusion/complex_test.py
+++ b/tests/transformations/subgraph_fusion/complex_test.py
@@ -12,16 +12,13 @@ from dace.transformation.subgraph import SubgraphFusion
 from util import expand_maps, expand_reduce, fusion
 
 N, M, O = [dace.symbol(s) for s in ['N', 'M', 'O']]
-N.set(50)
-M.set(60)
-O.set(70)
 
-A = np.random.rand(N.get()).astype(np.float64)
-B = np.random.rand(M.get()).astype(np.float64)
-C = np.random.rand(O.get()).astype(np.float64)
-out1 = np.ndarray((N.get(), M.get()), np.float64)
+A = np.random.rand(50).astype(np.float64)
+B = np.random.rand(60).astype(np.float64)
+C = np.random.rand(70).astype(np.float64)
+out1 = np.ndarray((50, 60), np.float64)
 out2 = np.ndarray((1), np.float64)
-out3 = np.ndarray((N.get(), M.get(), O.get()), np.float64)
+out3 = np.ndarray((50, 60, 70), np.float64)
 
 
 @dace.program
@@ -98,17 +95,17 @@ def subgraph_fusion_complex(A: dace.float64[N], B: dace.float64[M], C: dace.floa
 
 def _test_quantitatively(sdfg, graph):
 
-    A = np.random.rand(N.get()).astype(np.float64)
-    B = np.random.rand(M.get()).astype(np.float64)
-    C = np.random.rand(O.get()).astype(np.float64)
-    out1_base = np.ndarray((N.get(), M.get()), np.float64)
+    A = np.random.rand(50).astype(np.float64)
+    B = np.random.rand(60).astype(np.float64)
+    C = np.random.rand(70).astype(np.float64)
+    out1_base = np.ndarray((50, 60), np.float64)
     out2_base = np.ndarray((1), np.float64)
-    out3_base = np.ndarray((N.get(), M.get(), O.get()), np.float64)
-    out1 = np.ndarray((N.get(), M.get()), np.float64)
+    out3_base = np.ndarray((50, 60, 70), np.float64)
+    out1 = np.ndarray((50, 60), np.float64)
     out2 = np.ndarray((1), np.float64)
-    out3 = np.ndarray((N.get(), M.get(), O.get()), np.float64)
+    out3 = np.ndarray((50, 60, 70), np.float64)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C, out1=out1_base, out2=out2_base, out3=out3_base, N=N, M=M, O=O)
+    csdfg(A=A, B=B, C=C, out1=out1_base, out2=out2_base, out3=out3_base, N=50, M=60, O=70)
     del csdfg
 
     expand_reduce(sdfg, graph)
@@ -120,7 +117,7 @@ def _test_quantitatively(sdfg, graph):
     fusion(sdfg, graph)
     sdfg.validate()
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C, out1=out1, out2=out2, out3=out3, N=N, M=M, O=O)
+    csdfg(A=A, B=B, C=C, out1=out1, out2=out2, out3=out3, N=50, M=60, O=70)
     del csdfg
 
     assert np.allclose(out1, out1_base)

--- a/tests/transformations/subgraph_fusion/create_out_transient_test.py
+++ b/tests/transformations/subgraph_fusion/create_out_transient_test.py
@@ -12,9 +12,6 @@ import sys
 from util import fusion
 
 N, M, O = [dace.symbol(s) for s in ['N', 'M', 'O']]
-N.set(50)
-M.set(60)
-O.set(70)
 
 
 @dace.program
@@ -69,17 +66,17 @@ def program2(A: dace.float64[M, N], B: dace.float64[M, N], C: dace.float64[M, N]
 
 
 def _test_quantitatively(sdfg, graph):
-    A = np.random.rand(M.get(), N.get()).astype(np.float64)
-    B1 = np.zeros(shape=[M.get(), N.get()], dtype=np.float64)
-    C1 = np.zeros(shape=[M.get(), N.get()], dtype=np.float64)
-    B2 = np.zeros(shape=[M.get(), N.get()], dtype=np.float64)
-    C2 = np.zeros(shape=[M.get(), N.get()], dtype=np.float64)
+    A = np.random.rand(60, 50).astype(np.float64)
+    B1 = np.zeros(shape=[60, 50], dtype=np.float64)
+    C1 = np.zeros(shape=[60, 50], dtype=np.float64)
+    B2 = np.zeros(shape=[60, 50], dtype=np.float64)
+    C2 = np.zeros(shape=[60, 50], dtype=np.float64)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B1, C=C1, N=N, M=M)
+    csdfg(A=A, B=B1, C=C1, N=50, M=60)
     del csdfg
     fusion(sdfg, graph)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B2, C=C2, N=N, M=M)
+    csdfg(A=A, B=B2, C=C2, N=50, M=60)
     del csdfg
     assert np.allclose(B1, B2)
     assert np.allclose(C1, C2)

--- a/tests/transformations/subgraph_fusion/disjoint_test.py
+++ b/tests/transformations/subgraph_fusion/disjoint_test.py
@@ -14,8 +14,6 @@ from dace.transformation.subgraph import SubgraphFusion
 
 M = dace.symbol('M')
 N = dace.symbol('N')
-N.set(20)
-M.set(30)
 
 
 # TRUE
@@ -86,12 +84,12 @@ def test_p1():
     sdfg.simplify()
     state = sdfg.nodes()[0]
     assert len(sdfg.nodes()) == 1
-    A = np.random.rand(M.get(), 2).astype(np.float64)
+    A = np.random.rand(30, 2).astype(np.float64)
     A1 = A.copy()
     A2 = A.copy()
 
     csdfg = sdfg.compile()
-    csdfg(A=A1, N=N, M=M)
+    csdfg(A=A1, N=20, M=30)
     del csdfg
 
     subgraph = SubgraphView(state, state.nodes())
@@ -101,7 +99,7 @@ def test_p1():
     sf.apply(sdfg)
 
     csdfg = sdfg.compile()
-    csdfg(A=A2, M=M)
+    csdfg(A=A2, M=30)
     del csdfg
 
     assert np.allclose(A1, A2)

--- a/tests/transformations/subgraph_fusion/expansion_test.py
+++ b/tests/transformations/subgraph_fusion/expansion_test.py
@@ -12,9 +12,6 @@ from dace.transformation.subgraph import SubgraphFusion
 from util import expand_maps, expand_reduce, fusion
 
 N, M, O = [dace.symbol(s) for s in ['N', 'M', 'O']]
-N.set(50)
-M.set(60)
-O.set(70)
 
 
 @dace.program
@@ -72,10 +69,10 @@ def test_expansion2():
     sdfg = expansion2.to_sdfg()
     graph = sdfg.nodes()[0]
     kwargs = {
-        'A': np.random.rand(M.get(), N.get()).astype(np.float64),
-        'B': np.random.rand(M.get(), O.get()).astype(np.float64),
-        'out1': np.ndarray((M.get(), N.get()), dtype=np.float64),
-        'out2': np.ndarray((M.get(), O.get()), dtype=np.float64),
+        'A': np.random.rand(60, 50).astype(np.float64),
+        'B': np.random.rand(60, 70).astype(np.float64),
+        'out1': np.ndarray((60, 50), dtype=np.float64),
+        'out2': np.ndarray((60, 70), dtype=np.float64),
         'N': N,
         'M': M,
         'O': O
@@ -101,10 +98,10 @@ def test_expansion1():
     sdfg = expansion1.to_sdfg()
     graph = sdfg.nodes()[0]
     kwargs = {
-        'A': np.random.rand(M.get(), N.get(), O.get()).astype(np.float64),
-        'B': np.random.rand(M.get(), N.get(), O.get()).astype(np.float64),
-        'C': np.random.rand(M.get(), N.get(), O.get()).astype(np.float64),
-        'out1': np.ndarray((M.get(), N.get(), O.get()), dtype=np.float64),
+        'A': np.random.rand(60, 50, 70).astype(np.float64),
+        'B': np.random.rand(60, 50, 70).astype(np.float64),
+        'C': np.random.rand(60, 50, 70).astype(np.float64),
+        'out1': np.ndarray((60, 50, 70), dtype=np.float64),
         'N': N,
         'M': M,
         'O': O

--- a/tests/transformations/subgraph_fusion/expansion_test.py
+++ b/tests/transformations/subgraph_fusion/expansion_test.py
@@ -73,9 +73,9 @@ def test_expansion2():
         'B': np.random.rand(60, 70).astype(np.float64),
         'out1': np.ndarray((60, 50), dtype=np.float64),
         'out2': np.ndarray((60, 70), dtype=np.float64),
-        'N': N,
-        'M': M,
-        'O': O
+        'N': 50,
+        'M': 60,
+        'O': 70
     }
 
     run(sdfg, graph, kwargs)
@@ -102,9 +102,9 @@ def test_expansion1():
         'B': np.random.rand(60, 50, 70).astype(np.float64),
         'C': np.random.rand(60, 50, 70).astype(np.float64),
         'out1': np.ndarray((60, 50, 70), dtype=np.float64),
-        'N': N,
-        'M': M,
-        'O': O
+        'N': 50,
+        'M': 60,
+        'O': 70
     }
     run(sdfg, graph, kwargs)
     out1 = kwargs['out1'].copy()

--- a/tests/transformations/subgraph_fusion/intermediate_mimo_test.py
+++ b/tests/transformations/subgraph_fusion/intermediate_mimo_test.py
@@ -14,7 +14,6 @@ from typing import Union, List
 from dace.sdfg.graph import SubgraphView
 
 N = dace.symbol('N')
-N.set(1000)
 
 
 @dace.program
@@ -47,15 +46,15 @@ def mimo(A: dace.float64[N], B: dace.float64[N], C: dace.float64[N], D: dace.flo
 
 def _test_quantitatively(sdfg):
     graph = sdfg.nodes()[0]
-    A = np.random.rand(N.get()).astype(np.float64)
-    B = np.random.rand(N.get()).astype(np.float64)
-    C1 = np.random.rand(N.get()).astype(np.float64)
-    C2 = np.random.rand(N.get()).astype(np.float64)
-    D1 = np.random.rand(N.get()).astype(np.float64)
-    D2 = np.random.rand(N.get()).astype(np.float64)
+    A = np.random.rand(1000).astype(np.float64)
+    B = np.random.rand(1000).astype(np.float64)
+    C1 = np.random.rand(1000).astype(np.float64)
+    C2 = np.random.rand(1000).astype(np.float64)
+    D1 = np.random.rand(1000).astype(np.float64)
+    D2 = np.random.rand(1000).astype(np.float64)
 
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C1, D=D1, N=N)
+    csdfg(A=A, B=B, C=C1, D=D1, N=1000)
     del csdfg
 
     subgraph = SubgraphView(graph, [node for node in graph.nodes()])
@@ -71,7 +70,7 @@ def _test_quantitatively(sdfg):
     sf.apply(sdfg)
 
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C2, D=D2, N=N)
+    csdfg(A=A, B=B, C=C2, D=D2, N=1000)
 
     assert np.allclose(C1, C2)
     assert np.allclose(D1, D2)

--- a/tests/transformations/subgraph_fusion/invariant_dimension_test.py
+++ b/tests/transformations/subgraph_fusion/invariant_dimension_test.py
@@ -16,14 +16,11 @@ import sys
 from util import fusion
 
 N, M, O = [dace.symbol(s) for s in ['N', 'M', 'O']]
-N.set(50)
-M.set(60)
-O.set(70)
 
-A = np.random.rand(N.get(), M.get(), O.get()).astype(np.float64)
-B = np.random.rand(N.get(), M.get(), O.get()).astype(np.float64)
-C = np.random.rand(N.get(), M.get(), O.get()).astype(np.float64)
-out1 = np.ndarray((N.get(), M.get(), O.get()), np.float64)
+A = np.random.rand(50, 60, 70).astype(np.float64)
+B = np.random.rand(50, 60, 70).astype(np.float64)
+C = np.random.rand(50, 60, 70).astype(np.float64)
+out1 = np.ndarray((50, 60, 70), np.float64)
 
 
 @dace.program
@@ -101,14 +98,14 @@ def fix_sdfg(sdfg, graph):
 
 
 def _test_quantitatively(sdfg, graph):
-    A = np.random.rand(N.get(), M.get(), O.get()).astype(np.float64)
-    B = np.random.rand(N.get(), M.get(), O.get()).astype(np.float64)
-    C1 = np.zeros([N.get(), M.get(), O.get()], dtype=np.float64)
-    C2 = np.zeros([N.get(), M.get(), O.get()], dtype=np.float64)
+    A = np.random.rand(50, 60, 70).astype(np.float64)
+    B = np.random.rand(50, 60, 70).astype(np.float64)
+    C1 = np.zeros([50, 60, 70], dtype=np.float64)
+    C2 = np.zeros([50, 60, 70], dtype=np.float64)
 
     sdfg.validate()
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C1, N=N, M=M, O=O)
+    csdfg(A=A, B=B, C=C1, N=50, M=60, O=70)
     del csdfg
 
     subgraph = SubgraphView(graph, graph.nodes())
@@ -118,7 +115,7 @@ def _test_quantitatively(sdfg, graph):
 
     fusion(sdfg, graph)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C2, N=N, M=M, O=O)
+    csdfg(A=A, B=B, C=C2, N=50, M=60, O=70)
     del csdfg
 
     assert np.allclose(C1, C2)

--- a/tests/transformations/subgraph_fusion/parallel_test.py
+++ b/tests/transformations/subgraph_fusion/parallel_test.py
@@ -56,34 +56,34 @@ def subgraph_fusion_parallel(A: dace.float64[N], B: dace.float64[M], C: dace.flo
 
 def test_p1():
 
-    N.set(20)
-    M.set(30)
-    O.set(50)
-    P.set(40)
-    Q.set(42)
-    R.set(25)
+    N = 20
+    M = 30
+    O = 50
+    P = 40
+    Q = 42
+    R = 25
 
     sdfg = subgraph_fusion_parallel.to_sdfg()
     sdfg.simplify()
     state = sdfg.nodes()[0]
 
-    A = np.random.rand(N.get()).astype(np.float64)
-    B = np.random.rand(M.get()).astype(np.float64)
-    C = np.random.rand(O.get()).astype(np.float64)
-    D = np.random.rand(M.get()).astype(np.float64)
-    E = np.random.rand(N.get()).astype(np.float64)
-    F = np.random.rand(P.get()).astype(np.float64)
-    G = np.random.rand(M.get()).astype(np.float64)
-    H = np.random.rand(P.get()).astype(np.float64)
-    I = np.random.rand(N.get()).astype(np.float64)
-    J = np.random.rand(R.get()).astype(np.float64)
-    X = np.random.rand(N.get()).astype(np.float64)
-    Y = np.random.rand(M.get()).astype(np.float64)
-    Z = np.random.rand(P.get()).astype(np.float64)
-    o1 = np.random.rand(N.get(), M.get(), O.get())
-    o2 = np.random.rand(M.get(), N.get(), P.get())
-    o3 = np.random.rand(P.get(), N.get(), R.get())
-    o4 = np.random.rand(N.get(), M.get(), P.get())
+    A = np.random.rand(N).astype(np.float64)
+    B = np.random.rand(M).astype(np.float64)
+    C = np.random.rand(O).astype(np.float64)
+    D = np.random.rand(M).astype(np.float64)
+    E = np.random.rand(N).astype(np.float64)
+    F = np.random.rand(P).astype(np.float64)
+    G = np.random.rand(M).astype(np.float64)
+    H = np.random.rand(P).astype(np.float64)
+    I = np.random.rand(N).astype(np.float64)
+    J = np.random.rand(R).astype(np.float64)
+    X = np.random.rand(N).astype(np.float64)
+    Y = np.random.rand(M).astype(np.float64)
+    Z = np.random.rand(P).astype(np.float64)
+    o1 = np.random.rand(N, M, O)
+    o2 = np.random.rand(M, N, P)
+    o3 = np.random.rand(P, N, R)
+    o4 = np.random.rand(N, M, P)
 
     csdfg = sdfg.compile()
     csdfg(A=A,

--- a/tests/transformations/subgraph_fusion/reduction_fuse_test.py
+++ b/tests/transformations/subgraph_fusion/reduction_fuse_test.py
@@ -14,8 +14,6 @@ from dace.transformation.dataflow import ReduceExpansion
 
 M = dace.symbol('M')
 N = dace.symbol('N')
-N.set(20)
-M.set(30)
 
 
 @dace.program
@@ -40,19 +38,19 @@ def test_p3(in_transient, out_transient):
     sdfg = reduction_test_3.to_sdfg()
     sdfg.simplify()
     state = sdfg.nodes()[0]
-    A = np.random.rand(M.get(), N.get()).astype(np.float64)
-    B = np.random.rand(M.get(), N.get()).astype(np.float64)
-    C1 = np.zeros([N.get()], dtype=np.float64)
-    C2 = np.zeros([N.get()], dtype=np.float64)
-    C3 = np.zeros([N.get()], dtype=np.float64)
+    A = np.random.rand(30, 20).astype(np.float64)
+    B = np.random.rand(30, 20).astype(np.float64)
+    C1 = np.zeros([20], dtype=np.float64)
+    C2 = np.zeros([20], dtype=np.float64)
+    C3 = np.zeros([20], dtype=np.float64)
 
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C1, N=N, M=M)
+    csdfg(A=A, B=B, C=C1, N=20, M=30)
     del csdfg
 
     expand_reduce(sdfg, state, create_in_transient=in_transient, create_out_transient=out_transient)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C2, N=N, M=M)
+    csdfg(A=A, B=B, C=C2, N=20, M=30)
     del csdfg
 
     expand_maps(sdfg, state)

--- a/tests/transformations/subgraph_fusion/reduction_fuse_test.py
+++ b/tests/transformations/subgraph_fusion/reduction_fuse_test.py
@@ -56,7 +56,7 @@ def test_p3(in_transient, out_transient):
     expand_maps(sdfg, state)
     fusion(sdfg, state)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C3, N=N, M=M)
+    csdfg(A=A, B=B, C=C3, N=20, M=30)
     del csdfg
 
     assert np.linalg.norm(C1) > 0.01
@@ -65,6 +65,6 @@ def test_p3(in_transient, out_transient):
 
 
 if __name__ == "__main__":
-    test_p3()
-    test_p3(in_transient=True)
-    test_p3(out_transient=True)
+    test_p3(False, False)
+    test_p3(True, False)
+    test_p3(False, True)

--- a/tests/transformations/subgraph_fusion/reduction_test.py
+++ b/tests/transformations/subgraph_fusion/reduction_test.py
@@ -14,8 +14,6 @@ from dace.transformation.dataflow import ReduceExpansion
 
 M = dace.symbol('M')
 N = dace.symbol('N')
-N.set(20)
-M.set(30)
 
 
 @dace.program
@@ -56,18 +54,18 @@ def test_p1(in_transient, out_transient):
     rexp.setup_match(sdfg, sdfg.sdfg_id, 0, {ReduceExpansion.reduce: state.node_id(reduce_node)}, 0)
     assert rexp.can_be_applied(state, 0, sdfg) == True
 
-    A = np.random.rand(M.get(), N.get()).astype(np.float64)
-    B = np.random.rand(M.get(), N.get()).astype(np.float64)
-    C1 = np.zeros([N.get()], dtype=np.float64)
-    C2 = np.zeros([N.get()], dtype=np.float64)
+    A = np.random.rand(30, 20).astype(np.float64)
+    B = np.random.rand(30, 20).astype(np.float64)
+    C1 = np.zeros([20], dtype=np.float64)
+    C2 = np.zeros([20], dtype=np.float64)
 
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C1, N=N, M=M)
+    csdfg(A=A, B=B, C=C1, N=20, M=30)
     del csdfg
 
     expand_reduce(sdfg, state, create_in_transient=in_transient, create_out_transient=out_transient)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C2, N=N, M=M)
+    csdfg(A=A, B=B, C=C2, N=20, M=30)
     del csdfg
 
     assert np.linalg.norm(C1) > 0.01
@@ -82,18 +80,18 @@ def test_p2(in_transient, out_transient):
     sdfg = reduction_test_2.to_sdfg()
     sdfg.simplify()
     state = sdfg.nodes()[0]
-    A = np.random.rand(M.get(), N.get()).astype(np.float64)
-    B = np.random.rand(M.get(), N.get()).astype(np.float64)
-    C1 = np.zeros([N.get()], dtype=np.float64)
-    C2 = np.zeros([N.get()], dtype=np.float64)
+    A = np.random.rand(30, 20).astype(np.float64)
+    B = np.random.rand(30, 20).astype(np.float64)
+    C1 = np.zeros([20], dtype=np.float64)
+    C2 = np.zeros([20], dtype=np.float64)
 
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C1, N=N, M=M)
+    csdfg(A=A, B=B, C=C1, N=20, M=30)
     del csdfg
 
     expand_reduce(sdfg, state, create_in_transient=in_transient, create_out_transient=out_transient)
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C2, N=N, M=M)
+    csdfg(A=A, B=B, C=C2, N=20, M=30)
 
     assert np.linalg.norm(C1) > 0.01
     assert np.allclose(C1, C2)

--- a/tests/transformations/subgraph_fusion/sequential1_test.py
+++ b/tests/transformations/subgraph_fusion/sequential1_test.py
@@ -28,15 +28,15 @@ def subgraph_fusion_sequential(A: dace.float64[N], B: dace.float64[N], C: dace.f
 
 
 def test_sequential():
-    N.set(1000)
+    N = 1000
 
     sdfg = subgraph_fusion_sequential.to_sdfg()
     state = sdfg.nodes()[0]
 
-    A = np.random.rand(N.get()).astype(np.float64)
-    B = np.random.rand(N.get()).astype(np.float64)
-    C1 = np.random.rand(N.get()).astype(np.float64)
-    C2 = np.random.rand(N.get()).astype(np.float64)
+    A = np.random.rand(N).astype(np.float64)
+    B = np.random.rand(N).astype(np.float64)
+    C1 = np.random.rand(N).astype(np.float64)
+    C2 = np.random.rand(N).astype(np.float64)
 
     csdfg = sdfg.compile()
     csdfg(A=A, B=B, C=C1, N=N)

--- a/tests/transformations/subgraph_fusion/sequential2_cudatest.py
+++ b/tests/transformations/subgraph_fusion/sequential2_cudatest.py
@@ -30,15 +30,15 @@ def program(A: dace.float64[N], C: dace.float64[N]):
 
 @pytest.mark.gpu
 def test():
-    N.set(50)
+    N = 50
 
     sdfg = program.to_sdfg()
     sdfg.apply_gpu_transformations()
     state = sdfg.nodes()[0]
 
-    A = np.random.rand(N.get()).astype(np.float64)
-    C1 = np.random.rand(N.get()).astype(np.float64)
-    C2 = np.random.rand(N.get()).astype(np.float64)
+    A = np.random.rand(N).astype(np.float64)
+    C1 = np.random.rand(N).astype(np.float64)
+    C2 = np.random.rand(N).astype(np.float64)
 
     csdfg = sdfg.compile()
     csdfg(A=A, C=C1, N=N)

--- a/tests/transformations/subgraph_fusion/sequential2_test.py
+++ b/tests/transformations/subgraph_fusion/sequential2_test.py
@@ -28,15 +28,15 @@ def sequential2(A: dace.float64[N], C: dace.float64[N]):
 
 
 def test_sequential():
-    N.set(1000)
+    N = 1000
 
     sdfg = sequential2.to_sdfg()
     state = sdfg.nodes()[0]
 
-    A = np.random.rand(N.get()).astype(np.float64)
-    B = np.random.rand(N.get()).astype(np.float64)
-    C1 = np.random.rand(N.get()).astype(np.float64)
-    C2 = np.random.rand(N.get()).astype(np.float64)
+    A = np.random.rand(N).astype(np.float64)
+    B = np.random.rand(N).astype(np.float64)
+    C1 = np.random.rand(N).astype(np.float64)
+    C2 = np.random.rand(N).astype(np.float64)
 
     csdfg = sdfg.compile()
     csdfg(A=A, B=B, C=C1, N=N)

--- a/tests/transformations/subgraph_fusion/smax_test.py
+++ b/tests/transformations/subgraph_fusion/smax_test.py
@@ -45,12 +45,6 @@ def softmax(X_in: dace_dtype[H, B, SN, SM]):
     return out
 
 
-H.set(10)
-B.set(10)
-SN.set(20)
-SM.set(20)
-
-
 def get_partition(sdfg, graph):
     subgraph1 = SubgraphView(graph, [])
     subgraph2 = SubgraphView(graph, [])
@@ -78,10 +72,10 @@ def test_2fuse():
     sdfg = softmax.to_sdfg()
     sdfg.name = 'softmax_2part'
     sdfg.simplify()
-    X_in = np.random.rand(H.get(), B.get(), SN.get(), SM.get()).astype(np.float32)
+    X_in = np.random.rand(10, 10, 20, 20).astype(np.float32)
 
     csdfg = sdfg.compile()
-    res1 = csdfg(X_in=X_in, H=H, B=B, SN=SN, SM=SM)
+    res1 = csdfg(X_in=X_in, H=10, B=10, SN=20, SM=20)
     del csdfg
 
     subgraph = get_partition(sdfg, sdfg.nodes()[0])
@@ -90,7 +84,7 @@ def test_2fuse():
     fusion(sdfg, sdfg.nodes()[0], subgraph)
 
     csdfg = sdfg.compile()
-    res2 = csdfg(X_in=X_in, H=H, B=B, SN=SN, SM=SM)
+    res2 = csdfg(X_in=X_in, H=10, B=10, SN=20, SM=20)
     del csdfg
 
     assert np.allclose(res1, res2)
@@ -102,10 +96,10 @@ def test_1fuse():
     sdfg = softmax.to_sdfg()
     sdfg.name = 'softmax_fused'
     sdfg.simplify()
-    X_in = np.random.rand(H.get(), B.get(), SN.get(), SM.get()).astype(np.float32)
+    X_in = np.random.rand(10, 10, 20, 20).astype(np.float32)
 
     csdfg = sdfg.compile()
-    res1 = csdfg(X_in=X_in, H=H, B=B, SN=SN, SM=SM)
+    res1 = csdfg(X_in=X_in, H=10, B=10, SN=20, SM=20)
     del csdfg
 
     expand_reduce(sdfg, sdfg.nodes()[0])
@@ -113,7 +107,7 @@ def test_1fuse():
     fusion(sdfg, sdfg.nodes()[0])
 
     csdfg = sdfg.compile()
-    res2 = csdfg(X_in=X_in, H=H, B=B, SN=SN, SM=SM)
+    res2 = csdfg(X_in=X_in, H=10, B=10, SN=20, SM=20)
     del csdfg
 
     print(np.linalg.norm(res1))
@@ -127,10 +121,10 @@ def test_1fuse():
     sdfg = softmax.to_sdfg()
     sdfg.name = 'softmax_fused'
     sdfg.simplify()
-    X_in = np.random.rand(H.get(), B.get(), SN.get(), SM.get()).astype(np.float32)
+    X_in = np.random.rand(10, 10, 20, 20).astype(np.float32)
 
     csdfg = sdfg.compile()
-    res1 = csdfg(X_in=X_in, H=H, B=B, SN=SN, SM=SM)
+    res1 = csdfg(X_in=X_in, H=10, B=10, SN=20, SM=20)
     del csdfg
 
     expand_reduce(sdfg, sdfg.nodes()[0])
@@ -139,7 +133,7 @@ def test_1fuse():
 
     #sdfg.specialize({'SM':SM})
     csdfg = sdfg.compile()
-    res2 = csdfg(X_in=X_in, H=H, B=B, SN=SN, SM=SM)
+    res2 = csdfg(X_in=X_in, H=10, B=10, SN=20, SM=20)
     del csdfg
 
     print(np.linalg.norm(res1))

--- a/tests/transformations/subgraph_fusion/tiling_pool_test.py
+++ b/tests/transformations/subgraph_fusion/tiling_pool_test.py
@@ -11,7 +11,6 @@ import pytest
 import itertools
 
 N = dace.symbol('N')
-N.set(100)
 
 
 @dace.program
@@ -56,10 +55,10 @@ def stencil_offset(A: dace.float64[2 * N], B: dace.float64[N]):
 
 def invoke_stencil(tile_size, offset=False, unroll=False):
 
-    A = np.random.rand(N.get() * 2).astype(np.float64)
-    B1 = np.zeros((N.get()), dtype=np.float64)
-    B2 = np.zeros((N.get()), dtype=np.float64)
-    B3 = np.zeros((N.get()), dtype=np.float64)
+    A = np.random.rand(100 * 2).astype(np.float64)
+    B1 = np.zeros((100), dtype=np.float64)
+    B2 = np.zeros((100), dtype=np.float64)
+    B3 = np.zeros((100), dtype=np.float64)
 
     if offset:
         sdfg = stencil_offset.to_sdfg()
@@ -71,7 +70,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
     # baseline
     sdfg.name = f'baseline_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B1, N=N)
+    csdfg(A=A, B=B1, N=100)
     del csdfg
 
     subgraph = SubgraphView(graph, [n for n in graph.nodes()])
@@ -86,7 +85,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
 
     sdfg.name = f'tiled_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B2, N=N)
+    csdfg(A=A, B=B2, N=100)
     del csdfg
 
     sdfg.simplify()
@@ -98,7 +97,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False):
 
     sdfg.name = f'fused_{tile_size}_{offset}_{unroll}'
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B3, N=N)
+    csdfg(A=A, B=B3, N=100)
     del csdfg
 
     print(np.linalg.norm(B1))

--- a/tests/transformations/subgraph_fusion/tiling_stencil_test.py
+++ b/tests/transformations/subgraph_fusion/tiling_stencil_test.py
@@ -11,7 +11,6 @@ import pytest
 import itertools
 
 N = dace.symbol('N')
-N.set(100)
 
 
 @dace.program
@@ -96,10 +95,10 @@ def stencil_offset(A: dace.float64[N], B: dace.float64[N]):
 
 def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
 
-    A = np.random.rand(N.get()).astype(np.float64)
-    B1 = np.zeros((N.get()), dtype=np.float64)
-    B2 = np.zeros((N.get()), dtype=np.float64)
-    B3 = np.zeros((N.get()), dtype=np.float64)
+    A = np.random.rand(100).astype(np.float64)
+    B1 = np.zeros((100), dtype=np.float64)
+    B2 = np.zeros((100), dtype=np.float64)
+    B3 = np.zeros((100), dtype=np.float64)
 
     if offset:
         sdfg = stencil_offset.to_sdfg()
@@ -113,7 +112,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     # baseline
     sdfg.name = 'baseline'
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B1, N=N)
+    csdfg(A=A, B=B1, N=100)
     del csdfg
 
     subgraph = SubgraphView(graph, [n for n in graph.nodes()])
@@ -130,7 +129,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     sdfg.name = 'tiled'
     sdfg.validate()
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B2, N=N)
+    csdfg(A=A, B=B2, N=100)
     del csdfg
     assert np.allclose(B1, B2)
 
@@ -144,7 +143,7 @@ def invoke_stencil(tile_size, offset=False, unroll=False, view=False):
     sf.apply(sdfg)
     sdfg.name = 'fused'
     csdfg = sdfg.compile()
-    csdfg(A=A, B=B3, N=N)
+    csdfg(A=A, B=B3, N=100)
     del csdfg
 
     print(np.linalg.norm(B1))

--- a/tests/transformations/tasklet_fusion_test.py
+++ b/tests/transformations/tasklet_fusion_test.py
@@ -32,7 +32,7 @@ def _make_sdfg(language: str, with_data: bool = False):
     sdfg.add_array('A', (N, ), datatype)
     sdfg.add_array('B', (M, ), datatype)
     sdfg.add_array('C', (M, ), datatype)
-    state = sdfg.add_state(is_start_state=True)
+    state = sdfg.add_state(is_start_block=True)
     A = state.add_read('A')
     B = state.add_read('B')
     C = state.add_write('C')
@@ -95,6 +95,7 @@ def _make_sdfg(language: str, with_data: bool = False):
 
 
 def test_basic():
+
     @dace.program
     def test_basic_tf(A: datatype[5, 5]):
         B = A + 1
@@ -113,6 +114,7 @@ def test_basic():
 
 
 def test_same_name():
+
     @dace.program
     def test_same_name(A: datatype[5, 5]):
         B = A + 1
@@ -132,6 +134,7 @@ def test_same_name():
 
 
 def test_same_name_different_memlet():
+
     @dace.program
     def test_same_name_different_memlet(A: datatype[5, 5], B: datatype[5, 5]):
         C = B * 3
@@ -152,6 +155,7 @@ def test_same_name_different_memlet():
 
 
 def test_tasklet_fusion_multiline():
+
     @dace.program
     def test_tasklet_fusion_multiline(A: datatype):
         B = A + 1
@@ -177,6 +181,7 @@ def test_tasklet_fusion_multiline():
 
 
 def test_map_param():
+
     @dace.program
     def map_uses_param(A: dace.float32[10], B: dace.float32[10], C: dace.float32[10]):
         for i in dace.map[0:10]:
@@ -214,7 +219,9 @@ def test_map_with_tasklets(language: str, with_data: bool):
     ref = map_with_tasklets.f(A, B)
     assert (np.allclose(C, ref))
 
+
 def test_none_connector():
+
     @dace.program
     def sdfg_none_connector(A: dace.float32[32], B: dace.float32[32]):
         tmp = dace.define_local([32], dace.float32)
@@ -229,7 +236,6 @@ def test_none_connector():
                 a << A[i]
                 b >> tmp2[i]
                 b = a + 1
-
 
         for i in dace.map[0:32]:
             with dace.tasklet:
@@ -248,7 +254,7 @@ def test_none_connector():
         if isinstance(node, dace.nodes.MapEntry):
             map_entry = node
             break
-    
+
     assert map_entry is not None
     assert len([edge.src_conn for edge in sdfg.start_state.out_edges(map_entry) if edge.src_conn is None]) == 1
 
@@ -260,20 +266,20 @@ def test_none_connector():
 
 
 def test_intermediate_transients():
+
     @dace.program
     def sdfg_intermediate_transients(A: dace.float32[10], B: dace.float32[10]):
         tmp = dace.define_local_scalar(dace.float32)
-        
+
         # Use tmp twice to test removal of data
         tmp = A[0] + 1
         tmp = tmp * 2
         B[0] = tmp
 
-
     sdfg = sdfg_intermediate_transients.to_sdfg(simplify=True)
     assert len([node for node in sdfg.start_state.data_nodes() if node.data == "tmp"]) == 2
 
-    xforms = Optimizer(sdfg=sdfg).get_pattern_matches(patterns=(TaskletFusion,))
+    xforms = Optimizer(sdfg=sdfg).get_pattern_matches(patterns=(TaskletFusion, ))
     applied = False
     for xform in xforms:
         if xform.data.data == "tmp":
@@ -284,6 +290,7 @@ def test_intermediate_transients():
     assert applied
     assert len([node for node in sdfg.start_state.data_nodes() if node.data == "tmp"]) == 1
     assert "tmp" in sdfg.arrays
+
 
 if __name__ == '__main__':
     test_basic()

--- a/tests/unparse_memlet_test.py
+++ b/tests/unparse_memlet_test.py
@@ -15,16 +15,16 @@ def floor_div(Input, Output):
 
 
 def test():
-    N.set(25)
-    A = np.random.rand(N.get())
-    B = np.zeros([N.get()], dtype=np.float64)
+    N = 25
+    A = np.random.rand(N)
+    B = np.zeros([N], dtype=np.float64)
 
     floor_div(A, B)
 
-    if N.get() % 2 == 0:
-        expected = 2.0 * np.sum(A[0:N.get() // 2])
+    if N % 2 == 0:
+        expected = 2.0 * np.sum(A[0:N // 2])
     else:
-        expected = 2.0 * np.sum(A[0:N.get() // 2]) + A[N.get() // 2]
+        expected = 2.0 * np.sum(A[0:N // 2]) + A[N // 2]
     actual = np.sum(B)
     diff = abs(actual - expected)
     print('Difference:', diff)

--- a/tests/vector_min_test.py
+++ b/tests/vector_min_test.py
@@ -11,11 +11,11 @@ def test():
     print('Dynamic SDFG test with vectorization and min')
     # Externals (parameters, symbols)
     N = dp.symbol('N')
-    N.set(20)
+    n = 20
 
-    input = np.random.rand(N.get()).astype(np.float32)
-    input2 = np.random.rand(N.get()).astype(np.float32)
-    output = dp.ndarray([N], dp.float32)
+    input = np.random.rand(n).astype(np.float32)
+    input2 = np.random.rand(n).astype(np.float32)
+    output = dp.ndarray([n], dp.float32)
     output[:] = dp.float32(0)
 
     # Construct SDFG
@@ -42,9 +42,9 @@ def test():
     state.add_edge(B, None, map_entry, None, Memlet.simple(B, '0:N'))
     state.add_edge(map_exit, None, C, None, Memlet.simple(C, '0:N'))
 
-    mysdfg(A=input, B=input2, C=output, N=N)
+    mysdfg(A=input, B=input2, C=output, N=n)
 
-    diff = np.linalg.norm(np.minimum(input, input2) - output) / N.get()
+    diff = np.linalg.norm(np.minimum(input, input2) - output) / n
     print("Difference:", diff)
     print("==== Program end ====")
     assert diff <= 1e-5

--- a/tests/vla_test.py
+++ b/tests/vla_test.py
@@ -22,13 +22,12 @@ state.add_nedge(tmp, B, dace.Memlet.simple('tmp', '0:N'))
 
 
 def test():
-    N.set(12)
     A = np.random.rand(12).astype(np.float32)
     B = np.random.rand(12).astype(np.float32)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        sdfg(A=A, B=B, N=N)
+        sdfg(A=A, B=B, N=12)
 
         assert w
         assert any('Variable-length' in str(warn.message) for warn in w)

--- a/tutorials/explicit.ipynb
+++ b/tutorials/explicit.ipynb
@@ -206,12 +206,12 @@
    "outputs": [],
    "source": [
     "N = dace.symbol('N')\n",
-    "N.set(255)\n",
+    "n = 255\n",
     "\n",
-    "storage = dace.ndarray(shape=[N], dtype=dace.int32)\n",
+    "storage = dace.ndarray(shape=[n], dtype=dace.int32)\n",
     "# The size of \"output\" will actually be lesser or equal to N, but we need to \n",
     "# statically allocate the memory.\n",
-    "output = dace.ndarray(shape=[N], dtype=dace.int32)\n",
+    "output = dace.ndarray(shape=[n], dtype=dace.int32)\n",
     "# The size is a scalar\n",
     "output_size = dace.scalar(dtype=dace.uint32)"
    ]
@@ -286,9 +286,9 @@
    "source": [
     "# Define some random integers and zero outputs\n",
     "import numpy as np\n",
-    "storage[:] = np.random.randint(0, 100, size=N.get())\n",
+    "storage[:] = np.random.randint(0, 100, size=n)\n",
     "output_size[0] = 0\n",
-    "output[:] = np.zeros(N.get()).astype(np.int32)\n",
+    "output[:] = np.zeros(n).astype(np.int32)\n",
     "\n",
     "# Compute expected output using numpy\n",
     "expected = storage[np.where(storage > thres)]"
@@ -325,7 +325,7 @@
     }
    ],
    "source": [
-    "qfunc(data=storage, output=output, outsz=output_size, threshold=thres, N=N)\n",
+    "qfunc(data=storage, output=output, outsz=output_size, threshold=thres, N=n)\n",
     "output_size"
    ]
   },


### PR DESCRIPTION
This also fixes FPGA CI, which now runs in parallel and depended on that deprecated functionality.