### PR TITLE
Add host_map and host_data properties to control which maps and array…

### DIFF
--- a/dace/data.py
+++ b/dace/data.py
@@ -1202,7 +1202,7 @@ class Scalar(Data):
                  host_data=False):
         self.allow_conflicts = allow_conflicts
         shape = [1]
-        super(Scalar, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo)
+        super(Scalar, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo, host_data)
 
     @staticmethod
     def from_json(json_obj, context=None):

--- a/dace/data.py
+++ b/dace/data.py
@@ -27,7 +27,7 @@ from dace.properties import (DebugInfoProperty, DictProperty, EnumProperty, List
 
 def create_datadescriptor(obj, no_custom_desc=False):
     """ Creates a data descriptor from various types of objects.
-        
+
         :see: dace.data.Data
     """
     from dace import dtypes  # Avoiding import loops
@@ -176,8 +176,9 @@ class Data:
                             default=dtypes.AllocationLifetime.Scope)
     location = DictProperty(key_type=str, value_type=str, desc='Full storage location identifier (e.g., rank, GPU ID)')
     debuginfo = DebugInfoProperty(allow_none=True)
+    host_data = Property(dtype=bool, default=False, desc="If set to true, to_X transformation can decide to not offload the map to device")
 
-    def __init__(self, dtype, shape, transient, storage, location, lifetime, debuginfo):
+    def __init__(self, dtype, shape, transient, storage, location, lifetime, debuginfo, host_data):
         self.dtype = dtype
         self.shape = shape
         self.transient = transient
@@ -185,6 +186,7 @@ class Data:
         self.location = location if location is not None else {}
         self.lifetime = lifetime
         self.debuginfo = debuginfo
+        self.host_data = host_data
         self._validate()
 
     def __call__(self):
@@ -376,7 +378,8 @@ class Structure(Data):
                  storage: dtypes.StorageType = dtypes.StorageType.Default,
                  location: Dict[str, str] = None,
                  lifetime: dtypes.AllocationLifetime = dtypes.AllocationLifetime.Scope,
-                 debuginfo: dtypes.DebugInfo = None):
+                 debuginfo: dtypes.DebugInfo = None,
+                 host_data: bool = False):
 
         self.members = OrderedDict(members)
         for k, v in self.members.items():
@@ -415,7 +418,7 @@ class Structure(Data):
 
         dtype = dtypes.pointer(dtypes.struct(name, **fields_and_types))
         shape = (1, )
-        super(Structure, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo)
+        super(Structure, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo, host_data)
 
     @staticmethod
     def from_json(json_obj, context=None):
@@ -541,7 +544,7 @@ class TensorIndex(ABC):
     def iteration_type(self) -> TensorIterationTypes:
         """
         Iteration capability supported by this index.
-        
+
         See TensorIterationTypes for reference.
         """
         pass
@@ -559,7 +562,7 @@ class TensorIndex(ABC):
     def assembly(self) -> TensorAssemblyType:
         """
         What assembly type is supported by the index.
-        
+
         See TensorAssemblyType for reference.
         """
         pass
@@ -569,7 +572,7 @@ class TensorIndex(ABC):
     def full(self) -> bool:
         """
         True if the level is full, False otw.
-         
+
         A level is considered full if it encompasses all valid coordinates along
         the corresponding tensor dimension.
         """
@@ -580,7 +583,7 @@ class TensorIndex(ABC):
     def ordered(self) -> bool:
         """
         True if the level is ordered, False otw.
-        
+
         A level is ordered when all coordinates that share the same ancestor are
         ordered by increasing value (e.g. in typical CSR).
         """
@@ -591,7 +594,7 @@ class TensorIndex(ABC):
     def unique(self) -> bool:
         """
         True if coordinate in the level are unique, False otw.
-        
+
         A level is considered unique if no collection of coordinates that share
         the same ancestor contains duplicates. In CSR this is True, in COO it is
         not.
@@ -603,7 +606,7 @@ class TensorIndex(ABC):
     def branchless(self) -> bool:
         """
         True if the level doesn't branch, false otw.
-        
+
         A level is considered branchless if no coordinate has a sibling (another
         coordinate with same ancestor) and all coordinates in parent level have
         a child. In other words if there is a bijection between the coordinates
@@ -617,7 +620,7 @@ class TensorIndex(ABC):
     def compact(self) -> bool:
         """
         True if the level is compact, false otw.
-        
+
         A level is compact if no two coordinates are separated by an unlabled
         node that does not encode a coordinate. An example of a compact level
         can be found in CSR, while the DIA formats range and offset levels are
@@ -630,7 +633,7 @@ class TensorIndex(ABC):
     def fields(self, lvl: int, dummy_symbol: symbolic.SymExpr) -> Dict[str, Data]:
         """
         Generates the fields needed for the index.
-        
+
         :return: a Dict of fields that need to be present in the struct
         """
         pass
@@ -668,7 +671,7 @@ class TensorIndex(ABC):
 class TensorIndexDense(TensorIndex):
     """
     Dense tensor index.
-    
+
     Levels of this type encode the the coordinate in the interval [0, N), where
     N is the size of the corresponding dimension. This level doesn't need any
     index structure beyond the corresponding dimension size.
@@ -735,9 +738,9 @@ class TensorIndexDense(TensorIndex):
 class TensorIndexCompressed(TensorIndex):
     """
     Tensor level that stores coordinates in segmented array.
-    
+
     Levels of this type are compressed using a segented array. The pos array
-    holds the start and end positions of the segment in the crd (coordinate) 
+    holds the start and end positions of the segment in the crd (coordinate)
     array that holds the child coordinates corresponding the parent.
     """
 
@@ -809,7 +812,7 @@ class TensorIndexCompressed(TensorIndex):
 class TensorIndexSingleton(TensorIndex):
     """
     Tensor index that encodes a single coordinate per parent coordinate.
-    
+
     Levels of this type hold exactly one coordinate for every coordinate in the
     parent level. An example can be seen in the COO format, where every
     coordinate but the first is encoded in this manner.
@@ -882,7 +885,7 @@ class TensorIndexSingleton(TensorIndex):
 class TensorIndexRange(TensorIndex):
     """
     Tensor index that encodes a interval of coordinates for every parent.
-    
+
     The interval is computed from an offset for each parent together with the
     tensor dimension size of this level (M) and the parent level (N) parents
     corresponding tensor. Given the parent coordinate i, the level encodes the
@@ -952,7 +955,7 @@ class TensorIndexRange(TensorIndex):
 class TensorIndexOffset(TensorIndex):
     """
     Tensor index that encodes the next coordinates as offset from parent.
-    
+
     Given a parent coordinate i and an offset index k, the level encodes the
     coordinate j = i + offset[k].
     """
@@ -1020,7 +1023,7 @@ class TensorIndexOffset(TensorIndex):
 class Tensor(Structure):
     """
     Abstraction for Tensor storage format.
-    
+
     This abstraction is based on [https://doi.org/10.1145/3276493].
     """
 
@@ -1040,14 +1043,15 @@ class Tensor(Structure):
                  storage: dtypes.StorageType = dtypes.StorageType.Default,
                  location: Dict[str, str] = None,
                  lifetime: dtypes.AllocationLifetime = dtypes.AllocationLifetime.Scope,
-                 debuginfo: dtypes.DebugInfo = None):
+                 debuginfo: dtypes.DebugInfo = None,
+                 host_data: bool = False):
         """
         Constructor for Tensor storage format.
 
         Below are examples of common matrix storage formats:
 
         .. code-block:: python
-            
+
             M, N, nnz = (dace.symbol(s) for s in ('M', 'N', 'nnz'))
 
             csr = dace.data.Tensor(
@@ -1123,7 +1127,7 @@ class Tensor(Structure):
 
         :param value_type: data type of the explicitly stored values.
         :param tensor_shape: logical shape of tensor (#rows, #cols, etc...)
-        :param indices: 
+        :param indices:
             a list of tuples, each tuple represents a level in the tensor
             storage hirachy, specifying the levels tensor index type, and the
             corresponding dimension this level encodes (as index of the
@@ -1164,7 +1168,7 @@ class Tensor(Structure):
         for (lvl, index) in enumerate(indices):
             fields.update(index.fields(lvl, value_count))
 
-        super(Tensor, self).__init__(fields, name, transient, storage, location, lifetime, debuginfo)
+        super(Tensor, self).__init__(fields, name, transient, storage, location, lifetime, debuginfo, host_data)
 
     def __repr__(self):
         return f"{self.name} (dtype: {self.value_dtype}, shape: {list(self.tensor_shape)}, indices: {self.indices})"
@@ -1194,7 +1198,8 @@ class Scalar(Data):
                  allow_conflicts=False,
                  location=None,
                  lifetime=dtypes.AllocationLifetime.Scope,
-                 debuginfo=None):
+                 debuginfo=None,
+                 host_data=False):
         self.allow_conflicts = allow_conflicts
         shape = [1]
         super(Scalar, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo)
@@ -1298,12 +1303,12 @@ class Array(Data):
     how it should behave.
 
     The array definition is flexible in terms of data allocation, it allows arbitrary multidimensional, potentially
-    symbolic shapes (e.g., an array with size ``N+1 x M`` will have ``shape=(N+1, M)``), of arbitrary data 
+    symbolic shapes (e.g., an array with size ``N+1 x M`` will have ``shape=(N+1, M)``), of arbitrary data
     typeclasses (``dtype``). The physical data layout of the array is controlled by several properties:
 
        * The ``strides`` property determines the ordering and layout of the dimensions --- it specifies how many
          elements in memory are skipped whenever one element in that dimension is advanced. For example, the contiguous
-         dimension always has a stride of ``1``; a C-style MxN array will have strides ``(N, 1)``, whereas a 
+         dimension always has a stride of ``1``; a C-style MxN array will have strides ``(N, 1)``, whereas a
          FORTRAN-style array of the same size will have ``(1, M)``. Strides can be larger than the shape, which allows
          post-padding of the contents of each dimension.
        * The ``start_offset`` property is a number of elements to pad the beginning of the memory buffer with. This is
@@ -1320,7 +1325,7 @@ class Array(Data):
          to zero.
 
     To summarize with an example, a two-dimensional array with pre- and post-padding looks as follows:
-    
+
     .. code-block:: text
 
         [xxx][          |xx]
@@ -1338,7 +1343,7 @@ class Array(Data):
 
 
     Notice that the last padded row does not appear in strides, but is a consequence of ``total_size`` being larger.
-    
+
 
     Apart from memory layout, other properties of ``Array`` help the data-centric transformation infrastructure make
     decisions about the array. ``allow_conflicts`` states that warnings should not be printed if potential conflicted
@@ -1394,9 +1399,10 @@ class Array(Data):
                  total_size=None,
                  start_offset=None,
                  optional=None,
-                 pool=False):
+                 pool=False,
+                 host_data=False):
 
-        super(Array, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo)
+        super(Array, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo, host_data)
 
         self.allow_conflicts = allow_conflicts
         self.may_alias = may_alias
@@ -1620,7 +1626,8 @@ class Stream(Data):
                  location=None,
                  offset=None,
                  lifetime=dtypes.AllocationLifetime.Scope,
-                 debuginfo=None):
+                 debuginfo=None,
+                 host_data=False):
 
         if shape is None:
             shape = (1, )
@@ -1787,7 +1794,8 @@ class ContainerArray(Array):
                  total_size=None,
                  start_offset=None,
                  optional=None,
-                 pool=False):
+                 pool=False,
+                 host_data=False):
 
         self.stype = stype
         if stype:
@@ -1799,7 +1807,7 @@ class ContainerArray(Array):
             dtype = dtypes.pointer(dtypes.typeclass(None))  # void*
         super(ContainerArray,
               self).__init__(dtype, shape, transient, allow_conflicts, storage, location, strides, offset, may_alias,
-                             lifetime, alignment, debuginfo, total_size, start_offset, optional, pool)
+                             lifetime, alignment, debuginfo, total_size, start_offset, optional, pool, host_data)
 
     @classmethod
     def from_json(cls, json_obj, context=None):
@@ -1820,7 +1828,7 @@ class ContainerArray(Array):
 
 
 class View:
-    """ 
+    """
     Data descriptor that acts as a static reference (or view) of another data container.
     Can be used to reshape or reinterpret existing data without copying it.
 
@@ -1832,9 +1840,9 @@ class View:
         node, and the other side (out/in) has a different number of edges.
       * If there is one incoming and one outgoing edge, and one leads to a code
         node, the one that leads to an access node is the viewed data.
-      * If both sides lead to access nodes, if one memlet's data points to the 
+      * If both sides lead to access nodes, if one memlet's data points to the
         view it cannot point to the viewed node.
-      * If both memlets' data are the respective access nodes, the access 
+      * If both memlets' data are the respective access nodes, the access
         node at the highest scope is the one that is viewed.
       * If both access nodes reside in the same scope, the input data is viewed.
 
@@ -1860,7 +1868,8 @@ class View:
                                    storage=viewed_container.storage,
                                    location=viewed_container.location,
                                    lifetime=viewed_container.lifetime,
-                                   debuginfo=debuginfo)
+                                   debuginfo=debuginfo,
+                                   host_data=viewed_container.host_data)
         elif isinstance(viewed_container, ContainerArray):
             result = ContainerView(stype=cp.deepcopy(viewed_container.stype),
                                    shape=viewed_container.shape,
@@ -1876,7 +1885,8 @@ class View:
                                    total_size=viewed_container.total_size,
                                    start_offset=viewed_container.start_offset,
                                    optional=viewed_container.optional,
-                                   pool=viewed_container.pool)
+                                   pool=viewed_container.pool,
+                                   host_data=viewed_container.host_data)
         elif isinstance(viewed_container, (Array, Scalar)):
             result = ArrayView(dtype=viewed_container.dtype,
                                shape=viewed_container.shape,
@@ -1892,7 +1902,8 @@ class View:
                                total_size=viewed_container.total_size,
                                start_offset=viewed_container.start_offset,
                                optional=viewed_container.optional,
-                               pool=viewed_container.pool)
+                               pool=viewed_container.pool,
+                               host_data=viewed_container.host_data)
         else:
             # In undefined cases, make a container array view of size 1
             result = ContainerView(cp.deepcopy(viewed_container), [1], debuginfo=debuginfo)
@@ -1903,11 +1914,11 @@ class View:
 
 
 class Reference:
-    """ 
+    """
     Data descriptor that acts as a dynamic reference of another data descriptor. It can be used just like a regular
     data descriptor, except that it could be set to an arbitrary container (or subset thereof) at runtime. To set a
     reference, connect another access node to it and use the "set" connector.
-    
+
     In order to enable data-centric analysis and optimizations, avoid using References as much as possible.
     """
 
@@ -1958,7 +1969,7 @@ class Reference:
 
 @make_properties
 class ArrayView(Array, View):
-    """ 
+    """
     Data descriptor that acts as a static reference (or view) of another array. Can
     be used to reshape or reinterpret existing data without copying it.
 
@@ -1982,7 +1993,7 @@ class ArrayView(Array, View):
 
 @make_properties
 class StructureView(Structure, View):
-    """ 
+    """
     Data descriptor that acts as a view of another structure.
     """
 
@@ -2013,7 +2024,7 @@ class StructureView(Structure, View):
 
 @make_properties
 class ContainerView(ContainerArray, View):
-    """ 
+    """
     Data descriptor that acts as a view of another container array. Can
     be used to access nested container types without a copy.
     """
@@ -2034,10 +2045,11 @@ class ContainerView(ContainerArray, View):
                  total_size=None,
                  start_offset=None,
                  optional=None,
-                 pool=False):
+                 pool=False,
+                 host_data=False):
         shape = [1] if shape is None else shape
         super().__init__(stype, shape, transient, allow_conflicts, storage, location, strides, offset, may_alias,
-                         lifetime, alignment, debuginfo, total_size, start_offset, optional, pool)
+                         lifetime, alignment, debuginfo, total_size, start_offset, optional, pool, host_data)
 
     def validate(self):
         super().validate()
@@ -2055,9 +2067,9 @@ class ContainerView(ContainerArray, View):
 
 @make_properties
 class ArrayReference(Array, Reference):
-    """ 
+    """
     Data descriptor that acts as a dynamic reference of another array. See ``Reference`` for more information.
-    
+
     In order to enable data-centric analysis and optimizations, avoid using References as much as possible.
     """
 
@@ -2077,9 +2089,9 @@ class ArrayReference(Array, Reference):
 
 @make_properties
 class StructureReference(Structure, Reference):
-    """ 
+    """
     Data descriptor that acts as a dynamic reference of another Structure. See ``Reference`` for more information.
-    
+
     In order to enable data-centric analysis and optimizations, avoid using References as much as possible.
     """
 
@@ -2102,10 +2114,10 @@ class StructureReference(Structure, Reference):
 
 @make_properties
 class ContainerArrayReference(ContainerArray, Reference):
-    """ 
+    """
     Data descriptor that acts as a dynamic reference of another data container array. See ``Reference`` for more
     information.
-    
+
     In order to enable data-centric analysis and optimizations, avoid using References as much as possible.
     """
 

--- a/dace/data.py
+++ b/dace/data.py
@@ -493,7 +493,7 @@ class Structure(Data):
 
     def clone(self):
         return Structure(self.members, self.name, self.transient, self.storage, self.location, self.lifetime,
-                         self.debuginfo)
+                         self.debuginfo, self.host_data)
 
     # NOTE: Like scalars?
     @property
@@ -1220,7 +1220,7 @@ class Scalar(Data):
 
     def clone(self):
         return Scalar(self.dtype, self.transient, self.storage, self.allow_conflicts, self.location, self.lifetime,
-                      self.debuginfo)
+                      self.debuginfo, self.host_data)
 
     @property
     def strides(self):
@@ -1438,7 +1438,7 @@ class Array(Data):
     def clone(self):
         return type(self)(self.dtype, self.shape, self.transient, self.allow_conflicts, self.storage, self.location,
                           self.strides, self.offset, self.may_alias, self.lifetime, self.alignment, self.debuginfo,
-                          self.total_size, self.start_offset, self.optional, self.pool)
+                          self.total_size, self.start_offset, self.optional, self.pool, self.host_data)
 
     def to_json(self):
         attrs = serialize.all_properties_to_json(self)
@@ -1641,7 +1641,7 @@ class Stream(Data):
         else:
             self.offset = [0] * len(shape)
 
-        super(Stream, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo)
+        super(Stream, self).__init__(dtype, shape, transient, storage, location, lifetime, debuginfo, host_data)
 
     def to_json(self):
         attrs = serialize.all_properties_to_json(self)
@@ -1683,7 +1683,7 @@ class Stream(Data):
 
     def clone(self):
         return type(self)(self.dtype, self.buffer_size, self.shape, self.transient, self.storage, self.location,
-                          self.offset, self.lifetime, self.debuginfo)
+                          self.offset, self.lifetime, self.debuginfo, self.host_data)
 
     # Checks for equivalent shape and type
     def is_equivalent(self, other):
@@ -1906,7 +1906,7 @@ class View:
                                host_data=viewed_container.host_data)
         else:
             # In undefined cases, make a container array view of size 1
-            result = ContainerView(cp.deepcopy(viewed_container), [1], debuginfo=debuginfo)
+            result = ContainerView(cp.deepcopy(viewed_container), [1], debuginfo=debuginfo, host_data=viewed_container.host_data)
 
         # Views are always transient
         result.transient = True
@@ -1955,9 +1955,10 @@ class Reference:
                                     start_offset=0,
                                     optional=viewed_container.optional,
                                     pool=False,
-                                    byval=False)
+                                    byval=False,
+                                    host_data=viewed_container.host_data)
         else:  # In undefined cases, make a container array reference of size 1
-            result = ContainerArrayReference(result, [1], debuginfo=debuginfo)
+            result = ContainerArrayReference(result, [1], debuginfo=debuginfo, host_data=viewed_container.host_data)
 
         if debuginfo is not None:
             result.debuginfo = debuginfo

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -920,6 +920,8 @@ class Map(object):
                                  "(including tuples) sets it explicitly.",
                                  serialize_if=lambda m: m.schedule in dtypes.GPU_SCHEDULES)
 
+    host_map = Property(dtype=bool, desc="If set to true, to_X transformations can decide to not map X to device", default=False)
+
     def __init__(self,
                  label,
                  params,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1028,7 +1028,7 @@ class SDFG(ControlFlowRegion):
 
     def call_with_instrumented_data(self, dreport: 'InstrumentedDataReport', *args, **kwargs):
         """
-        Invokes an SDFG with an instrumented data report, generating and compiling code if necessary. 
+        Invokes an SDFG with an instrumented data report, generating and compiling code if necessary.
         Arguments given as ``args`` and ``kwargs`` will be overriden by the data containers defined in the report.
 
         :param dreport: The instrumented data report to use upon calling.
@@ -1687,7 +1687,8 @@ class SDFG(ControlFlowRegion):
                   total_size=None,
                   find_new_name=False,
                   alignment=0,
-                  may_alias=False) -> Tuple[str, dt.Array]:
+                  may_alias=False,
+                  host_data=False) -> Tuple[str, dt.Array]:
         """ Adds an array to the SDFG data descriptor store. """
 
         # convert strings to int if possible
@@ -1715,7 +1716,8 @@ class SDFG(ControlFlowRegion):
                         alignment=alignment,
                         debuginfo=debuginfo,
                         total_size=total_size,
-                        may_alias=may_alias)
+                        may_alias=may_alias,
+                        host_data=host_data)
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
 
@@ -1848,7 +1850,8 @@ class SDFG(ControlFlowRegion):
                    transient=False,
                    lifetime=dace.dtypes.AllocationLifetime.Scope,
                    debuginfo=None,
-                   find_new_name=False) -> Tuple[str, dt.Scalar]:
+                   find_new_name=False,
+                   host_data=False) -> Tuple[str, dt.Scalar]:
         """ Adds a scalar to the SDFG data descriptor store. """
 
         if isinstance(dtype, type) and dtype in dtypes._CONSTANT_TYPES[:-1]:
@@ -1860,6 +1863,7 @@ class SDFG(ControlFlowRegion):
             transient=transient,
             lifetime=lifetime,
             debuginfo=debuginfo,
+            host_data=host_data
         )
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
@@ -2598,7 +2602,7 @@ class SDFG(ControlFlowRegion):
                                               print_report: Optional[bool] = None,
                                               order_by_transformation: bool = True,
                                               progress: Optional[bool] = None) -> int:
-        """ 
+        """
         This function applies a transformation or a set of (unique) transformations
         until throughout the entire SDFG once. Operates in-place.
 
@@ -2714,7 +2718,7 @@ class SDFG(ControlFlowRegion):
 
     def generate_code(self):
         """ Generates code from this SDFG and returns it.
-        
+
             :return: A list of `CodeObject` objects containing the generated
                       code of different files and languages.
         """

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1733,7 +1733,8 @@ class SDFG(ControlFlowRegion):
                  total_size=None,
                  find_new_name=False,
                  alignment=0,
-                 may_alias=False) -> Tuple[str, dt.ArrayView]:
+                 may_alias=False,
+                 host_data=False) -> Tuple[str, dt.ArrayView]:
         """ Adds a view to the SDFG data descriptor store. """
 
         # convert strings to int if possible
@@ -1759,7 +1760,8 @@ class SDFG(ControlFlowRegion):
                             alignment=alignment,
                             debuginfo=debuginfo,
                             total_size=total_size,
-                            may_alias=may_alias)
+                            may_alias=may_alias,
+                            host_data=host_data)
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
 
@@ -1775,7 +1777,8 @@ class SDFG(ControlFlowRegion):
                       total_size=None,
                       find_new_name=False,
                       alignment=0,
-                      may_alias=False) -> Tuple[str, dt.Reference]:
+                      may_alias=False,
+                      host_data=False) -> Tuple[str, dt.Reference]:
         """ Adds a reference to the SDFG data descriptor store. """
 
         # convert strings to int if possible
@@ -1801,7 +1804,8 @@ class SDFG(ControlFlowRegion):
                                  alignment=alignment,
                                  debuginfo=debuginfo,
                                  total_size=total_size,
-                                 may_alias=may_alias)
+                                 may_alias=may_alias,
+                                 host_data=host_data)
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
 
@@ -1815,7 +1819,8 @@ class SDFG(ControlFlowRegion):
                    offset=None,
                    lifetime=dace.dtypes.AllocationLifetime.Scope,
                    debuginfo=None,
-                   find_new_name=False) -> Tuple[str, dt.Stream]:
+                   find_new_name=False,
+                   host_data=False) -> Tuple[str, dt.Stream]:
         """ Adds a stream to the SDFG data descriptor store. """
 
         # Convert to int if possible, otherwise to symbolic
@@ -1839,6 +1844,7 @@ class SDFG(ControlFlowRegion):
             offset=offset,
             lifetime=lifetime,
             debuginfo=debuginfo,
+            host_data=host_data
         )
 
         return self.add_datadesc(name, desc, find_new_name=find_new_name), desc
@@ -1882,7 +1888,8 @@ class SDFG(ControlFlowRegion):
                       total_size=None,
                       find_new_name=False,
                       alignment=0,
-                      may_alias=False) -> Tuple[str, dt.Array]:
+                      may_alias=False,
+                      host_data=False) -> Tuple[str, dt.Array]:
         """ Convenience function to add a transient array to the data
             descriptor store. """
         return self.add_array(name,
@@ -1899,7 +1906,8 @@ class SDFG(ControlFlowRegion):
                               total_size=total_size,
                               alignment=alignment,
                               may_alias=may_alias,
-                              find_new_name=find_new_name)
+                              find_new_name=find_new_name,
+                              host_data=host_data)
 
     def temp_data_name(self):
         """ Returns a temporary data descriptor name that can be used in this SDFG. """
@@ -1925,7 +1933,8 @@ class SDFG(ControlFlowRegion):
                            allow_conflicts=False,
                            total_size=None,
                            alignment=0,
-                           may_alias=False):
+                           may_alias=False,
+                           host_data=False):
         """ Convenience function to add a transient array with a temporary name to the data
             descriptor store. """
         return self.add_array(self.temp_data_name(),
@@ -1941,9 +1950,10 @@ class SDFG(ControlFlowRegion):
                               debuginfo=debuginfo,
                               allow_conflicts=allow_conflicts,
                               total_size=total_size,
-                              may_alias=may_alias)
+                              may_alias=may_alias,
+                              host_data=host_data)
 
-    def add_temp_transient_like(self, desc: Union[dt.Array, dt.Scalar], dtype=None, debuginfo=None):
+    def add_temp_transient_like(self, desc: Union[dt.Array, dt.Scalar], dtype=None, debuginfo=None, host_data=False):
         """ Convenience function to add a transient array with a temporary name to the data
             descriptor store. """
         debuginfo = debuginfo or desc.debuginfo
@@ -1952,6 +1962,7 @@ class SDFG(ControlFlowRegion):
         newdesc.dtype = dtype
         newdesc.transient = True
         newdesc.debuginfo = debuginfo
+        newdesc.host_data = host_data
         return self.add_datadesc(self.temp_data_name(), newdesc), newdesc
 
     def add_datadesc(self, name: str, datadesc: dt.Data, find_new_name=False) -> str:


### PR DESCRIPTION
In the preprocessing step of velocity tendencies I have noticed that I need to prevent some stuff from being offloaded to the GPU. I suggest the following idea as a proposal.

(`to_gpu_transformations` always maps transient scalars to GPU even if it is not used in any map or used in interstate edge. This also let's avoid those errors)

