### PR TITLE
Specified behaviour of `Subset.covers()` for different dimensionality

### DIFF
--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -28,7 +28,10 @@ def bounding_box_cover_exact(subset_a, subset_b) -> bool:
 
     # Covering only make sense if the two subsets have the same number of dimensions.
     if len(min_elements_a) != len(min_elements_b):
-        return False
+        return ValueError(
+                f"A bounding box of dimensionality {len(min_elements_a)} can not"
+                f" cover a bounding box of dimensionality {len(min_elements_b)}."
+        )
 
     return all([(symbolic.simplify_ext(nng(rb)) <= symbolic.simplify_ext(nng(orb))) == True
                 and (symbolic.simplify_ext(nng(re)) >= symbolic.simplify_ext(nng(ore))) == True
@@ -43,7 +46,10 @@ def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> 
 
     # Covering only make sense if the two subsets have the same number of dimensions.
     if len(min_elements_a) != len(min_elements_b):
-        return False
+        return ValueError(
+                f"A bounding box of dimensionality {len(min_elements_a)} can not"
+                f" cover a bounding box of dimensionality {len(min_elements_b)}."
+        )
 
     for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
                                 min_elements_b, max_elements_b):
@@ -73,7 +79,9 @@ class Subset(object):
 
         # Subsets of different dimensionality can never cover each other.
         if self.dims() != other.dims():
-            return False
+            return ValueError(
+                    f"A subset of dimensionality {self.dim()} can not cover a subset of dimensionality {other.dims()}"
+            )
 
         if not Config.get('optimizer', 'symbolic_positive'):
             try:
@@ -97,7 +105,9 @@ class Subset(object):
 
         # Subsets of different dimensionality can never cover each other.
         if self.dims() != other.dims():
-            return False
+            return ValueError(
+                    f"A subset of dimensionality {self.dim()} can not cover a subset of dimensionality {other.dims()}"
+            )
 
         # If self does not cover other with a bounding box union, return false.
         symbolic_positive = Config.get('optimizer', 'symbolic_positive')

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -33,7 +33,7 @@ def bounding_box_cover_exact(subset_a, subset_b) -> bool:
     return all([(symbolic.simplify_ext(nng(rb)) <= symbolic.simplify_ext(nng(orb))) == True
                 and (symbolic.simplify_ext(nng(re)) >= symbolic.simplify_ext(nng(ore))) == True
                 for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
-                                            min_elements_b(), max_elements_b)])
+                                            min_elements_b, max_elements_b)])
 
 def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> bool:
     min_elements_a = subset_a.min_element_approx() if approximation else subset_a.min_element()

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -29,8 +29,8 @@ def bounding_box_cover_exact(subset_a, subset_b) -> bool:
     # Covering only make sense if the two subsets have the same number of dimensions.
     if len(min_elements_a) != len(min_elements_b):
         return ValueError(
-                f"A bounding box of dimensionality {len(min_elements_a)} can not"
-                f" cover a bounding box of dimensionality {len(min_elements_b)}."
+                f"A bounding box of dimensionality {len(min_elements_a)} cannot"
+                f" test covering a bounding box of dimensionality {len(min_elements_b)}."
         )
 
     return all([(symbolic.simplify_ext(nng(rb)) <= symbolic.simplify_ext(nng(orb))) == True
@@ -47,8 +47,8 @@ def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> 
     # Covering only make sense if the two subsets have the same number of dimensions.
     if len(min_elements_a) != len(min_elements_b):
         return ValueError(
-                f"A bounding box of dimensionality {len(min_elements_a)} can not"
-                f" cover a bounding box of dimensionality {len(min_elements_b)}."
+                f"A bounding box of dimensionality {len(min_elements_a)} cannot"
+                f" test covering a bounding box of dimensionality {len(min_elements_b)}."
         )
 
     for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
@@ -80,7 +80,7 @@ class Subset(object):
         # Subsets of different dimensionality can never cover each other.
         if self.dims() != other.dims():
             return ValueError(
-                    f"A subset of dimensionality {self.dim()} can not cover a subset of dimensionality {other.dims()}"
+                    f"A subset of dimensionality {self.dim()} cannot test covering a subset of dimensionality {other.dims()}"
             )
 
         if not Config.get('optimizer', 'symbolic_positive'):
@@ -106,7 +106,7 @@ class Subset(object):
         # Subsets of different dimensionality can never cover each other.
         if self.dims() != other.dims():
             return ValueError(
-                    f"A subset of dimensionality {self.dim()} can not cover a subset of dimensionality {other.dims()}"
+                    f"A subset of dimensionality {self.dim()} cannot test covering a subset of dimensionality {other.dims()}"
             )
 
         # If self does not cover other with a bounding box union, return false.

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -21,16 +21,29 @@ def nng(expr):
         return expr
 
 def bounding_box_cover_exact(subset_a, subset_b) -> bool:
+    min_elements_a = subset_a.min_element()
+    max_elements_a = subset_a.max_element()
+    min_elements_b = subset_b.min_element()
+    max_elements_b = subset_b.max_element()
+
+    # Covering only make sense if the two subsets have the same number of dimensions.
+    if len(min_elements_a) != len(min_elements_b):
+        return False
+
     return all([(symbolic.simplify_ext(nng(rb)) <= symbolic.simplify_ext(nng(orb))) == True
                 and (symbolic.simplify_ext(nng(re)) >= symbolic.simplify_ext(nng(ore))) == True
-                for rb, re, orb, ore in zip(subset_a.min_element(), subset_a.max_element(),
-                                            subset_b.min_element(), subset_b.max_element())])
+                for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
+                                            min_elements_b(), max_elements_b)])
 
 def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> bool:
     min_elements_a = subset_a.min_element_approx() if approximation else subset_a.min_element()
     max_elements_a = subset_a.max_element_approx() if approximation else subset_a.max_element()
     min_elements_b = subset_b.min_element_approx() if approximation else subset_b.min_element()
     max_elements_b = subset_b.max_element_approx() if approximation else subset_b.max_element()
+
+    # Covering only make sense if the two subsets have the same number of dimensions.
+    if len(min_elements_a) != len(min_elements_b):
+        return False
 
     for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
                                 min_elements_b, max_elements_b):
@@ -53,12 +66,16 @@ def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> 
 
 class Subset(object):
     """ Defines a subset of a data descriptor. """
+
     def covers(self, other):
         """ Returns True if this subset covers (using a bounding box) another
             subset. """
-        symbolic_positive = Config.get('optimizer', 'symbolic_positive')
 
-        if not symbolic_positive:
+        # Subsets of different dimensionality can never cover each other.
+        if self.dims() != other.dims():
+            return False
+
+        if not Config.get('optimizer', 'symbolic_positive'):
             try:
                 return all([(symbolic.simplify_ext(nng(rb)) <= symbolic.simplify_ext(nng(orb))) == True
                             and (symbolic.simplify_ext(nng(re)) >= symbolic.simplify_ext(nng(ore))) == True
@@ -66,7 +83,6 @@ class Subset(object):
                                                         other.min_element_approx(), other.max_element_approx())])
             except TypeError:
                 return False
-
         else:
             try:
                 if not bounding_box_symbolic_positive(self, other, True):
@@ -78,6 +94,10 @@ class Subset(object):
         
     def covers_precise(self, other):
         """ Returns True if self contains all the elements in other. """
+
+        # Subsets of different dimensionality can never cover each other.
+        if self.dims() != other.dims():
+            return False
 
         # If self does not cover other with a bounding box union, return false.
         symbolic_positive = Config.get('optimizer', 'symbolic_positive')


### PR DESCRIPTION
Before all cover functions ignored the case if the subsets have different lengths. The effect was that the subsets `A = Range.from_string("i, k, 0:N, 1")` and `B = Range.from_string("i, k")` would cover each other. This case was considered undefined behaviour.

This commit changes the behaviour of these function such that for covering it is required that the subsets must have the same dimensions.