### PR TITLE
Changed more `==` to `equal_valued`

### DIFF
--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -395,7 +395,7 @@ class ExpandGemmGPUBLAS(ExpandTransformation):
             nstate.add_edge(tasklet, '_conn_c', gc, None, dace.Memlet.from_array('_c_gpu', cdesc))
             nstate.add_nedge(gc, c, dace.Memlet.from_array('_c', cdesc))
 
-            if node.beta != 0.0:
+            if not equal_valued(0, node.beta):
                 rc = nstate.add_read('_c')
                 rgc = nstate.add_access('_c_gpu')
                 tasklet.add_in_connector('_conn_cin')
@@ -461,7 +461,7 @@ class ExpandGemmPBLAS(ExpandTransformation):
         (_, adesc, ashape, astrides), (_, bdesc, bshape, bstrides), _ = _get_matmul_operands(node, state, sdfg)
         dtype = adesc.dtype.base_type
 
-        if node.beta != 0:
+        if not equal_valued(0, node.beta):
             raise NotImplementedError
 
         M = ashape[0]
@@ -588,7 +588,7 @@ class ExpandGemmFPGA1DSystolic(ExpandTransformation):
         new_sdfg.add_array("_b", shape_b, dtype_b, strides=strides_b, storage=outer_array_b.storage)
         new_sdfg.add_array("_c", shape_c, dtype_c, strides=strides_c, storage=outer_array_c.storage)
 
-        if node.beta != 0:
+        if not equal_valued(0, node.beta):
             new_sdfg.add_array("_cin", shape_c, dtype_c, strides=strides_c, storage=outer_array_c.storage)
 
         def make_read_A(state):
@@ -672,7 +672,7 @@ to_kernel = data""")
             # Receives the results and adds it to C
 
             pipe = state.add_read("C_pipe")
-            if node.beta != 0:
+            if not equal_valued(0, node.beta):
                 mem_read = state.add_read("_cin")
             mem = state.add_write("_c")
 
@@ -688,15 +688,15 @@ to_kernel = data""")
 
             # deal with out-of-bound accesses
 
-            mul_accumulated = f"{node.alpha} * from_kernel" if node.alpha != 1.0 else "from_kernel"
-            if node.beta != 0:
-                if node.beta != 1.0:
+            mul_accumulated = f"{node.alpha} * from_kernel" if not equal_valued(1, node.alpha) else "from_kernel"
+            if not equal_valued(0, node.beta):
+                if not equal_valued(1, node.beta):
                     add_prev_c = f" + {node.beta} * prev_c"
                 else:
                     add_prev_c = " + prev_c"
             else:
                 add_prev_c = ""
-            tasklet_inputs = {"from_kernel", "prev_c"} if node.beta != 0 else {"from_kernel"}
+            tasklet_inputs = {"from_kernel", "prev_c"} if not equal_valued(0, node.beta) else {"from_kernel"}
             tasklet = state.add_tasklet(
                 "write_C", tasklet_inputs, {"to_memory"}, f"""\
 if tm * {T} + m  < {M}  and  n0 * {P} + n1 < {N} :                                               
@@ -707,7 +707,7 @@ if tm * {T} + m  < {M}  and  n0 * {P} + n1 < {N} :
                                   tasklet,
                                   dst_conn="from_kernel",
                                   memlet=dace.Memlet(f"C_pipe[{P}-1]"))
-            if node.beta != 0:
+            if not equal_valued(0, node.beta):
                 state.add_memlet_path(mem_read,
                                       entry_map,
                                       tasklet,
@@ -998,7 +998,7 @@ class Gemm(dace.sdfg.nodes.LibraryNode):
     def __init__(self, name, location=None, transA=False, transB=False, alpha=1, beta=0, cin=True):
         super().__init__(name,
                          location=location,
-                         inputs=({"_a", "_b", "_cin"} if beta != 0 and cin else {"_a", "_b"}),
+                         inputs=({"_a", "_b", "_cin"} if not equal_valued(0, beta) and cin else {"_a", "_b"}),
                          outputs={"_c"})
         self.transA = True if transA else False
         self.transB = True if transB else False
@@ -1091,7 +1091,7 @@ def gemm_libnode(pv: 'ProgramVisitor',
     state.add_edge(B_in, None, libnode, '_b', mm.Memlet(B))
     state.add_edge(libnode, '_c', C_out, None, mm.Memlet(C))
 
-    if beta != 0:
+    if not equal_valued(0, beta):
         C_in = state.add_read(C)
         state.add_edge(C_in, None, libnode, '_cin', mm.Memlet(C))
 

--- a/tests/numpy/einsum_test.py
+++ b/tests/numpy/einsum_test.py
@@ -296,7 +296,7 @@ def test_lift_einsum_alpha_beta(symbolic):
         if isinstance(node, Einsum):
             assert node.einsum_str == 'ij,jk->ik'
             assert node.alpha == alph
-            assert node.beta == 1.0
+            assert symbolic.equal_valued(1, node.beta)
 
     if not symbolic:
         C = 1 + 2 * A @ B

--- a/tests/numpy/einsum_test.py
+++ b/tests/numpy/einsum_test.py
@@ -268,12 +268,12 @@ def test_lift_einsum_beta():
     assert np.allclose(sdfg(A, B), C)
 
 
-@pytest.mark.parametrize('symbolic', (False, True))
-def test_lift_einsum_alpha_beta(symbolic):
+@pytest.mark.parametrize('symbolic_alpha', (False, True))
+def test_lift_einsum_alpha_beta(symbolic_alpha):
     from dace.libraries.blas.nodes.einsum import Einsum
     from dace.transformation.dataflow import LiftEinsum
 
-    alph = dace.symbol('alph') if symbolic else 2
+    alph = dace.symbol('alph') if symbolic_alpha else 2
 
     @dace.program
     def tester(A, B):
@@ -298,7 +298,7 @@ def test_lift_einsum_alpha_beta(symbolic):
             assert node.alpha == alph
             assert symbolic.equal_valued(1, node.beta)
 
-    if not symbolic:
+    if not symbolic_alpha:
         C = 1 + 2 * A @ B
         assert np.allclose(sdfg(A, B), C)
 


### PR DESCRIPTION
Follow up to #1620.

Replaced more `==` with `equal_valued`, since SymPy 1.13 changed the semantics of `==` for their symbolic expressions.