### PR TITLE
Changed default of serialize_all_fields to False

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -945,10 +945,10 @@ required:
 
             serialize_all_fields:
                 type: bool
-                default: true
+                default: false
                 title: Serialize all unmodified fields in SDFG files
                 description: >
-                    If False, saving an SDFG keeps only the modified non-default properties. If True,
+                    If False (default), saving an SDFG keeps only the modified non-default properties. If True,
                     saves all fields.
 
     #############################################


### PR DESCRIPTION
For the 0.16 release, we want to introduce the change to the default of `serialize_all_fields` to `False`.

This reverts PR "Changed default of serialize_all_fields to True #1470".
This reverts commit bfe4163f1297e049921c40e2a1bcb208fccc076b.