### PR TITLE
CI[pyFV3]: retry even when connection is refused

### DIFF
--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -53,11 +53,11 @@ jobs:
           cd pyFV3
           mkdir -p test_data
           cd test_data
-          wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.D_SW.tar.gz
+          wget --retry-connrefused https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.D_SW.tar.gz
           tar -xzvf 8.1.3_c12_6ranks_standard.D_SW.tar.gz
-          wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.RiemSolver3.tar.gz
+          wget --retry-connrefused https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.RiemSolver3.tar.gz
           tar -xzvf 8.1.3_c12_6ranks_standard.RiemSolver3.tar.gz
-          wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.Remapping.tar.gz
+          wget --retry-connrefused https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.Remapping.tar.gz
           tar -xzvf 8.1.3_c12_6ranks_standard.Remapping.tar.gz
           cd ../..
       # Clean up caches between run for stale un-expanded SDFG to trip the build system (NDSL side issue)


### PR DESCRIPTION
According to @phschaad, the pyFV3 workflow occasionally fails with connection refused errors when attempting to download the test data set for regression testing. This PR configures `wget` to retry even in case of fatal connection errors (like 404 (not found) or 503 (connection refused)).

Let's see if this helps in the short term. In the long run, we should think about leveraging caches for that data because it rarely changes and it's kind of a wast to download it every time from scratch.

Follow-up PR from https://github.com/spcl/dace/pull/1731#issuecomment-2458989370.

/cc @FlorianDeconinck FYI