### PR TITLE
Removed GCC 13 from Pace CI

### DIFF
--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -37,6 +37,7 @@ jobs:
               python-version: ${{ matrix.python-version }}
       - name: Install library dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libopenmpi-dev libboost-all-dev gcc-13
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13
           gcc --version

--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install library dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libopenmpi-dev libboost-all-dev gcc-13
+          sudo apt-get install -y libopenmpi-dev libboost-all-dev gcc-13
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13
           gcc --version
       # Because Github doesn't allow us to do a git checkout in code

--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Install library dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libopenmpi-dev libboost-all-dev gcc-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13
+          sudo apt-get install -y libopenmpi-dev libboost-all-dev
           gcc --version
       # Because Github doesn't allow us to do a git checkout in code
       # we use a trick to checkout DaCe first (not using the external submodule)    

--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, ci-fix ]
   pull_request:
     branches: [ master, ci-fix ]
+  merge_group:
+    branches: [ master, ci-fix ]
 
 defaults:
     run:


### PR DESCRIPTION
Fixes various smaller issues of the Pace CI:

- Removed installation command for non-existent `gcc-13` package
- Adds Pace CI to merge queue (see: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)
- Adds `apt-get update` before `apt-get install`
- Adds `-y` flag to `apt-get install`