### PR TITLE
Instead of compiler specific align hint use C++ standard aligned alloc

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -494,7 +494,7 @@ class CPUCodeGen(TargetCodeGenerator):
             if not declared:
                 declaration_stream.write(f'{nodedesc.dtype.ctype} *{name};\n', cfg, state_id, node)
             allocation_stream.write(
-                "%s = static_cast<{nodedesc.dtype.ctype}*>(std::aligned_alloc(64, %s * sizeof(%s)));\n" % (alloc_name, cpp.sym2cpp(arrsize), nodedesc.dtype.ctype), cfg,
+                "%s = static_cast<%s*>(std::aligned_alloc(64, %s * sizeof(%s)));\n" % (nodedesc.dtype.ctype, alloc_name, cpp.sym2cpp(arrsize), nodedesc.dtype.ctype), cfg,
                 state_id, node)
             define_var(name, DefinedType.Pointer, ctypedef)
 

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -587,7 +587,7 @@ class CPUCodeGen(TargetCodeGenerator):
             callsite_stream.write(
                 """#pragma omp parallel
                 {{
-                    std::fre({name});
+                    std::free({name});
                 }}""".format(name=alloc_name),
                 cfg,
                 state_id,

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -494,7 +494,7 @@ class CPUCodeGen(TargetCodeGenerator):
             if not declared:
                 declaration_stream.write(f'{nodedesc.dtype.ctype} *{name};\n', cfg, state_id, node)
             allocation_stream.write(
-                "%s = new %s DACE_ALIGN(64)[%s];\n" % (alloc_name, nodedesc.dtype.ctype, cpp.sym2cpp(arrsize)), cfg,
+                "%s =  std::aligned_alloc(64, %s * sizeof(%s));\n" % (alloc_name, cpp.sym2cpp(arrsize), nodedesc.dtype.ctype), cfg,
                 state_id, node)
             define_var(name, DefinedType.Pointer, ctypedef)
 
@@ -512,7 +512,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 raise NotImplementedError('Start offset unsupported for registers')
             if node.setzero:
                 declaration_stream.write(
-                    "%s %s[%s]  DACE_ALIGN(64) = {0};\n" % (nodedesc.dtype.ctype, name, cpp.sym2cpp(arrsize)),
+                    "%s alignas(64) %s[%s]{0};\n" % (nodedesc.dtype.ctype, name, cpp.sym2cpp(arrsize)),
                     cfg,
                     state_id,
                     node,
@@ -520,7 +520,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 define_var(name, DefinedType.Pointer, ctypedef)
                 return
             declaration_stream.write(
-                "%s %s[%s]  DACE_ALIGN(64);\n" % (nodedesc.dtype.ctype, name, cpp.sym2cpp(arrsize)),
+                "%s alignas(64) %s[%s];\n" % (nodedesc.dtype.ctype, name, cpp.sym2cpp(arrsize)),
                 cfg,
                 state_id,
                 node,
@@ -544,7 +544,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 """
                 #pragma omp parallel
                 {{
-                    {name} = new {ctype} DACE_ALIGN(64)[{arrsize}];""".format(ctype=nodedesc.dtype.ctype,
+                    {name} = ({ctype}*)std::aligned_alloc(64, {arrsize} * sizeof({ctype}));""".format(ctype=nodedesc.dtype.ctype,
                                                                               name=alloc_name,
                                                                               arrsize=cpp.sym2cpp(arrsize)),
                 cfg,
@@ -581,13 +581,13 @@ class CPUCodeGen(TargetCodeGenerator):
             return
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or (nodedesc.storage == dtypes.StorageType.Register and symbolic.issymbolic(arrsize, sdfg.constants))):
-            callsite_stream.write("delete[] %s;\n" % alloc_name, cfg, state_id, node)
+            callsite_stream.write("std::free(%s);\n" % alloc_name, cfg, state_id, node)
         elif nodedesc.storage is dtypes.StorageType.CPU_ThreadLocal:
             # Deallocate in each OpenMP thread
             callsite_stream.write(
                 """#pragma omp parallel
                 {{
-                    delete[] {name};
+                    std::fre({name});
                 }}""".format(name=alloc_name),
                 cfg,
                 state_id,

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -494,7 +494,7 @@ class CPUCodeGen(TargetCodeGenerator):
             if not declared:
                 declaration_stream.write(f'{nodedesc.dtype.ctype} *{name};\n', cfg, state_id, node)
             allocation_stream.write(
-                "%s =  std::aligned_alloc(64, %s * sizeof(%s));\n" % (alloc_name, cpp.sym2cpp(arrsize), nodedesc.dtype.ctype), cfg,
+                "%s = static_cast<{nodedesc.dtype.ctype}*>(std::aligned_alloc(64, %s * sizeof(%s)));\n" % (alloc_name, cpp.sym2cpp(arrsize), nodedesc.dtype.ctype), cfg,
                 state_id, node)
             define_var(name, DefinedType.Pointer, ctypedef)
 
@@ -544,7 +544,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 """
                 #pragma omp parallel
                 {{
-                    {name} = ({ctype}*)std::aligned_alloc(64, {arrsize} * sizeof({ctype}));""".format(ctype=nodedesc.dtype.ctype,
+                    {name} = static_cast<{ctype}*>(std::aligned_alloc(64, {arrsize} * sizeof({ctype})));""".format(ctype=nodedesc.dtype.ctype,
                                                                               name=alloc_name,
                                                                               arrsize=cpp.sym2cpp(arrsize)),
                 cfg,

--- a/dace/runtime/include/dace/dace.h
+++ b/dace/runtime/include/dace/dace.h
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <tuple>
 #include <cstring>
+#include <cstdlib>
 
 // The order in which these are included matters - sorting them
 // alphabetically causes compilation to fail.


### PR DESCRIPTION
We can use `alignas, std::aligned_alloc and std::free` that are in the C++ standard instead of using `DACE_ALIGN` + delete[] which are compiler specific. Even though both Clang, GCC support this extension...