### PR TITLE
Used valid FORTRAN test program for a couple frontend tests + Made `floatlit2string()` convert the FORTRAN real literal strings into python floats.

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -987,9 +987,6 @@ class InternalFortranAst:
                                                   body=ast_internal_classes.Execution_Part_Node(execution=body),
                                                   line_number=do.line_number)
 
-    def real_literal_constant(self, node: FASTNode):
-        return node
-
     def subscript_triplet(self, node: FASTNode):
         if node.string == ":":
             return ast_internal_classes.ParDecl_Node(type="ALL")

--- a/tests/fortran/ast_utils_test.py
+++ b/tests/fortran/ast_utils_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from dace.frontend.fortran.ast_internal_classes import Real_Literal_Node
+
+from dace.frontend.fortran.ast_utils import TaskletWriter
+
+
+def test_floatlit2string():
+    def parse(fl: str) -> float:
+        t = TaskletWriter([], [])  # The parameters won't matter.
+        return t.floatlit2string(Real_Literal_Node(value=fl))
+
+    assert parse('1.0') == '1.0'
+    assert parse('1.') == '1.0'
+    assert parse('1.e5') == '100000.0'
+    assert parse('1.d5') == '100000.0'
+    assert parse('1._kinder') == '1.0'
+    assert parse('1.e5_kinder') == '100000.0'
+    with pytest.raises(AssertionError):
+        parse('1.d5_kinder')
+    with pytest.raises(AssertionError):
+        parse('1._kinder_kinder')
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        parse('1.2.0')
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        parse('1.d0d0')
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        parse('foo')


### PR DESCRIPTION
Replace some of the invalid fortran test programs with valid ones (that passes under `gfortran -Wall`). This breaks some of the tests, so add fix for them too. `test_fortran_frontend_loop1()` still has an invalid test program, but the nearest valid one breaks for a different reason, and will be fixed later.