### PR TITLE
CI: Update checkout and setup-python actions

### DIFF
--- a/.github/workflows/fpga-ci.yml
+++ b/.github/workflows/fpga-ci.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-ci') }}
     runs-on: [self-hosted, linux, intel-fpga, xilinx-fpga]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies

--- a/.github/workflows/general-ci.yml
+++ b/.github/workflows/general-ci.yml
@@ -18,11 +18,11 @@ jobs:
         simplify: [0,1,autoopt]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'no-ci')"
     runs-on: [self-hosted, gpu]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies

--- a/.github/workflows/hardware_test.yml
+++ b/.github/workflows/hardware_test.yml
@@ -4,7 +4,7 @@ jobs:
   test-rtl:
     runs-on: [self-hosted, linux, xilinx-fpga]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies

--- a/.github/workflows/heterogeneous-ci.yml
+++ b/.github/workflows/heterogeneous-ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'no-ci')"
     runs-on: [self-hosted, linux]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies

--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -21,18 +21,18 @@ jobs:
               python-version: [3.11.7]
 
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
               repository: 'NOAA-GFDL/PyFV3'
               ref: 'ci/DaCe'
               submodules: 'recursive'
               path: 'pyFV3'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with: 
             path: 'dace'
             submodules: 'recursive'
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
               python-version: ${{ matrix.python-version }}
       - name: Install library dependencies

--- a/.github/workflows/verilator_compatibility.yml
+++ b/.github/workflows/verilator_compatibility.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - name: trigger reason
         run: echo "Trigger Reason:" ${{ github.event.inputs.reason }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: checkout submodules
         run: git submodule update --init --recursive
       - name: install apt packages
         run: sudo apt-get update && sudo apt-get -y install git make autoconf g++ flex bison libfl2 libfl-dev
       - name: compile verilator
         run: git clone https://github.com/verilator/verilator.git && cd verilator && git fetch origin && if [ ! "${{ matrix.verilator_version }}" == "master" ]; then  git checkout v${{ matrix.verilator_version }}; fi && autoconf && ./configure && make -j2 && sudo make install
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
           architecture: 'x64'


### PR DESCRIPTION
GitHub Actions workflows use outdated versions of

- actions/checkout
- actions/setup-python

These actions are built for specific node versions, which are now end of life. While the workflows continue to run, GitHub issues a warning (visible in the online interface) and runs them with newer versions of node.

![image](https://github.com/user-attachments/assets/159f4d86-33f5-4d9c-ad45-a5657ad51a57)

Since both, checkout and setup-python, are basic actions, none of the features that DaCe workflows are using changed. We might see slight speedup from out of the box caching added to setup-python in recent versions.

Parent issue: https://github.com/GEOS-ESM/SMT-Nebulae/issues/89