### PR TITLE
Fix GPU transform mapping free access nodes always to GPU storage 

### DIFF
--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -14,19 +14,18 @@ from typing import Dict
 gpu_storage = [dtypes.StorageType.GPU_Global, dtypes.StorageType.GPU_Shared, dtypes.StorageType.CPU_Pinned]
 
 
-def _recursive_out_check(node, state, gpu_data, check_type=data.Scalar):
+def _recursive_out_check(node, state, gpu_scalars):
     """
     Recursively checks if the outputs of a node are scalars and if they are/should be stored in GPU memory.
     """
     scalset = set()
     scalout = True
     sdfg = state.parent
-    gpu_scalars = gpu_data
     for e in state.out_edges(node):
         last_edge = state.memlet_path(e)[-1]
         if isinstance(last_edge.dst, nodes.AccessNode):
             desc = sdfg.arrays[last_edge.dst.data]
-            if isinstance(desc, check_type):
+            if isinstance(desc, data.Scalar):
                 if desc.storage in gpu_storage or last_edge.dst.data in gpu_scalars:
                     scalout = False
                 scalset.add(last_edge.dst.data)
@@ -34,7 +33,7 @@ def _recursive_out_check(node, state, gpu_data, check_type=data.Scalar):
                 scalset = scalset.union(sset)
                 scalout = scalout and ssout
                 continue
-            if check_type == data.Scalar and desc.shape == (1, ):  # Pseudo-scalar
+            if desc.shape == (1, ):  # Pseudo-scalar
                 scalout = False
                 sset, ssout = _recursive_out_check(last_edge.dst, state, gpu_scalars)
                 scalset = scalset.union(sset)
@@ -49,7 +48,7 @@ def _recursive_out_check(node, state, gpu_data, check_type=data.Scalar):
     return scalset, scalout
 
 
-def _recursive_in_check(node, state, gpu_data, check_type=data.Scalar):
+def _recursive_in_check(node, state, gpu_scalars):
     """
     Recursively checks if the inputs of a node are scalars and if they are/should be stored in GPU memory.
     """
@@ -60,63 +59,27 @@ def _recursive_in_check(node, state, gpu_data, check_type=data.Scalar):
         last_edge = state.memlet_path(e)[0]
         if isinstance(last_edge.src, nodes.AccessNode):
             desc = sdfg.arrays[last_edge.src.data]
-            if isinstance(desc, check_type):
-                if desc.storage in gpu_storage or last_edge.src.data in gpu_data:
+            if isinstance(desc, data.Scalar):
+                if desc.storage in gpu_storage or last_edge.src.data in gpu_scalars:
                     scalout = False
                 scalset.add(last_edge.src.data)
-                sset, ssout = _recursive_in_check(last_edge.src, state, gpu_data)
+                sset, ssout = _recursive_in_check(last_edge.src, state, gpu_scalars)
                 scalset = scalset.union(sset)
                 scalout = scalout and ssout
                 continue
-            if check_type == data.Scalar and desc.shape == (1, ):  # Pseudo-scalar
+            if desc.shape == (1, ):  # Pseudo-scalar
                 scalout = False
-                sset, ssout = _recursive_in_check(last_edge.src, state, gpu_data)
+                sset, ssout = _recursive_in_check(last_edge.src, state, gpu_scalars)
                 scalset = scalset.union(sset)
                 scalout = scalout and ssout
                 continue
             if desc.storage not in gpu_storage and last_edge.data.num_elements() == 1:
-                sset, ssout = _recursive_in_check(last_edge.src, state, gpu_data)
+                sset, ssout = _recursive_in_check(last_edge.src, state, gpu_scalars)
                 scalset = scalset.union(sset)
                 scalout = scalout and ssout
                 continue
             scalout = False
     return scalset, scalout
-
-def _get_data_to_offload(sdfg, global_code_nodes, check_type):
-    gpu_data = {}
-    nsdfgs = []
-    changed = True
-    # Iterates over Tasklets that not inside a GPU kernel. Such Tasklets must be moved inside a GPU kernel only
-    # if they write to GPU memory. The check takes into account the fact that GPU kernels can read host-based
-    # Scalars, but cannot write to them.
-    while changed:
-        changed = False
-        for state in sdfg.states():
-            for node in state.nodes():
-                # Handle NestedSDFGs later.
-                if isinstance(node, nodes.NestedSDFG):
-                    if state.entry_node(node) is None and not scope.is_devicelevel_gpu_kernel(
-                            state.parent, state, node):
-                        nsdfgs.append((node, state))
-                elif isinstance(node, nodes.Tasklet):
-                    if node in global_code_nodes[state]:
-                        continue
-                    if state.entry_node(node) is None and not scope.is_devicelevel_gpu_kernel(
-                            state.parent, state, node):
-                        data, data_output = _recursive_out_check(node, state, gpu_data, check_type)
-                        sset, ssout = _recursive_in_check(node, state, gpu_data, check_type)
-                        data = data.union(sset)
-                        data_output = data_output and ssout
-                        csdfg = state.parent
-                        # If the tasklet is not adjacent only to scalars or it is in a GPU scope.
-                        # The latter includes NestedSDFGs that have a GPU-Device schedule but are not in a GPU kernel.
-                        if (not data_output
-                                or (csdfg.parent is not None
-                                    and csdfg.parent_nsdfg_node.schedule == dtypes.ScheduleType.GPU_Default)):
-                            global_code_nodes[state].append(node)
-                            gpu_data.update({k: None for k in data})
-                            changed = True
-    return gpu_data, nsdfgs
 
 
 @make_properties
@@ -383,8 +346,39 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
         # Also recursively call GPUTransformSDFG on NestedSDFGs that have GPU device schedule but are not actually
         # inside a GPU kernel.
 
-        gpu_scalars, nsdfgs = _get_data_to_offload(sdfg, global_code_nodes, data.Scalar)
-        gpu_arrays, _ = _get_data_to_offload(sdfg, global_code_nodes, data.Array)
+        gpu_scalars = {}
+        nsdfgs = []
+        changed = True
+        # Iterates over Tasklets that not inside a GPU kernel. Such Tasklets must be moved inside a GPU kernel only
+        # if they write to GPU memory. The check takes into account the fact that GPU kernels can read host-based
+        # Scalars, but cannot write to them.
+        while changed:
+            changed = False
+            for state in sdfg.states():
+                for node in state.nodes():
+                    # Handle NestedSDFGs later.
+                    if isinstance(node, nodes.NestedSDFG):
+                        if state.entry_node(node) is None and not scope.is_devicelevel_gpu_kernel(
+                                state.parent, state, node):
+                            nsdfgs.append((node, state))
+                    elif isinstance(node, nodes.Tasklet):
+                        if node in global_code_nodes[state]:
+                            continue
+                        if state.entry_node(node) is None and not scope.is_devicelevel_gpu_kernel(
+                                state.parent, state, node):
+                            scalars, scalar_output = _recursive_out_check(node, state, gpu_scalars)
+                            sset, ssout = _recursive_in_check(node, state, gpu_scalars)
+                            scalars = scalars.union(sset)
+                            scalar_output = scalar_output and ssout
+                            csdfg = state.parent
+                            # If the tasklet is not adjacent only to scalars or it is in a GPU scope.
+                            # The latter includes NestedSDFGs that have a GPU-Device schedule but are not in a GPU kernel.
+                            if (not scalar_output
+                                    or (csdfg.parent is not None
+                                        and csdfg.parent_nsdfg_node.schedule == dtypes.ScheduleType.GPU_Default)):
+                                global_code_nodes[state].append(node)
+                                gpu_scalars.update({k: None for k in scalars})
+                                changed = True
 
         # Apply GPUTransformSDFG recursively to NestedSDFGs.
         for node, state in nsdfgs:
@@ -411,6 +405,7 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
         # Step 6: Modify transient data storage
 
         const_syms = xfh.constant_symbols(sdfg)
+
         for state in sdfg.nodes():
             sdict = state.scope_dict()
             for node in state.nodes():
@@ -427,9 +422,7 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
                         if isinstance(nodedesc, data.Scalar) and not node.data in gpu_scalars:
                             continue
 
-                        if isinstance(nodedesc, data.Array) and not node.data in gpu_arrays:
-                            continue
-
+                        # NOTE: the cloned arrays match too but it's the same storage so we don't care
                         nodedesc.storage = dtypes.StorageType.GPU_Global
 
                         # Try to move allocation/deallocation out of loops

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -438,6 +438,29 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
         #######################################################
         # Step 7: Wrap free tasklets and nested SDFGs with a GPU map
 
+        # Extend global_code_nodes with tasklets that write/read from an array
+        # Previous steps map all arrays to GPU storage, but only checks tasklets that write to/read from
+        # Scalars to be wrapped in a GPU Map
+        for state in sdfg.states():
+            for node in state.nodes():
+                if isinstance(node, nodes.Tasklet):
+                    if node in global_code_nodes[state]:
+                        continue
+                    if state.entry_node(node) is None and not scope.is_devicelevel_gpu_kernel(
+                            state.parent, state, node):
+                        memlet_path_roots = set()
+                        memlet_path_roots = memlet_path_roots.union(
+                            [state.memlet_tree(e).root().edge.src for e in state.in_edges(node)]
+                            )
+                        memlet_path_roots = memlet_path_roots.union(
+                            [state.memlet_tree(e).root().edge.dst for e in state.out_edges(node)]
+                            )
+                        gpu_accesses = [n.data for n in memlet_path_roots
+                                        if isinstance(n, nodes.AccessNode) and
+                                           sdfg.arrays[n.data].storage in gpu_storage]
+                        if len(gpu_accesses) > 0:
+                            global_code_nodes[state].append(node)
+
         for state, gcodes in global_code_nodes.items():
             for gcode in gcodes:
                 if gcode.label in self.exclude_tasklets.split(','):

--- a/tests/transformations/gpu_transform_test.py
+++ b/tests/transformations/gpu_transform_test.py
@@ -118,41 +118,22 @@ def test_write_subset_dynamic():
 
     assert np.array_equal(ref, val)
 
-
-@pytest.mark.parametrize("transient", [False, True])
-def test_free_tasklet_and_array(transient):
+@pytest.mark.parametrize(["transient", "scalar"],
+                         [[False, False], [False, True],
+                          [True, False], [True, True]])
+def test_free_tasklet(transient, scalar):
     sdfg = dace.SDFG("assign")
 
     state = sdfg.add_state("main")
-    arr_name, arr = sdfg.add_array("A", (4,), dace.float32, transient=transient)
+    if scalar:
+        arr_name, arr = sdfg.add_scalar("A", dace.float32, transient=transient)
+    else:
+        arr_name, arr = sdfg.add_array("A", (4,), dace.float32, transient=transient)
+
     an = state.add_access(arr_name)
 
     t = state.add_tasklet("assign", {}, {"_out"}, "_out = 2.0")
-    state.add_edge(t, "_out", an, None, dace.memlet.Memlet("A[0]"))
-
-    sdfg.validate()
-
-    sdfg.apply_gpu_transformations(
-        validate = True,
-        validate_all = True,
-        permissive = True,
-        sequential_innermaps=True,
-        register_transients=False,
-        simplify=False
-    )
-
-    sdfg.validate()
-
-@pytest.mark.parametrize("transient", [False, True])
-def test_free_tasklet_and_scalar(transient):
-    sdfg = dace.SDFG("assign")
-
-    state = sdfg.add_state("main")
-    arr_name, arr = sdfg.add_scalar("A", dace.float32, transient=transient)
-    an = state.add_access(arr_name)
-
-    t = state.add_tasklet("assign", {}, {"_out"}, "_out = 2.0")
-    state.add_edge(t, "_out", an, None, dace.memlet.Memlet("A"))
+    state.add_edge(t, "_out", an, None, dace.memlet.Memlet("A" if scalar else "A[0]"))
 
     sdfg.validate()
 
@@ -173,6 +154,6 @@ if __name__ == '__main__':
     test_write_subset()
     test_write_full()
     test_write_subset_dynamic()
-    for transient in [False, True]:
-        test_free_tasklet_and_array(transient)
-        test_free_tasklet_and_array(transient)
+    for scalar in [False, True]:
+        for transient in [False, True]:
+            test_free_tasklet(transient, scalar)


### PR DESCRIPTION
Fix GPU transform mapping free access nodes always to GPU storage 
This results with tasklets running on host, that want to write to or read from data marked as GPU storage.