### PR TITLE
Changed Xilinx C++11 flag to C++14

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -540,7 +540,7 @@ required:
                         type: str
                         title: Synthesis arguments
                         description: High-level synthesis C++ flags
-                        default: "-std=c++11"
+                        default: "-std=c++14"
 
                     build_flags:
                         type: str


### PR DESCRIPTION
Our documentation already states that DaCe requires a C++14 capable compiler: https://spcldace.readthedocs.io/en/latest/setup/installation.html#dependencies

Additionally, Xilinx Vitis HLS does support C++14. It just wasn't enabled (instead, C++11 support was enabled).