### PR TITLE
Fixed an error regarding the `pow()` function of the DaCe runtime.

### DIFF
--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -482,7 +482,7 @@ namespace dace
         template<typename T, typename E>
         DACE_CONSTEXPR DACE_HDFI T pow(const T& a, const E& b)
         {
-            return (T)std::pow(a, (T)b);
+            return (T)std::pow(a, b);
         }
 
 #ifndef DACE_XILINX

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -479,30 +479,29 @@ namespace dace
             return (T)std::pow(a, b);
         }
 
+        template<typename T, typename E>
+        DACE_CONSTEXPR DACE_HDFI T pow(const T& a, const E& b)
+        {
+            return (T)std::pow(a, (T)b);
+        }
+
 #ifndef DACE_XILINX
         static DACE_CONSTEXPR DACE_HDFI int pow(const int& a, const int& b)
         {
-/*#ifndef __CUDA_ARCH__
-            return std::pow(a, b);
-#else*/
             if (b < 0) return 0;
             int result = 1;
             for (int i = 0; i < b; ++i)
                 result *= a;
             return result;
-//#endif
         }
+
         static DACE_CONSTEXPR DACE_HDFI unsigned int pow(const unsigned int& a,
                                        const unsigned int& b)
         {
-/*#ifndef __CUDA_ARCH__
-            return std::pow(a, b);
-#else*/
             unsigned int result = 1;
             for (unsigned int i = 0; i < b; ++i)
                 result *= a;
             return result;
-//#endif
         }
 #endif
 


### PR DESCRIPTION
Currently there was an inplementation for `T pow(T, T)`, where `T` is a template and two for the case where `T` is a signed or unsigned integer. This is a problem if we consider the call `pow(double, long long)` because the call is ambigious and results in a compiler error. As a solution I added the function `T pow(T, E)`, where both `T` and `E` are templates.
