### PR TITLE
Adds support for ArrayView to the Python Frontend

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -823,7 +823,7 @@ class TaskletTransformer(ExtNodeTransformer):
             arr_type = type(parent_array)
         if arr_type == data.Scalar:
             self.sdfg.add_scalar(var_name, dtype)
-        elif arr_type in (data.Array, data.View):
+        elif issubclass(arr_type, data.Array):
             self.sdfg.add_array(var_name, shape, dtype, strides=strides)
         elif arr_type == data.Stream:
             self.sdfg.add_stream(var_name, dtype)
@@ -3116,7 +3116,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 arr_type = data.Scalar
         if arr_type == data.Scalar:
             self.sdfg.add_scalar(var_name, dtype)
-        elif arr_type in (data.Array, data.View):
+        elif issubclass(arr_type, data.Array):
             if non_squeezed:
                 strides = [parent_array.strides[d] for d in non_squeezed]
             else:


### PR DESCRIPTION
The refactoring of Views in PR #1504 led to the creation of the ArrayView type. This PR addresses an issue in the Python ProgramVisitor, where ArrayViews are not recognized properly as Views (of Arrays), leading to a NotImplementedError. The fix is simple: when checking if a container is an Array or a View (of an Array), instead of making a direct equality comparison to Array or View, a subclass comparison against Array is performed. The latter returns true if the container is an Array or any Array subclass, including ArrayViews.