### PR TITLE
Correction in the docstring of the SDFG class's init method

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -461,8 +461,8 @@ class SDFG(ControlFlowRegion):
 
             :param name: Name for the SDFG (also used as the filename for
                          the compiled shared library).
-            :param symbols: Additional dictionary of symbol names -> types that the SDFG
-                            defines, apart from symbolic data sizes.
+            :param constants: Additional dictionary of compile-time constants
+                              {name (str): tuple(type (dace.data.Data), value (Any))}.
             :param propagate: If False, disables automatic propagation of
                               memlet subsets from scopes outwards. Saves
                               processing time but disallows certain


### PR DESCRIPTION
This PR corrects the `SDFG.__init__` docstring to refer to the correct parameter `constants` (compile-time constants) instead of `symbols` (scalars that are immutable in the SDFG scope). See also #1563 