### PR TITLE
Rename misleading topological_sort to bfs_nodes

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -2096,7 +2096,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
         # Get all non-sequential scopes from the same level
         all_scopes = [
-            node for node in parent_scope.topological_sort(scope_entry)
+            node for node in parent_scope.bfs_nodes(scope_entry)
             if isinstance(node, nodes.EntryNode) and node.map.schedule != dtypes.ScheduleType.Sequential
         ]
 

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -1848,7 +1848,7 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
         parent_scope = dfg.scope_subgraph(parent_scope_entry)
 
         # Get all scopes from the same level
-        all_scopes = [node for node in parent_scope.topological_sort() if isinstance(node, dace.sdfg.nodes.EntryNode)]
+        all_scopes = [node for node in parent_scope.bfs_nodes() if isinstance(node, dace.sdfg.nodes.EntryNode)]
 
         return all_scopes[all_scopes.index(scope_entry) + 1:]
 

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -476,7 +476,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
             cft = cflow.structured_control_flow_tree(sdfg, dispatch_state)
         else:
             # If disabled, generate entire graph as general control flow block
-            states_topological = list(sdfg.topological_sort(sdfg.start_state))
+            states_topological = list(sdfg.bfs_nodes(sdfg.start_state))
             last = states_topological[-1]
             cft = cflow.GeneralBlock(dispatch_state, None,
                                      [cflow.SingleState(dispatch_state, s, s is last) for s in states_topological], [],
@@ -553,7 +553,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
             array_names = sdfg.arrays.keys(
             )  #set(k for k, v in sdfg.arrays.items() if v.lifetime == dtypes.AllocationLifetime.Scope)
             # Iterate topologically to get state-order
-            for state in sdfg.topological_sort():
+            for state in sdfg.bfs_nodes():
                 for node in state.data_nodes():
                     if node.data not in array_names:
                         continue

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -364,7 +364,7 @@ class Graph(Generic[NodeT, EdgeT]):
         """Returns nodes with no outgoing edges."""
         return [n for n in self.nodes() if self.out_degree(n) == 0]
 
-    def topological_sort(self, source: NodeT = None) -> Sequence[NodeT]:
+    def bfs_nodes(self, source: NodeT = None) -> Sequence[NodeT]:
         """Returns nodes in topological order iff the graph contains exactly
         one node with no incoming edges."""
         if source is not None:

--- a/dace/sdfg/graph.py
+++ b/dace/sdfg/graph.py
@@ -6,7 +6,7 @@ import itertools
 import networkx as nx
 from dace.dtypes import deduplicate
 import dace.serialize
-from typing import Any, Callable, Generic, Iterable, List, Sequence, TypeVar, Union
+from typing import Any, Callable, Generic, Iterable, List, Optional, Sequence, TypeVar, Union
 
 
 class NodeNotFoundError(Exception):
@@ -364,19 +364,19 @@ class Graph(Generic[NodeT, EdgeT]):
         """Returns nodes with no outgoing edges."""
         return [n for n in self.nodes() if self.out_degree(n) == 0]
 
-    def bfs_nodes(self, source: NodeT = None) -> Sequence[NodeT]:
-        """Returns nodes in topological order iff the graph contains exactly
-        one node with no incoming edges."""
+    def bfs_nodes(self, source: Optional[NodeT] = None) -> Iterable[NodeT]:
+        """Returns an iterable over nodes traversed in breadth-first search
+        order starting from ``source``."""
         if source is not None:
             sources = [source]
         else:
             sources = self.source_nodes()
-            if len(sources) == 0:
-                sources = [self.nodes()[0]]
-                #raise RuntimeError("No source nodes found")
-            if len(sources) > 1:
-                sources = [self.nodes()[0]]
-                #raise RuntimeError("Multiple source nodes found")
+            if len(sources) != 1:
+                source = next(iter(self.nodes()), None)
+                if source is None:
+                    return [] # graph has no nodes
+                sources = [source]
+
         seen = OrderedDict()  # No OrderedSet in Python
         queue = deque(sources)
         while len(queue) > 0:

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -2563,7 +2563,7 @@ class ControlFlowRegion(OrderedDiGraph[ControlFlowBlock, 'dace.sdfg.InterstateEd
         used_before_assignment = set() if used_before_assignment is None else used_before_assignment
 
         try:
-            ordered_blocks = self.topological_sort(self.start_block)
+            ordered_blocks = self.bfs_nodes(self.start_block)
         except ValueError:  # Failsafe (e.g., for invalid or empty SDFGs)
             ordered_blocks = self.nodes()
 


### PR DESCRIPTION
This is currently work in progress to see how we can best fix this misleading naming.

Fixes https://github.com/spcl/dace/issues/1560

Since https://github.com/spcl/dace/issues/1560 is still in flux, we have to make sure the PR stays in sync with what we are discussing in https://github.com/spcl/dace/issues/1560.

Additionally, at the call-sites of the _previous topological_sort_ (before renaming), there are various comments to use a topoligical sort. After the renaming, they become misleading, so we should probably fix/improve those comments.