### PR TITLE
DeadDataflowElimination: Fix type hint annotation for booleans

### DIFF
--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -159,8 +159,9 @@ class DeadDataflowElimination(ppl.Pass):
                                             for code in leaf.src.code.code:
                                                 ast_find.generic_visit(code)
                                         except astutils.NameFound:
-                                            # then add the hint expression 
-                                            leaf.src.code.code = ast.parse(f'{leaf.src_conn}: dace.{ctype.to_string()}\n').body + leaf.src.code.code
+                                            # then add the hint expression
+                                            type_string = "bool_" if ctype.dtype == dtypes.bool else ctype.to_string()
+                                            leaf.src.code.code = ast.parse(f'{leaf.src_conn}: dace.{type_string}\n').body + leaf.src.code.code
                                 else:
                                     raise NotImplementedError(f'Cannot eliminate dead connector "{leaf.src_conn}" on '
                                                               'tasklet due to its code language.')

--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -161,7 +161,8 @@ class DeadDataflowElimination(ppl.Pass):
                                         except astutils.NameFound:
                                             # then add the hint expression
                                             type_string = "bool_" if ctype.dtype == dtypes.bool else ctype.to_string()
-                                            leaf.src.code.code = ast.parse(f'{leaf.src_conn}: dace.{type_string}\n').body + leaf.src.code.code
+                                            leaf.src.code.code = ast.parse(
+                                                f'{leaf.src_conn}: dace.{type_string}\n').body + leaf.src.code.code
                                 else:
                                     raise NotImplementedError(f'Cannot eliminate dead connector "{leaf.src_conn}" on '
                                                               'tasklet due to its code language.')


### PR DESCRIPTION
## Description

DeadDataflowElimination might alter Tasklet code, e.g. in case the out connector is never used and the variable can be localized to the Tasklet. PR https://github.com/spcl/dace/pull/1499 added missing type hints in case of Tasklets containing python code. These type hints seem to break down in case the newly localized variable is a boolean.

![image](https://github.com/user-attachments/assets/0aeff630-b849-472b-9c91-465e53472b3e)
_original Tasklet with dead access to boolean `gtOUT__condition_gen_0` (mapped to `condition_gen_0`)_

![image](https://github.com/user-attachments/assets/b96e204f-47bf-4414-a6d0-0c0919c60e08)
_simplified Tasklet with localized boolean `gtOUT__condition_gen_0` of type `dace.bool`_

While this seems to work nicely, the problem comes when compiling because this translates to

```cpp
///////////////////
// Tasklet code (...)
dace::bool gtOUT__condition_gen_0;
//    ^^^^ the compiler is unhappy with this type

gtOUT__condition_gen_0 = (parameter < dace::float32(dace::int64(10)));
gtOUT__mask_140216878537040_gen_0 = gtOUT__condition_gen_0;
///////////////////
```

which fails to compile with the GNU compiler because `error: expected unqualified-id before ‘bool’`.

#### Proposed solution

The solution proposed here is to change the type added inside the Tasklet (from `dace.bool`  to `dace.bool_`). This will run through and generate `dace::bool_ gtOUT__condition_gen_0;` (with the extra underscore).

#### Question

Is this the right place to fix that issue? Assuming `dace.bool` exists as python type hint, this could also be an issue with the cpp code generation (from the python code). If it should be solved in code generation, I'd be happy about pointers where to find that code. Still trying to find my way around in this new codebase ... 

Regardless of where this should be fixed, I'll be working on a simple test case to be added to `tests/passes/dead_code_elimination_test.py`

Related issues https://github.com/spcl/dace/issues/1150, https://github.com/GEOS-ESM/NDSL/issues/53