### PR TITLE
Python frontend dealias integration

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: Tal
   - family-names: de Fine Licht
     given-names: Johannes
-  - family-names: Nikolaos Ziogas
-    given-names: Alexandros
+  - family-names: Ziogas
+    given-names: Alexandros Nikolaos
   - family-names: Schneider
     given-names: Timo
   - family-names: Hoefler

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -78,7 +78,7 @@ def dealias_sdfg(sdfg: SDFG):
                     previous_syms |= child_arr.used_symbols(all_symbols=True)
                 new_syms = parent_arr.used_symbols(all_symbols=True) - previous_syms
                 for sym in new_syms:
-                    if sym not in parent_node.symbol_mapping:
+                    if str(sym) not in nsdfg.symbols:
                         nsdfg.add_symbol(str(sym), parent_sdfg.symbols[str(sym)])
                         parent_node.symbol_mapping[str(sym)] = str(sym)
                 
@@ -126,14 +126,14 @@ def dealias_sdfg(sdfg: SDFG):
                         if new_src_memlet is not None:
                             new_syms = new_src_memlet.used_symbols(all_symbols=True) - previous_syms
                             for sym in new_syms:
-                                if sym not in parent_node.symbol_mapping:
+                                if sym not in nsdfg.symbols:
                                     nsdfg.add_symbol(str(sym), dace.int32)
                                     parent_node.symbol_mapping[sym] = sym
                             e.data.src_subset = new_src_memlet.subset
                         if new_dst_memlet is not None:
                             new_syms = new_dst_memlet.used_symbols(all_symbols=True) - previous_syms
                             for sym in new_syms:
-                                if sym not in parent_node.symbol_mapping:
+                                if sym not in nsdfg.symbols:
                                     nsdfg.add_symbol(str(sym), dace.int32)
                                     parent_node.symbol_mapping[sym] = sym
                             e.data.dst_subset = new_dst_memlet.subset

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -180,6 +180,17 @@ def dealias_sdfg(sdfg: SDFG):
                     e._src_conn = replacements[e.src_conn]
                 elif e.dst_conn in replacements:
                     e._dst_conn = replacements[e.dst_conn]
+            
+            # Remove multiple edges to the same connectors
+            for name in replacements.values():
+                in_edges = list(parent_state.in_edges_by_connector(parent_node, name))
+                out_edges = list(parent_state.out_edges_by_connector(parent_node, name))
+                if len(in_edges) > 1:
+                    for edge in in_edges[1:]:
+                        parent_state.remove_memlet_path(edge)
+                if len(out_edges) > 1:
+                    for edge in out_edges[1:]:
+                        parent_state.remove_memlet_path(edge)
 
 
 def normalize_memlet(sdfg: SDFG, state: SDFGState, original: gr.MultiConnectorEdge[Memlet], data: str) -> Memlet:

--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -46,6 +46,9 @@ def dealias_sdfg(sdfg: SDFG):
         parent_state = nsdfg.parent
         parent_node = nsdfg.parent_nsdfg_node
 
+        # TODO: Without this, tests/python_frontend/conditional_test.py:test_call_while fails
+        parent_sdfg = parent_sdfg or parent_state.parent
+
         inner_replacements: Dict[str, str] = {}
 
         # Rename nested arrays that happen to have the same name with an unrelated parent array.

--- a/dace/sdfg/analysis/writeset_underapproximation.py
+++ b/dace/sdfg/analysis/writeset_underapproximation.py
@@ -650,6 +650,8 @@ def _filter_undefined_symbols(border_memlet: Memlet,
             for rng in subset:
                 fall_back = False
                 for item in rng:
+                    if not symbolic.issymbolic(item):
+                        continue
                     if any(str(s) not in outer_symbols for s in item.free_symbols):
                         fall_back = True
                         break

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -978,7 +978,7 @@ def propagate_memlets_nested_sdfg(parent_sdfg, parent_state, nsdfg_node):
     # the corresponding memlets and use them to calculate the memlet volume and
     # subset corresponding to the outside memlet attached to that connector.
     # This is passed out via `border_memlets` and propagated along from there.
-    for state in sdfg.nodes():
+    for state in sdfg.states():
         for node in state.data_nodes():
             for direction in border_memlets:
                 if (node.label not in border_memlets[direction]):

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1158,7 +1158,7 @@ def propagate_memlets_sdfg(sdfg):
     # Reset previous annotations first
     reset_state_annotations(sdfg)
 
-    for state in sdfg.nodes():
+    for state in sdfg.states():
         propagate_memlets_state(sdfg, state)
 
     propagate_states(sdfg)

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -196,3 +196,6 @@ def replace_datadesc_names(sdfg, repl: Dict[str, str]):
                 for edge in block.edges():
                     if edge.data.data in repl:
                         edge.data.data = repl[edge.data.data]
+        
+        # Replace in properties
+        replace_properties_dict(cf, repl)

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -217,7 +217,8 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
 
             # Because of how the code generator works Scalars can not be return values.
             #  TODO: Remove this limitation as the CompiledSDFG contains logic for that.
-            if isinstance(desc, dt.Scalar) and name.startswith("__return") and not desc.transient:
+            if (sdfg.parent_sdfg is None and isinstance(desc, dt.Scalar) and name.startswith("__return") and
+                    not desc.transient):
                 raise InvalidSDFGError(f'Can not use scalar "{name}" as return value.', sdfg, None)
 
             # Validate array names

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -770,16 +770,16 @@ def _get_internal_subset(internal_memlet: Memlet,
                          external_memlet: Memlet,
                          use_src_subset: bool = False,
                          use_dst_subset: bool = False) -> subsets.Subset:
-    if (internal_memlet.data != external_memlet.data and internal_memlet.other_subset is not None):
-        return internal_memlet.other_subset
-    if not use_src_subset and not use_dst_subset:
-        return internal_memlet.subset
     if use_src_subset and use_dst_subset:
         raise ValueError('Source and destination subsets cannot be specified at the same time')
     if use_src_subset and internal_memlet.src_subset is not None:
         return internal_memlet.src_subset
     if use_dst_subset and internal_memlet.dst_subset is not None:
         return internal_memlet.dst_subset
+    if (internal_memlet.data != external_memlet.data and internal_memlet.other_subset is not None):
+        return internal_memlet.other_subset
+    if not use_src_subset and not use_dst_subset:
+        return internal_memlet.subset
     return internal_memlet.subset
 
 

--- a/dace/transformation/interstate/multistate_inline.py
+++ b/dace/transformation/interstate/multistate_inline.py
@@ -87,7 +87,7 @@ class InlineMultistateSDFG(transformation.SingleStateTransformation):
 
         # Must be
         # - connected to access nodes only
-        # - read full subsets
+        # - read/write subsets must start at 0
         # - not use views inside
         for edge in state.in_edges(nested_sdfg):
             if edge.data.data is None:
@@ -96,7 +96,7 @@ class InlineMultistateSDFG(transformation.SingleStateTransformation):
             if not isinstance(edge.src, nodes.AccessNode):
                 return False
 
-            if edge.data.subset != subsets.Range.from_array(sdfg.arrays[edge.data.data]):
+            if edge.data.subset.min_element() != [0] * len(edge.data.subset):
                 return False
 
             outer_desc = sdfg.arrays[edge.data.data]
@@ -114,7 +114,7 @@ class InlineMultistateSDFG(transformation.SingleStateTransformation):
             if not isinstance(edge.dst, nodes.AccessNode):
                 return False
 
-            if edge.data.subset != subsets.Range.from_array(sdfg.arrays[edge.data.data]):
+            if edge.data.subset.min_element() != [0] * len(edge.data.subset):
                 return False
 
             outer_desc = sdfg.arrays[edge.data.data]

--- a/tests/memlet_propagation_decreasing_test.py
+++ b/tests/memlet_propagation_decreasing_test.py
@@ -10,10 +10,10 @@ def test_decreasing_propagation():
     ref = q.copy()
 
     @dace.program
-    def copy_nw_corner(q: dace.float64[19, 19]):
+    def copy_nw_corner(q: dace.float64[19, 19], r: dace.float64[19, 19]):
         for j in dace.map[15:19]:
             for i in dace.map[0:3]:
-                q[i, j] = q[j - 12, 17 - i]
+                r[i, j] = q[j - 12, 17 - i]
 
     sdfg = copy_nw_corner.to_sdfg()
     me = None
@@ -30,8 +30,8 @@ def test_decreasing_propagation():
     subset = edges[0].data.src_subset
     assert (subset.ranges == [(3, 6, 1), (15, 17, 1)])
 
-    copy_nw_corner(q)
-    copy_nw_corner.f(ref)
+    copy_nw_corner(q, q)
+    copy_nw_corner.f(ref, ref)
     assert (np.allclose(q, ref))
 
 

--- a/tests/numpy/array_creation_test.py
+++ b/tests/numpy/array_creation_test.py
@@ -77,6 +77,7 @@ def test_zeros_like(A: dace.complex64[N, M, 2]):
     return np.zeros_like(A)
 
 
+# TODO: FIX ME
 @compare_numpy_output()
 def test_full():
     return np.full([N, N], fill_value=np.complex32(5 + 6j))

--- a/tests/python_frontend/augassign_wcr_test.py
+++ b/tests/python_frontend/augassign_wcr_test.py
@@ -61,9 +61,10 @@ def test_augassign_wcr():
         test_sdfg = augassign_wcr.to_sdfg(simplify=False)
     wcr_count = 0
     for sdfg in test_sdfg.cfg_list:
-        for state in sdfg.nodes():
+        for state in sdfg.states():
             for edge in state.edges():
-                if edge.data.wcr:
+                if edge.data.wcr and (isinstance(edge.src, dace.nodes.Tasklet) or
+                                      isinstance(edge.dst, dace.nodes.Tasklet)):
                     wcr_count += 1
     assert (wcr_count == 1)
 
@@ -82,9 +83,10 @@ def test_augassign_wcr2():
         test_sdfg = augassign_wcr2.to_sdfg(simplify=False)
     wcr_count = 0
     for sdfg in test_sdfg.cfg_list:
-        for state in sdfg.nodes():
+        for state in sdfg.states():
             for edge in state.edges():
-                if edge.data.wcr:
+                if edge.data.wcr and (isinstance(edge.src, dace.nodes.Tasklet) or
+                                      isinstance(edge.dst, dace.nodes.Tasklet)):
                     wcr_count += 1
     assert (wcr_count == 2)
 
@@ -106,9 +108,10 @@ def test_augassign_wcr3():
         test_sdfg = augassign_wcr3.to_sdfg(simplify=False)
     wcr_count = 0
     for sdfg in test_sdfg.cfg_list:
-        for state in sdfg.nodes():
+        for state in sdfg.states():
             for edge in state.edges():
-                if edge.data.wcr:
+                if edge.data.wcr and (isinstance(edge.src, dace.nodes.Tasklet) or
+                                      isinstance(edge.dst, dace.nodes.Tasklet)):
                     wcr_count += 1
     assert (wcr_count == 2)
 

--- a/tests/python_frontend/dealias_test.py
+++ b/tests/python_frontend/dealias_test.py
@@ -1,0 +1,59 @@
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+''' Tests dealising of the SDFG produced by the Python frontend. '''
+
+import dace
+import numpy as np
+
+size = 32
+
+
+@dace.program()
+def mmm_dace(X: dace.float32[size, size], Y: dace.float32[size, size], Z: dace.float32[size, size], S: dace.float32[1]):
+    T: dace.float32[size, size, size] = np.zeros((size, size, size), dtype=dace.float32)
+
+    for i in dace.map[0:size]:
+        for j in dace.map[0:size]:
+            for k in dace.map[0:size]:
+                T[i, j, k] = X[i, k] * Y[k, j]
+            Z[i, j] = np.sum(T[i, j])
+
+    @dace.map(_[0:size, 0:size])
+    def summap(i, j):
+        s >> S(1, lambda x, y: x + y)[0]
+        z << Z[i, j]
+        s = z
+
+
+def test_simplify_mmm():
+    # Input initialization
+    X = np.random.rand(size, size).astype(np.float32)
+    Y = np.random.rand(size, size).astype(np.float32)
+    Z = np.zeros((size, size), dtype=np.float32)
+    S = np.zeros((1, ), dtype=np.float32)
+
+    sdfg = mmm_dace.to_sdfg(simplify=False)
+    sdfg(X=X, Y=Y, Z=Z, S=S)
+
+    # Numerically validate the results of the non-simplified SDFG
+    assert np.allclose(Z, np.matmul(X, Y))
+    assert np.allclose(S, sum(sum(np.matmul(X, Y))))
+
+    # Simplify the SDFG
+    # NOTE: If the SDFG has not been dealised properly, simplification will violate semantics.
+    sdfg.simplify()
+
+    # Input reinitialization just in case
+    X = np.random.rand(size, size).astype(np.float32)
+    Y = np.random.rand(size, size).astype(np.float32)
+    Z = np.zeros((size, size), dtype=np.float32)
+    S = np.zeros((1, ), dtype=np.float32)
+
+    sdfg(X=X, Y=Y, Z=Z, S=S)
+
+    # Numerically validate the results of the simplified SDFG
+    assert np.allclose(Z, np.matmul(X, Y))
+    assert np.allclose(S, sum(sum(np.matmul(X, Y))))
+
+
+if __name__ == "__main__":
+    test_simplify_mmm()


### PR DESCRIPTION
The PR adds dealiasing capability to the Python front end. After parsing a DaCe program to an SDFG, the ProgramVisitor calls the ScheduleTree's  `dealias_sdfg` helper method and propagates all Memlets.