### PR TITLE
Added `PatternNode` to `dace.transformation` imports.

### DIFF
--- a/dace/transformation/__init__.py
+++ b/dace/transformation/__init__.py
@@ -1,3 +1,4 @@
-from .transformation import (PatternTransformation, SingleStateTransformation, MultiStateTransformation,
-                             SubgraphTransformation, ExpandTransformation, experimental_cfg_block_compatible)
+from .transformation import (PatternNode, PatternTransformation, SingleStateTransformation,
+                             MultiStateTransformation, SubgraphTransformation, ExpandTransformation,
+                             experimental_cfg_block_compatible, single_level_sdfg_only)
 from .pass_pipeline import Pass, Pipeline, FixedPointPipeline


### PR DESCRIPTION
It was very inconvenient, as `PatternTransformation` can be imported from `dace.transformation` but the node has to be imported from `dace.transformation.transformation`.