### PR TITLE
It is now possible to suppress output in `view()`

### DIFF
--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -23,7 +23,7 @@ def partialclass(cls, *args, **kwds):
     return NewCls
 
 
-def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
+def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None, verbose: bool = True):
     """
     View an sdfg in the system's HTML viewer
 
@@ -33,6 +33,7 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
                     the generated HTML and related sources will be
                     served using a basic web server on that port,
                     blocking the current thread.
+    :param verbose: Be verbose.
     """
     # If vscode is open, try to open it inside vscode
     if filename is None:
@@ -71,7 +72,8 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
     with open(html_filename, "w") as f:
         f.write(html)
 
-    print("File saved at %s" % html_filename)
+    if(verbose):
+        print("File saved at %s" % html_filename)
 
     if fd is not None:
         os.close(fd)
@@ -83,7 +85,8 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None):
         # start the web server
         handler = partialclass(http.server.SimpleHTTPRequestHandler, directory=dirname)
         httpd = http.server.HTTPServer(('localhost', filename), handler)
-        print(f"Serving at localhost:{filename}, press enter to stop...")
+        if(verbose):
+            print(f"Serving at localhost:{filename}, press enter to stop...")
 
         # start the server in a different thread
         def serve():

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1547,14 +1547,15 @@ class SDFG(ControlFlowRegion):
 
         return None
 
-    def view(self, filename=None):
+    def view(self, filename=None, verbose=False):
         """
         View this sdfg in the system's HTML viewer
 
         :param filename: the filename to write the HTML to. If `None`, a temporary file will be created.
+        :param verbose: Be verbose, `False` by default.
         """
         from dace.cli.sdfv import view
-        view(self, filename=filename)
+        view(self, filename=filename, verbose=verbose)
 
     @staticmethod
     def _from_file(fp: BinaryIO) -> 'SDFG':


### PR DESCRIPTION
Beside making it possible to suppress the output of `sdfv.view`, this commit also changed the default behaviour of `SDFG.view()` by no longer outputting in which file it was saved.
