### PR TITLE
Added  `can_be_applied_to()` To Transformation Interface

### DIFF
--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -290,33 +290,37 @@ class PatternTransformation(TransformationBase):
         }
 
     @classmethod
-    def apply_to(cls,
-                 sdfg: SDFG,
-                 options: Optional[Dict[str, Any]] = None,
-                 expr_index: int = 0,
-                 verify: bool = True,
-                 annotate: bool = True,
-                 permissive: bool = False,
-                 save: bool = True,
-                 **where: Union[nd.Node, SDFGState]):
+    def _can_be_applied_and_apply(
+            cls,
+            verify: bool,
+            apply: bool,
+            sdfg: SDFG,
+            options: Optional[Dict[str, Any]] = None,
+            expr_index: int = 0,
+            annotate: bool = True,
+            permissive: bool = False,
+            save: bool = True,
+            **where: Union[nd.Node, SDFGState]):
         """
-        Applies this transformation to a given subgraph, defined by a set of
-        nodes. Raises an error if arguments are invalid or transformation is
-        not applicable.
+        Applies `can_be_applied()` and/or `apply()` to a given subgraph, defined by
+        a set of nodes.
 
         The subgraph is defined by the `where` dictionary, where each key is
         taken from the `PatternNode` fields of the transformation. For example,
         applying `MapCollapse` on two maps can pe performed as follows:
 
-        ```
-        MapCollapse.apply_to(sdfg, outer_map_entry=map_a, inner_map_entry=map_b)
-        ```
+        If `apply` is `True` then the function will apply the transformation, if `verify`
+        is also `True` the function will first call `can_be_applied()` to ensure the
+        transformation can be applied. If not an error is genrated.
+        If `apply` is `False` the function will only call `can_be_applied()` and
+        returns its result.
 
         :param sdfg: The SDFG to apply the transformation to.
+        :param verify: Check that `can_be_applied` returns True before applying.
+        :param apply: Also apply the transformation.
         :param options: A set of parameters to use for applying the
                         transformation.
         :param expr_index: The pattern expression index to try to match with.
-        :param verify: Check that `can_be_applied` returns True before applying.
         :param annotate: Run memlet propagation after application if necessary.
         :param permissive: Apply transformation in permissive mode.
         :param save: Save transformation as part of the SDFG file. Set to
@@ -324,6 +328,10 @@ class PatternTransformation(TransformationBase):
         :param where: A dictionary of node names (from the transformation) to
                       nodes in the SDFG or a single state.
         """
+
+        if not (apply or verify):
+            raise ValueError('Neither "apply" or "verify" must be specialized.')
+
         if len(where) == 0:
             raise ValueError('At least one node is required')
         options = options or {}
@@ -365,12 +373,97 @@ class PatternTransformation(TransformationBase):
             setattr(instance, optname, optval)
 
         if verify:
-            if not instance.can_be_applied(graph, expr_index, sdfg, permissive=permissive):
+            can_be_applied = instance.can_be_applied(graph, expr_index, sdfg, permissive=permissive)
+            if apply and (not can_be_applied):
                 raise ValueError('Transformation cannot be applied on the '
                                  'given subgraph ("can_be_applied" failed)')
+            elif not apply:
+                return can_be_applied
 
         # Apply to SDFG
         return instance.apply_pattern(annotate=annotate, append=save)
+
+    @classmethod
+    def apply_to(cls,
+                 sdfg: SDFG,
+                 options: Optional[Dict[str, Any]] = None,
+                 expr_index: int = 0,
+                 verify: bool = True,
+                 annotate: bool = True,
+                 permissive: bool = False,
+                 save: bool = True,
+                 **where: Union[nd.Node, SDFGState]):
+        """
+        Applies this transformation to a given subgraph, defined by a set of
+        nodes. Raises an error if arguments are invalid or transformation is
+        not applicable.
+
+        The subgraph is defined by the `where` dictionary, where each key is
+        taken from the `PatternNode` fields of the transformation. For example,
+        applying `MapCollapse` on two maps can pe performed as follows:
+
+        ```
+        MapCollapse.apply_to(sdfg, outer_map_entry=map_a, inner_map_entry=map_b)
+        ```
+
+        :param sdfg: The SDFG to apply the transformation to.
+        :param options: A set of parameters to use for applying the
+                        transformation.
+        :param expr_index: The pattern expression index to try to match with.
+        :param verify: Check that `can_be_applied` returns True before applying.
+        :param annotate: Run memlet propagation after application if necessary.
+        :param permissive: Apply transformation in permissive mode.
+        :param save: Save transformation as part of the SDFG file. Set to
+                     False if composing transformations.
+        :param where: A dictionary of node names (from the transformation) to
+                      nodes in the SDFG or a single state.
+        """
+        return cls._can_be_applied_and_apply(
+                verify=verify,
+                apply=True,
+                sdfg=sdfg,
+                options=options,
+                expr_index=expr_index,
+                annotate=annotate,
+                permissive=permissive,
+                save=save,
+                **where,
+        )
+
+    @classmethod
+    def can_be_applied_to(cls,
+                          sdfg: SDFG,
+                          options: Optional[Dict[str, Any]] = None,
+                          expr_index: int = 0,
+                          permissive: bool = False,
+                          **where: Union[nd.Node, SDFGState]) -> bool:
+        """
+        Checks if the given transformation can be applied to a subgraph, defined by
+        a set of nodes.
+
+        :param sdfg: The SDFG to apply the transformation to.
+        :param options: A set of parameters to use for applying the
+                        transformation.
+        :param expr_index: The pattern expression index to try to match with.
+        :param verify: Check that `can_be_applied` returns True before applying.
+        :param annotate: Run memlet propagation after application if necessary.
+        :param permissive: Apply transformation in permissive mode.
+        :param save: Save transformation as part of the SDFG file. Set to
+                     False if composing transformations.
+        :param where: A dictionary of node names (from the transformation) to
+                      nodes in the SDFG or a single state.
+        """
+        return cls._can_be_applied_and_apply(
+                verify=True,
+                apply=False,
+                sdfg=sdfg,
+                options=options,
+                expr_index=expr_index,
+                annotate=False,
+                permissive=permissive,
+                save=False,
+                **where,
+        )
 
     def __str__(self) -> str:
         return type(self).__name__
@@ -787,36 +880,36 @@ class SubgraphTransformation(TransformationBase):
         return self.apply(sdfg)
 
     @classmethod
-    def apply_to(cls,
-                 sdfg: SDFG,
-                 *where: Union[nd.Node, SDFGState, gr.SubgraphView],
-                 verify: bool = True,
-                 **options: Any):
+    def _can_be_applied_and_apply(cls,
+                                  *where: Union[nd.Node, SDFGState, gr.SubgraphView],
+                                  verify: bool,
+                                  apply: bool,
+                                  sdfg: SDFG,
+                                  **options: Any):
         """
-        Applies this transformation to a given subgraph, defined by a set of
-        nodes. Raises an error if arguments are invalid or transformation is
-        not applicable.
 
-        To apply the transformation on a specific subgraph, the ``where``
-        parameter can be used either on a subgraph object (``SubgraphView``), or
-        on directly on a list of subgraph nodes, given as ``Node`` or ``SDFGState``
-        objects. Transformation properties can then be given as keyword
-        arguments. For example, applying ``SubgraphFusion`` on a subgraph of three
-        nodes can be called in one of two ways:
-        
-        .. code-block:: python
+        Applies `can_be_applied()` and/or `apply()` to a given subgraph, defined by
+        a set of nodes.
 
-            # Subgraph
-            SubgraphFusion.apply_to(
-                sdfg, SubgraphView(state, [node_a, node_b, node_c]))
+        The subgraph is defined by the `where` dictionary, where each key is
+        taken from the `PatternNode` fields of the transformation. For example,
+        applying `MapCollapse` on two maps can pe performed as follows:
 
-            # Simplified API: list of nodes
-            SubgraphFusion.apply_to(sdfg, node_a, node_b, node_c)
-        
+        The subgraph is defined by the ``where`` parameter can be used either
+        on a subgraph object (``SubgraphView``), or on directly on a list of
+        subgraph nodes, given as ``Node`` or ``SDFGState`` objects. Transformation
+        properties can then be given as keyword arguments.
+
+        If `apply` is `True` then the function will apply the transformation, if `verify`
+        is also `True` the function will first call `can_be_applied()` to ensure the
+        transformation can be applied. If not an error is genrated.
+        If `apply` is `False` the function will only call `can_be_applied()` and
+        returns its result.
 
         :param sdfg: The SDFG to apply the transformation to.
-        :param where: A set of nodes in the SDFG/state, or a subgraph thereof.
         :param verify: Check that ``can_be_applied`` returns True before applying.
+        :param apply: Apply the transformation to the subgraph.
+        :param where: A set of nodes in the SDFG/state, or a subgraph thereof.
         :param options: A set of parameters to use for applying the transformation.
         """
         subgraph = None
@@ -857,12 +950,94 @@ class SubgraphTransformation(TransformationBase):
             setattr(instance, optname, optval)
 
         if verify:
-            if not instance.can_be_applied(sdfg, subgraph):
+            can_be_applied = instance.can_be_applied(sdfg, subgraph)
+            if apply and (not can_be_applied):
                 raise ValueError('Transformation cannot be applied on the '
                                  'given subgraph ("can_be_applied" failed)')
+            elif not apply:
+                return can_be_applied
 
         # Apply to SDFG
         return instance.apply(sdfg)
+
+    @classmethod
+    def apply_to(cls,
+                 sdfg: SDFG,
+                 *where: Union[nd.Node, SDFGState, gr.SubgraphView],
+                 verify: bool = True,
+                 **options: Any):
+        """
+        Applies this transformation to a given subgraph, defined by a set of
+        nodes. Raises an error if arguments are invalid or transformation is
+        not applicable.
+
+        To apply the transformation on a specific subgraph, the ``where``
+        parameter can be used either on a subgraph object (``SubgraphView``), or
+        on directly on a list of subgraph nodes, given as ``Node`` or ``SDFGState``
+        objects. Transformation properties can then be given as keyword
+        arguments. For example, applying ``SubgraphFusion`` on a subgraph of three
+        nodes can be called in one of two ways:
+
+        .. code-block:: python
+
+            # Subgraph
+            SubgraphFusion.apply_to(
+                sdfg, SubgraphView(state, [node_a, node_b, node_c]))
+
+            # Simplified API: list of nodes
+            SubgraphFusion.apply_to(sdfg, node_a, node_b, node_c)
+
+
+        :param sdfg: The SDFG to apply the transformation to.
+        :param where: A set of nodes in the SDFG/state, or a subgraph thereof.
+        :param verify: Check that ``can_be_applied`` returns True before applying.
+        :param options: A set of parameters to use for applying the transformation.
+        """
+        return cls._can_be_applied_and_apply(
+                verify=verify,
+                apply=True,
+                sdfg=sdfg,
+                *where,
+                **options,
+        )
+
+    @classmethod
+    def can_be_applied_to(cls,
+                          sdfg: SDFG,
+                          *where: Union[nd.Node, SDFGState, gr.SubgraphView],
+                          **options: Any) -> bool:
+        """
+        Checks if the transformation can be applied to a given subgraph, defined
+        by a set of nodes.
+
+        To apply the transformation on a specific subgraph, the ``where``
+        parameter can be used either on a subgraph object (``SubgraphView``), or
+        on directly on a list of subgraph nodes, given as ``Node`` or ``SDFGState``
+        objects. Transformation properties can then be given as keyword arguments.
+        For example, to check if ``SubgraphFusion`` can be applied on a subgraph
+        of three nodes can be done either:
+
+        .. code-block:: python
+
+            # Subgraph
+            SubgraphFusion.can_be_applied_to(
+                sdfg, SubgraphView(state, [node_a, node_b, node_c]))
+
+            # Simplified API: list of nodes
+            SubgraphFusion.can_be_applied_to(sdfg, node_a, node_b, node_c)
+
+
+        :param sdfg: The SDFG to apply the transformation to.
+        :param where: A set of nodes in the SDFG/state, or a subgraph thereof.
+        :param options: A set of parameters to use for applying the transformation.
+        """
+        return cls._can_be_applied_and_apply(
+                verify=True,
+                apply=False,
+                sdfg=sdfg,
+                *where,
+                **options,
+        )
 
     def to_json(self, parent=None):
         props = serialize.all_properties_to_json(self)

--- a/tests/transformations/apply_to_test.py
+++ b/tests/transformations/apply_to_test.py
@@ -1,6 +1,8 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ Tests the `apply_to` transformation API. """
 import dace
+import numpy as np
+import pytest
 from dace.sdfg import utils as sdutil
 from dace.transformation.dataflow import MapFusion
 from dace.transformation.subgraph import SubgraphFusion
@@ -9,29 +11,20 @@ from dace.transformation.passes.pattern_matching import enumerate_matches
 
 @dace.function
 def dbladd(A: dace.float64[100, 100], B: dace.float64[100, 100]):
+    """Test function of two maps that can be fused."""
     dbl = B
     return A + dbl * B
 
-
-def test_applyto_pattern():
-    sdfg = dbladd.to_sdfg()
-    sdfg.simplify()
-
-    # Since there is only one state (thanks to StateFusion), we can use the
-    # first one in the SDFG
-    state = sdfg.node(0)
-
-    # The multiplication map is called "_Mult__map" (see above graph), we can
-    # query it
-    mult_exit = next(n for n in state.nodes() if isinstance(n, dace.nodes.MapExit) and n.label == '_Mult__map')
-    # Same goes for the addition entry
-    add_entry = next(n for n in state.nodes() if isinstance(n, dace.nodes.MapEntry) and n.label == '_Add__map')
-    # Since all redundant arrays have been removed by simplification pass,
-    # we can get the only transient array that remains in the graph
-    transient = next(aname for aname, desc in sdfg.arrays.items() if desc.transient)
-    access_node = next(n for n in state.nodes() if isinstance(n, dace.nodes.AccessNode) and n.data == transient)
-
-    MapFusion.apply_to(sdfg, first_map_exit=mult_exit, array=access_node, second_map_entry=add_entry)
+@dace.program
+def unfusable(A: dace.float64[100], B: dace.float64[100, 100]):
+    """Test function of two maps that can not be fused."""
+    tmp = np.empty_like(A)
+    ret = np.empty_like(B)
+    for k in dace.map[0:100]:
+        tmp[k] = A[k] + 3
+    for i, j in dace.map[0:100, 0:100]:
+        ret[i, j] = B[i, j] * tmp[i]
+    return ret
 
 
 def test_applyto_enumerate():
@@ -47,15 +40,95 @@ def test_applyto_enumerate():
                            second_map_entry=subgraph.sink_nodes()[0])
 
 
+def test_applyto_pattern():
+    sdfg = dbladd.to_sdfg()
+    sdfg.simplify()
+    assert sdfg.number_of_nodes() == 1
+
+    state = sdfg.node(0)
+
+    # The multiplication map is called "_Mult__map" (see above graph), we can
+    # query it
+    mult_exit = next(n for n in state.nodes() if isinstance(n, dace.nodes.MapExit) and n.label == '_Mult__map')
+    # Same goes for the addition entry
+    add_entry = next(n for n in state.nodes() if isinstance(n, dace.nodes.MapEntry) and n.label == '_Add__map')
+    # Since all redundant arrays have been removed by simplification pass,
+    # we can get the only transient array that remains in the graph
+    transient = next(aname for aname, desc in sdfg.arrays.items() if desc.transient)
+    access_node = next(n for n in state.nodes() if isinstance(n, dace.nodes.AccessNode) and n.data == transient)
+
+    assert MapFusion.can_be_applied_to(sdfg, first_map_exit=mult_exit, array=access_node, second_map_entry=add_entry)
+
+    MapFusion.apply_to(sdfg, first_map_exit=mult_exit, array=access_node, second_map_entry=add_entry)
+
+    assert len([node for node in state.nodes() if isinstance(node, dace.nodes.MapEntry)]) == 1
+
+
+def test_applyto_pattern_2():
+    """Tests if the `can_be_applied_to()` also returns negative results."""
+    sdfg: dace.SDFG = unfusable.to_sdfg()
+    sdfg.simplify()
+    assert sdfg.number_of_nodes() == 1
+
+    state: dace.SDFGState = sdfg.node(0)
+
+    # We identify the maps my looking for the `tmp` node.
+    tmp: dace.nodes.AccessNode = next(n for n in state.data_nodes() if n.data == "tmp")
+    assert state.in_degree(tmp) == 1 and state.out_degree(tmp) == 1
+    assert tmp.desc(sdfg).transient
+
+    # Now get the two maps.
+    map_exit_1 = next(e.src for e in state.in_edges(tmp) if isinstance(e.src, dace.nodes.MapExit))
+    map_entry_2 = next(e.dst for e in state.out_edges(tmp) if isinstance(e.dst, dace.nodes.MapEntry))
+
+    assert not MapFusion.can_be_applied_to(
+            sdfg,
+            first_map_exit=map_exit_1,
+            array=tmp,
+            second_map_entry=map_entry_2
+    )
+    with pytest.raises(
+            ValueError,
+            match='Transformation cannot be applied on the given subgraph \("can_be_applied" failed\)',
+    ):
+        MapFusion.apply_to(
+            sdfg,
+            verify=True,
+            first_map_exit=map_exit_1,
+            array=tmp,
+            second_map_entry=map_entry_2
+        )
+
+
 def test_applyto_subgraph():
     sdfg = dbladd.to_sdfg()
     sdfg.simplify()
     state = sdfg.node(0)
+
     # Apply to subgraph
+    assert SubgraphFusion.can_be_applied_to(sdfg, *state.nodes())
     SubgraphFusion.apply_to(sdfg, state.nodes())
 
 
+def test_applyto_subgraph_2():
+    """Tests if the `can_be_applied_to()` also returns negative results."""
+    sdfg = unfusable.to_sdfg()
+    sdfg.simplify()
+    state = sdfg.node(0)
+
+    # Apply to subgraph
+    assert not SubgraphFusion.can_be_applied_to(sdfg, state.nodes())
+
+    with pytest.raises(
+            ValueError,
+            match='Transformation cannot be applied on the given subgraph \("can_be_applied" failed\)',
+    ):
+        SubgraphFusion.apply_to(sdfg, state.nodes())
+
+
 if __name__ == '__main__':
-    test_applyto_pattern()
     test_applyto_enumerate()
+    test_applyto_pattern()
+    test_applyto_pattern_2()
     test_applyto_subgraph()
+    test_applyto_subgraph_2()


### PR DESCRIPTION
Before there was only the `apply_to()` function which allowed to perform the transformation. However, sometimes when transformations are composed it is useful to be able to check if a transformation could be applied later. Sometimes this follows directly from the operation that is currently done, but sometimes it is not easy to check it.