### PR TITLE
Fix a bug in `RedundantArray`

### DIFF
--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -24,7 +24,7 @@ from dace.transformation import transformation as pm
 def _validate_subsets(edge: graph.MultiConnectorEdge,
                       arrays: Dict[str, data.Data],
                       src_name: str = None,
-                      dst_name: str = None) -> Tuple[subsets.Subset]:
+                      dst_name: str = None) -> Tuple[subsets.Subset, subsets.Subset]:
     """ Extracts and validates src and dst subsets from the edge. """
 
     # Find src and dst names
@@ -637,6 +637,8 @@ class RedundantArray(pm.SingleStateTransformation):
                     src_subset = other_subset
                 else:
                     src_subset = None
+                if isinstance(e3.dst, nodes.AccessNode):
+                    dst_subset = None
 
                 subset = src_subset if src_is_data else dst_subset
                 other_subset = dst_subset if src_is_data else src_subset

--- a/tests/transformations/redundant_array_test.py
+++ b/tests/transformations/redundant_array_test.py
@@ -1,0 +1,38 @@
+import os
+
+from dace.transformation.dataflow import RedundantArray
+
+from dace.cli import sdfg_diff
+
+from dace import SDFG
+
+
+def load_graph(relative_path: str):
+    path = os.path.join(os.path.dirname(__file__), relative_path)
+    print('Loading:', path)
+    return SDFG.from_file(os.path.join(os.path.dirname(__file__), 'testdata/redundant-array-0.sdfg'))
+
+
+def test_bug_1690():
+    """Corresponds to https://github.com/spcl/dace/issues/1690"""
+
+    # Make sure our input and golden data is good.
+    g = load_graph('testdata/redundant-array-0.sdfg')
+    g.validate()
+    g.compile()
+    g_corr = load_graph('testdata/redundant-array-0-correct.sdfg')
+    g_corr.validate()
+    g_corr.compile()
+
+    # Apply and diff
+    application_count = g.apply_transformations(RedundantArray)
+    removed_keys, added_keys, changed_keys = sdfg_diff._sdfg_diff(g, g_corr)
+    sdfg_diff._print_diff(g, g_corr, (removed_keys, added_keys, changed_keys))
+
+    # Verify
+    assert application_count == 1
+    g.validate()
+    g.compile()
+
+    if __name__ == '__main__':
+        test_bug_1690()


### PR DESCRIPTION
Fixes #1690.

The problem was mishandling of the memlet path. Unfortunately, the difference is quite difficult to spot, since the vscode UI does not show it correctly.