### PR TITLE
Fixed MapExpansion Transformation

### DIFF
--- a/dace/transformation/dataflow/map_expansion.py
+++ b/dace/transformation/dataflow/map_expansion.py
@@ -136,10 +136,14 @@ class MapExpansion(pm.SingleStateTransformation):
             graph.add_edge(entries[-1], edge.src_conn, edge.dst, edge.dst_conn, memlet=copy.deepcopy(edge.data))
             graph.remove_edge(edge)
 
-        if graph.in_degree(map_entry) == 0:
+        if graph.in_degree(map_entry) == 0 or all(
+            e.dst_conn is None for e in graph.in_edges(map_entry)
+        ):
             graph.add_memlet_path(map_entry, *entries, memlet=dace.Memlet())
         else:
             for edge in graph.in_edges(map_entry):
+                if edge.dst_conn is None:
+                    continue
                 if not edge.dst_conn.startswith("IN_"):
                     continue
                 

--- a/dace/transformation/dataflow/map_expansion.py
+++ b/dace/transformation/dataflow/map_expansion.py
@@ -137,7 +137,8 @@ class MapExpansion(pm.SingleStateTransformation):
             graph.remove_edge(edge)
 
         if graph.in_degree(map_entry) == 0 or all(
-            e.dst_conn is None for e in graph.in_edges(map_entry)
+            e.dst_conn is None or not edge.dst_conn.startswith("IN_")
+            for e in graph.in_edges(map_entry)
         ):
             graph.add_memlet_path(map_entry, *entries, memlet=dace.Memlet())
         else:

--- a/dace/transformation/dataflow/map_expansion.py
+++ b/dace/transformation/dataflow/map_expansion.py
@@ -137,7 +137,7 @@ class MapExpansion(pm.SingleStateTransformation):
             graph.remove_edge(edge)
 
         if graph.in_degree(map_entry) == 0 or all(
-            e.dst_conn is None or not edge.dst_conn.startswith("IN_")
+            e.dst_conn is None or not e.dst_conn.startswith("IN_")
             for e in graph.in_edges(map_entry)
         ):
             graph.add_memlet_path(map_entry, *entries, memlet=dace.Memlet())


### PR DESCRIPTION
The transformation did not consider maps that are connected with dependency edges.
Now, the transformation skips dependency edges if non-dependency edges exist.
Otherwise, it connects the inner and outer maps with a single dependency edge to maintain connectivity.