### PR TITLE
framecode: Fix missing BasicCFBlock argument

### DIFF
--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -492,7 +492,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
             states_topological = list(sdfg.bfs_nodes(sdfg.start_state))
             last = states_topological[-1]
             cft = cflow.GeneralBlock(dispatch_state, None,
-                                    [cflow.BasicCFBlock(dispatch_state, sdfg, s, s is last) for s in states_topological],
+                                    [cflow.BasicCFBlock(dispatch_state, None, s is last, s) for s in states_topological],
                                     [], [], [], [], False)
 
         callsite_stream.write(cft.as_cpp(self, sdfg.symbols), sdfg)

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -492,7 +492,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
             states_topological = list(sdfg.bfs_nodes(sdfg.start_state))
             last = states_topological[-1]
             cft = cflow.GeneralBlock(dispatch_state, None,
-                                    [cflow.BasicCFBlock(dispatch_state, s, s is last) for s in states_topological],
+                                    [cflow.BasicCFBlock(dispatch_state, sdfg, s, s is last) for s in states_topological],
                                     [], [], [], [], False)
 
         callsite_stream.write(cft.as_cpp(self, sdfg.symbols), sdfg)


### PR DESCRIPTION
Updated for v0.16: The (renamed) `BasicCFBlock` class still requires 4 arguments in a different order and with none being optional. The new `__init__` method as provided by `@dataclass` looks like this:

```python
def __init__(self,
    dispatch_state: Callable[[SDFGState], str],  # from ControlFlow
    parent: Optional['ControlFlow'],  # from ControlFlow
    last_block: bool,  # from ControlFlow
    state: SDFGState,
)
```

The current code still supplies 3 arguments and in a wrong order. This PR fixes that.

Original PR description (when I was still running on DaCe v0.15.1) follows.

---

With `optimizer.detect_control_flow == False`, this part of code causes an error later on:

```text
  File "/home/ibug/examples/dace/dace/codegen/control_flow.py", line 221, in as_cpp
    expr += elem.as_cpp(codegen, symbols)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ibug/examples/dace/dace/codegen/control_flow.py", line 128, in as_cpp
    sdfg = self.state.parent
           ^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'parent'
```

I identified this as `cflow.SingleState` requiring 4 arguments to its `__init__` method with the last one being optional, i.e.:

```python
def __init__(self,
    dispatch_state: Callable[[SDFGState], str],  # from ControlFlow
    parent: Optional['ControlFlow'],  # from ControlFlow
    state: SDFGState,
    last_state: bool = False,
)
```

The current code incorrectly feeds 3 and did not trigger a `TypeError` due to the last one having a default value.

This PR adds back the missing `parent` argument, although I'm not sure if the `sdfg` object is correct. Local testing shows that `None` suffices, though.