### PR TITLE
Add state replication and if raising transformations

### DIFF
--- a/dace/transformation/interstate/__init__.py
+++ b/dace/transformation/interstate/__init__.py
@@ -16,3 +16,5 @@ from .move_loop_into_map import MoveLoopIntoMap
 from .trivial_loop_elimination import TrivialLoopElimination
 from .multistate_inline import InlineMultistateSDFG
 from .move_assignment_outside_if import MoveAssignmentOutsideIf
+from .state_replication import StateReplication
+from .if_raising import IfRaising

--- a/dace/transformation/interstate/if_raising.py
+++ b/dace/transformation/interstate/if_raising.py
@@ -1,0 +1,67 @@
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+""" If raising transformation """
+
+from dace import data as dt, sdfg as sd
+from dace.sdfg import InterstateEdge
+from dace.sdfg import utils as sdutil
+from dace.sdfg.state import SDFGState
+from dace.transformation import transformation
+from dace.properties import make_properties
+
+@make_properties
+class IfRaising(transformation.MultiStateTransformation):
+    """
+    Duplicates an if guard and anticipates the evaluation of the condition
+    """
+
+    if_guard = transformation.PatternNode(sd.SDFGState)
+
+    @staticmethod
+    def annotates_memlets():
+        return False
+
+    @classmethod
+    def expressions(cls):
+        return [sdutil.node_path_graph(cls.if_guard)]
+
+    def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
+        if_guard: SDFGState = self.if_guard
+
+        out_edges = graph.out_edges(if_guard)
+
+        if len(out_edges) != 2:
+            return False
+
+        if if_guard.is_empty():
+            return False
+
+        # check that condition does not depend on computations in the state
+        condition_symbols = out_edges[0].data.condition.get_free_symbols()
+        _, wset = if_guard.read_and_write_sets()
+        if len(condition_symbols.intersection(wset)) != 0:
+            return False
+
+        return True
+
+
+    def apply(self, _, sdfg: sd.SDFG):
+        if_guard: SDFGState = self.if_guard
+
+        raised_if_guard = sdfg.add_state('raised_if_guard')
+        sdutil.change_edge_dest(sdfg, if_guard, raised_if_guard)
+
+        replica = sd.SDFGState.from_json(if_guard.to_json(), context={'sdfg': sdfg})
+        all_block_names = set([s.label for s in sdfg.nodes()])
+        replica.label = dt.find_new_name(replica.label, all_block_names)
+        sdfg.add_node(replica)
+
+        # move conditional edges up
+        if_branch, else_branch = sdfg.out_edges(if_guard)
+        sdfg.remove_edge(if_branch)
+        sdfg.remove_edge(else_branch)
+
+        sdfg.add_edge(if_guard, if_branch.dst, InterstateEdge(assignments=if_branch.data.assignments))
+        sdfg.add_edge(replica, else_branch.dst, InterstateEdge(assignments=else_branch.data.assignments))
+
+        sdfg.add_edge(raised_if_guard, if_guard, InterstateEdge(condition=if_branch.data.condition))
+        sdfg.add_edge(raised_if_guard, replica, InterstateEdge(condition=else_branch.data.condition))

--- a/dace/transformation/interstate/state_replication.py
+++ b/dace/transformation/interstate/state_replication.py
@@ -1,0 +1,78 @@
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+""" State replication transformation """
+
+from dace import data as dt, sdfg as sd
+from dace.sdfg import utils as sdutil
+from dace.sdfg.state import SDFGState
+from dace.transformation import transformation
+from copy import deepcopy
+from dace.transformation.interstate.loop_detection import DetectLoop
+from dace.properties import make_properties
+
+@make_properties
+class StateReplication(transformation.MultiStateTransformation):
+    """
+    Creates a copy of a state for each of its incoming edge. Then, redirects every edge to a different copy.
+    This results in states with only one incoming edge.
+    """
+
+    target_state = transformation.PatternNode(sd.SDFGState)
+
+    @staticmethod
+    def annotates_memlets():
+        return True
+
+    @classmethod
+    def expressions(cls):
+        return [sdutil.node_path_graph(cls.target_state)]
+
+
+    def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
+        target_state: SDFGState = self.target_state
+
+        out_edges = graph.out_edges(target_state)
+        in_edges = graph.in_edges(target_state)
+
+        if len(in_edges) < 2:
+            return False
+
+        # avoid useless replications
+        if target_state.is_empty() and len(out_edges) < 2:
+            return False
+
+        # make sure this is not a loop guard
+        if len(out_edges) == 2:
+            detect = DetectLoop()
+            detect.loop_guard = target_state
+            detect.loop_begin = out_edges[0].dst
+            detect.exit_state = out_edges[1].dst
+            if detect.can_be_applied(graph, 0, sdfg):
+                return False
+            detect.exit_state = out_edges[0].dst
+            detect.loop_begin = out_edges[1].dst
+            if detect.can_be_applied(graph, 0, sdfg):
+                return False
+        
+        return True
+    
+    def apply(self, _, sdfg: sd.SDFG):
+        target_state: SDFGState = self.target_state
+
+        if len(sdfg.out_edges(target_state)) == 0:
+            sdfg.add_state_after(target_state)
+
+        state_names = set(s.label for s in sdfg.nodes())
+
+        root_blueprint = target_state.to_json()
+        for e in sdfg.in_edges(target_state)[1:]:
+            state_copy = sd.SDFGState.from_json(root_blueprint, context={'sdfg': sdfg})
+            state_copy.label = dt.find_new_name(state_copy.label, state_names)
+            state_names.add(state_copy.label)
+            sdfg.add_node(state_copy)
+
+            sdfg.remove_edge(e)
+            sdfg.add_edge(e.src, state_copy, e.data)
+
+            # connect out edges
+            for oe in sdfg.out_edges(target_state):
+                sdfg.add_edge(state_copy, oe.dst, deepcopy(oe.data))


### PR DESCRIPTION
This PR adds the StateReplication and IfRaising transformations.
StateReplication performs a normalization step. It takes a state with `n` incoming edges and creates an equivalent SDFG with `n` replicas of the original state, each with a single incoming edge.

IfRaising takes an if guard and 'raises' the evaluation of the conditional. The condition needs to be independent of the computations done in the if guard. The if guard is replicated in each branch and the conditional is evaluated earlier in a new empty state.

The combination of these two transformations unlocks extra dataflow in the case of "diamond" patterns that can be found in some weather codes. In particular, it targets the case where some flag changes what computation is performed.

Example before:
![image](https://github.com/user-attachments/assets/b868524a-9a6f-4fa5-a7fc-43bc73a76563)
After:
![image](https://github.com/user-attachments/assets/090d00a9-302c-4037-b621-854ed4241724)
After State, Map, and Tasklet fusion:
![image](https://github.com/user-attachments/assets/f897ea0a-3757-44f1-95ee-dc25a998d4c9)