### PR TITLE
Reworked Optional Serializing

### DIFF
--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -87,6 +87,12 @@ GPU_SCHEDULES = [
     ScheduleType.GPU_Persistent,
 ]
 
+# A subset of CPU schedule types
+CPU_SCHEDULES = [
+    ScheduleType.CPU_Multicore,
+    ScheduleType.CPU_Pinned,
+]
+
 # A subset of on-GPU storage types
 GPU_STORAGES = [
     StorageType.GPU_Shared,

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -90,7 +90,7 @@ GPU_SCHEDULES = [
 # A subset of CPU schedule types
 CPU_SCHEDULES = [
     ScheduleType.CPU_Multicore,
-    ScheduleType.CPU_Pinned,
+    ScheduleType.CPU_Persistent,
 ]
 
 # A subset of on-GPU storage types

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -54,15 +54,13 @@ class Property(Generic[T]):
             indirected=False,  # This property belongs to a different class
             category='General',
             desc="",
-            optional=False,
-            optional_condition=lambda _: True):
+            serialize_if=lambda _: True): # By default serialize always
 
         self._getter = getter
         self._setter = setter
         self._dtype = dtype
         self._default = default
-        self._optional = optional
-        self._optional_condition = optional_condition
+        self._serialize_if = serialize_if
 
         if allow_none is False and default is None:
             try:
@@ -203,12 +201,8 @@ class Property(Generic[T]):
         return self._dtype
 
     @property
-    def optional(self):
-        return self._optional
-
-    @property
-    def optional_condition(self):
-        return self._optional_condition
+    def serialize_if(self):
+        return self._serialize_if
 
     def typestring(self):
         typestr = ""

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -894,36 +894,28 @@ class Map(object):
     omp_num_threads = Property(dtype=int,
                                default=0,
                                desc="Number of OpenMP threads executing the Map",
-                               optional=True,
-                               optional_condition=lambda m: m.schedule in
-                               (dtypes.ScheduleType.CPU_Multicore, dtypes.ScheduleType.CPU_Persistent))
+                               serialize_if=lambda m: m.schedule in dtypes.CPU_SCHEDULES)
     omp_schedule = EnumProperty(dtype=dtypes.OMPScheduleType,
                                 default=dtypes.OMPScheduleType.Default,
                                 desc="OpenMP schedule {static, dynamic, guided}",
-                                optional=True,
-                                optional_condition=lambda m: m.schedule in
-                                (dtypes.ScheduleType.CPU_Multicore, dtypes.ScheduleType.CPU_Persistent))
+                                serialize_if=lambda m: m.schedule in dtypes.CPU_SCHEDULES)
     omp_chunk_size = Property(dtype=int,
                               default=0,
                               desc="OpenMP schedule chunk size",
-                              optional=True,
-                              optional_condition=lambda m: m.schedule in
-                              (dtypes.ScheduleType.CPU_Multicore, dtypes.ScheduleType.CPU_Persistent))
+                              serialize_if=lambda m: m.schedule in dtypes.CPU_SCHEDULES)
 
     gpu_block_size = ListProperty(element_type=int,
                                   default=None,
                                   allow_none=True,
                                   desc="GPU kernel block size",
-                                  optional=True,
-                                  optional_condition=lambda m: m.schedule in dtypes.GPU_SCHEDULES)
+                                  serialize_if=lambda m: m.schedule in dtypes.GPU_SCHEDULES)
 
     gpu_launch_bounds = Property(dtype=str,
                                  default="0",
                                  desc="GPU kernel launch bounds. A value of -1 disables the statement, 0 (default) "
                                  "enables the statement if block size is not symbolic, and any other value "
                                  "(including tuples) sets it explicitly.",
-                                 optional=True,
-                                 optional_condition=lambda m: m.schedule in dtypes.GPU_SCHEDULES)
+                                 serialize_if=lambda m: m.schedule in dtypes.GPU_SCHEDULES)
 
     def __init__(self,
                  label,

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -2940,11 +2940,11 @@ class LoopRegion(ControlFlowRegion):
     present).
     """
 
-    update_statement = CodeProperty(optional=True,
+    update_statement = CodeProperty(serialize_if=lambda ustmnt: ustmnt is not None,
                                     allow_none=True,
                                     default=None,
                                     desc='The loop update statement. May be None if the update happens elsewhere.')
-    init_statement = CodeProperty(optional=True,
+    init_statement = CodeProperty(serialize_if=lambda istmnt: istmnt is not None,
                                   allow_none=True,
                                   default=None,
                                   desc='The loop init statement. May be None if the initialization happens elsewhere.')

--- a/dace/serialize.py
+++ b/dace/serialize.py
@@ -187,7 +187,7 @@ def all_properties_to_json(object_with_properties):
     for x, v in object_with_properties.properties():
         if not save_all_fields and v == x.default:  # Skip default fields
             continue
-        if x.serialize_if(object_with_properties):
+        if not x.serialize_if(object_with_properties):
             continue
         retdict[x.attr_name] = x.to_json(v)
 

--- a/dace/serialize.py
+++ b/dace/serialize.py
@@ -187,7 +187,7 @@ def all_properties_to_json(object_with_properties):
     for x, v in object_with_properties.properties():
         if not save_all_fields and v == x.default:  # Skip default fields
             continue
-        if x.optional and not x.optional_condition(object_with_properties):
+        if x.serialize_if(object_with_properties):
             continue
         retdict[x.attr_name] = x.to_json(v)
 


### PR DESCRIPTION
Before there were `optional` and `optional_condition` (which had the oposite meaning, i.e. not optional if the callable evaluates to `True`). This was all replaced by the `serialize_if` callable, which if it returns `True` what the default does the property is serialized and if it rerturns `False` the property is not serialized. This commit also introduces the `dtypes.CPU_SCHEDULES` collection.