### PR TITLE
Add a `SubrangeMapper` helper class which maps a _subrange_ of `src` range to its counterpart in `dst` range, if possible.

### DIFF
--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -103,7 +103,8 @@ class ExpandReducePure(pm.ExpandTransformation):
                 'reduce_init', {'_o%d' % i: '0:%s' % symstr(d)
                                 for i, d in enumerate(outedge.data.subset.size())}, {},
                 '__out = %s' % node.identity,
-                {'__out': dace.Memlet.simple('_out', ','.join(['_o%d' % i for i in range(output_dims)]))},
+                # {'__out': dace.Memlet.simple('_out', ','.join(['_o%d' % i for i in range(output_dims)]))},
+                {'__out': dace.Memlet.simple('_out', ','.join(['_o%d' % i for i in osqdim]))},
                 external_edges=True)
         else:
             nstate = nsdfg.add_state()

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -1,5 +1,4 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
-import operator
 import re
 import warnings
 from functools import reduce
@@ -344,8 +343,8 @@ class Range(Subset):
         ]
 
     def volume_exact(self) -> int:
-        """ Returns the total number of elements in all dimenssions together. """
-        return reduce(operator.mul, self.size_exact())
+        """ Returns the total number of elements in all dimensions together. """
+        return reduce(lambda a, b: a * b, self.size_exact())
 
     def bounding_box_size(self):
         """ Returns the size of a bounding box around this range. """
@@ -910,8 +909,8 @@ class Indices(Subset):
         return self.size()
 
     def volume_exact(self) -> int:
-        """ Returns the total number of elements in all dimenssions together. """
-        return reduce(operator.mul, self.size_exact())
+        """ Returns the total number of elements in all dimensions together. """
+        return reduce(lambda a, b: a * b, self.size_exact())
 
     def min_element(self):
         return self.indices

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -1390,8 +1390,8 @@ class SubrangeMapper:
         assert self.src.dims() == r.dims()
         out = []
         src_i, dst_i = 0, 0
-        while src_i < self.src.dims():
-            assert dst_i < self.dst.dims()
+        while src_i < self.src.dims() and dst_i < self.dst.dims():
+            # If we run out only on one side, handle that case after the loop.
 
             # Find the next smallest segments of `src` and `dst` whose volumes matches (and therefore can possibly have
             # a mapping).
@@ -1446,4 +1446,12 @@ class SubrangeMapper:
                 return None
 
             src_i, dst_i = src_j, dst_j
+        if src_i < self.src.dims():
+            src_segment = Range(self.src.ranges[src_i: self.src.dims()])
+            assert src_segment.volume_exact() == 1
+        if dst_i < self.dst.dims():
+            # Take the remaining dst segment which must have a volume of 1 by now.
+            dst_segment = Range(self.dst.ranges[dst_i: self.dst.dims()])
+            assert dst_segment.volume_exact() == 1
+            out.extend(dst_segment.ranges)
         return Range(out)

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -1406,9 +1406,10 @@ class SubrangeMapper:
             if src_j is None:
                 return None
 
-            if Range(r.ranges[src_i: src_j]).volume_exact() == 1:
-                # If we are selecting just a single point in this segment, we can just pick the mapping of that point.
-                src_segment, dst_segment = Range(self.src.ranges[src_i: src_j]), Range(self.dst.ranges[dst_i: dst_j])
+            # If we are selecting just a single point in this segment, we can just pick the mapping of that point.
+            src_segment, dst_segment, r_segment = Range(self.src.ranges[src_i: src_j]), Range(
+                self.dst.ranges[dst_i: dst_j]), Range(r.ranges[src_i: src_j])
+            if r_segment.volume_exact() == 1:
                 # Compute the local 1D coordinate of the point on `src`.
                 loc = 0
                 for (idx, _, _), (ridx, _, _), s in zip(reversed(src_segment.ranges),

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -1,14 +1,16 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import operator
+import re
+import warnings
+from functools import reduce
+from typing import List, Optional, Sequence, Set, Union
+
+import sympy as sp
+import sympy.core.sympify
+from sympy import ceiling
 
 import dace.serialize
-from dace import data, symbolic, dtypes
-import re
-import sympy as sp
-from functools import reduce
-import sympy.core.sympify
-from typing import List, Optional, Sequence, Set, Union
-import warnings
+from dace import symbolic
 from dace.config import Config
 
 
@@ -22,6 +24,7 @@ def nng(expr):
     except AttributeError:  # No free_symbols in expr
         return expr
 
+
 def bounding_box_cover_exact(subset_a, subset_b) -> bool:
     min_elements_a = subset_a.min_element()
     max_elements_a = subset_a.max_element()
@@ -31,8 +34,8 @@ def bounding_box_cover_exact(subset_a, subset_b) -> bool:
     # Covering only make sense if the two subsets have the same number of dimensions.
     if len(min_elements_a) != len(min_elements_b):
         return ValueError(
-                f"A bounding box of dimensionality {len(min_elements_a)} cannot"
-                f" test covering a bounding box of dimensionality {len(min_elements_b)}."
+            f"A bounding box of dimensionality {len(min_elements_a)} cannot"
+            f" test covering a bounding box of dimensionality {len(min_elements_b)}."
         )
 
     return all([(symbolic.simplify_ext(nng(rb)) <= symbolic.simplify_ext(nng(orb))) == True
@@ -40,7 +43,8 @@ def bounding_box_cover_exact(subset_a, subset_b) -> bool:
                 for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
                                             min_elements_b, max_elements_b)])
 
-def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> bool:
+
+def bounding_box_symbolic_positive(subset_a, subset_b, approximation=False) -> bool:
     min_elements_a = subset_a.min_element_approx() if approximation else subset_a.min_element()
     max_elements_a = subset_a.max_element_approx() if approximation else subset_a.max_element()
     min_elements_b = subset_b.min_element_approx() if approximation else subset_b.min_element()
@@ -49,8 +53,8 @@ def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> 
     # Covering only make sense if the two subsets have the same number of dimensions.
     if len(min_elements_a) != len(min_elements_b):
         return ValueError(
-                f"A bounding box of dimensionality {len(min_elements_a)} cannot"
-                f" test covering a bounding box of dimensionality {len(min_elements_b)}."
+            f"A bounding box of dimensionality {len(min_elements_a)} cannot"
+            f" test covering a bounding box of dimensionality {len(min_elements_b)}."
         )
 
     for rb, re, orb, ore in zip(min_elements_a, max_elements_a,
@@ -72,6 +76,7 @@ def bounding_box_symbolic_positive(subset_a, subset_b, approximation = False)-> 
                 return False
     return True
 
+
 class Subset(object):
     """ Defines a subset of a data descriptor. """
 
@@ -82,7 +87,7 @@ class Subset(object):
         # Subsets of different dimensionality can never cover each other.
         if self.dims() != other.dims():
             return ValueError(
-                    f"A subset of dimensionality {self.dim()} cannot test covering a subset of dimensionality {other.dims()}"
+                f"A subset of dimensionality {self.dim()} cannot test covering a subset of dimensionality {other.dims()}"
             )
 
         if not Config.get('optimizer', 'symbolic_positive'):
@@ -101,20 +106,22 @@ class Subset(object):
                 return False
 
             return True
-        
+
     def covers_precise(self, other):
         """ Returns True if self contains all the elements in other. """
 
         # Subsets of different dimensionality can never cover each other.
         if self.dims() != other.dims():
             return ValueError(
-                    f"A subset of dimensionality {self.dim()} cannot test covering a subset of dimensionality {other.dims()}"
+                f"A subset of dimensionality {self.dim()} cannot test covering a subset of dimensionality {other.dims()}"
             )
 
         # If self does not cover other with a bounding box union, return false.
         symbolic_positive = Config.get('optimizer', 'symbolic_positive')
         try:
-            bounding_box_cover = bounding_box_cover_exact(self, other) if symbolic_positive else bounding_box_symbolic_positive(self, other)
+            bounding_box_cover = bounding_box_cover_exact(self,
+                                                          other) if symbolic_positive else bounding_box_symbolic_positive(
+                self, other)
             if not bounding_box_cover:
                 return False
         except TypeError:
@@ -153,13 +160,12 @@ class Subset(object):
                     except:
                         return False
                     return True
-        # unknown type
+            # unknown type
             else:
                 raise TypeError
 
         except TypeError:
             return False
-
 
     def __repr__(self):
         return '%s (%s)' % (type(self).__name__, self.__str__())
@@ -231,6 +237,7 @@ def _tuple_to_symexpr(val):
 @dace.serialize.serializable
 class Range(Subset):
     """ Subset defined in terms of a fixed range. """
+
     def __init__(self, ranges):
         parsed_ranges = []
         parsed_tiles = []
@@ -584,7 +591,7 @@ class Range(Subset):
                 value = symbolic.pystr_to_symbolic(uni_dim_tokens[0].strip())
                 ranges.append((value, value, 1))
                 continue
-                #return Range(ranges)
+                # return Range(ranges)
             # If dimension has more than 4 tokens, the range is invalid
             if len(uni_dim_tokens) > 4:
                 raise SyntaxError("Invalid range: {}".format(multi_dim_tokens))
@@ -854,6 +861,7 @@ class Range(Subset):
 class Indices(Subset):
     """ A subset of one element representing a single index in an
         N-dimensional data descriptor. """
+
     def __init__(self, indices):
         if indices is None or len(indices) == 0:
             raise TypeError('Expected an array of index expressions: got empty' ' array or None')
@@ -880,7 +888,7 @@ class Indices(Subset):
             raise TypeError("from_json of class \"Indices\" called on json "
                             "with type %s (expected 'Indices')" % obj['type'])
 
-        #return Indices(symbolic.SymExpr(obj['indices']))
+        # return Indices(symbolic.SymExpr(obj['indices']))
         return Indices([*map(symbolic.pystr_to_symbolic, obj['indices'])])
 
     def __hash__(self):
@@ -1091,6 +1099,7 @@ class Indices(Subset):
             return self
         return None
 
+
 class SubsetUnion(Subset):
     """
     Wrapper subset type that stores multiple Subsets in a list.
@@ -1128,7 +1137,7 @@ class SubsetUnion(Subset):
             return False
         else:
             return any(s.covers(other) for s in self.subset_list)
-        
+
     def covers_precise(self, other):
         """ 
         Returns True if this SubsetUnion covers another
@@ -1154,7 +1163,7 @@ class SubsetUnion(Subset):
                 string += " "
             string += subset.__str__()
         return string
-    
+
     def dims(self):
         if not self.subset_list:
             return 0
@@ -1178,7 +1187,7 @@ class SubsetUnion(Subset):
         for subset in self.subset_list:
             result |= subset.free_symbols
         return result
-    
+
     def replace(self, repl_dict):
         for subset in self.subset_list:
             subset.replace(repl_dict)
@@ -1188,13 +1197,12 @@ class SubsetUnion(Subset):
         min = 0
         for subset in self.subset_list:
             try:
-                if subset.num_elements() < min or min ==0:
+                if subset.num_elements() < min or min == 0:
                     min = subset.num_elements()
             except:
                 continue
-            
-        return min
 
+        return min
 
 
 def _union_special_cases(arb: symbolic.SymbolicType, brb: symbolic.SymbolicType, are: symbolic.SymbolicType,
@@ -1259,8 +1267,6 @@ def bounding_box_union(subset_a: Subset, subset_b: Subset) -> Range:
         result.append((minrb, maxre, 1))
 
     return Range(result)
-
-
 
 
 def union(subset_a: Subset, subset_b: Subset) -> Subset:
@@ -1331,6 +1337,7 @@ def list_union(subset_a: Subset, subset_b: Subset) -> Subset:
     except TypeError:
         return None
 
+
 def intersects(subset_a: Subset, subset_b: Subset) -> Union[bool, None]:
     """
     Returns True if two subsets intersect, False if they do not, or
@@ -1352,3 +1359,85 @@ def intersects(subset_a: Subset, subset_b: Subset) -> Union[bool, None]:
         return None
     except TypeError:  # cannot determine truth value of Relational
         return None
+
+
+class SubrangeMapper:
+    """
+    Equipped with a `src` and a `dst` range of equal volumes but possibly different shapes or even dimensions (i.e.,
+    there is an 1-to-1 correspondence between the elements of `src` and `dst`), maps a subrange of `src` to its
+    counterpart in `dst`, if possible.
+
+    Note that such subrange-to-subrange mapping may not always exist.
+    """
+
+    def __init__(self, src: Range, dst: Range):
+        src, dst = self.canonical(src), self.canonical(dst)
+        assert src.volume_exact() == dst.volume_exact()
+        self.src, self.dst = src, dst
+
+    @staticmethod
+    def canonical(r: Range) -> Range:
+        """
+        Extends the (excluded) upper bound of each component of the ranges as much as possible, without affecting the
+        volume of the range.
+        """
+        return Range([(b, b + s * ceiling((e - b + 1) / s) - 1, s)
+                      for b, e, s in r.ndrange()])
+
+    def map(self, r: Range) -> Optional[Range]:
+        r = self.canonical(r)
+        # Ideally we also have `assert self.src.covers_precise(r)`. However, we cannot determine that for symbols.
+        assert self.src.dims() == r.dims()
+        out = []
+        src_i, dst_i = 0, 0
+        while src_i < self.src.dims():
+            assert dst_i < self.dst.dims()
+
+            src_j, dst_j = None, None
+            for sj in range(src_i + 1, self.src.dims() + 1):
+                for dj in range(dst_i + 1, self.dst.dims() + 1):
+                    if Range(self.src.ranges[src_i:sj]).volume_exact() == Range(
+                            self.dst.ranges[dst_i:dj]).volume_exact():
+                        src_j, dst_j = sj, dj
+                        break
+                else:
+                    continue
+                break
+            if src_j is None:
+                return None
+
+            if Range(r.ranges[src_i: src_j]).volume_exact() == 1:
+                # If we are selecting just a single point in this segment, we can just pick the mapping of that point.
+                src_segment, dst_segment = Range(self.src.ranges[src_i: src_j]), Range(self.dst.ranges[dst_i: dst_j])
+                # Compute the local 1D coordinate of the point on `src`.
+                loc = 0
+                for (idx, _, _), (ridx, _, _), s in zip(reversed(src_segment.ranges),
+                                                        reversed(r.ranges[src_i: src_j]),
+                                                        reversed(src_segment.size())):
+                    loc = loc * s + (ridx - idx)
+                # Translate that local 1D coordinate onto `dst`.
+                dst_coord = []
+                for (idx, _, _), s in zip(dst_segment.ranges, dst_segment.size()):
+                    dst_coord.append(loc % s + idx)
+                    loc = loc // s
+                out.extend([(idx, idx, 1) for idx in dst_coord])
+            elif self.src.ranges[src_i: src_j] == r.ranges[src_i: src_j]:
+                # If we are selecting the entirety of this segment, we can just pick the corresponding mapped segment in
+                # its entirety too.
+                out.extend(self.dst.ranges[dst_i:dst_j])
+            elif src_j - src_i == 1 and dst_j - dst_i == 1:
+                # If the segment lengths on both sides are just 1, the mapping is easy to compute.
+                sb, se, ss = self.src.ranges[src_i]
+                db, de, ds = self.dst.ranges[dst_i]
+                b, e, s = r.ranges[src_i]
+                lb, le, ls = (b - sb) // ss, (e - se) // ss - 1, s // ss
+                tb, te, ts = db + lb * ds, de + (le + 1) * ds, ds * ls
+                out.append((tb, te, ts))
+            else:
+                # TODO: Can we narrow down this case even more? That would be number theoretic problem.
+                # E.g., If we are reshaping [6, 5] to [2, 15], we are demanding that these dimensions must be wholly
+                # selected for now.
+                return None
+
+            src_i, dst_i = src_j, dst_j
+        return Range(out)

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -1,4 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import operator
+
 import dace.serialize
 from dace import data, symbolic, dtypes
 import re
@@ -333,6 +335,10 @@ class Range(Subset):
                             (step.expr if isinstance(step, symbolic.SymExpr) else step))
             for (iMin, iMax, step), ts in zip(self.ranges, self.tile_sizes)
         ]
+
+    def volume_exact(self) -> int:
+        """ Returns the total number of elements in all dimenssions together. """
+        return reduce(operator.mul, self.size_exact())
 
     def bounding_box_size(self):
         """ Returns the size of a bounding box around this range. """
@@ -894,6 +900,10 @@ class Indices(Subset):
 
     def size_exact(self):
         return self.size()
+
+    def volume_exact(self) -> int:
+        """ Returns the total number of elements in all dimenssions together. """
+        return reduce(operator.mul, self.size_exact())
 
     def min_element(self):
         return self.indices

--- a/tests/subsets_test.py
+++ b/tests/subsets_test.py
@@ -1,0 +1,51 @@
+import unittest
+
+from sympy import ceiling
+
+from dace.subsets import Range, Indices
+
+import dace
+
+
+class Volume(unittest.TestCase):
+    def test_range(self):
+        K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
+
+        # A regular cube.
+        r = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
+        self.assertEqual(K * N * M, r.volume_exact())
+
+        # A regular cube with offsets.
+        r = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
+        self.assertEqual(K * N * M, r.volume_exact())
+
+        # A regular cube with strides.
+        r = Range([(0, K - 1, 2), (0, N - 1, 3), (0, M - 1, 4)])
+        self.assertEqual(ceiling(K / 2) * ceiling(N / 3) * ceiling(M / 4), r.volume_exact())
+
+        # A regular cube with both offsets and strides.
+        r = Range([(1, 1 + K - 1, 2), (2, 2 + N - 1, 3), (3, 3 + M - 1, 4)])
+        self.assertEqual(ceiling(K / 2) * ceiling(N / 3) * ceiling(M / 4), r.volume_exact())
+
+        # A 2D square on 3D coordinate system.
+        r = Range([(1, 1 + K - 1, 2), (2, 2, 3), (3, 3 + M - 1, 4)])
+        self.assertEqual(ceiling(K / 2) * ceiling(M / 4), r.volume_exact())
+
+        # A 3D point.
+        r = Range([(1, 1, 2), (2, 2, 3), (3, 3, 4)])
+        self.assertEqual(1, r.volume_exact())
+
+    def test_indices(self):
+        # Indices always have volume 1 no matter what, since they are just points.
+        ind = Indices([0, 1, 2])
+        self.assertEqual(1, ind.volume_exact())
+
+        ind = Indices([1])
+        self.assertEqual(1, ind.volume_exact())
+
+        ind = Indices([0, 2])
+        self.assertEqual(1, ind.volume_exact())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/subsets_test.py
+++ b/tests/subsets_test.py
@@ -162,7 +162,7 @@ class RangeRemapperTest(unittest.TestCase):
         # A regular cube.
         src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1), (0, 0, 1)])
         # A regular cube with different shape.
-        dst = Range([(0, K - 1, 1), (0, N * M - 1, 1), (0, 0, 1), (0, 0, 1)])
+        dst = Range([(0, K - 1, 1), (0, 0, 1), (0, N * M - 1, 1), (0, 0, 1), (0, 0, 1)])
         # A Mapper
         sm = SubrangeMapper(src, dst)
         sm_inv = SubrangeMapper(dst, src)
@@ -179,7 +179,10 @@ class RangeRemapperTest(unittest.TestCase):
         # Pick a point K//2, N//2, M//2.
         for args in argslist:
             orig = Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1), (0, 0, 1)])
-            orig_maps_to = Range([(K // 2, K // 2, 1), ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1), (0, 0, 1), (0, 0, 1)])
+            orig_maps_to = Range([(K // 2, K // 2, 1),
+                                  (0, 0, 1),
+                                  ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1),
+                                  (0, 0, 1), (0, 0, 1)])
             want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
             self.assertEqual(want, got)
             want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
@@ -191,7 +194,10 @@ class RangeRemapperTest(unittest.TestCase):
         # Pick only points in problematic quadrants, but larger subsets elsewhere.
         for args in argslist:
             orig = Range([(0, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1), (0, 0, 1)])
-            orig_maps_to = Range([(0, K // 2, 1), ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1), (0, 0, 1), (0, 0, 1)])
+            orig_maps_to = Range([(0, K // 2, 1),
+                                  (0, 0, 1),
+                                  ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1),
+                                  (0, 0, 1), (0, 0, 1)])
             want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
             self.assertEqual(want, got)
             want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)

--- a/tests/subsets_test.py
+++ b/tests/subsets_test.py
@@ -13,196 +13,201 @@ def eval_range(r: Range, vals: Dict):
     return Range([(simplify(b).subs(vals), simplify(e).subs(vals), simplify(s).subs(vals)) for b, e, s in r.ranges])
 
 
-class VolumeTest(unittest.TestCase):
-    def test_range(self):
-        K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
+def test_volume_of_range():
+    K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
 
-        # A regular cube.
-        r = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
-        self.assertEqual(K * N * M, r.volume_exact())
+    # A regular cube.
+    r = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
+    assert K * N * M == r.volume_exact()
 
-        # A regular cube with offsets.
-        r = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
-        self.assertEqual(K * N * M, r.volume_exact())
+    # A regular cube with offsets.
+    r = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
+    assert K * N * M == r.volume_exact()
 
-        # A regular cube with strides.
-        r = Range([(0, K - 1, 2), (0, N - 1, 3), (0, M - 1, 4)])
-        self.assertEqual(ceiling(K / 2) * ceiling(N / 3) * ceiling(M / 4), r.volume_exact())
+    # A regular cube with strides.
+    r = Range([(0, K - 1, 2), (0, N - 1, 3), (0, M - 1, 4)])
+    assert ceiling(K / 2) * ceiling(N / 3) * ceiling(M / 4) == r.volume_exact()
 
-        # A regular cube with both offsets and strides.
-        r = Range([(1, 1 + K - 1, 2), (2, 2 + N - 1, 3), (3, 3 + M - 1, 4)])
-        self.assertEqual(ceiling(K / 2) * ceiling(N / 3) * ceiling(M / 4), r.volume_exact())
+    # A regular cube with both offsets and strides.
+    r = Range([(1, 1 + K - 1, 2), (2, 2 + N - 1, 3), (3, 3 + M - 1, 4)])
+    assert ceiling(K / 2) * ceiling(N / 3) * ceiling(M / 4) == r.volume_exact()
 
-        # A 2D square on 3D coordinate system.
-        r = Range([(1, 1 + K - 1, 2), (2, 2, 3), (3, 3 + M - 1, 4)])
-        self.assertEqual(ceiling(K / 2) * ceiling(M / 4), r.volume_exact())
+    # A 2D square on 3D coordinate system.
+    r = Range([(1, 1 + K - 1, 2), (2, 2, 3), (3, 3 + M - 1, 4)])
+    assert ceiling(K / 2) * ceiling(M / 4) == r.volume_exact()
 
-        # A 3D point.
-        r = Range([(1, 1, 2), (2, 2, 3), (3, 3, 4)])
-        self.assertEqual(1, r.volume_exact())
-
-    def test_indices(self):
-        # Indices always have volume 1 no matter what, since they are just points.
-        ind = Indices([0, 1, 2])
-        self.assertEqual(1, ind.volume_exact())
-
-        ind = Indices([1])
-        self.assertEqual(1, ind.volume_exact())
-
-        ind = Indices([0, 2])
-        self.assertEqual(1, ind.volume_exact())
+    # A 3D point.
+    r = Range([(1, 1, 2), (2, 2, 3), (3, 3, 4)])
+    assert 1 == r.volume_exact()
 
 
-class RangeRemapperTest(unittest.TestCase):
-    def test_mapping_without_symbols(self):
-        K, N, M = 6, 7, 8
+def test_volume_of_indices():
+    # Indices always have volume 1 no matter what, since they are just points.
+    ind = Indices([0, 1, 2])
+    assert 1 == ind.volume_exact()
 
-        # A regular cube.
-        src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
-        # A regular cube with offsets.
-        dst = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
-        # A Mapper
-        sm = SubrangeMapper(src, dst)
+    ind = Indices([1])
+    assert 1 == ind.volume_exact()
 
-        # Pick the entire range.
-        self.assertEqual(dst, sm.map(src))
-        # Pick a point 0, 0, 0.
-        self.assertEqual(Range([(1, 1, 1), (2, 2, 1), (3, 3, 1)]),
-                         sm.map(Range([(0, 0, 1), (0, 0, 1), (0, 0, 1)])))
+    ind = Indices([0, 2])
+    assert 1 == ind.volume_exact()
+
+
+def test_subrange_mapping_no_symbols():
+    K, N, M = 6, 7, 8
+
+    # A regular cube.
+    src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
+    # A regular cube with offsets.
+    dst = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
+    # A Mapper
+    sm = SubrangeMapper(src, dst)
+
+    # Pick the entire range.
+    assert dst == sm.map(src)
+    # Pick a point 0, 0, 0.
+    assert (Range([(1, 1, 1), (2, 2, 1), (3, 3, 1)])
+            == sm.map(Range([(0, 0, 1), (0, 0, 1), (0, 0, 1)])))
+    # Pick a point K//2, N//2, M//2.
+    assert (Range([(1 + K // 2, 1 + K // 2, 1), (2 + N // 2, 2 + N // 2, 1), (3 + M // 2, 3 + M // 2, 1)])
+            == sm.map(Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])))
+    # Pick a point K-1, N-1, M-1.
+    assert (Range([(1 + K - 1, 1 + K - 1, 1), (2 + N - 1, 2 + N - 1, 1), (3 + M - 1, 3 + M - 1, 1)])
+            == sm.map(Range([(K - 1, K - 1, 1), (N - 1, N - 1, 1), (M - 1, M - 1, 1)])))
+    # Pick a quadrant.
+    assert (Range([(1, 1 + K // 2, 1), (2, 2 + N // 2, 1), (3, 3 + M // 2, 1)])
+            == sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1)])))
+
+
+def test_subrange_mapping__with_symbols():
+    K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
+
+    # A regular cube.
+    src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
+    # A regular cube with offsets.
+    dst = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
+    # A Mapper
+    sm = SubrangeMapper(src, dst)
+
+    # Pick the entire range.
+    assert dst == sm.map(src)
+
+    # NOTE: I couldn't make SymPy understand that `(K//2) % K == (K//2)` always holds for postive integers `K`.
+    # Hence, the numerical approach.
+    argslist = [{'K': k, 'N': n, 'M': m} for k, n, m in zip(np.random.randint(1, 100, size=20),
+                                                            np.random.randint(1, 100, size=20),
+                                                            np.random.randint(1, 100, size=20))]
+    for args in argslist:
         # Pick a point K//2, N//2, M//2.
-        self.assertEqual(Range([(1 + K // 2, 1 + K // 2, 1), (2 + N // 2, 2 + N // 2, 1), (3 + M // 2, 3 + M // 2, 1)]),
-                         sm.map(Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])))
-        # Pick a point K-1, N-1, M-1.
-        self.assertEqual(Range([(1 + K - 1, 1 + K - 1, 1), (2 + N - 1, 2 + N - 1, 1), (3 + M - 1, 3 + M - 1, 1)]),
-                         sm.map(Range([(K - 1, K - 1, 1), (N - 1, N - 1, 1), (M - 1, M - 1, 1)])))
+        want = eval_range(
+            Range([(1 + K // 2, 1 + K // 2, 1), (2 + N // 2, 2 + N // 2, 1), (3 + M // 2, 3 + M // 2, 1)]),
+            args)
+        got = eval_range(
+            sm.map(Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])),
+            args)
+        assert want == got
         # Pick a quadrant.
-        self.assertEqual(Range([(1, 1 + K // 2, 1), (2, 2 + N // 2, 1), (3, 3 + M // 2, 1)]),
-                         sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1)])))
+        want = eval_range(
+            Range([(1, 1 + K // 2, 1), (2, 2 + N // 2, 1), (3, 3 + M // 2, 1)]),
+            args)
+        got = eval_range(
+            sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1)])),
+            args)
+        assert want == got
 
-    def test_mapping_with_symbols(self):
-        K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
 
-        # A regular cube.
-        src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
-        # A regular cube with offsets.
-        dst = Range([(1, 1 + K - 1, 1), (2, 2 + N - 1, 1), (3, 3 + M - 1, 1)])
-        # A Mapper
-        sm = SubrangeMapper(src, dst)
+def test_subrange_mapping__with_reshaping():
+    K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
 
-        # Pick the entire range.
-        self.assertEqual(dst, sm.map(src))
+    # A regular cube.
+    src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
+    # A regular cube with different shape.
+    dst = Range([(0, K - 1, 1), (0, N * M - 1, 1)])
+    # A Mapper
+    sm = SubrangeMapper(src, dst)
+    sm_inv = SubrangeMapper(dst, src)
 
-        # NOTE: I couldn't make SymPy understand that `(K//2) % K == (K//2)` always holds for postive integers `K`.
-        # Hence, the numerical approach.
-        argslist = [{'K': k, 'N': n, 'M': m} for k, n, m in zip(np.random.randint(1, 100, size=20),
-                                                                np.random.randint(1, 100, size=20),
-                                                                np.random.randint(1, 100, size=20))]
-        for args in argslist:
-            # Pick a point K//2, N//2, M//2.
-            want = eval_range(
-                Range([(1 + K // 2, 1 + K // 2, 1), (2 + N // 2, 2 + N // 2, 1), (3 + M // 2, 3 + M // 2, 1)]),
-                args)
-            got = eval_range(
-                sm.map(Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])),
-                args)
-            self.assertEqual(want, got)
-            # Pick a quadrant.
-            want = eval_range(
-                Range([(1, 1 + K // 2, 1), (2, 2 + N // 2, 1), (3, 3 + M // 2, 1)]),
-                args)
-            got = eval_range(
-                sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1)])),
-                args)
-            self.assertEqual(want, got)
+    # Pick the entire range.
+    assert dst == sm.map(src)
+    assert src == sm_inv.map(dst)
 
-    def test_mapping_with_reshaping(self):
-        K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
+    # NOTE: I couldn't make SymPy understand that `(K//2) % K == (K//2)` always holds for postive integers `K`.
+    # Hence, the numerical approach.
+    argslist = [{'K': k, 'N': n, 'M': m} for k, n, m in zip(np.random.randint(1, 10, size=20),
+                                                            np.random.randint(1, 10, size=20),
+                                                            np.random.randint(1, 10, size=20))]
+    # Pick a point K//2, N//2, M//2.
+    for args in argslist:
+        orig = Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])
+        orig_maps_to = Range([(K // 2, K // 2, 1), ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1)])
+        want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
+        assert want == got
+        want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
+        assert want == got
+    # Pick a quadrant.
+    # But its mapping cannot be expressed as a simple range with offset and stride.
+    assert sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1)])) is None
+    # Pick only points in problematic quadrants, but larger subsets elsewhere.
+    for args in argslist:
+        orig = Range([(0, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])
+        orig_maps_to = Range([(0, K // 2, 1), ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1)])
+        want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
+        assert want == got
+        want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
+        assert want == got
 
-        # A regular cube.
-        src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1)])
-        # A regular cube with different shape.
-        dst = Range([(0, K - 1, 1), (0, N * M - 1, 1)])
-        # A Mapper
-        sm = SubrangeMapper(src, dst)
-        sm_inv = SubrangeMapper(dst, src)
 
-        # Pick the entire range.
-        self.assertEqual(dst, sm.map(src))
-        self.assertEqual(src, sm_inv.map(dst))
+def test_subrange_mapping__with_reshaping_unit_dims():
+    K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
 
-        # NOTE: I couldn't make SymPy understand that `(K//2) % K == (K//2)` always holds for postive integers `K`.
-        # Hence, the numerical approach.
-        argslist = [{'K': k, 'N': n, 'M': m} for k, n, m in zip(np.random.randint(1, 10, size=20),
-                                                                np.random.randint(1, 10, size=20),
-                                                                np.random.randint(1, 10, size=20))]
-        # Pick a point K//2, N//2, M//2.
-        for args in argslist:
-            orig = Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])
-            orig_maps_to = Range([(K // 2, K // 2, 1), ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1)])
-            want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
-            self.assertEqual(want, got)
-            want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
-            self.assertEqual(want, got)
-        # Pick a quadrant.
-        for args in argslist:
-            # But its mapping cannot be expressed as a simple range with offset and stride.
-            self.assertIsNone(sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1)])))
-        # Pick only points in problematic quadrants, but larger subsets elsewhere.
-        for args in argslist:
-            orig = Range([(0, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1)])
-            orig_maps_to = Range([(0, K // 2, 1), ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1)])
-            want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
-            self.assertEqual(want, got)
-            want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
-            self.assertEqual(want, got)
+    # A regular cube.
+    src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1), (0, 0, 1)])
+    # A regular cube with different shape.
+    dst = Range([(0, K - 1, 1), (0, 0, 1), (0, N * M - 1, 1), (0, 0, 1), (0, 0, 1)])
+    # A Mapper
+    sm = SubrangeMapper(src, dst)
+    sm_inv = SubrangeMapper(dst, src)
 
-    def test_mapping_with_reshaping_unit_dims(self):
-        K, N, M = dace.symbol('K', positive=True), dace.symbol('N', positive=True), dace.symbol('M', positive=True)
+    # Pick the entire range.
+    assert dst == sm.map(src)
+    assert src == sm_inv.map(dst)
 
-        # A regular cube.
-        src = Range([(0, K - 1, 1), (0, N - 1, 1), (0, M - 1, 1), (0, 0, 1)])
-        # A regular cube with different shape.
-        dst = Range([(0, K - 1, 1), (0, 0, 1), (0, N * M - 1, 1), (0, 0, 1), (0, 0, 1)])
-        # A Mapper
-        sm = SubrangeMapper(src, dst)
-        sm_inv = SubrangeMapper(dst, src)
-
-        # Pick the entire range.
-        self.assertEqual(dst, sm.map(src))
-        self.assertEqual(src, sm_inv.map(dst))
-
-        # NOTE: I couldn't make SymPy understand that `(K//2) % K == (K//2)` always holds for postive integers `K`.
-        # Hence, the numerical approach.
-        argslist = [{'K': k, 'N': n, 'M': m} for k, n, m in zip(np.random.randint(1, 10, size=20),
-                                                                np.random.randint(1, 10, size=20),
-                                                                np.random.randint(1, 10, size=20))]
-        # Pick a point K//2, N//2, M//2.
-        for args in argslist:
-            orig = Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1), (0, 0, 1)])
-            orig_maps_to = Range([(K // 2, K // 2, 1),
-                                  (0, 0, 1),
-                                  ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1),
-                                  (0, 0, 1), (0, 0, 1)])
-            want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
-            self.assertEqual(want, got)
-            want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
-            self.assertEqual(want, got)
-        # Pick a quadrant.
-        for args in argslist:
-            # But its mapping cannot be expressed as a simple range with offset and stride.
-            self.assertIsNone(sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1), (0, 0, 1)])))
-        # Pick only points in problematic quadrants, but larger subsets elsewhere.
-        for args in argslist:
-            orig = Range([(0, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1), (0, 0, 1)])
-            orig_maps_to = Range([(0, K // 2, 1),
-                                  (0, 0, 1),
-                                  ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1),
-                                  (0, 0, 1), (0, 0, 1)])
-            want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
-            self.assertEqual(want, got)
-            want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
-            self.assertEqual(want, got)
+    # NOTE: I couldn't make SymPy understand that `(K//2) % K == (K//2)` always holds for postive integers `K`.
+    # Hence, the numerical approach.
+    argslist = [{'K': k, 'N': n, 'M': m} for k, n, m in zip(np.random.randint(1, 10, size=20),
+                                                            np.random.randint(1, 10, size=20),
+                                                            np.random.randint(1, 10, size=20))]
+    # Pick a point K//2, N//2, M//2.
+    for args in argslist:
+        orig = Range([(K // 2, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1), (0, 0, 1)])
+        orig_maps_to = Range([(K // 2, K // 2, 1),
+                              (0, 0, 1),
+                              ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1),
+                              (0, 0, 1), (0, 0, 1)])
+        want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
+        assert want == got
+        want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
+        assert want == got
+    # Pick a quadrant.
+    # But its mapping cannot be expressed as a simple range with offset and stride.
+    assert sm.map(Range([(0, K // 2, 1), (0, N // 2, 1), (0, M // 2, 1), (0, 0, 1)])) is None
+    # Pick only points in problematic quadrants, but larger subsets elsewhere.
+    for args in argslist:
+        orig = Range([(0, K // 2, 1), (N // 2, N // 2, 1), (M // 2, M // 2, 1), (0, 0, 1)])
+        orig_maps_to = Range([(0, K // 2, 1),
+                              (0, 0, 1),
+                              ((N // 2) + (M // 2) * N, (N // 2) + (M // 2) * N, 1),
+                              (0, 0, 1), (0, 0, 1)])
+        want, got = eval_range(orig_maps_to, args), eval_range(sm.map(orig), args)
+        assert want == got
+        want, got = eval_range(orig, args), eval_range(sm_inv.map(orig_maps_to), args)
+        assert want == got
 
 
 if __name__ == '__main__':
-    unittest.main()
+    test_volume_of_range()
+    test_volume_of_indices()
+    test_subrange_mapping_no_symbols()
+    test_subrange_mapping__with_symbols()
+    test_subrange_mapping__with_reshaping()
+    test_subrange_mapping__with_reshaping_unit_dims()


### PR DESCRIPTION
Equipped with a `src` and a `dst` range of equal volumes but possibly different shapes or even dimensions (i.e.,
there is an 1-to-1 correspondence between the elements of `src` and `dst`), maps a subrange of `src` to its
counterpart in `dst`, if possible (which is not always the case).

It remains dead-code in this PR and not used anywhere at all. But it should help with correctly reshaping memlet subsets in a following PR (which will aim to fix `RedundantArray` transform by simplying it to something like this: https://github.com/pratyai/dace/blob/be571d21aa8abbc465daa11d04941040fbf93401/dace/transformation/dataflow/redundant_array.py#L426-L480).