### PR TITLE
Python frontend stability and inline storage specification

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -2215,7 +2215,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                 'auto {param}) {{'.format(fine_grained=('true' if Config.get_bool(
                     'compiler', 'cuda', 'dynamic_map_fine_grained') else 'false'),
                                           bsize=total_block_size,
-                                          kmapIdx=outer_scope.map.params[0],
+                                          kmapIdx=outer_scope.map.params[-1],
                                           param=dynmap_var), cfg, state_id, scope_entry)
 
             for e in dace.sdfg.dynamic_map_inputs(dfg, scope_entry):

--- a/dace/codegen/tools/type_inference.py
+++ b/dace/codegen/tools/type_inference.py
@@ -9,7 +9,7 @@
 
 import numpy as np
 import ast
-from dace import dtypes
+from dace import data, dtypes
 from dace import symbolic
 from dace.codegen import cppunparse
 from dace.symbolic import symbol, SymExpr, symstr
@@ -285,6 +285,8 @@ def _Name(t, symbols, inferred_symbols):
             if isinstance(inferred_type, np.dtype):
                 inferred_type = dtypes.typeclass(inferred_type.type)
             elif isinstance(inferred_type, symbolic.symbol):
+                inferred_type = inferred_type.dtype
+            elif isinstance(inferred_type, data.Data):
                 inferred_type = inferred_type.dtype
         elif t_id in inferred_symbols:
             inferred_type = inferred_symbols[t_id]

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -1,10 +1,8 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 """ A module that contains various DaCe type definitions. """
-from __future__ import print_function
 import ctypes
 import aenum
 import inspect
-import itertools
 import numpy
 import re
 from collections import OrderedDict

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -4630,10 +4630,16 @@ class ProgramVisitor(ExtNodeVisitor):
         self._add_state('call_%d' % node.lineno)
         self.last_block.set_default_lineinfo(self.current_lineinfo)
 
-        if found_ufunc:
-            result = func(self, node, self.sdfg, self.last_block, ufunc_name, args, keywords)
-        else:
-            result = func(self, self.sdfg, self.last_block, *args, **keywords)
+        try:
+            if found_ufunc:
+                result = func(self, node, self.sdfg, self.last_block, ufunc_name, args, keywords)
+            else:
+                result = func(self, self.sdfg, self.last_block, *args, **keywords)
+        except DaceSyntaxError as ex:
+            # Attach source information to exception
+            if ex.node is None:
+                ex.node = node
+            raise
 
         self.last_block.set_default_lineinfo(None)
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1489,19 +1489,19 @@ class ProgramVisitor(ExtNodeVisitor):
             else:
                 values = str(val).split(':')
                 if len(values) == 1:
-                    result[name] = symbolic.symbol(name, infer_expr_type(values[0], {**self.globals, **dyn_inputs}))
+                    result[name] = symbolic.symbol(name, infer_expr_type(values[0], {**self.defined, **dyn_inputs}))
                 elif len(values) == 2:
                     result[name] = symbolic.symbol(
                         name,
                         dtypes.result_type_of(infer_expr_type(values[0], {
-                            **self.globals,
+                            **self.defined,
                             **dyn_inputs
                         }), infer_expr_type(values[1], {
-                            **self.globals,
+                            **self.defined,
                             **dyn_inputs
                         })))
                 elif len(values) == 3:
-                    result[name] = symbolic.symbol(name, infer_expr_type(values[0], {**self.globals, **dyn_inputs}))
+                    result[name] = symbolic.symbol(name, infer_expr_type(values[0], {**self.defined, **dyn_inputs}))
                 else:
                     raise DaceSyntaxError(
                         self, None, "Invalid number of arguments in a range iterator. "

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -4550,6 +4550,11 @@ def _ndarray_astype(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, 
         dtype = dtypes.typeclass(dtype)
     return _datatype_converter(sdfg, state, arr, dtype)[0]
 
+@oprepo.replaces_operator('Array', 'MatMult', otherclass='StorageType')
+def _cast_storage(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str, stype: dace.StorageType) -> str:
+    desc = sdfg.arrays[arr]
+    desc.storage = stype
+    return arr
 
 # Replacements that need ufuncs ###############################################
 # TODO: Fix by separating to different modules and importing

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -324,29 +324,28 @@ def _numpy_full(pv: ProgramVisitor,
     dtype = dtype or vtype
 
     # Handle one-dimensional inputs
-    try:
-        iter(shape)
-    except TypeError:
+    if isinstance(shape, (Number, str)) or symbolic.issymbolic(shape):
         shape = [shape]
+
+    if any(isinstance(s, str) for s in shape):
+        raise DaceSyntaxError(
+            pv, None, f'Data-dependent shape {shape} is currently not allowed. Only constants '
+            'and symbolic values can be used.')
 
     name, _ = sdfg.add_temp_transient(shape, dtype)
 
     if is_data:
         state.add_mapped_tasklet(
-            '_numpy_full_', {
-                "__i{}".format(i): "0: {}".format(s)
-                for i, s in enumerate(shape)
-            },
+            '_numpy_full_', {"__i{}".format(i): "0: {}".format(s)
+                             for i, s in enumerate(shape)},
             dict(__inp=dace.Memlet(data=fill_value, subset='0')),
             "__out = __inp",
             dict(__out=dace.Memlet.simple(name, ",".join(["__i{}".format(i) for i in range(len(shape))]))),
             external_edges=True)
     else:
         state.add_mapped_tasklet(
-            '_numpy_full_', {
-                "__i{}".format(i): "0: {}".format(s)
-                for i, s in enumerate(shape)
-            }, {},
+            '_numpy_full_', {"__i{}".format(i): "0: {}".format(s)
+                             for i, s in enumerate(shape)}, {},
             "__out = {}".format(fill_value),
             dict(__out=dace.Memlet.simple(name, ",".join(["__i{}".format(i) for i in range(len(shape))]))),
             external_edges=True)
@@ -466,10 +465,8 @@ def _numpy_flip(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, axis
     inpidx = ','.join([f'__i{i}' for i in range(ndim)])
     outidx = ','.join([f'{s} - __i{i} - 1' if a else f'__i{i}' for i, (a, s) in enumerate(zip(axis, desc.shape))])
     state.add_mapped_tasklet(name="_numpy_flip_",
-                             map_ranges={
-                                 f'__i{i}': f'0:{s}:1'
-                                 for i, s in enumerate(desc.shape)
-                             },
+                             map_ranges={f'__i{i}': f'0:{s}:1'
+                                         for i, s in enumerate(desc.shape)},
                              inputs={'__inp': Memlet(f'{arr}[{inpidx}]')},
                              code='__out = __inp',
                              outputs={'__out': Memlet(f'{arr_copy}[{outidx}]')},
@@ -539,10 +536,8 @@ def _numpy_rot90(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, k=1
 
     outidx = ','.join(out_indices)
     state.add_mapped_tasklet(name="_rot90_",
-                             map_ranges={
-                                 f'__i{i}': f'0:{s}:1'
-                                 for i, s in enumerate(desc.shape)
-                             },
+                             map_ranges={f'__i{i}': f'0:{s}:1'
+                                         for i, s in enumerate(desc.shape)},
                              inputs={'__inp': Memlet(f'{arr}[{inpidx}]')},
                              code='__out = __inp',
                              outputs={'__out': Memlet(f'{arr_copy}[{outidx}]')},
@@ -651,7 +646,8 @@ def _elementwise(pv: 'ProgramVisitor',
     else:
         state.add_mapped_tasklet(
             name="_elementwise_",
-            map_ranges={f'__i{dim}': f'0:{N}' for dim, N in enumerate(inparr.shape)},
+            map_ranges={f'__i{dim}': f'0:{N}'
+                        for dim, N in enumerate(inparr.shape)},
             inputs={'__inp': Memlet.simple(in_array, ','.join([f'__i{dim}' for dim in range(len(inparr.shape))]))},
             code=code,
             outputs={'__out': Memlet.simple(out_array, ','.join([f'__i{dim}' for dim in range(len(inparr.shape))]))},
@@ -701,10 +697,8 @@ def _simple_call(sdfg: SDFG, state: SDFGState, inpname: str, func: str, restype:
     else:
         state.add_mapped_tasklet(
             name=func,
-            map_ranges={
-                '__i%d' % i: '0:%s' % n
-                for i, n in enumerate(inparr.shape)
-            },
+            map_ranges={'__i%d' % i: '0:%s' % n
+                        for i, n in enumerate(inparr.shape)},
             inputs={'__inp': Memlet.simple(inpname, ','.join(['__i%d' % i for i in range(len(inparr.shape))]))},
             code='__out = {f}(__inp)'.format(f=func),
             outputs={'__out': Memlet.simple(outname, ','.join(['__i%d' % i for i in range(len(inparr.shape))]))},
@@ -1053,27 +1047,22 @@ def _argminmax(pv: ProgramVisitor,
     code = "__init = _val_and_idx(val={}, idx=-1)".format(
         dtypes.min_value(a_arr.dtype) if func == 'max' else dtypes.max_value(a_arr.dtype))
 
-    nest.add_state().add_mapped_tasklet(name="_arg{}_convert_".format(func),
-                                        map_ranges={
-                                            '__i%d' % i: '0:%s' % n
-                                            for i, n in enumerate(a_arr.shape) if i != axis
-                                        },
-                                        inputs={},
-                                        code=code,
-                                        outputs={
-                                            '__init':
-                                            Memlet.simple(
-                                                reduced_structs,
-                                                ','.join('__i%d' % i for i in range(len(a_arr.shape)) if i != axis))
-                                        },
-                                        external_edges=True)
+    nest.add_state().add_mapped_tasklet(
+        name="_arg{}_convert_".format(func),
+        map_ranges={'__i%d' % i: '0:%s' % n
+                    for i, n in enumerate(a_arr.shape) if i != axis},
+        inputs={},
+        code=code,
+        outputs={
+            '__init': Memlet.simple(reduced_structs,
+                                    ','.join('__i%d' % i for i in range(len(a_arr.shape)) if i != axis))
+        },
+        external_edges=True)
 
     nest.add_state().add_mapped_tasklet(
         name="_arg{}_reduce_".format(func),
-        map_ranges={
-            '__i%d' % i: '0:%s' % n
-            for i, n in enumerate(a_arr.shape)
-        },
+        map_ranges={'__i%d' % i: '0:%s' % n
+                    for i, n in enumerate(a_arr.shape)},
         inputs={'__in': Memlet.simple(a, ','.join('__i%d' % i for i in range(len(a_arr.shape))))},
         code="__out = _val_and_idx(idx={}, val=__in)".format("__i%d" % axis),
         outputs={
@@ -1093,10 +1082,8 @@ def _argminmax(pv: ProgramVisitor,
 
         nest.add_state().add_mapped_tasklet(
             name="_arg{}_extract_".format(func),
-            map_ranges={
-                '__i%d' % i: '0:%s' % n
-                for i, n in enumerate(a_arr.shape) if i != axis
-            },
+            map_ranges={'__i%d' % i: '0:%s' % n
+                        for i, n in enumerate(a_arr.shape) if i != axis},
             inputs={
                 '__in': Memlet.simple(reduced_structs,
                                       ','.join('__i%d' % i for i in range(len(a_arr.shape)) if i != axis))
@@ -1219,10 +1206,9 @@ def _unop(sdfg: SDFG, state: SDFGState, op1: str, opcode: str, opname: str):
         opcode = 'not'
 
     name, _ = sdfg.add_temp_transient(arr1.shape, restype, arr1.storage)
-    state.add_mapped_tasklet("_%s_" % opname, {
-        '__i%d' % i: '0:%s' % s
-        for i, s in enumerate(arr1.shape)
-    }, {'__in1': Memlet.simple(op1, ','.join(['__i%d' % i for i in range(len(arr1.shape))]))},
+    state.add_mapped_tasklet("_%s_" % opname, {'__i%d' % i: '0:%s' % s
+                                               for i, s in enumerate(arr1.shape)},
+                             {'__in1': Memlet.simple(op1, ','.join(['__i%d' % i for i in range(len(arr1.shape))]))},
                              '__out = %s __in1' % opcode,
                              {'__out': Memlet.simple(name, ','.join(['__i%d' % i for i in range(len(arr1.shape))]))},
                              external_edges=True)
@@ -4323,10 +4309,8 @@ def _ndarray_fill(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, va
     shape = sdfg.arrays[arr].shape
     state.add_mapped_tasklet(
         '_numpy_fill_',
-        map_ranges={
-            f"__i{dim}": f"0:{s}"
-            for dim, s in enumerate(shape)
-        },
+        map_ranges={f"__i{dim}": f"0:{s}"
+                    for dim, s in enumerate(shape)},
         inputs=inputs,
         code=f"__out = {body}",
         outputs={'__out': dace.Memlet.simple(arr, ",".join([f"__i{dim}" for dim in range(len(shape))]))},
@@ -4550,11 +4534,13 @@ def _ndarray_astype(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, 
         dtype = dtypes.typeclass(dtype)
     return _datatype_converter(sdfg, state, arr, dtype)[0]
 
+
 @oprepo.replaces_operator('Array', 'MatMult', otherclass='StorageType')
 def _cast_storage(visitor: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str, stype: dace.StorageType) -> str:
     desc = sdfg.arrays[arr]
     desc.storage = stype
     return arr
+
 
 # Replacements that need ufuncs ###############################################
 # TODO: Fix by separating to different modules and importing
@@ -4759,13 +4745,7 @@ def _tensordot(pv: 'ProgramVisitor',
 
 @oprepo.replaces("cupy._core.core.ndarray")
 @oprepo.replaces("cupy.ndarray")
-def _define_cupy_local(
-    pv: "ProgramVisitor",
-    sdfg: SDFG,
-    state: SDFGState,
-    shape: Shape,
-    dtype: typeclass
-):
+def _define_cupy_local(pv: "ProgramVisitor", sdfg: SDFG, state: SDFGState, shape: Shape, dtype: typeclass):
     """Defines a local array in a DaCe program."""
     if not isinstance(shape, (list, tuple)):
         shape = [shape]
@@ -4793,10 +4773,8 @@ def _cupy_full(pv: ProgramVisitor,
     name, _ = sdfg.add_temp_transient(shape, dtype, storage=dtypes.StorageType.GPU_Global)
 
     state.add_mapped_tasklet(
-        '_cupy_full_', {
-            "__i{}".format(i): "0: {}".format(s)
-            for i, s in enumerate(shape)
-        }, {},
+        '_cupy_full_', {"__i{}".format(i): "0: {}".format(s)
+                        for i, s in enumerate(shape)}, {},
         "__out = {}".format(fill_value),
         dict(__out=dace.Memlet.simple(name, ",".join(["__i{}".format(i) for i in range(len(shape))]))),
         external_edges=True)

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -322,6 +322,13 @@ def _numpy_full(pv: ProgramVisitor,
         is_data = True
         vtype = sdfg.arrays[fill_value].dtype
     dtype = dtype or vtype
+
+    # Handle one-dimensional inputs
+    try:
+        iter(shape)
+    except TypeError:
+        shape = [shape]
+
     name, _ = sdfg.add_temp_transient(shape, dtype)
 
     if is_data:

--- a/dace/sdfg/infer_types.py
+++ b/dace/sdfg/infer_types.py
@@ -116,8 +116,7 @@ def infer_connector_types(sdfg: SDFG):
             for e in state.out_edges(node):
                 cname = e.src_conn
                 if cname and node.out_connectors[cname] is None:
-                    raise TypeError('Ambiguous or uninferable type in'
-                                    ' connector "%s" of node "%s"' % (cname, node))
+                    raise TypeError('Ambiguous or uninferable type in' ' connector "%s" of node "%s"' % (cname, node))
 
 
 #############################################################################
@@ -301,6 +300,12 @@ def _set_default_schedule_in_scope(state: SDFGState,
     else:
         child_schedule = _determine_child_schedule(parent_schedules)
 
+        # Special case for dynamic thread-block neighboring schedules
+        if child_schedule == dtypes.ScheduleType.GPU_ThreadBlock:
+            from dace.transformation.helpers import gpu_map_has_explicit_dyn_threadblocks  # Avoid import loops
+            if gpu_map_has_explicit_dyn_threadblocks(state, parent_node):
+                child_schedule = dtypes.ScheduleType.GPU_ThreadBlock_Dynamic
+
     # Set child schedule type in scope
     for node in child_nodes[parent_node]:
         # Set default schedule types
@@ -392,6 +397,7 @@ def _get_storage_from_parent(data_name: str, sdfg: SDFG) -> dtypes.StorageType:
         return parent_sdfg.arrays[e.data.data].storage
 
     raise ValueError(f'Could not find data descriptor {data_name} in parent SDFG')
+
 
 def infer_aliasing(node: nodes.NestedSDFG, sdfg: SDFG, state: SDFGState) -> None:
     """

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -761,13 +761,13 @@ class SDFG(ControlFlowRegion):
             if name in self.symbols:
                 raise FileExistsError(f'Symbol "{name}" already exists in SDFG')
             if name in self.arrays:
-                raise FileExistsError(f'Can not create symbol "{name}", the name is used by a data descriptor.')
+                raise FileExistsError(f'Cannot create symbol "{name}", the name is used by a data descriptor.')
             if name in self._subarrays:
-                raise FileExistsError(f'Can not create symbol "{name}", the name is used by a subarray.')
+                raise FileExistsError(f'Cannot create symbol "{name}", the name is used by a subarray.')
             if name in self._rdistrarrays:
-                raise FileExistsError(f'Can not create symbol "{name}", the name is used by a RedistrArray.')
+                raise FileExistsError(f'Cannot create symbol "{name}", the name is used by a RedistrArray.')
             if name in self._pgrids:
-                raise FileExistsError(f'Can not create symbol "{name}", the name is used by a ProcessGrid.')
+                raise FileExistsError(f'Cannot create symbol "{name}", the name is used by a ProcessGrid.')
         if not isinstance(stype, dtypes.typeclass):
             stype = dtypes.dtype_to_typeclass(stype)
         self.symbols[name] = stype

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -390,7 +390,6 @@ def validate_state(state: 'dace.sdfg.SDFGState',
     symbols = symbols or {}
     initialized_transients = (initialized_transients if initialized_transients is not None else {'__pystate'})
     references = references or set()
-    scope = state.scope_dict()
 
     # Obtain whether we are already in an accelerator context
     if not hasattr(context, 'in_gpu'):
@@ -419,6 +418,8 @@ def validate_state(state: 'dace.sdfg.SDFGState',
 
     if state.has_cycles():
         raise InvalidSDFGError('State should be acyclic but contains cycles', sdfg, state_id)
+
+    scope = state.scope_dict()
 
     for nid, node in enumerate(state.nodes()):
         # Reference check

--- a/dace/transformation/dataflow/warp_tiling.py
+++ b/dace/transformation/dataflow/warp_tiling.py
@@ -55,6 +55,10 @@ class WarpTiling(xf.SingleStateTransformation):
         # Stride and offset all internal maps
         maps_to_stride = xfh.get_internal_scopes(graph, new_me, immediate=True)
         for nstate, nmap in maps_to_stride:
+            # Skip sequential maps
+            if nmap.schedule == dtypes.ScheduleType.Sequential:
+                continue
+
             nsdfg = nstate.parent
             nsdfg_node = nsdfg.parent_nsdfg_node
 

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -934,11 +934,7 @@ def replicate_scope(sdfg: SDFG, state: SDFGState, scope: ScopeSubgraphView) -> S
     return ScopeSubgraphView(state, new_nodes, new_entry)
 
 
-def offset_map(state: SDFGState,
-               entry: nodes.MapEntry,
-               dim: int,
-               offset: symbolic.SymbolicType,
-               negative: bool = True):
+def offset_map(state: SDFGState, entry: nodes.MapEntry, dim: int, offset: symbolic.SymbolicType, negative: bool = True):
     """
     Offsets a map parameter and its contents by a value.
 
@@ -1265,6 +1261,17 @@ def gpu_map_has_explicit_threadblocks(state: SDFGState, entry: nodes.EntryNode) 
         return True
     imm_maps = get_internal_scopes(state, entry, immediate=True)
     if any(m.schedule == dtypes.ScheduleType.Default for _, m in imm_maps):
+        return True
+
+    return False
+
+
+def gpu_map_has_explicit_dyn_threadblocks(state: SDFGState, entry: nodes.EntryNode) -> bool:
+    """
+    Returns True if GPU_Device map has explicit thread-block maps nested within.
+    """
+    internal_maps = get_internal_scopes(state, entry)
+    if any(m.schedule == dtypes.ScheduleType.GPU_ThreadBlock_Dynamic for _, m in internal_maps):
         return True
 
     return False

--- a/tests/dynamic_tb_map_cudatest.py
+++ b/tests/dynamic_tb_map_cudatest.py
@@ -329,7 +329,7 @@ def test_dynamic_nested_map():
     a = np.zeros((10, 11), dtype=np.float32)
     sdfg = dynamic_nested_map.to_sdfg(simplify=False)
     sdfg(a)
-    assert np.allclose(a, np.fromfunction(lambda i, j, k: i * 10 + j, (10, 11), dtype=np.float32))
+    assert np.allclose(a, np.fromfunction(lambda i, j: i * 10 + j, (10, 11), dtype=np.float32))
 
 
 @pytest.mark.gpu
@@ -344,12 +344,12 @@ def test_dynamic_default_schedule():
             smem = np.empty((10, ), dtype=np.float32) @ dace.StorageType.GPU_Shared
             smem[:] = 1
             for j in dace.map[0:10] @ dace.ScheduleType.GPU_ThreadBlock_Dynamic:
-                A[i, j] = i * 10 + smem[j]
+                A[i, j] = i * 65 + smem[j]
         a[:] = A
 
     a = np.zeros((65, 10), dtype=np.float32)
     tester(a)
-    assert np.allclose(a, np.fromfunction(lambda i, j, k: i * 10 + j, (65, 10), dtype=np.float32))
+    assert np.allclose(a, np.fromfunction(lambda i, j: i * 65 + 1, (65, 10), dtype=np.float32))
 
 
 if __name__ == '__main__':

--- a/tests/dynamic_tb_map_cudatest.py
+++ b/tests/dynamic_tb_map_cudatest.py
@@ -306,7 +306,7 @@ def test_dynamic_multidim_map():
     assert np.allclose(a, np.fromfunction(lambda i, j, k: i * 110 + j * 11 + k, (10, 11, 65), dtype=np.float32))
 
 
-@pytest.mark.gpu
+@pytest.mark.skip('Nested maps with work-stealing thread-block schedule are currently unsupported')
 def test_dynamic_nested_map():
     @dace.program
     def nested2(A: dace.float32[W], i: dace.int32, j: dace.int32):
@@ -361,5 +361,5 @@ if __name__ == '__main__':
     test_nested_dynamic_map()
     test_dynamic_map_with_step()
     test_dynamic_multidim_map()
-    test_dynamic_nested_map()
+    # test_dynamic_nested_map()
     test_dynamic_default_schedule()

--- a/tests/dynamic_tb_map_cudatest.py
+++ b/tests/dynamic_tb_map_cudatest.py
@@ -328,7 +328,10 @@ def test_dynamic_nested_map():
 
     a = np.zeros((10, 11), dtype=np.float32)
     sdfg = dynamic_nested_map.to_sdfg(simplify=False)
-    sdfg(a)
+    for _, _, arr in sdfg.arrays_recursive():
+        if arr.storage in (dace.StorageType.GPU_Shared, dace.StorageType.Default):
+            arr.storage = dace.StorageType.Register
+    sdfg(a, H=10, W=11)
     assert np.allclose(a, np.fromfunction(lambda i, j: i * 10 + j, (10, 11), dtype=np.float32))
 
 

--- a/tests/numpy/array_creation_test.py
+++ b/tests/numpy/array_creation_test.py
@@ -1,7 +1,9 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
+from dace.frontend.python.common import DaceSyntaxError
 import numpy as np
 from common import compare_numpy_output
+import pytest
 
 # M = dace.symbol('M')
 # N = dace.symbol('N')
@@ -218,6 +220,30 @@ def test_zeros_symbolic_size_scalar():
     assert (out.dtype == np.uint32)
 
 
+def test_ones_scalar_size_scalar():
+
+    @dace.program
+    def ones_scalar_size(k: dace.int32):
+        a = np.ones(k, dtype=np.uint32)
+        return np.sum(a)
+
+    with pytest.raises(DaceSyntaxError):
+        out = ones_scalar_size(20)
+        assert out == 20
+
+
+def test_ones_scalar_size():
+
+    @dace.program
+    def ones_scalar_size(k: dace.int32):
+        a = np.ones((k, k), dtype=np.uint32)
+        return np.sum(a)
+
+    with pytest.raises(DaceSyntaxError):
+        out = ones_scalar_size(20)
+        assert out == 20 * 20
+
+
 if __name__ == "__main__":
     test_empty()
     test_empty_like1()
@@ -246,3 +272,5 @@ if __name__ == "__main__":
     test_strides_2()
     test_strides_3()
     test_zeros_symbolic_size_scalar()
+    test_ones_scalar_size_scalar()
+    test_ones_scalar_size()

--- a/tests/numpy/array_creation_test.py
+++ b/tests/numpy/array_creation_test.py
@@ -154,7 +154,7 @@ def test_arange_6():
 def program_strides_0():
     A = dace.ndarray((2, 2), dtype=dace.int32, strides=(2, 1))
     for i, j in dace.map[0:2, 0:2]:
-            A[i, j] = i * 2 + j
+        A[i, j] = i * 2 + j
     return A
 
 
@@ -168,7 +168,7 @@ def test_strides_0():
 def program_strides_1():
     A = dace.ndarray((2, 2), dtype=dace.int32, strides=(4, 2))
     for i, j in dace.map[0:2, 0:2]:
-            A[i, j] = i * 2 + j
+        A[i, j] = i * 2 + j
     return A
 
 
@@ -182,7 +182,7 @@ def test_strides_1():
 def program_strides_2():
     A = dace.ndarray((2, 2), dtype=dace.int32, strides=(1, 2))
     for i, j in dace.map[0:2, 0:2]:
-            A[i, j] = i * 2 + j
+        A[i, j] = i * 2 + j
     return A
 
 
@@ -196,7 +196,7 @@ def test_strides_2():
 def program_strides_3():
     A = dace.ndarray((2, 2), dtype=dace.int32, strides=(2, 4))
     for i, j in dace.map[0:2, 0:2]:
-            A[i, j] = i * 2 + j
+        A[i, j] = i * 2 + j
     return A
 
 
@@ -204,6 +204,18 @@ def test_strides_3():
     A = program_strides_3()
     assert A.strides == (8, 16)
     assert np.allclose(A, [[0, 1], [2, 3]])
+
+
+def test_zeros_symbolic_size_scalar():
+    K = dace.symbol('K')
+
+    @dace.program
+    def zeros_symbolic_size():
+        return np.zeros((K), dtype=np.uint32)
+
+    out = zeros_symbolic_size(K=10)
+    assert (list(out.shape) == [10])
+    assert (out.dtype == np.uint32)
 
 
 if __name__ == "__main__":
@@ -233,3 +245,4 @@ if __name__ == "__main__":
     test_strides_1()
     test_strides_2()
     test_strides_3()
+    test_zeros_symbolic_size_scalar()

--- a/tests/numpy/map_syntax_test.py
+++ b/tests/numpy/map_syntax_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import numpy as np
 import dace
+import pytest
 
 M, N, K = (dace.symbol(name) for name in ['M', 'N', 'K'])
 
@@ -35,6 +36,33 @@ def test_map_python():
     assert np.allclose(A[:, 1:], B[:, 1:])
 
 
+@pytest.mark.skip('Fails due to bug in Python frontend')
+def test_nested_map_with_indirection():
+    N = dace.symbol('N')
+
+    @dace.program
+    def indirect_to_indirect(arr1: dace.float64[N], ind: dace.int32[10], arr2: dace.float64[N]):
+        for i in dace.map[0:9]:
+            begin, end, stride = ind[i], ind[i + 1], 1
+            for _ in dace.map[0:1]:
+                for j in dace.map[begin:end:stride]:
+                    arr2[j] = arr1[j] + i
+
+    a = np.random.rand(50)
+    b = np.zeros(50)
+    ind = np.array([0, 5, 10, 15, 20, 25, 30, 35, 40, 45], dtype=np.int32)
+    sdfg = indirect_to_indirect.to_sdfg(simplify=False)
+    sdfg(a, ind, b)
+
+    ref = np.zeros(50)
+    for i in range(9):
+        begin, end = ind[i], ind[i + 1]
+        ref[begin:end] = a[begin:end] + i
+
+    assert np.allclose(b, ref)
+
+
 if __name__ == '__main__':
     test_copy3d()
     test_map_python()
+    # test_nested_map_with_indirection()

--- a/tests/numpy/map_syntax_test.py
+++ b/tests/numpy/map_syntax_test.py
@@ -62,7 +62,31 @@ def test_nested_map_with_indirection():
     assert np.allclose(b, ref)
 
 
+@pytest.mark.skip('Fails due to bug in Python frontend')
+def test_dynamic_map_range_scalar():
+    """
+    From issue #650.
+    """
+
+    @dace.program
+    def test(A: dace.float64[20], B: dace.float64[20]):
+        N = dace.define_local_scalar(dace.int32)
+        N = 5
+        for i in dace.map[0:N]:
+            for j in dace.map[0:N]:
+                with dace.tasklet:
+                    a << A[i]
+                    b >> B[j]
+                    b = a + 1
+
+    A = np.random.rand(20)
+    B = np.zeros(20)
+    test(A, B)
+    assert np.allclose(B[:5], A[:5] + 1)
+
+
 if __name__ == '__main__':
     test_copy3d()
     test_map_python()
     # test_nested_map_with_indirection()
+    # test_dynamic_map_range_scalar()

--- a/tests/python_frontend/device_annotations_test.py
+++ b/tests/python_frontend/device_annotations_test.py
@@ -1,16 +1,19 @@
-# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import pytest
+import numpy as np
 
 from dace.dtypes import StorageType, DeviceType, ScheduleType
 from dace import dtypes
 
-cupy = pytest.importorskip("cupy")
+try:
+    import cupy
+except (ImportError, ModuleNotFoundError):
+    cupy = None
 
 
 @pytest.mark.gpu
 def test_storage():
-
     @dace.program
     def add(X: dace.float32[32, 32] @ StorageType.GPU_Global):
         return X + 1
@@ -46,7 +49,6 @@ def test_schedule():
 
 @pytest.mark.gpu
 def test_pythonmode():
-
     def runs_on_gpu(a: dace.float64[20] @ StorageType.GPU_Global, b: dace.float64[20] @ StorageType.GPU_Global):
         # This map will become a GPU kernel
         for i in dace.map[0:20] @ ScheduleType.GPU_Device:
@@ -58,7 +60,40 @@ def test_pythonmode():
     assert cupy.allclose(gpu_b, gpu_a + 1)
 
 
+def test_inline_storage_hint():
+    N = dace.symbol('N')
+
+    @dace.program
+    def tester():
+        b = np.ones(N, dtype=np.float32) @ dace.StorageType.CPU_ThreadLocal
+        return b + 1
+
+    sdfg = tester.to_sdfg(simplify=False)
+    assert sdfg.arrays['b'].storage == StorageType.CPU_ThreadLocal
+
+    b = tester(N=10)
+    assert np.allclose(b, 2)
+
+
+def test_annotated_storage_hint():
+    N = dace.symbol('N')
+
+    @dace.program
+    def tester():
+        b: dace.float32[N] @ dace.StorageType.CPU_ThreadLocal = np.ones(N, dtype=np.float32)
+        return b + 1
+
+    sdfg = tester.to_sdfg(simplify=False)
+    assert sdfg.arrays['b'].storage == StorageType.CPU_ThreadLocal
+
+    b = tester(N=10)
+    assert np.allclose(b, 2)
+
+
 if __name__ == "__main__":
-    test_storage()
-    test_schedule()
-    test_pythonmode()
+    if cupy is not None:
+        test_storage()
+        test_schedule()
+        test_pythonmode()
+    test_inline_storage_hint()
+    test_annotated_storage_hint()

--- a/tests/python_frontend/type_statement_test.py
+++ b/tests/python_frontend/type_statement_test.py
@@ -1,22 +1,22 @@
-# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import pytest
-import sys
 
-# Check if Python version is 3.12 or higher
-if sys.version_info >= (3, 12):
-    def test_type_statement():
 
-        @dace.program
-        def type_statement():
-            type Scalar[T] = T
-            A: Scalar[dace.float32] = 0
-            return A
+# TODO: Investigate why pytest parses the DaCeProgram, even when the test is not supposed to run.
+# @pytest.mark.py312
+# def test_type_statement():
 
-        with pytest.raises(dace.frontend.python.common.DaceSyntaxError):
-            type_statement()
+#     @dace.program
+#     def type_statement():
+#         type Scalar[T] = T
+#         A: Scalar[dace.float32] = 0
+#         return A
+    
+#     with pytest.raises(dace.frontend.python.common.DaceSyntaxError):
+#         type_statement()
 
 
 if __name__ == '__main__':
-    if sys.version_info >= (3, 12):
-        test_type_statement()
+    # test_type_statement()
+    pass

--- a/tests/python_frontend/type_statement_test.py
+++ b/tests/python_frontend/type_statement_test.py
@@ -1,22 +1,22 @@
-# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import pytest
+import sys
 
+# Check if Python version is 3.12 or higher
+if sys.version_info >= (3, 12):
+    def test_type_statement():
 
-# TODO: Investigate why pytest parses the DaCeProgram, even when the test is not supposed to run.
-# @pytest.mark.py312
-# def test_type_statement():
+        @dace.program
+        def type_statement():
+            type Scalar[T] = T
+            A: Scalar[dace.float32] = 0
+            return A
 
-#     @dace.program
-#     def type_statement():
-#         type Scalar[T] = T
-#         A: Scalar[dace.float32] = 0
-#         return A
-    
-#     with pytest.raises(dace.frontend.python.common.DaceSyntaxError):
-#         type_statement()
+        with pytest.raises(dace.frontend.python.common.DaceSyntaxError):
+            type_statement()
 
 
 if __name__ == '__main__':
-    # test_type_statement()
-    pass
+    if sys.version_info >= (3, 12):
+        test_type_statement()

--- a/tests/sdfg/cycles_test.py
+++ b/tests/sdfg/cycles_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 import dace
-
+from dace.sdfg.validation import InvalidSDFGError
 
 def test_cycles():
     with pytest.raises(ValueError, match="Found cycles.*"):
@@ -29,6 +29,23 @@ def test_cycles_memlet_path():
         sdfg.validate()
 
 
+def test_cycles_1562():
+    """
+    Test for issue #1562.
+    """
+    with pytest.raises(InvalidSDFGError, match="cycles"):
+        sdfg = dace.SDFG("foo")
+        state = sdfg.add_state()
+        mentry_2, mexit_2 = state.add_map("map_2", dict(i="0:9"))
+        mentry_6, mexit_6 = state.add_map("map_6", dict(i="0:9"))
+        mentry_8, mexit_8 = state.add_map("map_8", dict(i="0:9"))
+        state.add_edge(mentry_8, "OUT_0", mentry_6, "IN_0", dace.Memlet(data="bla", subset='0:9'))
+        state.add_edge(mentry_6, "OUT_0", mentry_2, "IN_0", dace.Memlet(data="bla", subset='0:9'))
+        state.add_edge(mentry_2, "OUT_0", mentry_6, "IN_0", dace.Memlet(data="bla", subset='0:9'))
+        sdfg.validate()
+
+
 if __name__ == '__main__':
     test_cycles()
     test_cycles_memlet_path()
+    test_cycles_1562()


### PR DESCRIPTION
The PR adds a new syntax to support inline storage specification with the `@` operator, supporting the following statements: `a = np.ones(M) @ dace.StorageType.CPU_ThreadLocal`.

This PR also fixes multiple minor issues in the Python frontend:
- [x] `WarpTiling` did not respect sequential map schedules
- [x] Non-sequence inputs for `numpy.fill` variants (e.g., `numpy.zeros(N)`)
- [x] NumPy replacement syntax errors would sometimes not have source information
- [x] Fix type inference for nested scopes in Python frontend
- [x] ~~Dynamic map range related issues with simple modifications to the SpMV program~~ Fix deferred to #1696 
- [x] ~~Dynamic thread block scheduling would not pass object to nested functions~~ Fix deferred to future PR, see #1189
- [x] Dynamic thread block scheduling does not support multi-dimensional maps
- [x] Default schedule inference should use dynamic thread blocks if they exist
- [x] Type hints with storage type not being adhered to by the Python frontend
- [x] Validation issue #1562 

