### PR TITLE
Improving the Usage of `#pragma unroll`

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -372,7 +372,7 @@ class CPUCodeGen(TargetCodeGenerator):
         # Check if array is already allocated
         if self._dispatcher.defined_vars.has(name):
             return
-        
+
         if len(tokens) > 1:
             for i in range(len(tokens) - 1):
                 tmp_name = '.'.join(tokens[:i + 1])
@@ -1119,7 +1119,7 @@ class CPUCodeGen(TargetCodeGenerator):
         """
         Write source to destination, where the source is a scalar, and the
         destination is a pointer.
-        
+
         :return: String of C++ performing the write.
         """
         codegen = codegen or self
@@ -1928,7 +1928,10 @@ class CPUCodeGen(TargetCodeGenerator):
                 begin, end, skip = r
 
                 if node.map.unroll:
-                    result.write("#pragma unroll", cfg, state_id, node)
+                    unroll_pragma = "#pragma unroll"
+                    if node.map.unroll_factor:
+                        unroll_pragma += f" {node.map.unroll_factor}"
+                    result.write(unroll_pragma, cfg, state_id, node)
 
                 result.write(
                     "for (auto %s = %s; %s < %s; %s += %s) {\n" %

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -302,7 +302,7 @@ def is_vendor_supported(fpga_vendor: str) -> bool:
     Returns wheter the given vendor is supported or not, by looking
     among the registered FPGA code-generators.
 
-    :param fpga_vendor: the fpga vendor 
+    :param fpga_vendor: the fpga vendor
     """
 
     registered_codegens = dace.codegen.targets.target.TargetCodeGenerator._registry_
@@ -416,8 +416,8 @@ class FPGACodeGen(TargetCodeGenerator):
         '''
         Finds a tasklet with SystemVerilog as its language, within the given subgraph, if it contains one.
 
-        :param subgraph: The subgraph to check. 
-        :return: The tasklet node if one exists, None otherwise. 
+        :param subgraph: The subgraph to check.
+        :return: The tasklet node if one exists, None otherwise.
         '''
         for n in subgraph.nodes():
             if isinstance(n, dace.nodes.NestedSDFG):

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -258,7 +258,7 @@ class AccessNode(Node):
     @property
     def label(self):
         return self.data
-    
+
     @property
     def root_data(self):
         return self.data.split('.')[0]
@@ -270,7 +270,7 @@ class AccessNode(Node):
         if isinstance(sdfg, (dace.sdfg.SDFGState, dace.sdfg.ScopeSubgraphView)):
             sdfg = sdfg.parent
         return sdfg.arrays[self.data]
-    
+
     def root_desc(self, sdfg):
         from dace.sdfg import SDFGState, ScopeSubgraphView
         if isinstance(sdfg, (SDFGState, ScopeSubgraphView)):
@@ -723,7 +723,7 @@ class ExitNode(Node):
 @dace.serialize.serializable
 class MapEntry(EntryNode):
     """ Node that opens a Map scope.
-        
+
         :see: Map
     """
 
@@ -800,7 +800,7 @@ class MapEntry(EntryNode):
 @dace.serialize.serializable
 class MapExit(ExitNode):
     """ Node that closes a Map scope.
-        
+
         :see: Map
     """
 
@@ -871,6 +871,10 @@ class Map(object):
     range = RangeProperty(desc="Ranges of map parameters", default=sbs.Range([]))
     schedule = EnumProperty(dtype=dtypes.ScheduleType, desc="Map schedule", default=dtypes.ScheduleType.Default)
     unroll = Property(dtype=bool, desc="Map unrolling")
+    unroll_factor = Property(dtype=int, allow_none=True, default=None,
+                             getter=lambda self: self._unroll_factor if self.unroll else None,
+                             desc="How much iterations should be unrolled."
+                             " To prevent unrolling, set this value to 1.")
     collapse = Property(dtype=int, default=1, desc="How many dimensions to collapse into the parallel range")
     debuginfo = DebugInfoProperty()
     is_collapsed = Property(dtype=bool, desc="Show this node/scope/state as collapsed", default=False)
@@ -960,7 +964,7 @@ MapEntry = indirect_properties(Map, lambda obj: obj.map)(MapEntry)
 @dace.serialize.serializable
 class ConsumeEntry(EntryNode):
     """ Node that opens a Consume scope.
-        
+
         :see: Consume
     """
 
@@ -1041,7 +1045,7 @@ class ConsumeEntry(EntryNode):
 @dace.serialize.serializable
 class ConsumeExit(ExitNode):
     """ Node that closes a Consume scope.
-        
+
         :see: Consume
     """
 

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -871,8 +871,7 @@ class Map(object):
     range = RangeProperty(desc="Ranges of map parameters", default=sbs.Range([]))
     schedule = EnumProperty(dtype=dtypes.ScheduleType, desc="Map schedule", default=dtypes.ScheduleType.Default)
     unroll = Property(dtype=bool, desc="Map unrolling")
-    unroll_factor = Property(dtype=int, allow_none=True, default=None,
-                             getter=lambda self: self._unroll_factor if self.unroll else None,
+    unroll_factor = Property(dtype=int, allow_none=True, default=0,
                              desc="How much iterations should be unrolled."
                              " To prevent unrolling, set this value to 1.")
     collapse = Property(dtype=int, default=1, desc="How many dimensions to collapse into the parallel range")


### PR DESCRIPTION
Before it was only possible to specify if a Map should be unrolled or not, i.e. if `#pragma unroll` should be added or not.
However. the pragma accepts an argument, the most interesting use case for this is to _prevent_ unrolling, i.e. adding `#pragma unroll 1`.

I solved this by adding a new property `unroll_factor` to the map that takes an integer, i.e. the argument.
I am open for other suggestions to solve this problem.
As a wrote the most interesting use case (and in fact our motivation for this fix) is the ability to prevent unrolling explicitly.