### PR TITLE
Fix Subscript literal evaluation for List

### DIFF
--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -761,7 +761,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                     if gkey == gslice:
                         return self._visit_potential_constant(v, True)
             elif isinstance(node.value, ast.List):  # List
-                if isinstance(node.value.elts[gslice], ast.List):
+                if isinstance(node.value.elts[gslice], List):
                     visited_list = astutils.copy_tree(node.value)
                     visited_list.elts.clear()
                     for v in node.value.elts[gslice]:
@@ -770,7 +770,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                     node.value = visited_list
                     return node
                 else:
-                    return self._visit_potential_constant(node.value.elts[gslice], True)    
+                    return self._visit_potential_constant(node.value.elts[gslice], True)
             else:
                 return self._visit_potential_constant(node, True)
 

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -761,13 +761,16 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                     if gkey == gslice:
                         return self._visit_potential_constant(v, True)
             elif isinstance(node.value, ast.List):  # List
-                visited_list = astutils.copy_tree(node.value)
-                visited_list.elts.clear()
-                for v in node.value.elts[gslice]:
-                    visited_cst = self._visit_potential_constant(v, True)
-                    visited_list.elts.append(visited_cst)
-                node.value = visited_list
-                return node
+                if isinstance(node.value.elts[gslice], ast.List):
+                    visited_list = astutils.copy_tree(node.value)
+                    visited_list.elts.clear()
+                    for v in node.value.elts[gslice]:
+                        visited_cst = self._visit_potential_constant(v, True)
+                        visited_list.elts.append(visited_cst)
+                    node.value = visited_list
+                    return node
+                else:
+                    return self._visit_potential_constant(node.value.elts[gslice], True)    
             else:
                 return self._visit_potential_constant(node, True)
 

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -752,7 +752,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                 return self.generic_visit(node)
 
             # Then query for the right value
-            if isinstance(node.value, ast.Dict):
+            if isinstance(node.value, ast.Dict): # Dict
                 for k, v in zip(node.value.keys, node.value.values):
                     try:
                         gkey = astutils.evalnode(k, self.globals)
@@ -760,7 +760,8 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                         continue
                     if gkey == gslice:
                         return self._visit_potential_constant(v, True)
-            elif isinstance(node.value, ast.List):  # List
+            elif isinstance(node.value, (ast.List, ast.Tuple)):  # List & Tuple
+                # Loop over the list if slicing makes it a list
                 if isinstance(node.value.elts[gslice], List):
                     visited_list = astutils.copy_tree(node.value)
                     visited_list.elts.clear()
@@ -771,7 +772,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                     return node
                 else:
                     return self._visit_potential_constant(node.value.elts[gslice], True)
-            else:
+            else: # Catch-all
                 return self._visit_potential_constant(node, True)
 
         return self._visit_potential_constant(node, True)

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -761,7 +761,13 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                     if gkey == gslice:
                         return self._visit_potential_constant(v, True)
             else:  # List or Tuple
-                return self._visit_potential_constant(node.value.elts[gslice], True)
+                visited_list = astutils.copy_tree(node.value)
+                visited_list.elts.clear()
+                for v in node.value.elts[gslice]:
+                    visited_cst = self._visit_potential_constant(v, True)
+                    visited_list.elts.append(visited_cst)
+                node.value = visited_list
+                return node
 
         return self._visit_potential_constant(node, True)
 

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -760,7 +760,7 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                         continue
                     if gkey == gslice:
                         return self._visit_potential_constant(v, True)
-            else:  # List or Tuple
+            elif isinstance(node.value, ast.List):  # List
                 visited_list = astutils.copy_tree(node.value)
                 visited_list.elts.clear()
                 for v in node.value.elts[gslice]:
@@ -768,6 +768,8 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                     visited_list.elts.append(visited_cst)
                 node.value = visited_list
                 return node
+            else:
+                return self._visit_potential_constant(node, True)
 
         return self._visit_potential_constant(node, True)
 

--- a/tests/python_frontend/unroll_test.py
+++ b/tests/python_frontend/unroll_test.py
@@ -169,6 +169,29 @@ def test_tuple_elements_enumerate():
     assert np.allclose(a, np.array([1, 2, 3]))
 
 
+def test_list_global_enumerate():
+    tracer_variables = ["vapor", "rain", "nope"]
+
+    @dace.program
+    def enumerate_parsing(
+        A,
+        tracers: dace.compiletime,  # Dict[str, np.float64]
+    ):
+        for i, q in enumerate(tracer_variables[0:2]):
+            tracers[q][:] = A
+
+    a = np.ones([3])
+    q = {
+        "vapor": np.zeros([3]),
+        "rain": np.zeros([3]),
+        "nope": np.zeros([3]),
+    }
+    enumerate_parsing(a, q)
+    assert np.allclose(q["vapor"], np.array([1, 1, 1]))
+    assert np.allclose(q["rain"], np.array([1, 1, 1]))
+    assert np.allclose(q["nope"], np.array([0, 0, 0]))
+
+
 def test_tuple_elements_zip():
     a1 = [2, 3, 4]
     a2 = (4, 5, 6)

--- a/tests/python_frontend/unroll_test.py
+++ b/tests/python_frontend/unroll_test.py
@@ -178,7 +178,30 @@ def test_list_global_enumerate():
         tracers: dace.compiletime,  # Dict[str, np.float64]
     ):
         for i, q in enumerate(tracer_variables[0:2]):
-            tracers[q][:] = A
+            tracers[q][:] = A  # type:ignore
+
+    a = np.ones([3])
+    q = {
+        "vapor": np.zeros([3]),
+        "rain": np.zeros([3]),
+        "nope": np.zeros([3]),
+    }
+    enumerate_parsing(a, q)
+    assert np.allclose(q["vapor"], np.array([1, 1, 1]))
+    assert np.allclose(q["rain"], np.array([1, 1, 1]))
+    assert np.allclose(q["nope"], np.array([0, 0, 0]))
+
+
+def test_tuple_global_enumerate():
+    tracer_variables = ("vapor", "rain", "nope")
+
+    @dace.program
+    def enumerate_parsing(
+        A,
+        tracers: dace.compiletime,  # Dict[str, np.float64]
+    ):
+        for i, q in enumerate(tracer_variables[0:2]):
+            tracers[q][:] = A  # type:ignore
 
     a = np.ones([3])
     q = {


### PR DESCRIPTION
Looking at: https://github.com/spcl/dace/issues/1568

The code was blindly calling down to a `_visit_potential_constant` which is written for single element rather collection of them. Unroll the list, like the `dict` is done in the `if` above.

