### PR TITLE
`SDFG.save()` now performs tilde expansion.

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1520,6 +1520,8 @@ class SDFG(ControlFlowRegion):
             :param compress: If True, uses gzip to compress the file upon saving.
             :return: The hash of the SDFG, or None if failed/not requested.
         """
+        filename = os.path.expanduser(filename)
+
         if compress:
             fileopen = lambda file, mode: gzip.open(file, mode + 't')
         else:


### PR DESCRIPTION
I noticed that it would be cool if I could write `sdfg.save("~/tmp/faulty.sdfg")` and it would save it into my home directory, instead in a directory `./~` in some random directory.