### PR TITLE
first commit, start to work on the fortran math intrinsics

### DIFF
--- a/tests/fortran/intrinsic_math.py
+++ b/tests/fortran/intrinsic_math.py
@@ -1,0 +1,74 @@
+import pytest
+import numpy as np
+from dace.frontend.fortran import fortran_parser
+
+def test_fortran_frontend_math_abs():
+    """
+    Test that the generated SDFG correctly computes the absolute value.
+    """
+    code = """
+            PROGRAM intrinsic_math_abs_test
+                IMPLICIT NONE
+                double precision, dimension(2) :: d
+                double precision, dimension(2) :: res
+                CALL intrinsic_math_test_function(d, res)
+            END
+            SUBROUTINE intrinsic_math_test_function(d, res)
+                double precision, dimension(2) :: d
+                double precision, dimension(2) :: res
+                res(1) = ABS(d(1))
+                res(2) = ABS(d(2))
+            END SUBROUTINE intrinsic_math_test_function
+    """
+    sdfg = fortran_parser.create_sdfg_from_string(code, "abs_test", False)
+    sdfg.simplify(verbose=True)
+    sdfg.compile()
+
+    size = 2
+    d = np.full([size], 42, order="F", dtype=np.float64)
+    d[0] = -99
+    d[1] = -1000
+    res = np.full([2], 42, order="F", dtype=np.float64)
+    # Execute the compiled SDFG
+    sdfg(d=d, res=res)
+
+    # Assert the expected result
+    assert res[0] == 99
+    assert res[1] == 1000
+
+# def test_fortran_frontend_math_log():
+#     """
+#     Test that the generated SDFG correctly computes the natural logarithm.
+#     """
+#     code = """
+#             PROGRAM intrinsic_math_log_test
+#                 IMPLICIT NONE
+#                 double precision, dimension(2) :: d
+#                 double precision, dimension(2) :: res
+#                 CALL intrinsic_math_test_function(d, res)
+#             END
+#             SUBROUTINE intrinsic_math_test_function(d, res)
+#                 double precision, dimension(2) :: d
+#                 double precision, dimension(2) :: res
+#                 res(1) = LOG(d(1))
+#                 res(2) = LOG(d(2))
+#             END SUBROUTINE intrinsic_math_test_function
+#     """
+#     sdfg = fortran_parser.create_sdfg_from_string(code, "log_test", False)
+#     sdfg.simplify(verbose=True)
+#     sdfg.compile()
+
+#     size = 2
+#     d = np.full([size], 1.0, order="F", dtype=np.float64)
+#     d[0] = np.e  # e^1 = 2.718281...
+#     d[1] = np.e**2  # e^2
+#     res = np.full([2], 0.0, order="F", dtype=np.float64)
+#     # Execute the compiled SDFG
+#     sdfg(d=d, res=res)
+
+#     # Assert the expected result
+#     assert np.isclose(res[0], 1.0)  # log(e) = 1
+#     assert np.isclose(res[1], 2.0)  # log(e^2) = 2
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Hi everyone. This PR is still a work in progress. I’ve been getting into the DaCe project, particularly around enhancing Fortran math intrinsics support. I decided to start with implementing the LOG function to get my feet wet.

I've added some mapping entries for LOG in FortranIntrinsics.replace_function_name and FortranIntrinsics.replace_function_reference, but I’ve hit a bit of a roadblock – it didn't pass the unit test I wrote for LOG, and I suspect there's something missing in my approach. Any hints, tips, or guidance you can offer would be awesome and really appreciated. Just looking for a nudge in the right direction.

Thanks a lot for taking the time to check this out. Excited to hear your thoughts and hoping to make this feature work with your help!