### PR TITLE
Modified `SetProperty`

### DIFF
--- a/dace/properties.py
+++ b/dace/properties.py
@@ -778,7 +778,11 @@ class DebugInfoProperty(Property):
 
 
 class SetProperty(Property):
-    """Property for a set of elements of one type, e.g., connectors. """
+    """Property for a set of elements of one type, e.g., connectors.
+
+    Despite its name, the property models a `frozenset`, this means that the set can
+    not be modified in place. Instead a new value has to be assigned to the property.
+    """
 
     def __init__(
             self,
@@ -796,7 +800,7 @@ class SetProperty(Property):
             to_json = self.to_json
         super(SetProperty, self).__init__(getter=getter,
                                           setter=setter,
-                                          dtype=set,
+                                          dtype=frozenset,
                                           default=default,
                                           from_json=from_json,
                                           to_json=to_json,
@@ -809,7 +813,13 @@ class SetProperty(Property):
 
     @property
     def dtype(self):
-        return set
+        # For full backwards compatibility we would need to return `set` however
+        #  this would break the implementation of `Property.__set__()`.
+        return frozenset
+
+    def typestring(self):
+        # For backwards compatibility we pretend to be a `set`.
+        return "set"
 
     @staticmethod
     def to_string(l):
@@ -827,28 +837,30 @@ class SetProperty(Property):
     def from_json(self, l, sdfg=None):
         if l is None:
             return None
-        return set(l)
+        return frozenset(l)
 
     def __get__(self, obj, objtype=None):
         val = super(SetProperty, self).__get__(obj, objtype)
         if val is None:
             return val
-        
-        # Copy to avoid changes in the set at callee to be reflected in
-        # the node directly
-        return set(val)
+
+        # `val` is a `frozenset` (see `__set__()`) thus it is safe to return it unprotected.
+        return val
 
     def __set__(self, obj, val):
         if val is None:
             return super(SetProperty, self).__set__(obj, val)
         
         # Check for uniqueness
-        if len(val) != len(set(val)):
+        if isinstance(val, (frozenset, set)):
+            pass
+        elif len(val) != len(set(val)):
             dups = set([x for x in val if val.count(x) > 1])
             raise ValueError('Duplicates found in set: ' + str(dups))
-        # Cast to element type
+
+        # Cast to element type and ensure that it is a frozen set.
         try:
-            new_set = set(self._element_type(elem) for elem in val)
+            new_set = frozenset(self._element_type(elem) for elem in val)
         except (TypeError, ValueError):
             raise ValueError('Some elements could not be converted to %s' % (str(self._element_type)))
 

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -137,17 +137,16 @@ def replace_properties_dict(node: Any,
                     for name, new_name in reduced_repl.items():
                         if name not in tokenized:
                             continue
-
                         # Use local variables and shadowing to replace
                         replacement = f'auto {name} = {cppunparse.pyexpr2cpp(new_name)};\n'
                         prefix = replacement + prefix
                         active_replacements.add(name)
+
                     if prefix:
                         propval.code = prefix + code
-
-                        # Ignore replaced symbols since they no longer exist as reads
                         if isinstance(node, dace.nodes.Tasklet):
-                            node._ignored_symbols.update(active_replacements)
+                            # Ignore replaced symbols since they no longer exist as reads
+                            node.ignored_symbols = node.ignored_symbols.union(active_replacements)
 
                 else:
                     warnings.warn('Replacement of %s with %s was not made '


### PR DESCRIPTION
Because of the implementation of the `__set__()` and `__get__()` functions such properties modeled an immutable set, by essentilly copying the value that was assigned to it and returning a copy of the internal set. However, because `__get__()` returned a regiular `set` this object was mutable, but all mutation did not affect the property, which is a rather unintuitive behaviour.

The effect is, that every single `assert` in the code bellow fails.
```
import dace

@dace.properties.make_properties
class Test:
    member = dace.properties.SetProperty(element_type=int)

    def __init__(self):
        self.member = set()

a = Test()

assert a.member is a.member
a.member.add(10)
assert len(a.member) == 1
assert 10 in a.member
```
It is important that even if the first assert is removed the second two asserts will still fail and the insertion line, will succeed without issue, because the operation is performed on a copy.

The new implementation now stores a `frozenset` internally and returns it when accessed. Thus the first assert will fail and lines such as `42 in a.member` will not produce a copy.
Furthermore and more importantly, the line `a.member.add(10)` will now fail, since a `frozenset` can not be modified. As a side note the last two assert will still fail because the set can not be updated in place. The only way to perform an update is now `a.member = set(...)` but this was true before.

For backward compatibility the property pretends to be a regular set during serialization (`typestring`), however, `dtype` is reported as `frozenset` because the underlying implementation of `Property.__set__()` requires this.