### PR TITLE
Fix constant propagation failing due to invalid topological sort

### DIFF
--- a/dace/sdfg/analysis/cfg.py
+++ b/dace/sdfg/analysis/cfg.py
@@ -298,6 +298,7 @@ def stateorder_topological_sort(sdfg: SDFG) -> Iterator[SDFGState]:
     # Annotate branches
     branch_merges: Dict[SDFGState, SDFGState] = {}
     adf = acyclic_dominance_frontier(sdfg)
+    ipostdom = sdutil.postdominators(sdfg)
     for state in sdfg.nodes():
         oedges = sdfg.out_edges(state)
         # Skip if not branch
@@ -316,5 +317,7 @@ def stateorder_topological_sort(sdfg: SDFG) -> Iterator[SDFGState]:
             common_frontier |= frontier
         if len(common_frontier) == 1:
             branch_merges[state] = next(iter(common_frontier))
+        elif len(common_frontier) > 1 and ipostdom[state] in common_frontier:
+            branch_merges[state] = ipostdom[state]
 
     yield from _stateorder_topological_sort(sdfg, sdfg.start_state, ptree, branch_merges, loopexits=loopexits)

--- a/dace/sdfg/analysis/cfg.py
+++ b/dace/sdfg/analysis/cfg.py
@@ -262,7 +262,7 @@ def _stateorder_topological_sort(sdfg: SDFG,
                 # Otherwise (e.g., with return/break statements), traverse through each branch,
                 # stopping at the end of the current tree level.
                 mergestate = next(e.dst for e in sdfg.out_edges(stop) if ptree[e.dst] != stop)
-            except StopIteration:
+            except (StopIteration, KeyError):
                 # If that fails, simply traverse branches in arbitrary order
                 mergestate = stop
 

--- a/dace/transformation/passes/constant_propagation.py
+++ b/dace/transformation/passes/constant_propagation.py
@@ -3,6 +3,7 @@
 import ast
 from dataclasses import dataclass
 from dace.frontend.python import astutils
+from dace.sdfg.analysis import cfg
 from dace.sdfg.sdfg import InterstateEdge
 from dace.sdfg import nodes, utils as sdutil
 from dace.transformation import pass_pipeline as ppl
@@ -192,7 +193,7 @@ class ConstantPropagation(ppl.Pass):
             result[start_state].update(initial_symbols)
 
         # Traverse SDFG topologically
-        for state in optional_progressbar(sdfg.topological_sort(start_state), 'Collecting constants',
+        for state in optional_progressbar(cfg.stateorder_topological_sort(sdfg), 'Collecting constants',
                                           sdfg.number_of_nodes(), self.progress):
             # NOTE: We must always check the start-state regardless if there are initial symbols. This is necessary
             # when the start-state is a scope's guard instead of a special initialization state, i.e., when the start-

--- a/dace/transformation/passes/prune_symbols.py
+++ b/dace/transformation/passes/prune_symbols.py
@@ -13,7 +13,7 @@ from dace.transformation import pass_pipeline as ppl
 @properties.make_properties
 class RemoveUnusedSymbols(ppl.Pass):
     """
-    Prunes unused symbols from the SDFG symbol repository (``sdfg.symbols``).
+    Prunes unused symbols from the SDFG symbol repository (``sdfg.symbols``) and interstate edges.
     Also includes uses in Tasklets of all languages.
     """
 
@@ -30,7 +30,7 @@ class RemoveUnusedSymbols(ppl.Pass):
 
     def apply_pass(self, sdfg: SDFG, _) -> Optional[Set[Tuple[int, str]]]:
         """
-        Propagates constants throughout the SDFG.
+        Removes unused symbols from the SDFG.
         
         :param sdfg: The SDFG to modify.
         :param pipeline_results: If in the context of a ``Pipeline``, a dictionary that is populated with prior Pass
@@ -41,13 +41,19 @@ class RemoveUnusedSymbols(ppl.Pass):
         """
         result: Set[str] = set()
 
-        symbols_to_consider = self.symbols or set(sdfg.symbols.keys())
+        repository_symbols_to_consider = self.symbols or set(sdfg.symbols.keys())
 
         # Compute used symbols
         used_symbols = self.used_symbols(sdfg)
 
-        # Remove unused symbols
-        for sym in symbols_to_consider - used_symbols:
+        # Remove unused symbols from interstate edge assignments.
+        for isedge in sdfg.all_interstate_edges():
+            edge_symbols_to_consider = set(isedge.data.assignments.keys())
+            for sym in edge_symbols_to_consider - used_symbols:
+                del isedge.data.assignments[sym]
+
+        # Remove unused symbols from the SDFG's symbols repository.
+        for sym in repository_symbols_to_consider - used_symbols:
             if sym in sdfg.symbols:
                 sdfg.remove_symbol(sym)
                 result.add(sym)


### PR DESCRIPTION
Constant propagation fails for certain graph structures due to an issue with `dace.sdfg.graph.Graph.topological_sort`. This is related to #1560.