### PR TITLE
Add back clang-format support

### DIFF
--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -13,6 +13,7 @@ import shlex
 import subprocess
 import re
 from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar, Union
+import warnings
 
 import dace
 from dace.config import Config
@@ -56,6 +57,18 @@ def generate_program_folder(sdfg, code_objects: List[CodeObject], out_path: str,
         basename = "{}.{}".format(name, extension)
         code_path = os.path.join(target_folder, basename)
         clean_code = code_object.clean_code
+
+        if Config.get_bool('compiler', 'format_code'):
+            config_file = Config.get('compiler', 'format_config_file')
+            if config_file is not None and config_file != "":
+                run_arg_list = ['clang-format', f"-style=file:{config_file}"]
+            else:
+                run_arg_list = ['clang-format']
+            result = subprocess.run(run_arg_list, input=clean_code, text=True, capture_output=True)
+            if result.returncode or result.stderr:
+                warnings.warn(f'clang-format failed to run: {result.stderr}')
+            else:
+                clean_code = result.stdout
 
         # Save the file only if it changed (keeps old timestamps and saves
         # build time)
@@ -260,7 +273,7 @@ def get_environment_flags(environments) -> Tuple[List[str], Set[str]]:
     """
     Returns the CMake environment and linkage flags associated with the
     given input environments/libraries.
-    
+
     :param environments: A list of ``@dace.library.environment``-decorated
                          classes.
     :return: A 2-tuple of (environment CMake flags, linkage CMake flags)

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -173,6 +173,20 @@ required:
                     The typename of this struct is derived by appending this value to the SDFG's name.
                     Note that the suffix may only contains letters, digits and underscores.
 
+            format_code:
+                type: bool
+                default: false
+                title: Format code with `clang-format`
+                description: >
+                    Formats the generated code with `clang-format` before saving the files.
+
+            format_config_file:
+                type: str
+                default: ""
+                title: Path the clang-format file
+                description: >
+                    Clang-format file to be used by clang-format, only used if format_code is true
+
             default_data_types:
                 type : str
                 default: Python
@@ -474,7 +488,7 @@ required:
                         title: Detect parts of an SDFG that can run in parallel
                         description: >
                             If set to false, DaCe will place each weakly connected
-                            component found in an SDFG state in a different Kernel/Processing Element. 
+                            component found in an SDFG state in a different Kernel/Processing Element.
                             If true, a heuristic will further inspect each independent component
                             for other parallelism opportunities (e.g., branches of the SDFG
                             that can be executed in parallel), creating the corresponding kernels.
@@ -800,7 +814,7 @@ required:
                 default: false
                 title: Check arguments on SDFG call
                 description: >
-                    Perform an early type check on arguments passed to an SDFG when called directly (from 
+                    Perform an early type check on arguments passed to an SDFG when called directly (from
                     ``SDFG.__call__``). Another type check is performed when calling compiled SDFGs.
 
             avoid_wcr:
@@ -835,18 +849,18 @@ required:
         title: Compiled cache entry naming policy
         description: >
             Determine the name of the generated ``.dacecache`` folder:
-            
-            
+
+
             * ``name`` uses the name of the SDFG directly, causing it to be
             overridden by other programs using the same SDFG name.
-            
+
             * ``hash`` uses a mangled name based on the hash of the SDFG, such that
             any change to the SDFG will generate a different cache folder.
-            
+
             * ``unique`` uses a name based on the currently running Python process
             at code generation time, such that no caching or clashes can happen
             between different processes or subsequent invocations of Python.
-            
+
             * ``single`` uses a single cache folder for all SDFGs, saving space and
             potentially build time, but disallows executing SDFGs in parallel
             and caching of more than one simultaneous SDFG.


### PR DESCRIPTION
Add back clang-format.

I generated with a style file, without a style file, and without clang format (uninstalled clang-format for this). SDFGs generate. I can add tests.