### PR TITLE
Made `TransientReuse` Less Verbose

### DIFF
--- a/dace/transformation/passes/transient_reuse.py
+++ b/dace/transformation/passes/transient_reuse.py
@@ -19,6 +19,12 @@ class TransientReuse(ppl.Pass):
 
     CATEGORY: str = 'Memory Footprint Reduction'
 
+    verbose = properties.Property(
+            dtype=bool,
+            default=False,
+            desc="Print information about the memory reduction.",
+    )
+
     def modifies(self) -> ppl.Modifies:
         return ppl.Modifies.Descriptors | ppl.Modifies.AccessNodes
 
@@ -154,11 +160,12 @@ class TransientReuse(ppl.Pass):
                                     edge.data.data = new
 
         # Analyze memory savings and output them
-        memory_after = 0
-        for a in sdfg.arrays:
-            memory_after += sdfg.arrays[a].total_size * sdfg.arrays[a].dtype.bytes
+        if self.verbose:
+            memory_after = 0
+            for a in sdfg.arrays:
+                memory_after += sdfg.arrays[a].total_size * sdfg.arrays[a].dtype.bytes
+            print('memory before: ', memory_before, 'B')
+            print('memory after: ', memory_after, 'B')
+            print('memory savings: ', memory_before - memory_after, 'B')
 
-        print('memory before: ', memory_before, 'B')
-        print('memory after: ', memory_after, 'B')
-        print('memory savings: ', memory_before - memory_after, 'B')
         return result or None


### PR DESCRIPTION
Added a flag to the `TransientReuse` transformation that prevents the transformation from unconditional printing of memory savings.
This commit changes the default behaviour, because now the report is not printed, but must be explicitly activated.