### PR TITLE
[Multi SDFG branch, Fortran frontend] Make `eliminate_dependencies()` support `use lib` without `only`.

### DIFF
--- a/dace/frontend/fortran/ast_utils.py
+++ b/dace/frontend/fortran/ast_utils.py
@@ -1,10 +1,11 @@
 # Copyright 2023 ETH Zurich and the DaCe authors. All rights reserved.
-from typing import List, Set, Iterator, Type, TypeVar, Dict, Tuple
+from itertools import chain
+from typing import List, Set, Iterator, Type, TypeVar, Dict, Tuple, Iterable
 
 import networkx as nx
 from fparser.two.Fortran2003 import Module_Stmt, Name, Interface_Block, Subroutine_Stmt, Specification_Part, Module, \
     Derived_Type_Def, Function_Stmt, Interface_Stmt, Function_Body, Type_Name, Rename, Entity_Decl, Kind_Selector, \
-    Intrinsic_Type_Spec, Declaration_Type_Spec, Use_Stmt
+    Intrinsic_Type_Spec, Use_Stmt, Declaration_Type_Spec
 from fparser.two.Fortran2008 import Type_Declaration_Stmt, Procedure_Stmt
 from fparser.two.utils import Base
 from numpy import finfo as finf
@@ -64,21 +65,27 @@ def eliminate_dependencies(dep_graph: nx.DiGraph) -> Tuple[nx.DiGraph, Dict]:
                 for k in in_names_local:
                     if k not in in_names:
                         in_names.append(k)
-        for j in out_edges:
-            out_names_local_obj = dep_graph.get_edge_data(j[0], j[1])["obj_list"]
+        for _, dep in out_edges:
+            out_names_local_obj = dep_graph.get_edge_data(i, dep)["obj_list"]
             out_names_local = []
-            if out_names_local_obj is not None:
-                for k in out_names_local_obj:
-                    if isinstance(k, Name):
-                        out_names_local.append(k.string)
-                    elif isinstance(k, Rename):
-                        out_names_local.append(k.children[1].string)
-                        out_names_local.append(k.children[2].string)
+            if out_names_local_obj is None:
+                # If `obj_list` does not have anything, it means there was no only-list and we're importing everything.
+                dep_info = dep_graph.nodes.get(dep).get('info_list')
+                assert isinstance(dep_info, FunctionSubroutineLister)  # TODO: Is there another possiblity?
+                out_names_local_obj = list(Name(name) for name in chain(dep_info.list_of_functions,
+                                                                        dep_info.list_of_subroutines,
+                                                                        dep_info.list_of_module_vars,
+                                                                        dep_info.list_of_types))
+            for k in out_names_local_obj:
+                if isinstance(k, Name):
+                    out_names_local.append(k.string)
+                elif isinstance(k, Rename):
+                    out_names_local.append(k.children[1].string)
+                    out_names_local.append(k.children[2].string)
 
-            if out_names_local is not None:
-                for k in out_names_local:
-                    if k not in out_names:
-                        out_names.append(k)
+            for k in out_names_local:
+                if k not in out_names:
+                    out_names.append(k)
         actually_used = []
         for name in in_names:
             actually_used.append(name)
@@ -213,17 +220,23 @@ def eliminate_dependencies(dep_graph: nx.DiGraph) -> Tuple[nx.DiGraph, Dict]:
             # print("NOT USED: "+ str(not_used))
 
         out_edges = dep_graph.out_edges(i)
-        out_names = []
-        for j in out_edges:
-            out_names_local_obj = dep_graph.get_edge_data(j[0], j[1])["obj_list"]
+        for _, dep in out_edges:
+            out_names_local_obj = dep_graph.get_edge_data(i, dep)["obj_list"]
             out_names_local = []
-            if out_names_local_obj is not None:
-                for k in out_names_local_obj:
-                    if isinstance(k, Name):
-                        out_names_local.append(k.string)
-                    elif isinstance(k, Rename):
-                        out_names_local.append(k.children[1].string)
-                        out_names_local.append(k.children[2].string)
+            if out_names_local_obj is None:
+                # If `obj_list` does not have anything, it means there was no only-list and we're importing everything.
+                dep_info = dep_graph.nodes.get(dep).get('info_list')
+                assert isinstance(dep_info, FunctionSubroutineLister)  # TODO: Is there another possiblity?
+                out_names_local_obj = list(Name(name) for name in chain(dep_info.list_of_functions,
+                                                                        dep_info.list_of_subroutines,
+                                                                        dep_info.list_of_module_vars,
+                                                                        dep_info.list_of_types))
+            for k in out_names_local_obj:
+                if isinstance(k, Name):
+                    out_names_local.append(k.string)
+                elif isinstance(k, Rename):
+                    out_names_local.append(k.children[1].string)
+                    out_names_local.append(k.children[2].string)
 
             new_out_names_local = []
             if len(out_names_local) == 0:
@@ -245,9 +258,9 @@ def eliminate_dependencies(dep_graph: nx.DiGraph) -> Tuple[nx.DiGraph, Dict]:
                         continue
                     else:
                         simple_graph.add_node(i, info_list=res)
-                if not simple_graph.has_node(j[1]):
-                    simple_graph.add_node(j[1])
-                simple_graph.add_edge(i, j[1], obj_list=new_out_names_local)
+                if not simple_graph.has_node(dep):
+                    simple_graph.add_node(dep)
+                simple_graph.add_edge(i, dep, obj_list=new_out_names_local)
         actually_used_in_module[i] = actually_used
         # print(simple_graph)
     return simple_graph, actually_used_in_module
@@ -841,7 +854,7 @@ def get_defined_modules(node: Base) -> List[str]:
 
 
 def get_used_modules(node: Base) -> Tuple[List[str], Dict[str, Base]]:
-    def _get_used_modules(_node: Base, _used_modules: List[str], _objects_in_use: Dict[str, Base])\
+    def _get_used_modules(_node: Base, _used_modules: List[str], _objects_in_use: Dict[str, Base]) \
             -> Tuple[List[str], Dict[str, Base]]:
         for m in _node.children:
             if isinstance(m, Use_Stmt):

--- a/tests/fortran/recursive_ast_improver_test.py
+++ b/tests/fortran/recursive_ast_improver_test.py
@@ -299,7 +299,7 @@ contains
 end module lib
 """).add_file("""
 program main
-  use lib, only : fun
+  use lib
   implicit none
   double precision d(4)
   call fun(d)
@@ -426,9 +426,9 @@ end program main
 
     # Verify simplification of the dependency graph.
     simple_graph, actually_used_in_module = simplified_dependency_graph(dep_graph.copy(), interface_blocks)
-    assert set(simple_graph.nodes) == {'main', 'lib_indirect'}
-    assert set(simple_graph.edges) == {('main', 'lib_indirect')}
-    assert actually_used_in_module == {'lib_indirect': ['fun_indirect'], 'main': []}
+    assert set(simple_graph.nodes) == {'main', 'lib', 'lib_indirect'}
+    assert set(simple_graph.edges) == {('main', 'lib_indirect'), ('lib_indirect', 'lib')}
+    assert actually_used_in_module == {'lib': ['fun'], 'lib_indirect': ['fun_indirect', 'fun'], 'main': []}
 
 
 def test_interface_block_contains_module_procedure():
@@ -498,8 +498,8 @@ end program main
 
     # Verify simplification of the dependency graph.
     simple_graph, actually_used_in_module = simplified_dependency_graph(dep_graph.copy(), interface_blocks)
-    assert not set(simple_graph.nodes)
-    assert not actually_used_in_module
+    assert set(simple_graph.nodes) == {'lib', 'main'}
+    assert actually_used_in_module == {'lib': ['fun'], 'main': []}
 
 
 def test_module_contains_interface_block():

--- a/tests/fortran/recursive_ast_improver_test.py
+++ b/tests/fortran/recursive_ast_improver_test.py
@@ -584,3 +584,83 @@ end program main
     assert set(simple_graph.nodes) == {'main', 'lib', 'lib_indirect'}
     assert set(simple_graph.edges) == {('main', 'lib_indirect'), ('lib_indirect', 'lib')}
     assert actually_used_in_module == {'lib': ['fun'], 'lib_indirect': ['fun', 'fun2'], 'main': []}
+
+
+def test_uses_module_but_prunes_unused_defs():
+    """
+    A simple program, but this time the subroutine is defined in a module. The main program uses the module and calls
+    the subroutine. So, we should have "recursively improved" the AST by parsing that module and constructing the
+    dependency graph.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+contains
+  subroutine fun(d)
+    implicit none
+    double precision d(4)
+    d(2) = 5.5
+  end subroutine fun
+  subroutine not_fun(d)  ! `main` only uses `fun`, so this should be dropped after simplification
+    implicit none
+    double precision d(4)
+    d(2) = 4.2
+  end subroutine not_fun
+end module lib
+""").add_file("""
+program main
+  use lib, only: fun
+  implicit none
+  double precision d(4)
+  call fun(d)
+end program main
+""").check_with_gfortran().get()
+    ast, dep_graph, interface_blocks, asts = parse_and_improve(sources)
+
+    # A matcher focused on correctly parsing the module definitions and uses.
+    m = M(Program, [
+        M(Main_Program, [
+            M.IGNORE(),  # program main
+            M(Specification_Part, [
+                M(Use_Stmt),  # use lib
+                *[M.IGNORE()] * 2,  # implicit none; double precision d(4)
+            ]),
+            M(Execution_Part, [M(Call_Stmt)]),  # call fun(d)
+            M.IGNORE(),  # end program main
+        ]),
+        M(Module, [
+            M(Module_Stmt, [M.IGNORE(), M(Name, has_attr={'string': M(has_value='lib')})]),  # module lib
+            M(Module_Subprogram_Part, [
+                M(Contains_Stmt),  # contains
+                M(Subroutine_Subprogram, [
+                    M(Subroutine_Stmt,  # subroutine fun(d)
+                      [M.IGNORE(), M(Name, has_attr={'string': M(has_value='fun')}), *[M.IGNORE()] * 2]),
+                    M(Specification_Part),  # implicit none; double precision d(4)
+                    M(Execution_Part),  # d(2) = 5.5
+                    M(End_Subroutine_Stmt),  # end subroutine fun
+                ]),
+                M(Subroutine_Subprogram, [
+                    M(Subroutine_Stmt,  # subroutine not_fun(d)
+                      [M.IGNORE(), M(Name, has_attr={'string': M(has_value='not_fun')}), *[M.IGNORE()] * 2]),
+                    M(Specification_Part),  # implicit none; double precision d(4)
+                    M(Execution_Part),  # d(2) = 4.2
+                    M(End_Subroutine_Stmt),  # end subroutine not_fun
+                ]),
+            ]),
+            M(End_Module_Stmt),  # end module lib
+        ]),
+    ])
+    m.check(ast)
+
+    # This time we have a module dependency.
+    assert set(dep_graph.nodes) == {'lib', 'main'}
+    assert set(dep_graph.edges) == {('main', 'lib')}
+    assert set(asts.keys()) == {'lib'}
+
+    # Verify that there is not much else to the program.
+    assert not interface_blocks
+
+    # Verify simplification of the dependency graph.
+    simple_graph, actually_used_in_module = simplified_dependency_graph(dep_graph.copy(), interface_blocks)
+    assert set(simple_graph.nodes) == {'main', 'lib'}
+    assert set(simple_graph.edges) == {('main', 'lib')}
+    assert actually_used_in_module == {'lib': ['fun'], 'main': []}


### PR DESCRIPTION
Currently it does not work without explicitly adding everything to be used on an `only`-list.