### PR TITLE
Const Assignment Map Fusion: If two maps assign the same value for every element in a subset of the underlying array (and the subset is not dependent on the array in any way), then we can often fuse the two maps (not always possible)

### DIFF
--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -356,6 +356,10 @@ def consume_map_with_grid_strided_loop(graph: SDFGState, dst: tuple[MapEntry, Ma
                               src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
                               memlet=Memlet.from_memlet(e.data))
         graph.remove_edge(e)
+    if len(graph.in_edges(en)) == 0:
+        graph.add_memlet_path(dst_en, en, memlet=Memlet())
+    if len(graph.out_edges(ex)) == 0:
+        graph.add_memlet_path(ex, dst_ex, memlet=Memlet())
 
 
 def fused_range(r1: Range, r2: Range) -> Optional[Range]:
@@ -511,6 +515,7 @@ class ConstAssignmentMapFusion(MapFusion):
                                                                          second_entry.map.range))},
                                schedule=first_entry.map.schedule)
         for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
+            assert en.map.range.covers(cur_en.map.range) or self.use_grid_strided_loops
             if en.map.range.covers(cur_en.map.range):
                 consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
             elif self.use_grid_strided_loops:

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -514,12 +514,16 @@ class ConstAssignmentMapFusion(MapFusion):
                                                              fused_range(first_entry.map.range,
                                                                          second_entry.map.range))},
                                schedule=first_entry.map.schedule)
-        for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
-            assert en.map.range.covers(cur_en.map.range) or self.use_grid_strided_loops
-            if en.map.range.covers(cur_en.map.range):
+        if first_entry.map.range == second_entry.map.range:
+            for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
                 consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
-            elif self.use_grid_strided_loops:
-                consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
+        elif self.use_grid_strided_loops:
+            assert ScheduleType.Sequential not in [first_entry.map.schedule, second_entry.map.schedule]
+            for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
+                if en.map.range == cur_en.map.range:
+                    consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
+                else:
+                    consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
 
         # Cleanup: remove duplicate empty dependencies.
         seen = set()

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -5,7 +5,6 @@ from itertools import chain
 from typing import Optional, Union
 
 from dace import transformation, SDFGState, SDFG, Memlet, subsets, ScheduleType
-from dace.sdfg import nodes
 from dace.sdfg.graph import OrderedDiGraph
 from dace.sdfg.nodes import Tasklet, ExitNode, MapEntry, MapExit, NestedSDFG, Node, EntryNode, AccessNode
 from dace.sdfg.state import ControlFlowBlock, ControlFlowRegion
@@ -31,6 +30,351 @@ def floating_nodes_graph(*args):
     return g
 
 
+def consistent_branch_const_assignment_table(graph: Node) -> tuple[bool, dict]:
+    """
+    If the graph consists of only conditional consistent constant assignments, produces a table mapping data arrays
+    and memlets to their consistent constant assignments. See the class docstring for what is considered consistent.
+    """
+    table = {}
+    # Basic premise check.
+    if not isinstance(graph, NestedSDFG):
+        return False, table
+    graph: SDFG = graph.sdfg
+    if not isinstance(graph, ControlFlowBlock):
+        return False, table
+
+    # Must have exactly 3 nodes, and exactly one of them a source, another a sink.
+    src, snk = graph.source_nodes(), graph.sink_nodes()
+    if len(graph.nodes()) != 3 or len(src) != 1 or len(snk) != 1:
+        return False, table
+    src, snk = src[0], snk[0]
+    body = set(graph.nodes()) - {src, snk}
+    if len(body) != 1:
+        return False, table
+    body = list(body)[0]
+
+    # Must have certain structure of outgoing edges.
+    src_eds = list(graph.out_edges(src))
+    if len(src_eds) != 2 or any(e.data.is_unconditional() or e.data.assignments for e in src_eds):
+        return False, table
+    tb, el = src_eds
+    if tb.dst != body:
+        tb, el = el, tb
+    if tb.dst != body or el.dst != snk:
+        return False, table
+    body_eds = list(graph.out_edges(body))
+    if len(body_eds) != 1 or body_eds[0].dst != snk or not body_eds[0].data.is_unconditional() or body_eds[
+        0].data.assignments:
+        return False, table
+
+    # Branch conditions must depend only on the loop variables.
+    for b in [tb, el]:
+        cond = b.data.condition
+        for c in cond.code:
+            used = set([ast_node.id for ast_node in ast.walk(c) if isinstance(ast_node, ast.Name)])
+            if not used.issubset(graph.free_symbols):
+                return False, table
+
+    # Body must have only constant assignments.
+    for n, _ in body.all_nodes_recursive():
+        # Each tasklet in this box...
+        if not isinstance(n, Tasklet):
+            continue
+        if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
+            # ...must assign...
+            return False, table
+        op = n.code.code[0]
+        if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
+            # ...a constant to a single target.
+            return False, table
+        const = op.value.value
+        for oe in body.out_edges(n):
+            dst = oe.data
+            dst_arr = oe.data.data
+            if dst_arr in table and table[dst_arr] != const:
+                # A target array can appear multiple times, but it must always be consistently assigned.
+                return False, table
+            table[dst] = const
+            table[dst_arr] = const
+    return True, table
+
+
+def consistent_const_assignment_table(graph: SDFGState, en: MapEntry, ex: MapExit) -> tuple[bool, dict]:
+    """
+    If the graph consists of only (conditional or unconditional) consistent constant assignments, produces a table
+    mapping data arrays and memlets to their consistent constant assignments. See the class docstring for what is
+    considered consistent.
+    """
+    table = {}
+    for n in graph.all_nodes_between(en, ex):
+        if isinstance(n, NestedSDFG):
+            # First handle the case of conditional constant assignment.
+            is_branch_const_assignment, internal_table = consistent_branch_const_assignment_table(n)
+            if not is_branch_const_assignment:
+                return False, table
+            for oe in graph.out_edges(n):
+                dst = oe.data
+                dst_arr = oe.data.data
+                if dst_arr in table and table[dst_arr] != internal_table[oe.src_conn]:
+                    # A target array can appear multiple times, but it must always be consistently assigned.
+                    return False, table
+                table[dst] = internal_table[oe.src_conn]
+                table[dst_arr] = internal_table[oe.src_conn]
+        elif isinstance(n, MapEntry):
+            is_const_assignment, internal_table = consistent_const_assignment_table(graph, n, graph.exit_node(n))
+            if not is_const_assignment:
+                return False, table
+            for k, v in internal_table.items():
+                if k in table and v != table[k]:
+                    return False, table
+                internal_table[k] = v
+        elif isinstance(n, MapExit):
+            pass  # Handled with `MapEntry`
+        else:
+            # Each of the nodes in this map must be...
+            if not isinstance(n, Tasklet):
+                # ...a tasklet...
+                return False, table
+            if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
+                # ...that assigns...
+                return False, table
+            op = n.code.code[0]
+            if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
+                # ...a constant to a single target.
+                return False, table
+            const = op.value.value
+            for oe in graph.out_edges(n):
+                dst = oe.data
+                dst_arr = oe.data.data
+                if dst_arr in table and table[dst_arr] != const:
+                    # A target array can appear multiple times, but it must always be consistently assigned.
+                    return False, table
+                table[dst] = const
+                table[dst_arr] = const
+    return True, table
+
+
+def add_equivalent_connectors(dst: Union[EntryNode, ExitNode], src: Union[EntryNode, ExitNode]):
+    """
+    Create the additional connectors in the first exit node that matches the second exit node (which will be removed
+    later).
+    """
+    conn_map = defaultdict()
+    for c, v in src.in_connectors.items():
+        assert c.startswith('IN_')
+        cbase = c.removeprefix('IN_')
+        sc = dst.next_connector(cbase)
+        conn_map[f"IN_{cbase}"] = f"IN_{sc}"
+        conn_map[f"OUT_{cbase}"] = f"OUT_{sc}"
+        dst.add_in_connector(f"IN_{sc}", dtype=v)
+        dst.add_out_connector(f"OUT_{sc}", dtype=v)
+    for c, v in src.out_connectors.items():
+        assert c in conn_map
+    return conn_map
+
+
+def connector_counterpart(c: Union[str, None]) -> Union[str, None]:
+    """If it's an input connector, find the corresponding output connector, and vice versa."""
+    if c is None:
+        return None
+    assert isinstance(c, str)
+    if c.startswith('IN_'):
+        return f"OUT_{c.removeprefix('IN_')}"
+    elif c.startswith('OUT_'):
+        return f"IN_{c.removeprefix('OUT_')}"
+    return None
+
+
+def consolidate_empty_dependencies(graph: SDFGState, first_entry: MapEntry, second_entry: MapEntry):
+    """
+    Remove all the incoming edges of the two maps and add empty edges from the union of the access nodes they
+    depended on before.
+
+    Preconditions:
+    1. All the incoming edges of the two maps must be from an access node and empty (i.e. have existed
+    only for synchronization).
+    2. The two maps must be constistent const assignments (see the class docstring for what is considered
+    consistent).
+    """
+    # First, construct a table of the dependencies.
+    table = {}
+    for en in [first_entry, second_entry]:
+        for e in graph.in_edges(en):
+            assert e.data.is_empty()
+            assert e.src_conn is None and e.dst_conn is None
+            if not isinstance(e.src, AccessNode):
+                continue
+            if e.src.data not in table:
+                table[e.src.data] = e.src
+            elif table[e.src.data] in graph.bfs_nodes(e.src):
+                # If this copy of the node is above the copy we've seen before, use this one instead.
+                table[e.src.data] = e.src
+            graph.remove_edge(e)
+    # Then, if we still have so that any of the map _writes_ to these nodes, we want to just create fresh copies to
+    # avoid cycles.
+    alt_table = {}
+    for k, v in table.items():
+        if v in graph.bfs_nodes(first_entry) or v in graph.bfs_nodes(second_entry):
+            alt_v = deepcopy(v)
+            graph.add_node(alt_v)
+            alt_table[k] = alt_v
+        else:
+            alt_table[k] = v
+    # Finally, these nodes should be depended on by _both_ maps.
+    for en in [first_entry, second_entry]:
+        for n in alt_table.values():
+            graph.add_memlet_path(n, en, memlet=Memlet())
+
+
+def consolidate_written_nodes(graph: SDFGState, first_exit: MapExit, second_exit: MapExit):
+    """
+    If the two maps write to the same underlying data array through two access nodes, replace those edges'
+    destination with a single shared copy.
+
+    Precondition:
+    1. The two maps must not depend on each other through an access node, which should be taken care of already by
+    `consolidate_empty_dependencies()`.
+    2. The two maps must be constistent const assignments (see the class docstring for what is considered
+    consistent).
+    """
+    # First, construct tables of the surviving and all written access nodes.
+    surviving_nodes, all_written_nodes = {}, set()
+    for ex in [first_exit, second_exit]:
+        for e in graph.out_edges(ex):
+            assert not e.data.is_empty()
+            assert e.src_conn is not None and ((e.dst_conn is None) == isinstance(e.dst, AccessNode))
+            if not isinstance(e.dst, AccessNode):
+                continue
+            all_written_nodes.add(e.dst)
+            if e.dst.data not in surviving_nodes:
+                surviving_nodes[e.dst.data] = e.dst
+            elif e.dst in graph.bfs_nodes(surviving_nodes[e.dst.data]):
+                # If this copy of the node is above the copy we've seen before, use this one instead.
+                surviving_nodes[e.dst.data] = e.dst
+    # Then, redirect all the edges toward the surviving copies of the destination access nodes.
+    for n in all_written_nodes:
+        for e in graph.in_edges(n):
+            assert e.src in [first_exit, second_exit]
+            assert e.dst_conn is None
+            graph.add_memlet_path(e.src, surviving_nodes[e.dst.data],
+                                  src_conn=e.src_conn, dst_conn=e.dst_conn,
+                                  memlet=Memlet.from_memlet(e.data))
+            graph.remove_edge(e)
+        for e in graph.out_edges(n):
+            assert e.src_conn is None
+            graph.add_memlet_path(surviving_nodes[e.src.data], e.dst,
+                                  src_conn=e.src_conn, dst_conn=e.dst_conn,
+                                  memlet=Memlet.from_memlet(e.data))
+            graph.remove_edge(e)
+    # Finally, cleanup the orphan nodes.
+    for n in all_written_nodes:
+        if graph.degree(n) == 0:
+            graph.remove_node(n)
+
+
+def consume_map_exactly(graph: SDFGState, dst: tuple[MapEntry, MapExit], src: tuple[MapEntry, MapExit]):
+    """
+    Transfer the entirety of `src` map's body into `dst` map. Only possible when the two maps' ranges are identical.
+    """
+    dst_en, dst_ex = dst
+    src_en, src_ex = src
+
+    assert all(e.data.is_empty() for e in graph.in_edges(src_en))
+    cmap = add_equivalent_connectors(dst_en, src_en)
+    for e in graph.in_edges(src_en):
+        graph.add_memlet_path(e.src, dst_en,
+                              src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+    for e in graph.out_edges(src_en):
+        graph.add_memlet_path(dst_en, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+    cmap = add_equivalent_connectors(dst_ex, src_ex)
+    for e in graph.in_edges(src_ex):
+        graph.add_memlet_path(e.src, dst_ex,
+                              src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+    for e in graph.out_edges(src_ex):
+        graph.add_memlet_path(dst_ex, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+    graph.remove_node(src_en)
+    graph.remove_node(src_ex)
+
+
+def consume_map_with_grid_strided_loop(graph: SDFGState, dst: tuple[MapEntry, MapExit],
+                                       src: tuple[MapEntry, MapExit]):
+    """
+    Transfer the entirety of `src` map's body into `dst` map, guarded behind a _grid-strided_ loop.
+    Prerequisite: `dst` map's range must cover `src` map's range in entirety. Statically checking this may not
+    always be possible.
+    """
+    dst_en, dst_ex = dst
+    src_en, src_ex = src
+
+    def range_for_grid_stride(r, val, bound):
+        r = list(r)
+        r[0] = val
+        r[1] = bound - 1
+        r[2] = bound
+        return tuple(r)
+
+    gsl_ranges = [range_for_grid_stride(rd, p, rs[1] + 1)
+                  for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
+    gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
+    en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),
+                           {k: v for k, v in zip(gsl_params, gsl_ranges)},
+                           schedule=ScheduleType.Sequential)
+    # graph.add_memlet_path(dst_en, en, memlet=Memlet())
+    consume_map_exactly(graph, (en, ex), src)
+    # graph.add_memlet_path(ex, dst_ex, memlet=Memlet())
+
+    assert all(e.data.is_empty() for e in graph.in_edges(en))
+    cmap = add_equivalent_connectors(dst_en, en)
+    for e in graph.in_edges(en):
+        graph.add_memlet_path(e.src, dst_en,
+                              src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.add_memlet_path(dst_en, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+    cmap = add_equivalent_connectors(dst_ex, ex)
+    for e in graph.out_edges(ex):
+        graph.add_memlet_path(e.src, dst_ex,
+                              src_conn=e.src_conn,
+                              dst_conn=connector_counterpart(cmap.get(e.src_conn)),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.add_memlet_path(dst_ex, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+
+def compatible_range(first_entry: MapEntry, second_entry: MapEntry) -> bool:
+    """Decide if the two ranges are compatible. See the class docstring for what is considered compatible."""
+    if first_entry.map.schedule != second_entry.map.schedule:
+        # If the two maps are not to be scheduled on the same device, don't fuse them.
+        return False
+    if len(first_entry.map.range) != len(second_entry.map.range):
+        # If it's not even possible to take component-wise union of the two map's range, don't fuse them.
+        # TODO(pratyai): Make it so that a permutation of the ranges, or even an union of the ranges will work.
+        return False
+    if first_entry.map.schedule == ScheduleType.Sequential:
+        # For _grid-strided loops_, fuse them only when their ranges are _exactly_ the same. I.e., never put them
+        # behind another layer of grid-strided loop.
+        if first_entry.map.range != second_entry.map.range:
+            return False
+    return True
+
+
 class ConstAssignmentMapFusion(MapFusion):
     """
     Fuses two maps within a state, where each map:
@@ -47,8 +391,8 @@ class ConstAssignmentMapFusion(MapFusion):
         - Exists a path like: MapExit -> AccessNode -> MapEntry
         - Neither map is dependent on the other. I.e. There is no dependency path between them.
     """
-    first_map_entry = transformation.PatternNode(nodes.EntryNode)
-    second_map_entry = transformation.PatternNode(nodes.EntryNode)
+    first_map_entry = transformation.PatternNode(MapEntry)
+    second_map_entry = transformation.PatternNode(MapEntry)
 
     @classmethod
     def expressions(cls):
@@ -56,155 +400,10 @@ class ConstAssignmentMapFusion(MapFusion):
         # in the middle and the second edge of the path is empty.
         return [floating_nodes_graph(cls.first_map_entry, cls.second_map_entry)]
 
-    @staticmethod
-    def consistent_branch_const_assignment_table(graph: Node) -> tuple[bool, dict]:
-        """
-        If the graph consists of only conditional consistent constant assignments, produces a table mapping data arrays
-        and memlets to their consistent constant assignments. See the class docstring for what is considered consistent.
-        """
-        table = {}
-        # Basic premise check.
-        if not isinstance(graph, NestedSDFG):
-            return False, table
-        graph: SDFG = graph.sdfg
-        if not isinstance(graph, ControlFlowBlock):
-            return False, table
-
-        # Must have exactly 3 nodes, and exactly one of them a source, another a sink.
-        src, snk = graph.source_nodes(), graph.sink_nodes()
-        if len(graph.nodes()) != 3 or len(src) != 1 or len(snk) != 1:
-            return False, table
-        src, snk = src[0], snk[0]
-        body = set(graph.nodes()) - {src, snk}
-        if len(body) != 1:
-            return False, table
-        body = list(body)[0]
-
-        # Must have certain structure of outgoing edges.
-        src_eds = list(graph.out_edges(src))
-        if len(src_eds) != 2 or any(e.data.is_unconditional() or e.data.assignments for e in src_eds):
-            return False, table
-        tb, el = src_eds
-        if tb.dst != body:
-            tb, el = el, tb
-        if tb.dst != body or el.dst != snk:
-            return False, table
-        body_eds = list(graph.out_edges(body))
-        if len(body_eds) != 1 or body_eds[0].dst != snk or not body_eds[0].data.is_unconditional() or body_eds[
-            0].data.assignments:
-            return False, table
-
-        # Branch conditions must depend only on the loop variables.
-        for b in [tb, el]:
-            cond = b.data.condition
-            for c in cond.code:
-                used = set([ast_node.id for ast_node in ast.walk(c) if isinstance(ast_node, ast.Name)])
-                if not used.issubset(graph.free_symbols):
-                    return False, table
-
-        # Body must have only constant assignments.
-        for n, _ in body.all_nodes_recursive():
-            # Each tasklet in this box...
-            if not isinstance(n, Tasklet):
-                continue
-            if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
-                # ...must assign...
-                return False, table
-            op = n.code.code[0]
-            if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
-                # ...a constant to a single target.
-                return False, table
-            const = op.value.value
-            for oe in body.out_edges(n):
-                dst = oe.data
-                dst_arr = oe.data.data
-                if dst_arr in table and table[dst_arr] != const:
-                    # A target array can appear multiple times, but it must always be consistently assigned.
-                    return False, table
-                table[dst] = const
-                table[dst_arr] = const
-        return True, table
-
-    @staticmethod
-    def consistent_const_assignment_table(graph: SDFGState, en: MapEntry, ex: MapExit) -> tuple[bool, dict]:
-        """
-        If the graph consists of only (conditional or unconditional) consistent constant assignments, produces a table
-        mapping data arrays and memlets to their consistent constant assignments. See the class docstring for what is
-        considered consistent.
-        """
-        table = {}
-        for n in graph.all_nodes_between(en, ex):
-            if isinstance(n, NestedSDFG):
-                # First handle the case of conditional constant assignment.
-                is_branch_const_assignment, internal_table = ConstAssignmentMapFusion.consistent_branch_const_assignment_table(
-                    n)
-                if not is_branch_const_assignment:
-                    return False, table
-                for oe in graph.out_edges(n):
-                    dst = oe.data
-                    dst_arr = oe.data.data
-                    if dst_arr in table and table[dst_arr] != internal_table[oe.src_conn]:
-                        # A target array can appear multiple times, but it must always be consistently assigned.
-                        return False, table
-                    table[dst] = internal_table[oe.src_conn]
-                    table[dst_arr] = internal_table[oe.src_conn]
-            elif isinstance(n, MapEntry):
-                is_const_assignment, internal_table = ConstAssignmentMapFusion.consistent_const_assignment_table(graph,
-                                                                                                                 n,
-                                                                                                                 graph.exit_node(
-                                                                                                                     n))
-                if not is_const_assignment:
-                    return False, table
-                for k, v in internal_table.items():
-                    if k in table and v != table[k]:
-                        return False, table
-                    internal_table[k] = v
-            elif isinstance(n, MapExit):
-                pass  # Handled with `MapEntry`
-            else:
-                # Each of the nodes in this map must be...
-                if not isinstance(n, Tasklet):
-                    # ...a tasklet...
-                    return False, table
-                if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
-                    # ...that assigns...
-                    return False, table
-                op = n.code.code[0]
-                if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
-                    # ...a constant to a single target.
-                    return False, table
-                const = op.value.value
-                for oe in graph.out_edges(n):
-                    dst = oe.data
-                    dst_arr = oe.data.data
-                    if dst_arr in table and table[dst_arr] != const:
-                        # A target array can appear multiple times, but it must always be consistently assigned.
-                        return False, table
-                    table[dst] = const
-                    table[dst_arr] = const
-        return True, table
-
     def map_nodes(self, graph: SDFGState):
         """Return the entry and exit nodes of the relevant maps as a tuple: entry_1, exit_1, entry_2, exit_2."""
         return (self.first_map_entry, graph.exit_node(self.first_map_entry),
                 self.second_map_entry, graph.exit_node(self.second_map_entry))
-
-    @staticmethod
-    def compatible_range(first_entry: MapEntry, second_entry: MapEntry) -> bool:
-        """Decide if the two ranges are compatible. See the class docstring for what is considered compatible."""
-        if first_entry.map.schedule != second_entry.map.schedule:
-            # If the two maps are not to be scheduled on the same device, don't fuse them.
-            return False
-        if len(first_entry.map.range) != len(second_entry.map.range):
-            # If it's not even possible to take component-wise union of the two map's range, don't fuse them.
-            # TODO(pratyai): Make it so that a permutation of the ranges, or even an union of the ranges will work.
-            return False
-        if first_entry.map.schedule == ScheduleType.Sequential:
-            # For _grid-strided loops_, fuse them only when their ranges are _exactly_ the same. I.e., never put them
-            # behind another layer of grid-strided loop.
-            if first_entry.map.range != second_entry.map.range:
-                return False
-        return True
 
     def no_dependency_pattern(self, graph: SDFGState) -> bool:
         """Decide if the two maps are independent of each other."""
@@ -239,15 +438,14 @@ class ConstAssignmentMapFusion(MapFusion):
             return False
 
         first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
-        if not self.compatible_range(first_entry, second_entry):
+        if not compatible_range(first_entry, second_entry):
             return False
 
         # Both maps must have consistent constant assignment for the target arrays.
-        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        is_const_assignment, assignments = consistent_const_assignment_table(graph, first_entry, first_exit)
         if not is_const_assignment:
             return False
-        is_const_assignment, further_assignments = self.consistent_const_assignment_table(graph, second_entry,
-                                                                                          second_exit)
+        is_const_assignment, further_assignments = consistent_const_assignment_table(graph, second_entry, second_exit)
         if not is_const_assignment:
             return False
         for k, v in further_assignments.items():
@@ -256,216 +454,12 @@ class ConstAssignmentMapFusion(MapFusion):
             assignments[k] = v
         return True
 
-    @staticmethod
-    def add_equivalent_connectors(dst: Union[EntryNode, ExitNode], src: Union[EntryNode, ExitNode]):
-        """
-        Create the additional connectors in the first exit node that matches the second exit node (which will be removed
-        later).
-        """
-        conn_map = defaultdict()
-        for c, v in src.in_connectors.items():
-            assert c.startswith('IN_')
-            cbase = c.removeprefix('IN_')
-            sc = dst.next_connector(cbase)
-            conn_map[f"IN_{cbase}"] = f"IN_{sc}"
-            conn_map[f"OUT_{cbase}"] = f"OUT_{sc}"
-            dst.add_in_connector(f"IN_{sc}", dtype=v)
-            dst.add_out_connector(f"OUT_{sc}", dtype=v)
-        for c, v in src.out_connectors.items():
-            assert c in conn_map
-        return conn_map
-
-    @staticmethod
-    def connector_counterpart(c: Union[str, None]) -> Union[str, None]:
-        """If it's an input connector, find the corresponding output connector, and vice versa."""
-        if c is None:
-            return None
-        assert isinstance(c, str)
-        if c.startswith('IN_'):
-            return f"OUT_{c.removeprefix('IN_')}"
-        elif c.startswith('OUT_'):
-            return f"IN_{c.removeprefix('OUT_')}"
-        return None
-
-    @staticmethod
-    def consolidate_empty_dependencies(graph: SDFGState, first_entry: MapEntry, second_entry: MapEntry):
-        """
-        Remove all the incoming edges of the two maps and add empty edges from the union of the access nodes they
-        depended on before.
-
-        Preconditions:
-        1. All the incoming edges of the two maps must be from an access node and empty (i.e. have existed
-        only for synchronization).
-        2. The two maps must be constistent const assignments (see the class docstring for what is considered
-        consistent).
-        """
-        # First, construct a table of the dependencies.
-        table = {}
-        for en in [first_entry, second_entry]:
-            for e in graph.in_edges(en):
-                assert e.data.is_empty()
-                assert e.src_conn is None and e.dst_conn is None
-                if not isinstance(e.src, AccessNode):
-                    continue
-                if e.src.data not in table:
-                    table[e.src.data] = e.src
-                elif table[e.src.data] in graph.bfs_nodes(e.src):
-                    # If this copy of the node is above the copy we've seen before, use this one instead.
-                    table[e.src.data] = e.src
-                graph.remove_edge(e)
-        # Then, if we still have so that any of the map _writes_ to these nodes, we want to just create fresh copies to
-        # avoid cycles.
-        alt_table = {}
-        for k, v in table.items():
-            if v in graph.bfs_nodes(first_entry) or v in graph.bfs_nodes(second_entry):
-                alt_v = deepcopy(v)
-                graph.add_node(alt_v)
-                alt_table[k] = alt_v
-            else:
-                alt_table[k] = v
-        # Finally, these nodes should be depended on by _both_ maps.
-        for en in [first_entry, second_entry]:
-            for n in alt_table.values():
-                graph.add_memlet_path(n, en, memlet=Memlet())
-
-    @staticmethod
-    def consolidate_written_nodes(graph: SDFGState, first_exit: MapExit, second_exit: MapExit):
-        """
-        If the two maps write to the same underlying data array through two access nodes, replace those edges'
-        destination with a single shared copy.
-
-        Precondition:
-        1. The two maps must not depend on each other through an access node (which should be taken care of already by
-        `consolidate_empty_dependencies()`.
-        2. The two maps must be constistent const assignments (see the class docstring for what is considered
-        consistent).
-        """
-        # First, construct tables of the surviving and all written access nodes.
-        surviving_nodes, all_written_nodes = {}, set()
-        for ex in [first_exit, second_exit]:
-            for e in graph.out_edges(ex):
-                assert not e.data.is_empty()
-                assert e.src_conn is not None and ((e.dst_conn is None) == isinstance(e.dst, AccessNode))
-                if not isinstance(e.dst, AccessNode):
-                    continue
-                all_written_nodes.add(e.dst)
-                if e.dst.data not in surviving_nodes:
-                    surviving_nodes[e.dst.data] = e.dst
-                elif e.dst in graph.bfs_nodes(surviving_nodes[e.dst.data]):
-                    # If this copy of the node is above the copy we've seen before, use this one instead.
-                    surviving_nodes[e.dst.data] = e.dst
-        # Then, redirect all the edges toward the surviving copies of the destination access nodes.
-        for n in all_written_nodes:
-            for e in graph.in_edges(n):
-                assert e.src in [first_exit, second_exit]
-                assert e.dst_conn is None
-                graph.add_memlet_path(e.src, surviving_nodes[e.dst.data],
-                                      src_conn=e.src_conn, dst_conn=e.dst_conn,
-                                      memlet=Memlet.from_memlet(e.data))
-                graph.remove_edge(e)
-            for e in graph.out_edges(n):
-                assert e.src_conn is None
-                graph.add_memlet_path(surviving_nodes[e.src.data], e.dst,
-                                      src_conn=e.src_conn, dst_conn=e.dst_conn,
-                                      memlet=Memlet.from_memlet(e.data))
-                graph.remove_edge(e)
-        # Finally, cleanup the orphan nodes.
-        for n in all_written_nodes:
-            if graph.degree(n) == 0:
-                graph.remove_node(n)
-
-    @staticmethod
-    def consume_map_exactly(graph: SDFGState, dst: tuple[MapEntry, MapExit], src: tuple[MapEntry, MapExit]):
-        """
-        Transfer the entirety of `src` map's body into `dst` map. Only possible when the two maps' ranges are identical.
-        """
-        dst_en, dst_ex = dst
-        src_en, src_ex = src
-
-        assert all(e.data.is_empty() for e in graph.in_edges(src_en))
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_en, src_en)
-        for e in graph.in_edges(src_en):
-            graph.add_memlet_path(e.src, dst_en,
-                                  src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-        for e in graph.out_edges(src_en):
-            graph.add_memlet_path(dst_en, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_ex, src_ex)
-        for e in graph.in_edges(src_ex):
-            graph.add_memlet_path(e.src, dst_ex,
-                                  src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-        for e in graph.out_edges(src_ex):
-            graph.add_memlet_path(dst_ex, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
-        graph.remove_node(src_en)
-        graph.remove_node(src_ex)
-
-    @staticmethod
-    def consume_map_with_grid_strided_loop(graph: SDFGState, dst: tuple[MapEntry, MapExit],
-                                           src: tuple[MapEntry, MapExit]):
-        """
-        Transfer the entirety of `src` map's body into `dst` map, guarded behind a _grid-strided_ loop.
-        Prerequisite: `dst` map's range must cover `src` map's range in entirety. Statically checking this may not
-        always be possible.
-        """
-        dst_en, dst_ex = dst
-        src_en, src_ex = src
-
-        def range_for_grid_stride(r, val, bound):
-            r = list(r)
-            r[0] = val
-            r[1] = bound - 1
-            r[2] = bound
-            return tuple(r)
-
-        gsl_ranges = [range_for_grid_stride(rd, p, rs[1] + 1)
-                      for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
-        gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
-        en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),
-                               {k: v for k, v in zip(gsl_params, gsl_ranges)},
-                               schedule=ScheduleType.Sequential)
-        # graph.add_memlet_path(dst_en, en, memlet=Memlet())
-        ConstAssignmentMapFusion.consume_map_exactly(graph, (en, ex), src)
-        # graph.add_memlet_path(ex, dst_ex, memlet=Memlet())
-
-        assert all(e.data.is_empty() for e in graph.in_edges(en))
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_en, en)
-        for e in graph.in_edges(en):
-            graph.add_memlet_path(e.src, dst_en,
-                                  src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.add_memlet_path(dst_en, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_ex, ex)
-        for e in graph.out_edges(ex):
-            graph.add_memlet_path(e.src, dst_ex,
-                                  src_conn=e.src_conn,
-                                  dst_conn=ConstAssignmentMapFusion.connector_counterpart(cmap.get(e.src_conn)),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.add_memlet_path(dst_ex, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
     def apply(self, graph: SDFGState, sdfg: SDFG):
         first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
 
         # By now, we know that the two maps are compatible, not reading anything, and just blindly writing constants
         # _consistently_.
-        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        is_const_assignment, assignments = consistent_const_assignment_table(graph, first_entry, first_exit)
         assert is_const_assignment
 
         # Rename in case loop variables are named differently.
@@ -476,10 +470,10 @@ class ConstAssignmentMapFusion(MapFusion):
         second_entry.map.params = first_entry.map.params
 
         # Consolidate the incoming dependencies of the two maps.
-        self.consolidate_empty_dependencies(graph, first_entry, second_entry)
+        consolidate_empty_dependencies(graph, first_entry, second_entry)
 
         # Consolidate the written access nodes of the two maps.
-        self.consolidate_written_nodes(graph, first_exit, second_exit)
+        consolidate_written_nodes(graph, first_exit, second_exit)
 
         # If the ranges are identical, then simply fuse the two maps. Otherwise, use grid-strided loops.
         en, ex = graph.add_map(sdfg._find_new_name('map_fusion_wrapper'),
@@ -488,9 +482,9 @@ class ConstAssignmentMapFusion(MapFusion):
                                schedule=first_entry.map.schedule)
         for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
             if en.map.range.covers(cur_en.map.range):
-                self.consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
+                consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
             else:
-                self.consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
+                consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
 
         # Cleanup: remove duplicate empty dependencies.
         seen = set()
@@ -529,9 +523,7 @@ class ConstAssignmentStateFusion(StateFusionExtended):
             en, ex = en_ex
             if any(not e.data.is_empty for e in st.in_edges(en)):
                 return False
-            is_const_assignment, further_assignments = ConstAssignmentMapFusion.consistent_const_assignment_table(st,
-                                                                                                                  en,
-                                                                                                                  ex)
+            is_const_assignment, further_assignments = consistent_const_assignment_table(st, en, ex)
             if not is_const_assignment:
                 return False
             for k, v in further_assignments.items():
@@ -540,8 +532,7 @@ class ConstAssignmentStateFusion(StateFusionExtended):
                 assignments[k] = v
 
         # Moreover, both states' ranges must be compatible.
-        if not ConstAssignmentMapFusion.compatible_range(unique_top_level_map_node(st0)[0],
-                                                         unique_top_level_map_node(st1)[0]):
+        if not compatible_range(unique_top_level_map_node(st0)[0], unique_top_level_map_node(st1)[0]):
             return False
 
         return True

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from itertools import chain
 from typing import Optional, Union
 
-from dace import transformation, SDFGState, SDFG, Memlet, subsets
+from dace import transformation, SDFGState, SDFG, Memlet, subsets, ScheduleType
 from dace.sdfg import nodes
 from dace.sdfg.graph import OrderedDiGraph
 from dace.sdfg.nodes import Tasklet, ExitNode, MapEntry, MapExit, NestedSDFG, Node, EntryNode, AccessNode
@@ -404,7 +404,8 @@ class ConstAssignmentMapFusion(MapFusion):
                       for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
         gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
         en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),
-                               {k: v for k, v in zip(gsl_params, gsl_ranges)})
+                               {k: v for k, v in zip(gsl_params, gsl_ranges)},
+                               schedule=ScheduleType.Sequential)
         # graph.add_memlet_path(dst_en, en, memlet=Memlet())
         ConstAssignmentMapFusion.consume_map_exactly(graph, (en, ex), src)
         # graph.add_memlet_path(ex, dst_ex, memlet=Memlet())

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -1,0 +1,149 @@
+import ast
+from itertools import chain
+
+import dace.subsets
+from dace import transformation, SDFGState, SDFG, Memlet
+from dace.sdfg import nodes
+from dace.sdfg.nodes import Tasklet, ExitNode
+from dace.transformation.dataflow import MapFusion
+
+
+class ConstAssignmentMapFusion(MapFusion):
+    first_map_exit = transformation.PatternNode(nodes.ExitNode)
+    array = transformation.PatternNode(nodes.AccessNode)
+    second_map_entry = transformation.PatternNode(nodes.EntryNode)
+
+    # NOTE: `expression()` is inherited.
+
+    @staticmethod
+    def consistent_const_assignment_table(graph, en, ex) -> tuple[bool, dict]:
+        table = {}
+        for n in graph.all_nodes_between(en, ex):
+            # Each of the nodes in this map must be...
+            if not isinstance(n, Tasklet):
+                # ...a tasklet...
+                return False, table
+            if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
+                # ...that assigns...
+                return False, table
+            op = n.code.code[0]
+            if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
+                # ...a constant to a single target.
+                return False, table
+            const = op.value.value
+            for oe in graph.out_edges(n):
+                dst = oe.data
+                dst_arr = oe.data.data
+                if dst_arr in table and table[dst_arr] != const:
+                    # A target array can appear multiple times, but it must always be consistently assigned.
+                    return False, table
+                table[dst] = const
+                table[dst_arr] = const
+        return True, table
+
+    def map_nodes(self, graph: SDFGState):
+        return (graph.entry_node(self.first_map_exit), self.first_map_exit,
+                self.second_map_entry, graph.exit_node(self.second_map_entry))
+
+    def can_be_applied(self, graph: SDFGState, expr_index: int, sdfg: SDFG, permissive: bool = False) -> bool:
+        first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
+        # TODO(pratyai): Make a better check for map compatibility.
+        if first_entry.map.range != second_entry.map.range or first_entry.map.schedule != second_entry.map.schedule:
+            # TODO(pratyai): Make it so that a permutation of the ranges, or even an union of the ranges will work.
+            return False
+
+        # Both maps must have consistent constant assignment for the target arrays.
+        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        if not is_const_assignment:
+            return False
+        is_const_assignment, further_assignments = self.consistent_const_assignment_table(graph, second_entry,
+                                                                                          second_exit)
+        if not is_const_assignment:
+            return False
+        for k, v in further_assignments.items():
+            if k in assignments and v != assignments[k]:
+                return False
+            assignments[k] = v
+        return True
+
+    @staticmethod
+    def track_access_nodes(graph: SDFGState, first_exit: ExitNode, second_exit: ExitNode):
+        # Track all the access nodes that will survive the purge.
+        access_nodes, remove_nodes = {}, set()
+        dst_nodes = set(e.dst for e in chain(graph.out_edges(first_exit), graph.out_edges(second_exit)))
+        for n in dst_nodes:
+            if n.data in access_nodes:
+                remove_nodes.add(n)
+            else:
+                access_nodes[n.data] = n
+        for n in remove_nodes:
+            assert n.data in access_nodes
+            assert access_nodes[n.data] != n
+        return access_nodes, remove_nodes
+
+    @staticmethod
+    def make_equivalent_connections(first_exit: ExitNode, second_exit: ExitNode):
+        # Set up the extra connections on the first node.
+        conn_map = {}
+        for c, v in second_exit.in_connectors.items():
+            assert c.startswith('IN_')
+            cbase = c.removeprefix('IN_')
+            sc = first_exit.next_connector(cbase)
+            conn_map[f"IN_{cbase}"] = f"IN_{sc}"
+            conn_map[f"OUT_{cbase}"] = f"OUT_{sc}"
+            first_exit.add_in_connector(f"IN_{sc}", dtype=v)
+            first_exit.add_out_connector(f"OUT_{sc}", dtype=v)
+        for c, v in second_exit.out_connectors.items():
+            assert c in conn_map
+        return conn_map
+
+    def apply(self, graph: SDFGState, sdfg: SDFG):
+        first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
+
+        # By now, we know that the two maps are compatible, not reading anything, and just blindly writing constants
+        # _consistently_.
+        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        assert is_const_assignment
+
+        # Track all the access nodes that will survive the purge.
+        access_nodes, remove_nodes = self.track_access_nodes(graph, first_exit, second_exit)
+
+        # Set up the extra connections on the first node.
+        conn_map = self.make_equivalent_connections(first_exit, second_exit)
+
+        # Redirect outgoing edges from exit nodes that are going to be invalidated.
+        for e in graph.out_edges(first_exit):
+            array_name = e.dst.data
+            assert array_name in access_nodes
+            if access_nodes[array_name] != e.dst:
+                graph.add_memlet_path(first_exit, access_nodes[array_name], src_conn=e.src_conn, dst_conn=e.dst_conn,
+                                      memlet=Memlet(str(e.data)))
+                graph.remove_edge(e)
+        for e in graph.out_edges(second_exit):
+            array_name = e.dst.data
+            assert array_name in access_nodes
+            graph.add_memlet_path(first_exit, access_nodes[array_name], src_conn=conn_map[e.src_conn],
+                                  dst_conn=e.dst_conn, memlet=Memlet(str(e.data)))
+            graph.remove_edge(e)
+
+        # Move the tasklets from the second map into the first map.
+        second_tasklets = graph.all_nodes_between(second_entry, second_exit)
+        for t in second_tasklets:
+            for e in graph.in_edges(t):
+                graph.add_memlet_path(first_entry, t, memlet=Memlet())
+                graph.remove_edge(e)
+            for e in graph.out_edges(t):
+                graph.add_memlet_path(e.src, first_exit, src_conn=e.src_conn, dst_conn=conn_map[e.dst_conn],
+                                      memlet=Memlet(str(e.data)))
+                graph.remove_edge(e)
+
+        # Redirect any outgoing edges from the nodes to be removed through their surviving counterparts.
+        for n in remove_nodes:
+            for e in graph.out_edges(n):
+                if e.dst != second_entry:
+                    alt_n = access_nodes[n.data]
+                    memlet = Memlet(str(e.data)) if not e.data.is_empty() else Memlet()
+                    graph.add_memlet_path(alt_n, e.dst, src_conn=e.src_conn, dst_conn=e.dst_conn, memlet=memlet)
+            graph.remove_node(n)
+        graph.remove_node(second_entry)
+        graph.remove_node(second_exit)

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -393,13 +393,14 @@ class ConstAssignmentMapFusion(MapFusion):
         dst_en, dst_ex = dst
         src_en, src_ex = src
 
-        def with_start_and_stride(r, start, stride):
+        def range_for_grid_stride(r, val, bound):
             r = list(r)
-            r[0] = start
-            r[2] = stride
+            r[0] = val
+            r[1] = bound - 1
+            r[2] = bound
             return tuple(r)
 
-        gsl_ranges = [with_start_and_stride(rd, p, rs[1] + 1)
+        gsl_ranges = [range_for_grid_stride(rd, p, rs[1] + 1)
                       for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
         gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
         en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -579,7 +579,7 @@ class ConstAssignmentStateFusion(StateFusionExtended):
             if not en_ex:
                 return False
             en, ex = en_ex
-            if any(not e.data.is_empty for e in st.in_edges(en)):
+            if any(not e.data.is_empty() for e in st.in_edges(en)):
                 return False
             is_const_assignment, further_assignments = _consistent_const_assignment_table(st, en, ex)
             if not is_const_assignment:

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -7,6 +7,7 @@ import dace
 from dace.transformation.dataflow.const_assignment_fusion import ConstAssignmentMapFusion, ConstAssignmentStateFusion
 from dace.transformation.interstate import StateFusionExtended
 
+K = dace.symbol('K')
 M = dace.symbol('M')
 N = dace.symbol('N')
 
@@ -152,6 +153,47 @@ def test_free_floating_fusion():
 
 
 @dace.program
+def assign_top_face(A: dace.float32[K, M, N]):
+    for t1, t2 in dace.map[0:M, 0:N]:
+        A[0, t1, t2] = 1
+
+
+@dace.program
+def assign_bottom_face(A: dace.float32[K, M, N]):
+    for t1, t2 in dace.map[0:M, 0:N]:
+        A[K - 1, t1, t2] = 1
+
+
+@dace.program
+def assign_bounary_3d(A: dace.float32[K, M, N], B: dace.float32[K, M, N]):
+    assign_top_face(A)
+    assign_bottom_face(B)
+
+
+def test_fusion_with_multiple_indices():
+    A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
+    B = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
+
+    # Construct SDFG with the maps on separate states.
+    g = assign_bounary_3d.to_sdfg(simplify=True, validate=True, use_cache=False)
+    g.save(os.path.join('_dacegraphs', '3d-0.sdfg'))
+    g.validate()
+    actual_A = deepcopy(A)
+    actual_B = deepcopy(B)
+    g(A=actual_A, B=actual_B, K=3, M=4, N=5)
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', '3d-1.sdfg'))
+    g.validate()
+    our_A = deepcopy(A)
+    our_B = deepcopy(B)
+    g(A=our_A, B=our_B, K=3, M=4, N=5)
+
+    # print(our_A)
+    assert np.allclose(our_A, actual_A)
+
+
+@dace.program
 def assign_bounary_with_branch(A: dace.float32[M, N], B: dace.float32[M, N]):
     assign_top_row_branched(A)
     assign_bottom_row(B)
@@ -185,3 +227,4 @@ if __name__ == '__main__':
     test_interstate_fusion()
     test_free_floating_fusion()
     test_fusion_with_branch()
+    test_fusion_with_multiple_indices()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -77,15 +77,19 @@ def test_within_state_fusion():
     g.save(os.path.join('_dacegraphs', 'simple-1.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'simple-2.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'simple-3.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 0
+    assert g.apply_transformations(ConstAssignmentMapFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'simple-4.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -105,15 +109,19 @@ def test_interstate_fusion():
     actual_A = deepcopy(A)
     g(A=actual_A, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentStateFusion)
+    assert g.apply_transformations(ConstAssignmentStateFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'interstate-1.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentStateFusion)
+    assert g.apply_transformations(ConstAssignmentStateFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'interstate-2.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentStateFusion)
+    assert g.apply_transformations(ConstAssignmentStateFusion) == 0
+    assert g.apply_transformations(ConstAssignmentStateFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'interstate-3.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -141,7 +149,7 @@ def test_free_floating_fusion():
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', 'floating-1.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -182,7 +190,7 @@ def test_fusion_with_multiple_indices():
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, K=3, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', '3d-1.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -211,7 +219,7 @@ def test_fusion_with_branch():
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', 'branched-1.sdfg'))
     g.validate()
     our_A = deepcopy(A)

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -13,26 +13,26 @@ N = dace.symbol('N')
 
 @dace.program
 def assign_top_row(A: dace.float32[M, N]):
-    for i in dace.map[0:N]:
-        A[0, i] = 1
+    for t in dace.map[0:N]:
+        A[0, t] = 1
 
 
 @dace.program
 def assign_bottom_row(A: dace.float32[M, N]):
-    for i in dace.map[0:N]:
-        A[M - 1, i] = 1
+    for b in dace.map[0:N]:
+        A[M - 1, b] = 1
 
 
 @dace.program
 def assign_left_col(A: dace.float32[M, N]):
-    for i in dace.map[0:M]:
-        A[i, 0] = 1
+    for l in dace.map[0:M]:
+        A[l, 0] = 1
 
 
 @dace.program
 def assign_right_col(A: dace.float32[M, N]):
-    for i in dace.map[0:M]:
-        A[i, N - 1] = 1
+    for r in dace.map[0:M]:
+        A[r, N - 1] = 1
 
 
 def assign_bounary_sdfg():

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -16,6 +16,12 @@ def assign_top_row(A: dace.float32[M, N]):
     for t in dace.map[0:N]:
         A[0, t] = 1
 
+@dace.program
+def assign_top_row_branched(A: dace.float32[M, N]):
+    for t, in dace.map[0:N]:
+        if t % 2 == 0:
+            A[0, t] = 1
+
 
 @dace.program
 def assign_bottom_row(A: dace.float32[M, N]):
@@ -144,6 +150,37 @@ def test_free_floating_fusion():
     assert np.allclose(our_A, actual_A)
 
 
+@dace.program
+def assign_bounary_with_branch(A: dace.float32[M, N], B: dace.float32[M, N]):
+    assign_top_row_branched(A)
+    assign_bottom_row(B)
+
+
+def test_fusion_with_branch():
+    A = np.random.uniform(size=(4, 5)).astype(np.float32)
+    B = np.random.uniform(size=(4, 5)).astype(np.float32)
+
+    # Construct SDFG with the maps on separate states.
+    g = assign_bounary_with_branch.to_sdfg(simplify=True)
+    g.save(os.path.join('_dacegraphs', 'branched-0.sdfg'))
+    g.validate()
+    actual_A = deepcopy(A)
+    actual_B = deepcopy(B)
+    g(A=actual_A, B=actual_B, M=4, N=5)
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'branched-1.sdfg'))
+    g.validate()
+    our_A = deepcopy(A)
+    our_B = deepcopy(B)
+    g(A=our_A, B=our_B, M=4, N=5)
+
+    # print(our_A)
+    assert np.allclose(our_A, actual_A)
+
+
 if __name__ == '__main__':
     test_within_state_fusion()
     test_interstate_fusion()
+    test_free_floating_fusion()
+    test_fusion_with_branch()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -1,0 +1,110 @@
+import os
+from copy import deepcopy
+
+import numpy as np
+
+import dace
+from dace.sdfg import nodes
+from dace.transformation.dataflow.const_assignment_fusion import ConstAssignmentMapFusion
+from dace.transformation.interstate import StateFusionExtended
+
+M = dace.symbol('M')
+N = dace.symbol('N')
+
+
+@dace.program
+def assign_top_row(A: dace.float32[M, N]):
+    for i in dace.map[0:N]:
+        A[0, i] = 1
+
+
+@dace.program
+def assign_bottom_row(A: dace.float32[M, N]):
+    for i in dace.map[0:N]:
+        A[M - 1, i] = 1
+
+
+@dace.program
+def assign_left_col(A: dace.float32[M, N]):
+    for i in dace.map[0:M]:
+        A[i, 0] = 1
+
+
+@dace.program
+def assign_right_col(A: dace.float32[M, N]):
+    for i in dace.map[0:M]:
+        A[i, N - 1] = 1
+
+
+def assign_bounary_sdfg():
+    st0 = assign_top_row.to_sdfg(simplify=True, validate=True)
+    st0.start_block.label = 'st0'
+
+    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True)
+    st1.start_block.label = 'st1'
+    st0.add_edge(st0.start_state, st1.start_state, dace.InterstateEdge())
+
+    st2 = assign_left_col.to_sdfg(simplify=True, validate=True)
+    st2.start_block.label = 'st2'
+    st0.add_edge(st1.start_state, st2.start_state, dace.InterstateEdge())
+
+    st3 = assign_right_col.to_sdfg(simplify=True, validate=True)
+    st3.start_block.label = 'st3'
+    st0.add_edge(st2.start_state, st3.start_state, dace.InterstateEdge())
+
+    return st0
+
+
+def find_access_node_by_name(g, name):
+    """ Finds the first data node by the given name"""
+    return next((n, s) for n, s in g.all_nodes_recursive()
+                if isinstance(n, nodes.AccessNode) and name == n.data)
+
+
+def find_map_entry_by_name(g, name):
+    """ Finds the first map entry node by the given name """
+    return next((n, s) for n, s in g.all_nodes_recursive()
+                if isinstance(n, nodes.MapEntry) and n.label.startswith(name))
+
+
+def find_map_exit_by_name(g, name):
+    """ Finds the first map entry node by the given name """
+    return next((n, s) for n, s in g.all_nodes_recursive()
+                if isinstance(n, nodes.MapExit) and n.label.startswith(name))
+
+
+def test_within_state_fusion():
+    A = np.random.uniform(size=(4, 5)).astype(np.float32)
+
+    # Construct SDFG with the maps on separate states.
+    g = assign_bounary_sdfg()
+    g.save(os.path.join('_dacegraphs', 'simple-0.sdfg'))
+    g.validate()
+    actual_A = deepcopy(A)
+    g(A=actual_A, M=4, N=5)
+
+    # Fuse the two states so that the const-assignment-fusion is applicable.
+    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    g.save(os.path.join('_dacegraphs', 'simple-1.sdfg'))
+    g.validate()
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'simple-2.sdfg'))
+    g.validate()
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'simple-3.sdfg'))
+    g.validate()
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'simple-4.sdfg'))
+    g.validate()
+    our_A = deepcopy(A)
+    g(A=our_A, M=4, N=5)
+
+    print(our_A)
+    assert np.allclose(our_A, actual_A)
+
+
+if __name__ == '__main__':
+    test_within_state_fusion()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -16,6 +16,7 @@ def assign_top_row(A: dace.float32[M, N]):
     for t in dace.map[0:N]:
         A[0, t] = 1
 
+
 @dace.program
 def assign_top_row_branched(A: dace.float32[M, N]):
     for t, in dace.map[0:N]:
@@ -42,18 +43,18 @@ def assign_right_col(A: dace.float32[M, N]):
 
 
 def assign_bounary_sdfg():
-    st0 = assign_top_row.to_sdfg(simplify=True, validate=True)
+    st0 = assign_top_row.to_sdfg(simplify=True, validate=True, use_cache=False)
     st0.start_block.label = 'st0'
 
-    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True)
+    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True, use_cache=False)
     st1.start_block.label = 'st1'
     st0.add_edge(st0.start_state, st1.start_state, dace.InterstateEdge())
 
-    st2 = assign_left_col.to_sdfg(simplify=True, validate=True)
+    st2 = assign_left_col.to_sdfg(simplify=True, validate=True, use_cache=False)
     st2.start_block.label = 'st2'
     st0.add_edge(st1.start_state, st2.start_state, dace.InterstateEdge())
 
-    st3 = assign_right_col.to_sdfg(simplify=True, validate=True)
+    st3 = assign_right_col.to_sdfg(simplify=True, validate=True, use_cache=False)
     st3.start_block.label = 'st3'
     st0.add_edge(st2.start_state, st3.start_state, dace.InterstateEdge())
 
@@ -132,7 +133,7 @@ def test_free_floating_fusion():
     B = np.random.uniform(size=(4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_free_floating.to_sdfg(simplify=True)
+    g = assign_bounary_free_floating.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', 'floating-0.sdfg'))
     g.validate()
     actual_A = deepcopy(A)
@@ -161,7 +162,7 @@ def test_fusion_with_branch():
     B = np.random.uniform(size=(4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_with_branch.to_sdfg(simplify=True)
+    g = assign_bounary_with_branch.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', 'branched-0.sdfg'))
     g.validate()
     actual_A = deepcopy(A)

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -425,8 +425,7 @@ def test_does_not_fuse_when_the_first_map_reads_anything_at_all():
     g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
     g.save(os.path.join('_dacegraphs', '3d-map1-reads-1.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    g(A=actual_A, K=3, M=4, N=5)
+    g.compile()
 
     # The map fusion won't work.
     assert g.apply_transformations_repeated(ConstAssignmentMapFusion) == 0

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -1,65 +1,69 @@
 import os
+from collections.abc import Collection
 from copy import deepcopy
+from itertools import chain
+from typing import Tuple, Sequence
 
 import numpy as np
 
 import dace
+from dace import SDFG, Memlet
+from dace.properties import CodeBlock
+from dace.sdfg.sdfg import InterstateEdge
+from dace.sdfg.state import SDFGState
+from dace.subsets import Range
 from dace.transformation.dataflow.const_assignment_fusion import ConstAssignmentMapFusion, ConstAssignmentStateFusion
 from dace.transformation.interstate import StateFusionExtended
 
-K = dace.symbol('K')
-M = dace.symbol('M')
-N = dace.symbol('N')
+K, M, N = dace.symbol('K'), dace.symbol('M'), dace.symbol('N')
 
 
-@dace.program
-def assign_top_row(A: dace.float32[M, N]):
-    for t in dace.map[0:N]:
-        A[0, t] = 1
+def _add_face_assignment_map(g: SDFGState, name: str, lims: Sequence[Tuple[str, dace.symbol]],
+                             fixed_dims: Collection[Tuple[int, int]], assigned_val: int, array: str):
+    idx = [k for k, v in lims]
+    for fd, at in fixed_dims:
+        idx.insert(fd, str(at))
+    t, en, ex = g.add_mapped_tasklet(name, [(k, Range([(0, v - 1, 1)])) for k, v in lims],
+                                     {}, f"__out = {assigned_val}", {'__out': Memlet(expr=f"{array}[{','.join(idx)}]")},
+                                     external_edges=True)
+    return en, ex, t
 
 
-@dace.program
-def assign_top_row_branched(A: dace.float32[M, N]):
-    for t, in dace.map[0:N]:
-        if t % 2 == 0:
-            A[0, t] = 1
-
-
-@dace.program
-def assign_bottom_row(A: dace.float32[M, N]):
-    for b in dace.map[0:N]:
-        A[M - 1, b] = 1
-
-
-@dace.program
-def assign_left_col(A: dace.float32[M, N]):
-    for l in dace.map[0:M]:
-        A[l, 0] = 1
-
-
-@dace.program
-def assign_right_col(A: dace.float32[M, N]):
-    for r in dace.map[0:M]:
-        A[r, N - 1] = 1
+def _simple_if_block(name: str, cond: str, val: int):
+    subg = SDFG(name)
+    subg.add_array('tmp', (1,), dace.float32)
+    # Outer structure.
+    head = subg.add_state('if_head')
+    branch = subg.add_state('if_b1')
+    tail = subg.add_state('if_tail')
+    subg.add_edge(head, branch, InterstateEdge(condition=f"({cond})"))
+    subg.add_edge(head, tail, InterstateEdge(condition=f"(not ({cond}))"))
+    subg.add_edge(branch, tail, InterstateEdge())
+    # Inner structure.
+    t = branch.add_tasklet('top', inputs={}, outputs={'__out'}, code=f"__out = {val}")
+    tmp = branch.add_access('tmp')
+    branch.add_edge(t, '__out', tmp, None, Memlet(expr='tmp[0]'))
+    return subg
 
 
 def assign_bounary_sdfg():
-    st0 = assign_top_row.to_sdfg(simplify=True, validate=True, use_cache=False)
-    st0.start_block.label = 'st0'
+    g = SDFG('prog')
+    g.add_array('A', (M, N), dace.float32)
 
-    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True, use_cache=False)
-    st1.start_block.label = 'st1'
-    st0.add_edge(st0.start_state, st1.start_state, dace.InterstateEdge())
+    st0 = g.add_state('top')
+    _add_face_assignment_map(st0, 'top', [('j', N)], [(0, 0)], 1, 'A')
+    st1 = g.add_state('bottom')
+    _add_face_assignment_map(st1, 'bottom', [('j', N)], [(0, M - 1)], 1, 'A')
+    st2 = g.add_state('left')
+    _add_face_assignment_map(st2, 'left', [('i', M)], [(1, 0)], 1, 'A')
+    st3 = g.add_state('right')
+    _add_face_assignment_map(st3, 'right', [('i', M)], [(1, N - 1)], 1, 'A')
 
-    st2 = assign_left_col.to_sdfg(simplify=True, validate=True, use_cache=False)
-    st2.start_block.label = 'st2'
-    st0.add_edge(st1.start_state, st2.start_state, dace.InterstateEdge())
+    g.add_edge(st0, st1, dace.InterstateEdge())
+    g.add_edge(st1, st2, dace.InterstateEdge())
+    g.add_edge(st2, st3, dace.InterstateEdge())
 
-    st3 = assign_right_col.to_sdfg(simplify=True, validate=True, use_cache=False)
-    st3.start_block.label = 'st3'
-    st0.add_edge(st2.start_state, st3.start_state, dace.InterstateEdge())
-
-    return st0
+    return g
 
 
 def test_within_state_fusion():
@@ -67,35 +71,26 @@ def test_within_state_fusion():
 
     # Construct SDFG with the maps on separate states.
     g = assign_bounary_sdfg()
+    # Fuse the two states so that the const-assignment-fusion is applicable.
+    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
     g.save(os.path.join('_dacegraphs', 'simple-0.sdfg'))
     g.validate()
+    g.compile()
+
+    # Get the reference data.
     actual_A = deepcopy(A)
     g(A=actual_A, M=4, N=5)
 
-    # Fuse the two states so that the const-assignment-fusion is applicable.
-    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    assert g.apply_transformations_repeated(ConstAssignmentMapFusion, options={'use_grid_strided_loops': True}) == 3
     g.save(os.path.join('_dacegraphs', 'simple-1.sdfg'))
     g.validate()
+    g.compile()
 
-    assert g.apply_transformations(ConstAssignmentMapFusion,
-                                   options={'use_grid_strided_loops': True}) == 1
-    g.save(os.path.join('_dacegraphs', 'simple-2.sdfg'))
-    g.validate()
-
-    assert g.apply_transformations(ConstAssignmentMapFusion,
-                                   options={'use_grid_strided_loops': True}) == 1
-    g.save(os.path.join('_dacegraphs', 'simple-3.sdfg'))
-    g.validate()
-
-    assert g.apply_transformations(ConstAssignmentMapFusion) == 0
-    assert g.apply_transformations(ConstAssignmentMapFusion,
-                                   options={'use_grid_strided_loops': True}) == 1
-    g.save(os.path.join('_dacegraphs', 'simple-4.sdfg'))
-    g.validate()
+    # Get our data.
     our_A = deepcopy(A)
     g(A=our_A, M=4, N=5)
 
-    # print(our_A)
+    # Verify numerically.
     assert np.allclose(our_A, actual_A)
 
 
@@ -106,35 +101,35 @@ def test_interstate_fusion():
     g = assign_bounary_sdfg()
     g.save(os.path.join('_dacegraphs', 'interstate-0.sdfg'))
     g.validate()
+    g.compile()
+
+    # Get the reference data.
     actual_A = deepcopy(A)
     g(A=actual_A, M=4, N=5)
 
-    assert g.apply_transformations(ConstAssignmentStateFusion,
-                                   options={'use_grid_strided_loops': True}) == 1
+    assert g.apply_transformations_repeated(ConstAssignmentStateFusion, options={'use_grid_strided_loops': True}) == 3
     g.save(os.path.join('_dacegraphs', 'interstate-1.sdfg'))
     g.validate()
+    g.compile()
 
-    assert g.apply_transformations(ConstAssignmentStateFusion,
-                                   options={'use_grid_strided_loops': True}) == 1
-    g.save(os.path.join('_dacegraphs', 'interstate-2.sdfg'))
-    g.validate()
-
-    assert g.apply_transformations(ConstAssignmentStateFusion) == 0
-    assert g.apply_transformations(ConstAssignmentStateFusion,
-                                   options={'use_grid_strided_loops': True}) == 1
-    g.save(os.path.join('_dacegraphs', 'interstate-3.sdfg'))
-    g.validate()
+    # Get our data.
     our_A = deepcopy(A)
     g(A=our_A, M=4, N=5)
 
-    # print(our_A)
+    # Verify numerically.
     assert np.allclose(our_A, actual_A)
 
 
-@dace.program
-def assign_bounary_free_floating(A: dace.float32[M, N], B: dace.float32[M, N]):
-    assign_top_row(A)
-    assign_bottom_row(B)
+def assign_bounary_free_floating_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (M, N), dace.float32)
+    g.add_array('B', (M, N), dace.float32)
+
+    st0 = g.add_state('st0')
+    _add_face_assignment_map(st0, 'top', [('j', N)], [(0, 0)], 1, 'A')
+    _add_face_assignment_map(st0, 'bottom', [('j', N)], [(0, M - 1)], 2, 'B')
+
+    return g
 
 
 def test_free_floating_fusion():
@@ -142,9 +137,13 @@ def test_free_floating_fusion():
     B = np.random.uniform(size=(4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_free_floating.to_sdfg(simplify=True, validate=True, use_cache=False)
+    g = assign_bounary_free_floating_sdfg()
+    # g = assign_bounary_free_floating.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', 'floating-0.sdfg'))
     g.validate()
+    g.compile()
+
+    # Get the reference data.
     actual_A = deepcopy(A)
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, M=4, N=5)
@@ -152,58 +151,30 @@ def test_free_floating_fusion():
     assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', 'floating-1.sdfg'))
     g.validate()
+
+    # Get our data.
     our_A = deepcopy(A)
     our_B = deepcopy(B)
     g(A=our_A, B=our_B, M=4, N=5)
 
-    # print(our_A)
+    # Verify numerically.
     assert np.allclose(our_A, actual_A)
 
 
-@dace.program
-def assign_top_face(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:M, 0:N]:
-        A[0, t1, t2] = 1
+def assign_boundary_3d_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (K, M, N), dace.float32)
+    g.add_array('B', (K, M, N), dace.float32)
 
+    st0 = g.add_state('top')
+    _add_face_assignment_map(st0, 'top', [('m', M), ('n', N)], [(0, 0)], 1, 'A')
+    _add_face_assignment_map(st0, 'bottom', [('m', M), ('n', N)], [(0, K - 1)], 2, 'B')
+    _add_face_assignment_map(st0, 'front', [('k', K), ('n', N)], [(1, 0)], 1, 'A')
+    _add_face_assignment_map(st0, 'back', [('k', K), ('n', N)], [(1, M - 1)], 2, 'B')
+    _add_face_assignment_map(st0, 'left', [('k', K), ('m', M)], [(2, 0)], 1, 'A')
+    _add_face_assignment_map(st0, 'right', [('k', K), ('m', M)], [(2, N - 1)], 2, 'B')
 
-@dace.program
-def assign_bottom_face(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:M, 0:N]:
-        A[K - 1, t1, t2] = 1
-
-
-@dace.program
-def assign_front_face(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:K, 0:N]:
-        A[t1, 0, t2] = 1
-
-
-@dace.program
-def assign_back_face(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:K, 0:N]:
-        A[t1, M - 1, t2] = 1
-
-
-@dace.program
-def assign_left_face(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:K, 0:M]:
-        A[t1, t2, 0] = 1
-
-
-@dace.program
-def assign_right_face(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:K, 0:M]:
-        A[t1, t2, N - 1] = 1
-
-
-@dace.program
-def assign_bounary_3d(A: dace.float32[K, M, N], B: dace.float32[K, M, N]):
-    assign_top_face(A)
-    assign_bottom_face(B)
-    assign_front_face(A)
-    assign_back_face(B)
-    assign_left_face(A)
-    assign_right_face(B)
+    return g
 
 
 def test_fusion_with_multiple_indices():
@@ -211,37 +182,64 @@ def test_fusion_with_multiple_indices():
     B = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_3d.to_sdfg(simplify=True, validate=True, use_cache=False)
+    g = assign_boundary_3d_sdfg()
+    # g = assign_bounary_3d.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', '3d-0.sdfg'))
     g.validate()
+    g.compile()
+
+    # Get the reference data.
     actual_A = deepcopy(A)
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, K=3, M=4, N=5)
 
-    assert g.apply_transformations_repeated(ConstAssignmentMapFusion, options={'use_grid_strided_loops': True}) == 3
+    assert g.apply_transformations_repeated(ConstAssignmentMapFusion, options={'use_grid_strided_loops': False}) == 3
     g.save(os.path.join('_dacegraphs', '3d-1.sdfg'))
     g.validate()
+    g.compile()
+
+    # Get our data.
     our_A = deepcopy(A)
     our_B = deepcopy(B)
     g(A=our_A, B=our_B, K=3, M=4, N=5)
 
-    # Here, the state fusion can apply only with GSLs.
-    assert g.apply_transformations_repeated(ConstAssignmentStateFusion) == 0
-    assert g.apply_transformations_repeated(ConstAssignmentStateFusion, options={'use_grid_strided_loops': True}) == 2
+    # Verify numerically.
+    assert np.allclose(our_A, actual_A)
+
+    # Here, the map fusion can apply only with GSLs.
+    assert g.apply_transformations_repeated(ConstAssignmentMapFusion, options={'use_grid_strided_loops': False}) == 0
+    assert g.apply_transformations_repeated(ConstAssignmentMapFusion, options={'use_grid_strided_loops': True}) == 2
     g.save(os.path.join('_dacegraphs', '3d-2.sdfg'))
     g.validate()
+    g.compile()
+
+    # Get our data.
     our_A = deepcopy(A)
     our_B = deepcopy(B)
     g(A=our_A, B=our_B, K=3, M=4, N=5)
 
-    # print(our_A)
+    # Verify numerically.
     assert np.allclose(our_A, actual_A)
 
 
-@dace.program
-def assign_bounary_with_branch(A: dace.float32[M, N], B: dace.float32[M, N]):
-    assign_top_row_branched(A)
-    assign_bottom_row(B)
+def assign_bounary_with_branch_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (M, N), dace.float32)
+    g.add_array('B', (M, N), dace.float32)
+
+    st0 = g.add_state('st0')
+    en, ex, t = _add_face_assignment_map(st0, 'top', [('j', N)], [(0, 0)], 1, 'A')
+    new_t = _simple_if_block('if_block', 'j == 0', 1)
+    new_t = st0.add_nested_sdfg(new_t, None, {}, {'tmp'}, symbol_mapping={'j': 'j'})
+    for e in list(chain(st0.in_edges(t), st0.out_edges(t))):
+        st0.remove_edge(e)
+    st0.add_nedge(en, new_t, Memlet())
+    st0.add_edge(new_t, 'tmp', ex, 'IN_A', Memlet(expr='A[0, j]'))
+    st0.remove_node(t)
+
+    _add_face_assignment_map(st0, 'bottom', [('j', N)], [(0, M - 1)], 1, 'A')
+
+    return g
 
 
 def test_fusion_with_branch():
@@ -249,7 +247,8 @@ def test_fusion_with_branch():
     B = np.random.uniform(size=(4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_with_branch.to_sdfg(simplify=True, validate=True, use_cache=False)
+    g = assign_bounary_with_branch_sdfg()
+    # g = assign_bounary_with_branch.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', 'branched-0.sdfg'))
     g.validate()
     actual_A = deepcopy(A)
@@ -267,112 +266,109 @@ def test_fusion_with_branch():
     assert np.allclose(our_A, actual_A)
 
 
-@dace.program
-def assign_bottom_face_flipped(A: dace.float32[K, M, N]):
-    for t2, t1 in dace.map[0:N, 0:M]:
-        A[K - 1, t1, t2] = 1
+def assign_bounary_3d_with_flip_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (K, M, N), dace.float32)
 
+    st0 = g.add_state('st0')
+    _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, 0)], 1, 'A')
+    _, _, t = _add_face_assignment_map(st0, 'face', [('k', N), ('j', M)], [(0, K - 1)], 1, 'A')
+    t.code = CodeBlock('A[0, j, k] = 1')
 
-@dace.program
-def assign_bounary_3d_with_flip(A: dace.float32[K, M, N], B: dace.float32[K, M, N]):
-    assign_top_face(A)
-    assign_bottom_face_flipped(B)
+    return g
 
 
 def test_does_not_permute_to_fuse():
     """ Negative test """
-    A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
-    B = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
-
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_3d_with_flip.to_sdfg(simplify=True, validate=True, use_cache=False)
-    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    g = assign_bounary_3d_with_flip_sdfg()
     g.save(os.path.join('_dacegraphs', '3d-flip-0.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    actual_B = deepcopy(B)
-    g(A=actual_A, B=actual_B, K=3, M=4, N=5)
+    g.compile()
 
     assert g.apply_transformations_repeated(ConstAssignmentMapFusion) == 0
 
 
-@dace.program
-def assign_mixed_dims(A: dace.float32[K, M, N], B: dace.float32[K, M, N]):
-    assign_top_face(A)
-    assign_left_col(B[0, :, :])
+def assign_mixed_dims_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (K, M, N), dace.float32)
+    g.add_array('B', (K, M, N), dace.float32)
+
+    st0 = g.add_state('st0')
+    _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, 0)], 1, 'A')
+    _add_face_assignment_map(st0, 'edge', [('k', N)], [(0, 0), (1, 0)], 2, 'B')
+
+    return g
 
 
 def test_does_not_extend_to_fuse():
     """ Negative test """
-    A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
-    B = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
-
     # Construct SDFG with the maps on separate states.
-    g = assign_mixed_dims.to_sdfg(simplify=True, validate=True, use_cache=False)
-    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    g = assign_mixed_dims_sdfg()
     g.save(os.path.join('_dacegraphs', '3d-mixed-0.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    actual_B = deepcopy(B)
-    g(A=actual_A, B=actual_B, K=3, M=4, N=5)
+    g.compile()
 
+    # Will not fuse if the number of dimensions are different.
     assert g.apply_transformations_repeated(ConstAssignmentMapFusion) == 0
 
 
-@dace.program
-def assign_bottom_face_42(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:M, 0:N]:
-        A[K - 1, t1, t2] = 42
+def assign_inconsistent_values_different_constants_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (K, M, N), dace.float32)
+
+    st0 = g.add_state('st0')
+    _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, 0)], 1, 'A')
+    _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, K - 1)], 42, 'A')
+
+    return g
 
 
-@dace.program
-def assign_bottom_face_index_sum(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:M, 0:N]:
-        A[K - 1, t1, t2] = t1 + t2
+def assign_inconsistent_values_non_constant_sdfg():
+    g = SDFG('prog')
+    g.add_array('A', (K, M, N), dace.float32)
 
+    st0 = g.add_state('st0')
+    _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, 0)], 1, 'A')
+    _, _, t = _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, K - 1)], 1, 'A')
+    t.code = CodeBlock('__out = j + k')
 
-@dace.program
-def assign_inconsistent_values_1(A: dace.float32[K, M, N]):
-    assign_top_face(A)
-    assign_bottom_face_42(A)
-
-
-@dace.program
-def assign_inconsistent_values_2(A: dace.float32[K, M, N]):
-    assign_top_face(A)
-    assign_bottom_face_index_sum(A)
+    return g
 
 
 def test_does_not_fuse_with_inconsistent_assignments():
     """ Negative test """
-    A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
-
     # Construct SDFG with the maps on separate states.
-    g = assign_inconsistent_values_1.to_sdfg(simplify=True, validate=True, use_cache=False)
-    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    g = assign_inconsistent_values_different_constants_sdfg()
     g.save(os.path.join('_dacegraphs', '3d-inconsistent-0.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    g(A=actual_A, K=3, M=4, N=5)
+    g.compile()
 
     assert g.apply_transformations_repeated(ConstAssignmentMapFusion) == 0
 
-    # Try another case: Construct SDFG with the maps on separate states.
-    g = assign_inconsistent_values_2.to_sdfg(simplify=True, validate=True, use_cache=False)
-    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    # Try another case.
+    # Construct SDFG with the maps on separate states.
+    g = assign_inconsistent_values_non_constant_sdfg()
     g.save(os.path.join('_dacegraphs', '3d-inconsistent-1.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    g(A=actual_A, K=3, M=4, N=5)
+    g.compile()
 
     assert g.apply_transformations_repeated(ConstAssignmentMapFusion) == 0
 
 
-@dace.program
-def tasklet_between_maps(A: dace.float32[K, M, N]):
-    assign_top_face(A)
-    A[0, 0, 0] = 1
-    assign_bottom_face(A)
+def sdfg_with_tasklet_between_maps():
+    g = SDFG('prog')
+    g.add_array('A', (K, M, N), dace.float32)
+
+    st0 = g.add_state('st0')
+    _, ex1, _ = _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, 0)], 1, 'A')
+    en2, _, _ = _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, K - 1)], 1, 'A')
+    t = st0.add_tasklet('noop', {}, {}, '')
+    st0.add_nedge(st0.out_edges(ex1)[0].dst, en2, Memlet())
+    st0.add_nedge(st0.out_edges(ex1)[0].dst, t, Memlet())
+    st0.add_nedge(t, en2, Memlet())
+
+    return g
 
 
 def test_does_not_fuse_with_unsuitable_dependencies():
@@ -380,26 +376,35 @@ def test_does_not_fuse_with_unsuitable_dependencies():
     A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = tasklet_between_maps.to_sdfg(simplify=True, validate=True, use_cache=False)
-    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    g = sdfg_with_tasklet_between_maps()
     g.save(os.path.join('_dacegraphs', '3d-baddeps-0.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    g(A=actual_A, K=3, M=4, N=5)
+    g.compile()
 
     assert g.apply_transformations_repeated(ConstAssignmentMapFusion) == 0
 
 
-@dace.program
-def assign_top_face_self_copy(A: dace.float32[K, M, N]):
-    for t1, t2 in dace.map[0:M, 0:N]:
-        A[0, t1, t2] = A[0, t1, t2]
+def sdfg_where_first_map_reads_data():
+    g = SDFG('prog')
+    g.add_array('A', (M, N), dace.float32)
 
+    st0 = g.add_state('top')
+    en1, _, t = _add_face_assignment_map(st0, 'top', [('j', N)], [(0, 0)], 1, 'A')
+    en1.add_in_connector('IN_A')
+    en1.add_out_connector('OUT_A')
+    t.add_in_connector('__blank')
+    A = st0.add_access('A')
+    st0.add_edge(A, None, en1, 'IN_A', Memlet(expr='A[0, 0:N]'))
+    for e in st0.out_edges(en1):
+        st0.remove_edge(e)
+    st0.add_edge(en1, 'OUT_A', t, '__blank', Memlet(expr='A[0, j]'))
 
-@dace.program
-def first_map_reads_data(A: dace.float32[K, M, N]):
-    assign_top_face_self_copy(A)
-    assign_bottom_face(A)
+    st1 = g.add_state('bottom')
+    _add_face_assignment_map(st1, 'bottom', [('j', N)], [(0, M - 1)], 1, 'A')
+
+    g.add_edge(st0, st1, InterstateEdge())
+
+    return g
 
 
 def test_does_not_fuse_when_the_first_map_reads_anything_at_all():
@@ -407,14 +412,14 @@ def test_does_not_fuse_when_the_first_map_reads_anything_at_all():
     A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = first_map_reads_data.to_sdfg(simplify=True, validate=True, use_cache=False)
+    g = sdfg_where_first_map_reads_data()
     g.save(os.path.join('_dacegraphs', '3d-map1-reads-0.sdfg'))
     g.validate()
-    actual_A = deepcopy(A)
-    g(A=actual_A, K=3, M=4, N=5)
+    g.compile()
 
+    # TODO:Fix.
     # The state fusion won't work.
-    assert g.apply_transformations_repeated(ConstAssignmentStateFusion) == 0
+    # assert g.apply_transformations_repeated(ConstAssignmentStateFusion) == 0
 
     # Fuse the states explicitly anyway.
     g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
@@ -433,3 +438,8 @@ if __name__ == '__main__':
     test_free_floating_fusion()
     test_fusion_with_branch()
     test_fusion_with_multiple_indices()
+    test_does_not_extend_to_fuse()
+    test_does_not_permute_to_fuse()
+    test_does_not_fuse_with_inconsistent_assignments()
+    test_does_not_fuse_with_unsuitable_dependencies()
+    test_does_not_fuse_when_the_first_map_reads_anything_at_all()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -272,8 +272,9 @@ def assign_bounary_3d_with_flip_sdfg():
 
     st0 = g.add_state('st0')
     _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, 0)], 1, 'A')
-    _, _, t = _add_face_assignment_map(st0, 'face', [('k', N), ('j', M)], [(0, K - 1)], 1, 'A')
-    t.code = CodeBlock('A[0, j, k] = 1')
+    en, _, _ = _add_face_assignment_map(st0, 'face', [('j', M), ('k', N)], [(0, K - 1)], 1, 'A')
+    en.map.range = Range(reversed(en.map.range.ranges))
+    en.map.params = list(reversed(en.map.params))
 
     return g
 

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -417,9 +417,8 @@ def test_does_not_fuse_when_the_first_map_reads_anything_at_all():
     g.validate()
     g.compile()
 
-    # TODO:Fix.
     # The state fusion won't work.
-    # assert g.apply_transformations_repeated(ConstAssignmentStateFusion) == 0
+    assert g.apply_transformations_repeated(ConstAssignmentStateFusion) == 0
 
     # Fuse the states explicitly anyway.
     g.apply_transformations_repeated(StateFusionExtended, validate_all=True)


### PR DESCRIPTION
Since scheduling multiple map kernels with very little internal operation can have a large overhead, sometimes we would like to fuse two such maps if possible. _Constant assignment maps_ are such a case. If two maps assign the same value for every element in a subset of the underlying array (and the subset is not dependent on the array in any way), then:
- If the two maps' subsets are identical, we can simply fuse the two maps by moving the body of one map to another (with appropriate wiring), since we know the order of the assignments do not matter here, and can even be deduplicated in some cases.
- If the two maps' subsets are _not_ identical, even then we can occasionally fuse them using a _grid-strided loop_ pattern (which essentially emulates a conditional to ensure that only the appropriate elements are assigned).

### Motivating Example
Consider the following graphs, all representing a computation that assigns `1` to the boundary of a 2D domain. The first table represents the graphs scheduled for CPU, the second for GPU.

| Device | Original  | w/o GSL | with GSL |
| - | - | - | - |
| CPU |  ![2d-orig](https://github.com/user-attachments/assets/0e46162f-b14f-45f6-a79b-06baa5213397) | ![2d-no-gsl](https://github.com/user-attachments/assets/0c66a591-251a-4072-a2b9-954d511b2083) | ![2d-with-gsl](https://github.com/user-attachments/assets/ccc11f88-401d-4b2a-83b5-d098ca66ecef) |
| GPU | ![2d-orig-GPU](https://github.com/user-attachments/assets/e52afde9-37f5-4b98-b482-27294195a4be) | ![2d-no-gsl-GPU](https://github.com/user-attachments/assets/2c98dfaf-1fef-4e62-9013-cb5be4f82fbd) | ![2d-with-gsl-GPU](https://github.com/user-attachments/assets/3761cae9-3a5f-44d9-b91c-c138cd6eb1ea) |

### Performance

We have profiled a 2D and a 3D boundary initialization, both on CPU and GPU (both on Davinci cluster).
Benchmark scripts and reports are to be found in https://github.com/pratyai/dace/tree/bench-const-assignment-fusion
I will be quoting the performance summaries in further comments.

#### Comment on GPU performance

The GPU transformation adds additional operation copying the _entire_ array to and from GPU memory, resulting in `O(n^d)` main <=> GPU movement, whereas the assignment itself only touches `O(n^{d-1})` elements. However, this is because the benchmark itself does not do anything else but the assignment. In real computations, we would likely need to move the entire array anyway.

Because of this, it is probably better to just focus on the combined performance of the map kernels here.