### PR TITLE
Make the import of `typing.Literal` portable between python versions 3.7 and 3.12

### DIFF
--- a/dace/cli/sdfg_diff.py
+++ b/dace/cli/sdfg_diff.py
@@ -7,7 +7,11 @@ import json
 import os
 import platform
 import tempfile
-from typing import Dict, Literal, Set, Tuple, Union
+from typing import Dict, Set, Tuple, Union
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import jinja2
 import dace


### PR DESCRIPTION
Addresses this problem: https://stackoverflow.com/a/67193166

This would be useful if we want to use this library to compare graphs in the unit tests.