### PR TITLE
Fixed an issue in the Memlet duplication verification.

### DIFF
--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -589,7 +589,9 @@ def validate_state(state: 'dace.sdfg.SDFGState',
                 f'Duplicate memlet detected: "{e}". Please copy objects '
                 'rather than using multiple references to the same one', sdfg, state_id, eid)
         references.add(id(e))
-        if id(e.data) in references:
+        if(e.data.is_empty()):
+            pass
+        elif id(e.data) in references:
             raise InvalidSDFGEdgeError(
                 f'Duplicate memlet detected: "{e.data}". Please copy objects '
                 'rather than using multiple references to the same one', sdfg, state_id, eid)

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -589,7 +589,7 @@ def validate_state(state: 'dace.sdfg.SDFGState',
                 f'Duplicate memlet detected: "{e}". Please copy objects '
                 'rather than using multiple references to the same one', sdfg, state_id, eid)
         references.add(id(e))
-        if(e.data.is_empty()):
+        if e.data.is_empty():
             pass
         elif id(e.data) in references:
             raise InvalidSDFGEdgeError(


### PR DESCRIPTION
It was not considered that an empty memlet has `data` equal to `None`. However, empty Memlets should not be considered as duplicated data as they do not move data.