### PR TITLE
[DO NOT REVIEW] Fix the SubgraphFusion bug

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -417,6 +417,7 @@ def reshape_strides(subset, strides, original_strides, copy_shape):
     dims = len(copy_shape)
 
     reduced_tile_sizes = [ts for ts, s in zip(subset.tile_sizes, original_copy_shape) if s != 1]
+    reduced_tile_sizes += [1] * (dims - len(reduced_tile_sizes))  # Pad the remainder with 1s to maintain dimensions.
 
     reshaped_copy = copy_shape + [ts for ts in subset.tile_sizes if ts != 1]
     reshaped_copy[:len(copy_shape)] = [s / ts for s, ts in zip(copy_shape, reduced_tile_sizes)]

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -420,7 +420,7 @@ def reshape_strides(subset, strides, original_strides, copy_shape):
     reduced_tile_sizes += [1] * (dims - len(reduced_tile_sizes))  # Pad the remainder with 1s to maintain dimensions.
 
     reshaped_copy = copy_shape + [ts for ts in subset.tile_sizes if ts != 1]
-    reshaped_copy[:len(copy_shape)] = [s / ts for s, ts in zip(copy_shape, reduced_tile_sizes)]
+    reshaped_copy[:len(copy_shape)] = [s // ts for s, ts in zip(copy_shape, reduced_tile_sizes)]
 
     new_strides = [0] * len(reshaped_copy)
     elements_remaining = functools.reduce(sp.Mul, copy_shape, 1)

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -7,7 +7,7 @@ from networkx import MultiDiGraph
 from dace.sdfg.state import ControlFlowRegion
 from dace.subsets import Range, Subset, union
 import dace.subsets as subsets
-from typing import Dict, List, Optional, Tuple, Set, Union
+from typing import Dict, List, Optional, Tuple, Set, Union, Iterable
 
 from dace import data, dtypes, symbolic
 from dace.codegen import control_flow as cf
@@ -275,7 +275,7 @@ def find_sdfg_control_flow(sdfg: SDFG) -> Dict[SDFGState, Set[SDFGState]]:
         if isinstance(child, cf.BasicCFBlock):
             if child.state in visited:
                 continue
-            components[child.state] = (set([child.state]), child)
+            components[child.state] = ({child.state}, child)
             visited[child.state] = False
         elif isinstance(child, (cf.ForScope, cf.WhileScope)):
             guard = child.guard
@@ -1031,11 +1031,11 @@ def are_subsets_contiguous(subset_a: subsets.Subset, subset_b: subsets.Subset, d
     return False
 
 
-def find_contiguous_subsets(subset_list: List[subsets.Subset], dim: int = None) -> Set[subsets.Subset]:
+def find_contiguous_subsets(subset_list: Iterable[subsets.Subset], dim: int = None) -> Set[subsets.Subset]:
     """ 
     Finds the set of largest contiguous subsets in a list of subsets. 
 
-    :param subsets: Iterable of subset objects.
+    :param subset_list: Iterable of subset objects.
     :param dim: Check for contiguity only for the specified dimension.
     :return: A list of contiguous subsets.
     """

--- a/dace/transformation/subgraph/stencil_tiling.py
+++ b/dace/transformation/subgraph/stencil_tiling.py
@@ -200,13 +200,13 @@ class StencilTiling(transformation.SubgraphTransformation):
 
         # get intermediate_nodes, out_nodes from SubgraphFusion Transformation
         try:
-            node_config = SubgraphFusion.get_adjacent_nodes(sdfg, graph, map_entries)
+            node_config = get_adjacent_nodes(sdfg, graph, map_entries)
             (_, intermediate_nodes, out_nodes) = node_config
         except NotImplementedError:
             return False
 
         # 1.4: check topological feasibility
-        if not SubgraphFusion.check_topo_feasibility(sdfg, graph, map_entries, intermediate_nodes, out_nodes):
+        if not check_topo_feasibility(sdfg, graph, map_entries, intermediate_nodes, out_nodes):
             return False
         # 1.5 nodes that are both intermediate and out nodes
         # are not supported in StencilTiling
@@ -215,7 +215,7 @@ class StencilTiling(transformation.SubgraphTransformation):
 
         # 1.6 check that we only deal with compressible transients
 
-        subgraph_contains_data = SubgraphFusion.determine_compressible_nodes(sdfg, graph, intermediate_nodes,
+        subgraph_contains_data = determine_compressible_nodes(sdfg, graph, intermediate_nodes,
                                                                              map_entries, map_exits)
         if any([s == False for s in subgraph_contains_data.values()]):
             return False

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -1071,7 +1071,6 @@ class SubgraphFusion(transformation.SubgraphTransformation):
 
         fuse_maps_into_global_map(graph, map_entries, map_exits, global_map_entry, global_map_exit,
                                   in_nodes, intermediate_nodes, out_nodes, transients_created, invariant_dimensions)
-        sdfg.validate()
 
         min_offsets = compress_transient_arrays(sdfg, graph, self.transient_allocation, subgraph_contains_data,
                                                 intermediate_nodes, invariant_dimensions)

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -1,30 +1,24 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 """ This module contains classes that implement subgraph fusion.    """
-import dace
+import warnings
+from collections import defaultdict
+from copy import deepcopy as dcpy
+from itertools import chain
+from typing import List, Tuple
+
 import networkx as nx
 
-from dace import dtypes, registry, symbolic, subsets, data
-from dace.sdfg import nodes, utils, replace, SDFG, scope_contains_scope
-from dace.sdfg.graph import SubgraphView
-from dace.sdfg.scope import ScopeTree
+import dace
+from dace import dtypes, symbolic, subsets, data
 from dace.memlet import Memlet
-from dace.transformation import transformation
 from dace.properties import EnumProperty, ListProperty, make_properties, Property
-from dace.symbolic import overapproximate
-from dace.sdfg.propagation import propagate_memlets_sdfg, propagate_memlet, propagate_memlets_scope, _propagate_node
-from dace.transformation.subgraph import helpers
-from dace.transformation.dataflow import RedundantArray
-from dace.sdfg.utils import consolidate_edges_scope, get_view_node
+from dace.sdfg import nodes, SDFG
+from dace.sdfg.graph import SubgraphView
+from dace.sdfg.propagation import _propagate_node
+from dace.sdfg.utils import consolidate_edges_scope
+from dace.transformation import transformation
 from dace.transformation.helpers import find_contiguous_subsets
-
-from copy import deepcopy as dcpy
-from typing import List, Union, Tuple
-import warnings
-
-import dace.libraries.standard as stdlib
-
-from collections import defaultdict
-from itertools import chain
+from dace.transformation.subgraph import helpers
 
 
 @make_properties

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -606,7 +606,7 @@ def compress_transient_arrays(sdfg: SDFG, graph: SDFGState, transient_allocation
 
             in_edges_iter = iter(in_edges)
             in_edge = next(in_edges_iter)
-            target_subset = dcpy(in_edge.data.subset)
+            target_subset = dcpy(in_edge.data.dst_subset)
             target_subset.pop(invariant_dimensions[data_name])
             while True:
                 try:  # executed if there are multiple in_edges
@@ -957,7 +957,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                                     for ie in graph.in_edges(e.src):
                                         # get corresponding inner memlet and join its subset to our access set
                                         if ie.dst_conn[2:] == e.src_conn[3:]:
-                                            current_subset = dcpy(ie.data.subset)
+                                            current_subset = dcpy(ie.data.dst_subset)
                                             current_subset.pop(invariant_dimensions[node_data])
 
                                             access_set = subsets.union(access_set, current_subset)

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -254,7 +254,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                             return False
 
         # 2.6 Check for disjoint accesses for arrays that cannot be compressed
-        if self.disjoint_subsets == True:
+        if self.disjoint_subsets:
             container_dict = defaultdict(list)
             for node in chain(in_nodes, intermediate_nodes, out_nodes):
                 if isinstance(node, nodes.AccessNode):
@@ -335,7 +335,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                                 intersection = rng_1dim.intersects(orng_1dim)
                             except TypeError:
                                 return False
-                            if intersection is None or intersection == True:
+                            if intersection is None or intersection:
                                 warnings.warn("SubgraphFusion::Disjoint Accesses found!")
                                 return False
 

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -537,7 +537,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
             graph.remove_edge(edge)
         return ret
 
-    def adjust_arrays_nsdfg(self, sdfg: dace.sdfg.SDFG, nsdfg: nodes.NestedSDFG, name: str, nname: str, memlet: Memlet):
+    def adjust_arrays_nsdfg(self, sdfg: dace.sdfg.SDFG, nsdfg: dace.sdfg.SDFG, name: str, nname: str, memlet: Memlet):
         """
         DFS to replace strides and volumes of data that exhibits nested SDFGs 
         adjacent to its corresponding access nodes, applied during post-processing 

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -1094,7 +1094,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                     # nested SDFG: adjust arrays connected
                     if isinstance(iedge.src, nodes.NestedSDFG):
                         nsdfg = iedge.src.sdfg
-                        nested_data_name = edge.src_conn
+                        nested_data_name = iedge.src_conn
                         self.adjust_arrays_nsdfg(sdfg, nsdfg, node.data, nested_data_name, iedge.data)
 
                 for cedge in out_edges:

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -963,8 +963,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                             port_created = (in_conn, out_conn)
 
                         else:
-                            in_conn = port_created.st
-                            out_conn = port_created.nd
+                            in_conn, out_conn = port_created
 
                         # map
                         graph.add_edge(global_map_exit, out_conn, dst, out_edge.dst_conn, dcpy(out_edge.data))

--- a/dace/transformation/subgraph/subgraph_fusion.py
+++ b/dace/transformation/subgraph/subgraph_fusion.py
@@ -40,26 +40,26 @@ class SubgraphFusion(transformation.SubgraphTransformation):
 
     transient_allocation = EnumProperty(dtype=dtypes.StorageType,
                                         desc="Storage Location to push transients to that are "
-                                        "fully contained within the subgraph.",
+                                             "fully contained within the subgraph.",
                                         default=dtypes.StorageType.Default)
 
     schedule_innermaps = Property(desc="Schedule of inner maps. If none, "
-                                  "keeps schedule.",
+                                       "keeps schedule.",
                                   dtype=dtypes.ScheduleType,
                                   default=None,
                                   allow_none=True)
     consolidate = Property(desc="Consolidate edges that enter and exit the fused map.", dtype=bool, default=False)
 
     propagate = Property(desc="Propagate memlets of edges that enter and exit the fused map."
-                         "Disable if this causes problems (e.g., if memlet propagation does"
-                         "not work correctly).",
+                              "Disable if this causes problems (e.g., if memlet propagation does"
+                              "not work correctly).",
                          dtype=bool,
                          default=True)
 
     disjoint_subsets = Property(desc="Check for disjoint subsets in can_be_applied. If multiple"
-                                "access nodes pointing to the same data appear within a subgraph"
-                                "to be fused, this check confirms that their access sets are"
-                                "independent per iteration space to avoid race conditions.",
+                                     "access nodes pointing to the same data appear within a subgraph"
+                                     "to be fused, this check confirms that their access sets are"
+                                     "independent per iteration space to avoid race conditions.",
                                 dtype=bool,
                                 default=True)
 
@@ -160,8 +160,8 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                 if in_edge.src in map_exits:
                     for iedge in graph.in_edges(in_edge.src):
                         if iedge.dst_conn[2:] == in_edge.src_conn[3:]:
-                            subset_to_add = dcpy(iedge.data.subset if iedge.data.data ==
-                                                 node.data else iedge.data.other_subset)
+                            subset_to_add = dcpy(iedge.data.subset
+                                                 if iedge.data.data == node.data else iedge.data.other_subset)
 
                             subset_to_add.pop(dims_to_discard)
                             upper_subsets.add(subset_to_add)
@@ -177,8 +177,8 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                 if out_edge.dst in map_entries:
                     for oedge in graph.out_edges(out_edge.dst):
                         if oedge.src_conn and oedge.src_conn[3:] == out_edge.dst_conn[2:]:
-                            subset_to_add = dcpy(oedge.data.subset if oedge.data.data ==
-                                                 node.data else oedge.data.other_subset)
+                            subset_to_add = dcpy(oedge.data.subset
+                                                 if oedge.data.data == node.data else oedge.data.other_subset)
                             subset_to_add.pop(dims_to_discard)
                             lower_subsets.add(subset_to_add)
 
@@ -329,8 +329,8 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                         subset_minus.replace(repl_dict)
 
                         for (rng, orng) in zip(subset_plus, subset_minus):
-                            rng_1dim = subsets.Range((rng, ))
-                            orng_1dim = subsets.Range((orng, ))
+                            rng_1dim = subsets.Range((rng,))
+                            orng_1dim = subsets.Range((orng,))
                             try:
                                 intersection = rng_1dim.intersects(orng_1dim)
                             except TypeError:
@@ -471,11 +471,11 @@ class SubgraphFusion(transformation.SubgraphTransformation):
             if in_edge.src in map_exits:
                 other_edge = graph.memlet_path(in_edge)[-2]
                 other_subset = other_edge.data.subset \
-                               if other_edge.data.data == node.data \
-                               else other_edge.data.other_subset
+                    if other_edge.data.data == node.data \
+                    else other_edge.data.other_subset
 
                 for (idx, (ssbs1, ssbs2)) \
-                    in enumerate(zip(in_edge.data.subset, other_subset)):
+                        in enumerate(zip(in_edge.data.subset, other_subset)):
                     if ssbs1 != ssbs2:
                         variant_dimensions.add(idx)
             else:
@@ -494,8 +494,8 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                 for other_edge in graph.out_edges(out_edge.dst):
                     if other_edge.src_conn and other_edge.src_conn[3:] == out_edge.dst_conn[2:]:
                         other_subset = other_edge.data.subset \
-                                       if other_edge.data.data == node.data \
-                                       else other_edge.data.other_subset
+                            if other_edge.data.data == node.data \
+                            else other_edge.data.other_subset
                         for (idx, (ssbs1, ssbs2)) in enumerate(zip(out_edge.data.subset, other_subset)):
                             if ssbs1 != ssbs2:
                                 variant_dimensions.add(idx)
@@ -629,15 +629,15 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                     # if so, add to data_counter_subgraph
                     # do not add if it is in out_nodes / in_nodes
                     if state == graph and \
-                        (node in intermediate_nodes or scope_dict[node] in map_entries):
+                            (node in intermediate_nodes or scope_dict[node] in map_entries):
                         data_counter_subgraph[node.data] += 1
 
         # next up: If intermediate_counter and global counter match and if the array
         # is declared transient, it is fully contained by the subgraph
 
-        subgraph_contains_data = {data: data_counter[data] == data_counter_subgraph[data] \
-                                        and sdfg.data(data).transient \
-                                        and data not in do_not_override \
+        subgraph_contains_data = {data: data_counter[data] == data_counter_subgraph[data]
+                                        and sdfg.data(data).transient
+                                        and data not in do_not_override
                                   for data in data_intermediate}
         return subgraph_contains_data
 
@@ -688,7 +688,8 @@ class SubgraphFusion(transformation.SubgraphTransformation):
         return transients_created
 
     def determine_invariant_dimensions(self, sdfg: dace.sdfg.SDFG, graph: dace.sdfg.SDFGState,
-                                       intermediate_nodes: Iterable[nodes.AccessNode], map_entries: List[nodes.MapEntry],
+                                       intermediate_nodes: Iterable[nodes.AccessNode],
+                                       map_entries: List[nodes.MapEntry],
                                        map_exits: List[nodes.MapExit]):
         """
         Determines the invariant dimensions for each node -- dimensions in 
@@ -825,9 +826,9 @@ class SubgraphFusion(transformation.SubgraphTransformation):
         # intermediate_nodes simultaneously
         # also check which dimensions of each transient data element correspond
         # to map axes and write this information into a dict.
-        node_info = self.prepare_intermediate_nodes(sdfg, graph, in_nodes, out_nodes, \
-                                                    intermediate_nodes,\
-                                                    map_entries, map_exits, \
+        node_info = self.prepare_intermediate_nodes(sdfg, graph, in_nodes, out_nodes,
+                                                    intermediate_nodes,
+                                                    map_entries, map_exits,
                                                     do_not_override)
 
         (subgraph_contains_data, transients_created, invariant_dimensions) = node_info
@@ -867,13 +868,11 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                             inconnectors_dict[src] = (edge, in_conn, out_conn)
 
                         # reroute in edge via global_map_entry
-                        self.copy_edge(graph, edge, new_dst = global_map_entry, \
-                                                        new_dst_conn = in_conn)
+                        self.copy_edge(graph, edge, new_dst=global_map_entry, new_dst_conn=in_conn)
 
                     # map out edges to new map
                     for out_edge in out_edges:
-                        self.copy_edge(graph, out_edge, new_src = global_map_entry, \
-                                                            new_src_conn = out_conn)
+                        self.copy_edge(graph, out_edge, new_src=global_map_entry, new_src_conn=out_conn)
 
                 else:
                     # connect directly
@@ -1113,7 +1112,7 @@ class SubgraphFusion(transformation.SubgraphTransformation):
                 if len(in_edges) > 1:
                     for oedge in out_edges:
                         if oedge.dst == global_map_exit and \
-                                            oedge.data.other_subset is None:
+                                oedge.data.other_subset is None:
                             oedge.data.other_subset = dcpy(oedge.data.subset)
                             oedge.data.other_subset.offset(min_offset, True)
 

--- a/tests/codegen/targets/cpp_test.py
+++ b/tests/codegen/targets/cpp_test.py
@@ -1,0 +1,75 @@
+import unittest
+from functools import reduce
+from operator import mul
+
+from dace.codegen.targets import cpp
+from dace.subsets import Range
+
+
+class ReshapeStrides(unittest.TestCase):
+    def test_multidim_array_all_dims_unit(self):
+        r = Range([(0, 0, 1), (0, 0, 1)])
+
+        # To smaller-sized shape
+        target_dims = [1]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, [1])
+
+        # To equal-sized shape
+        target_dims = [1, 1]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, [1, 1])
+
+        # To larger-sized shape
+        target_dims = [1, 1, 1]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, [1, 1, 1])
+
+    def test_multidim_array_some_dims_unit(self):
+        r = Range([(0, 1, 1), (0, 0, 1)])
+
+        # To smaller-sized shape
+        target_dims = [2]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+
+        # To equal-sized shape
+        target_dims = [2, 1]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+
+        # To equal-sized shape
+        target_dims = [2, 1, 1]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+
+    def test_multidim_array_different_shape(self):
+        r = Range([(0, 4, 1), (0, 5, 1)])
+
+        # To smaller-sized shape
+        target_dims = [30]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+
+        # To equal-sized shape
+        target_dims = [15, 2]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+
+        # To equal-sized shape
+        target_dims = [3, 5, 2]
+        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/codegen/targets/cpp_test.py
+++ b/tests/codegen/targets/cpp_test.py
@@ -12,63 +12,132 @@ class ReshapeStrides(unittest.TestCase):
 
         # To smaller-sized shape
         target_dims = [1]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, [1])
+        self.assertEqual(strides, [1])
 
         # To equal-sized shape
         target_dims = [1, 1]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, [1, 1])
+        self.assertEqual(strides, [1, 1])
 
         # To larger-sized shape
         target_dims = [1, 1, 1]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, [1, 1, 1])
+        self.assertEqual(strides, [1, 1, 1])
 
     def test_multidim_array_some_dims_unit(self):
         r = Range([(0, 1, 1), (0, 0, 1)])
 
         # To smaller-sized shape
         target_dims = [2]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [1])
 
         # To equal-sized shape
         target_dims = [2, 1]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [1, 1])
+        # To equal-sized shape, but units first.
+        target_dims = [1, 2]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [2, 1])
 
-        # To equal-sized shape
+        # To larger-sized shape.
         target_dims = [2, 1, 1]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [1, 1, 1])
+        # To larger-sized shape, but units first.
+        target_dims = [1, 1, 2]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [2, 2, 1])
 
     def test_multidim_array_different_shape(self):
         r = Range([(0, 4, 1), (0, 5, 1)])
 
         # To smaller-sized shape
         target_dims = [30]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [1])
 
         # To equal-sized shape
         target_dims = [15, 2]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [2, 1])
+
+        # To larger-sized shape
+        target_dims = [3, 5, 2]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [10, 2, 1])
+
+    def test_from_strided_range(self):
+        r = Range([(0, 4, 2), (0, 6, 2)])
+
+        # To smaller-sized shape
+        target_dims = [12]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [1])
 
         # To equal-sized shape
-        target_dims = [3, 5, 2]
-        self.assertEqual(r.num_elements_exact(), reduce(mul, target_dims))
+        target_dims = [4, 3]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
         reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
         self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [3, 1])
+
+        # To larger-sized shape
+        target_dims = [2, 3, 2]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [6, 2, 1])
+
+    def test_from_strided_and_offset_range(self):
+        r = Range([(10, 14, 2), (10, 16, 2)])
+
+        # To smaller-sized shape
+        target_dims = [12]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [1])
+
+        # To equal-sized shape
+        target_dims = [4, 3]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [3, 1])
+
+        # To larger-sized shape
+        target_dims = [2, 3, 2]
+        self.assertEqual(reduce(mul, r.size_exact()), reduce(mul, target_dims))
+        reshaped, strides = cpp.reshape_strides(r, None, None, target_dims)
+        self.assertEqual(reshaped, target_dims)
+        self.assertEqual(strides, [6, 2, 1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1687. The problem was about using a memlet's `subset` field where `dst_subset` would be more appropriate.

Only the last commit is the bug-fix: https://github.com/spcl/dace/commit/cab4d26fdf8812867c489b3063695d5ed9614736

The rest of the changes are about:
- fixing type annotations
- various formatting fixes (PEP 8 compliance suggested by IDE)
- taking out various helper functions out of the class
- and most importantly taking pieces of `fuse()` function out to their own helper functions so that it is actually possible to follow its logic. [This part is not complete though, since I only took out the parts until I was able to fix the bug]