### PR TITLE
[Multi SDFG branch, Fortran frontend] Change the interface of `recursive_ast_improver()` to hide the implementation-specific objects that helps the recursion, by defining a local function to manage the states involved in recursion internally.

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -3,7 +3,6 @@ from typing import Any, List, Optional, Type, TypeVar, Union, overload, TYPE_CHE
 
 from fparser.two import Fortran2003 as f03
 from fparser.two import Fortran2008 as f08
-from fparser.two import symbol_table
 
 from dace.frontend.fortran import ast_internal_classes
 from dace.frontend.fortran.ast_internal_classes import Name_Node
@@ -11,7 +10,7 @@ from dace.frontend.fortran.ast_internal_classes import Name_Node
 if TYPE_CHECKING:
     from dace.frontend.fortran.intrinsics import FortranIntrinsics
 
-#We rely on fparser to provide an initial AST and convert to a version that is more suitable for our purposes
+# We rely on fparser to provide an initial AST and convert to a version that is more suitable for our purposes
 
 # The following class is used to translate the fparser AST to our own AST of Fortran
 # the supported_fortran_types dictionary is used to determine which types are supported by our compiler
@@ -50,7 +49,7 @@ def get_child(node: Union[FASTNode, List[FASTNode]], child_type: Union[str, Type
 
     if len(children_of_type) == 1:
         return children_of_type[0]
-    #Temporary workaround to allow feature list to be generated
+    # Temporary workaround to allow feature list to be generated
     return None
     raise ValueError('Expected only one child of type {} but found {}'.format(child_type, children_of_type))
 
@@ -106,17 +105,15 @@ class InternalFortranAst:
     for each entry in the dictionary, the key is the name of the class in the fparser AST and the value
     is the name of the function that will be used to translate the fparser AST to our AST
     """
+
     def __init__(self):
         """
         Initialization of the AST converter
-        :param ast: the fparser AST
-        :param tables: the symbol table of the fparser AST
-
         """
         self.name_list = {}
-        self.to_parse_list= {}
+        self.to_parse_list = {}
         self.unsupported_fortran_syntax = {}
-        self.current_ast=None
+        self.current_ast = None
         self.functions_and_subroutines = []
         self.symbols = {}
         self.intrinsics_list = []
@@ -302,22 +299,20 @@ class InternalFortranAst:
             "Exit_Stmt": self.exit_stmt,
             "Enum_Def": self.enum_def,
 
-            #"Component_Decl_List": self.component_decl_list,
-            #"Component_Decl": self.component_decl,
+            # "Component_Decl_List": self.component_decl_list,
+            # "Component_Decl": self.component_decl,
         }
         self.type_arbitrary_array_variable_count = 0
-
 
     def fortran_intrinsics(self) -> "FortranIntrinsics":
         return self.intrinsic_handler
 
     def data_pointer_object(self, node: FASTNode):
         children = self.create_children(node)
-        if node.children[1] =="%":
-            return ast_internal_classes.Data_Ref_Node(parent_ref=children[0], part_ref=children[2],type="VOID")
+        if node.children[1] == "%":
+            return ast_internal_classes.Data_Ref_Node(parent_ref=children[0], part_ref=children[2], type="VOID")
         else:
             raise NotImplementedError("Data pointer object not supported yet")
-
 
     def add_name_list_for_module(self, module: str, name_list: List[str]):
         self.name_list[module] = name_list
@@ -330,8 +325,7 @@ class InternalFortranAst:
 
     def cycle_stmt(self, node: FASTNode):
         line = get_line(node)
-        return ast_internal_classes.Continue_Node( line_number=line)
-    
+        return ast_internal_classes.Continue_Node(line_number=line)
 
     def create_ast(self, node=None):
         """
@@ -344,10 +338,10 @@ class InternalFortranAst:
                 return [self.create_ast(child) for child in node]
 
             if type(node).__name__ in self.supported_fortran_syntax:
-                #print(type(node), type(node).__name__, type(node).__name__ in self.supported_fortran_syntax)
+                # print(type(node), type(node).__name__, type(node).__name__ in self.supported_fortran_syntax)
                 return self.supported_fortran_syntax[type(node).__name__](node)
             else:
-                if type(node).__name__=="Intrinsic_Name":
+                if type(node).__name__ == "Intrinsic_Name":
                     if node not in self.intrinsics_list:
                         self.intrinsics_list.append(node)
                 if self.unsupported_fortran_syntax.get(self.current_ast) is None:
@@ -359,7 +353,7 @@ class InternalFortranAst:
                     self.create_ast(i)
                 print("Unsupported syntax: ", type(node).__name__, node.string)
                 return None
-            #except Exception as e:
+            # except Exception as e:
             #    print("Error in create_ast: ", e)
             #    return None
 
@@ -372,18 +366,18 @@ class InternalFortranAst:
 
     def data_ref(self, node: FASTNode):
         children = self.create_children(node)
-        idx=len(children)-1
-        parent = children[idx-1]
+        idx = len(children) - 1
+        parent = children[idx - 1]
         part_ref = children[idx]
-        part_ref.isStructMember=True
-        #parent.isStructMember=True
-        idx=idx-1
-        current=ast_internal_classes.Data_Ref_Node(parent_ref=parent, part_ref=part_ref,type="VOID")
+        part_ref.isStructMember = True
+        # parent.isStructMember=True
+        idx = idx - 1
+        current = ast_internal_classes.Data_Ref_Node(parent_ref=parent, part_ref=part_ref, type="VOID")
 
-        while idx>0:
-            parent = children[idx-1]
-            current = ast_internal_classes.Data_Ref_Node(parent_ref=parent, part_ref=current,type="VOID")
-            idx=idx-1
+        while idx > 0:
+            parent = children[idx - 1]
+            current = ast_internal_classes.Data_Ref_Node(parent_ref=parent, part_ref=current, type="VOID")
+            idx = idx - 1
         return current
 
     def end_type_stmt(self, node: FASTNode):
@@ -391,44 +385,44 @@ class InternalFortranAst:
 
     def access_stmt(self, node: FASTNode):
         return None
-    
+
     def enum_def_stmt(self, node: FASTNode):
         children = self.create_children(node)
         return None
-    
+
     def enumerator_def_stmt(self, node: FASTNode):
         children = self.create_children(node)
         return children[1]
-    
+
     def enumerator_list(self, node: FASTNode):
         children = self.create_children(node)
         return children
-    
+
     def end_enum_stmt(self, node: FASTNode):
         return None
-    
+
     def enum_def(self, node: FASTNode):
         children = self.create_children(node)
         return children[1:-1]
-    
+
     def exit_stmt(self, node: FASTNode):
         line = get_line(node)
         return ast_internal_classes.Exit_Node(line_number=line)
-    
+
     def deferred_shape_spec(self, node: FASTNode):
         return ast_internal_classes.Defer_Shape_Node()
 
     def deferred_shape_spec_list(self, node: FASTNode):
         children = self.create_children(node)
         return children
-        
+
     def component_initialization(self, node: FASTNode):
         children = self.create_children(node)
         return ast_internal_classes.Component_Initialization_Node(init=children[1])
 
     def procedure_designator(self, node: FASTNode):
         children = self.create_children(node)
-        return ast_internal_classes.Procedure_Separator_Node(parent_ref=children[0],part_ref=children[2])
+        return ast_internal_classes.Procedure_Separator_Node(parent_ref=children[0], part_ref=children[2])
 
     def derived_type_def(self, node: FASTNode):
         children = self.create_children(node)
@@ -437,23 +431,24 @@ class InternalFortranAst:
         procedure_part = get_child(children, ast_internal_classes.Bound_Procedures_Node)
         from dace.frontend.fortran.ast_transforms import PartialRenameVar
         if component_part is not None:
-            component_part=PartialRenameVar(oldname="__f2dace_A", newname="__f2dace_SA").visit(component_part)
-            component_part=PartialRenameVar(oldname="__f2dace_OA", newname="__f2dace_SOA").visit(component_part)
-            new_placeholder={}
-            new_placeholder_offsets={}
-            for k,v in self.placeholders.items():
+            component_part = PartialRenameVar(oldname="__f2dace_A", newname="__f2dace_SA").visit(component_part)
+            component_part = PartialRenameVar(oldname="__f2dace_OA", newname="__f2dace_SOA").visit(component_part)
+            new_placeholder = {}
+            new_placeholder_offsets = {}
+            for k, v in self.placeholders.items():
                 if "__f2dace_A" in k:
-                    new_placeholder[k.replace("__f2dace_A","__f2dace_SA")]=self.placeholders[k]
+                    new_placeholder[k.replace("__f2dace_A", "__f2dace_SA")] = self.placeholders[k]
                 else:
-                    new_placeholder[k]=self.placeholders[k]
-            self.placeholders=new_placeholder
-            for k,v in self.placeholders_offsets.items():
+                    new_placeholder[k] = self.placeholders[k]
+            self.placeholders = new_placeholder
+            for k, v in self.placeholders_offsets.items():
                 if "__f2dace_OA" in k:
-                    new_placeholder_offsets[k.replace("__f2dace_OA","__f2dace_SOA")]=self.placeholders_offsets[k]
+                    new_placeholder_offsets[k.replace("__f2dace_OA", "__f2dace_SOA")] = self.placeholders_offsets[k]
                 else:
-                    new_placeholder_offsets[k]=self.placeholders_offsets[k]
-            self.placeholders_offsets=new_placeholder_offsets            
-        return ast_internal_classes.Derived_Type_Def_Node(name=name, component_part=component_part, procedure_part=procedure_part)
+                    new_placeholder_offsets[k] = self.placeholders_offsets[k]
+            self.placeholders_offsets = new_placeholder_offsets
+        return ast_internal_classes.Derived_Type_Def_Node(name=name, component_part=component_part,
+                                                          procedure_part=procedure_part)
 
     def derived_type_stmt(self, node: FASTNode):
         children = self.create_children(node)
@@ -480,10 +475,10 @@ class InternalFortranAst:
         return ast_internal_classes.Component_Decl_Node(name=name)
 
     def write_stmt(self, node: FASTNode):
-        #children=[]
-        #if node.children[0] is not None:
+        # children=[]
+        # if node.children[0] is not None:
         #    children = self.create_children(node.children[0])
-        #if node.children[1] is not None:
+        # if node.children[1] is not None:
         #    children = self.create_children(node.children[1])    
         line = get_line(node)
         return ast_internal_classes.Write_Stmt_Node(args=node.string, line_number=line)
@@ -522,7 +517,6 @@ class InternalFortranAst:
 
     def subroutine_subprogram(self, node: FASTNode):
 
-
         children = self.create_children(node)
 
         name = get_child(children, ast_internal_classes.Subroutine_Stmt_Node)
@@ -548,7 +542,7 @@ class InternalFortranAst:
             type=return_type,
             line_number=name.line_number,
             elemental=name.elemental,
-            
+
         )
 
     def end_program_stmt(self, node: FASTNode):
@@ -557,13 +551,13 @@ class InternalFortranAst:
     def only_list(self, node: FASTNode):
         children = self.create_children(node)
         names = [i for i in children if isinstance(i, ast_internal_classes.Name_Node)]
-        renames=[i for i in children if isinstance(i, ast_internal_classes.Rename_Node)]
-        return ast_internal_classes.Only_List_Node(names=names,renames=renames)
+        renames = [i for i in children if isinstance(i, ast_internal_classes.Rename_Node)]
+        return ast_internal_classes.Only_List_Node(names=names, renames=renames)
 
     def prefix_stmt(self, node: FASTNode):
         for i in node.children:
-                if i.string.lower()=="elemental":
-                    return ast_internal_classes.Prefix_Node(elemental=True)
+            if i.string.lower() == "elemental":
+                return ast_internal_classes.Prefix_Node(elemental=True)
         return ast_internal_classes.Prefix_Node(elemental=False)
 
     def function_subprogram(self, node: FASTNode):
@@ -595,14 +589,15 @@ class InternalFortranAst:
         else:
             elemental = prefix.elemental
         ret = get_child(children, ast_internal_classes.Suffix_Node)
-        if args==None:
+        if args == None:
             ret_args = []
         else:
             ret_args = args.args
-        return ast_internal_classes.Function_Stmt_Node(name=name, args=ret_args,return_type=ret, line_number=node.item.span,ret=ret,elemental=elemental)
+        return ast_internal_classes.Function_Stmt_Node(name=name, args=ret_args, return_type=ret,
+                                                       line_number=node.item.span, ret=ret, elemental=elemental)
 
     def subroutine_stmt(self, node: FASTNode):
-        #print(self.name_list)
+        # print(self.name_list)
         children = self.create_children(node)
         name = get_child(children, ast_internal_classes.Name_Node)
         args = get_child(children, ast_internal_classes.Arg_List_Node)
@@ -611,11 +606,12 @@ class InternalFortranAst:
             elemental = False
         else:
             elemental = prefix.elemental
-        if args==None:
+        if args == None:
             ret_args = []
         else:
             ret_args = args.args
-        return ast_internal_classes.Subroutine_Stmt_Node(name=name, args=ret_args, line_number=node.item.span,elemental=elemental)
+        return ast_internal_classes.Subroutine_Stmt_Node(name=name, args=ret_args, line_number=node.item.span,
+                                                         elemental=elemental)
 
     def ac_value_list(self, node: FASTNode):
         children = self.create_children(node)
@@ -624,11 +620,11 @@ class InternalFortranAst:
     def power_expr(self, node: FASTNode):
         children = self.create_children(node)
         line = get_line(node)
-        #child 0 is the base, child 2 is the exponent
-        #child 1 is "**"
+        # child 0 is the base, child 2 is the exponent
+        # child 1 is "**"
         return ast_internal_classes.Call_Expr_Node(name=ast_internal_classes.Name_Node(name="pow"),
                                                    args=[children[0], children[2]],
-                                                   line_number=line,type="REAL")
+                                                   line_number=line, type="REAL")
 
     def array_constructor(self, node: FASTNode):
         children = self.create_children(node)
@@ -664,12 +660,11 @@ class InternalFortranAst:
         line = get_line(node)
         name = get_child(children, ast_internal_classes.Type_Name_Node)
         args = get_child(children, ast_internal_classes.Component_Spec_List_Node)
-        if args==None:
+        if args == None:
             ret_args = []
         else:
             ret_args = args.args
-        return ast_internal_classes.Structure_Constructor_Node(name=name, args=ret_args, type=None,line_number=line)
-
+        return ast_internal_classes.Structure_Constructor_Node(name=name, args=ret_args, type=None, line_number=line)
 
     def intrinsic_function_reference(self, node: FASTNode):
         children = self.create_children(node)
@@ -678,10 +673,9 @@ class InternalFortranAst:
         args = get_child(children, ast_internal_classes.Arg_List_Node)
 
         if name is None:
-            return Name_Node(name="Error! "+node.children[0].string,type='VOID')
-        node = self.intrinsic_handler.replace_function_reference(name, args, line,self.symbols)
+            return Name_Node(name="Error! " + node.children[0].string, type='VOID')
+        node = self.intrinsic_handler.replace_function_reference(name, args, line, self.symbols)
         return node
-
 
     def end_subroutine_stmt(self, node: FASTNode):
         return node
@@ -691,14 +685,15 @@ class InternalFortranAst:
 
     def parenthesis_expr(self, node: FASTNode):
         children = self.create_children(node)
-        return ast_internal_classes.Parenthesis_Expr_Node(expr=children[1],type=children[1].type)
+        return ast_internal_classes.Parenthesis_Expr_Node(expr=children[1], type=children[1].type)
 
     def module_subprogram_part(self, node: FASTNode):
         children = self.create_children(node)
         function_definitions = [i for i in children if isinstance(i, ast_internal_classes.Function_Subprogram_Node)]
         subroutine_definitions = [i for i in children if isinstance(i, ast_internal_classes.Subroutine_Subprogram_Node)]
         return ast_internal_classes.Module_Subprogram_Part_Node(function_definitions=function_definitions,
-                                                                 subroutine_definitions=subroutine_definitions)
+                                                                subroutine_definitions=subroutine_definitions)
+
     def interface_block(self, node: FASTNode):
         children = self.create_children(node)
 
@@ -711,7 +706,7 @@ class InternalFortranAst:
             for child in i.namelists:
                 subroutines.extend(child.subroutines)
 
-        # Ignore other implementations the an interface block with overloaded procedures
+        # Ignore other implementations of an interface block with overloaded procedures
         if name is None or len(subroutines) == 0:
             return node
 
@@ -721,7 +716,7 @@ class InternalFortranAst:
         children = self.create_children(node)
 
         name = get_child(children, ast_internal_classes.Module_Stmt_Node)
-        module_subprogram_part=get_child(children, ast_internal_classes.Module_Subprogram_Part_Node)
+        module_subprogram_part = get_child(children, ast_internal_classes.Module_Subprogram_Part_Node)
         specification_part = get_child(children, ast_internal_classes.Specification_Part_Node)
 
         function_definitions = [i for i in children if isinstance(i, ast_internal_classes.Function_Subprogram_Node)]
@@ -762,8 +757,8 @@ class InternalFortranAst:
         name = get_child(children, ast_internal_classes.Name_Node)
         only_list = get_child(children, ast_internal_classes.Only_List_Node)
         if only_list is None:
-            return ast_internal_classes.Use_Stmt_Node(name=name.name,list=None, list_all=True)
-        return ast_internal_classes.Use_Stmt_Node(name=name.name, list=only_list.names,list_all=False)
+            return ast_internal_classes.Use_Stmt_Node(name=name.name, list=None, list_all=True)
+        return ast_internal_classes.Use_Stmt_Node(name=name.name, list=only_list.names, list_all=False)
 
     def implicit_part(self, node: FASTNode):
         return node
@@ -782,7 +777,7 @@ class InternalFortranAst:
         return node
 
     def declaration_type_spec(self, node: FASTNode):
-        #raise NotImplementedError("Declaration type spec is not supported yet")
+        # raise NotImplementedError("Declaration type spec is not supported yet")
         return node
 
     def assumed_shape_spec_list(self, node: FASTNode):
@@ -795,7 +790,7 @@ class InternalFortranAst:
         # handle size definition
         if len(dim_expr) == 1:
             dim_expr = dim_expr[0]
-            #now to add the dimension to the size list after processing it if necessary
+            # now to add the dimension to the size list after processing it if necessary
             size.append(self.create_ast(dim_expr))
             offset.append(1)
 
@@ -803,7 +798,7 @@ class InternalFortranAst:
         elif len(dim_expr) == 2:
             # extract offets
             if isinstance(dim_expr[0], f03.Int_Literal_Constant):
-                #raise TypeError("Array offsets must be constant expressions!")
+                # raise TypeError("Array offsets must be constant expressions!")
                 offset.append(int(dim_expr[0].tostr()))
             else:
                 expr = self.create_ast(dim_expr[0])
@@ -853,35 +848,34 @@ class InternalFortranAst:
                 raise NotImplementedError("Assumed array shape not supported yet if array name missing")
 
             sizes = []
-            offsets =[]
+            offsets = []
             for actual_array in processed_array_names:
 
                 size = []
                 offset = []
                 for i in range(dims_count):
-
                     name = f'__f2dace_A_{actual_array}_d_{i}_s_{self.type_arbitrary_array_variable_count}'
-                    offset_name= f'__f2dace_OA_{actual_array}_d_{i}_s_{self.type_arbitrary_array_variable_count}'
+                    offset_name = f'__f2dace_OA_{actual_array}_d_{i}_s_{self.type_arbitrary_array_variable_count}'
                     self.type_arbitrary_array_variable_count += 1
                     self.placeholders[name] = [actual_array, i, self.type_arbitrary_array_variable_count]
                     self.placeholders_offsets[name] = [actual_array, i, self.type_arbitrary_array_variable_count]
 
                     var = ast_internal_classes.Symbol_Decl_Node(name=name,
-                                                    type='INTEGER',
-                                                    alloc=False,
-                                                    sizes=None,
-                                                    offsets=None,
-                                                    init=None,
-                                                    kind=None,
-                                                    line_number=linenumber)
+                                                                type='INTEGER',
+                                                                alloc=False,
+                                                                sizes=None,
+                                                                offsets=None,
+                                                                init=None,
+                                                                kind=None,
+                                                                line_number=linenumber)
                     var2 = ast_internal_classes.Symbol_Decl_Node(name=offset_name,
-                                                    type='INTEGER',
-                                                    alloc=False,
-                                                    sizes=None,
-                                                    offsets=None,
-                                                    init=None,
-                                                    kind=None,
-                                                    line_number=linenumber)
+                                                                 type='INTEGER',
+                                                                 alloc=False,
+                                                                 sizes=None,
+                                                                 offsets=None,
+                                                                 init=None,
+                                                                 kind=None,
+                                                                 line_number=linenumber)
                     size.append(ast_internal_classes.Name_Node(name=name))
                     offset.append(ast_internal_classes.Name_Node(name=offset_name))
 
@@ -891,16 +885,16 @@ class InternalFortranAst:
                 sizes.append(size)
                 offsets.append(offset)
 
-            return sizes, vardecls ,offsets
+            return sizes, vardecls, offsets
         else:
-            return None, [] ,None
+            return None, [], None
 
     def type_declaration_stmt(self, node: FASTNode):
 
-        #decide if its a intrinsic variable type or a derived type
+        # decide if it's an intrinsic variable type or a derived type
 
         type_of_node = get_child(node, [f03.Intrinsic_Type_Spec, f03.Declaration_Type_Spec])
-        #if node.children[2].children[0].children[0].string.lower() =="BOUNDARY_MISSVAL".lower():
+        # if node.children[2].children[0].children[0].string.lower() =="BOUNDARY_MISSVAL".lower():
         #    print("found boundary missval")
         if isinstance(type_of_node, f03.Intrinsic_Type_Spec):
             derived_type = False
@@ -916,33 +910,33 @@ class InternalFortranAst:
         else:
             raise TypeError("Type of node must be either Intrinsic_Type_Spec or Declaration_Type_Spec")
         kind = None
-        size_later=False
+        size_later = False
         if len(type_of_node.items) >= 2:
             if type_of_node.items[1] is not None:
                 if not derived_type:
                     if basetype == "CLASS":
-                        kind="CLASS"
+                        kind = "CLASS"
                     elif basetype == "CHARACTER":
                         kind = type_of_node.items[1].items[1].string.lower()
-                        if kind=="*":
-                           size_later=True
+                        if kind == "*":
+                            size_later = True
                     else:
                         kind = type_of_node.items[1].items[1].string.lower()
                         if self.symbols[kind] is not None:
-                          if basetype == "REAL":
-                            while hasattr(self.symbols[kind], "name"):
-                                kind = self.symbols[kind].name
-                            if self.symbols[kind].value == "8":
-                                basetype = "REAL8"
-                          elif basetype == "INTEGER":
-                            while hasattr(self.symbols[kind], "name"):
-                                kind = self.symbols[kind].name
-                            if self.symbols[kind].value == "4":
-                                basetype = "INTEGER"
-                          else:
-                            raise TypeError("Derived type not supported")
+                            if basetype == "REAL":
+                                while hasattr(self.symbols[kind], "name"):
+                                    kind = self.symbols[kind].name
+                                if self.symbols[kind].value == "8":
+                                    basetype = "REAL8"
+                            elif basetype == "INTEGER":
+                                while hasattr(self.symbols[kind], "name"):
+                                    kind = self.symbols[kind].name
+                                if self.symbols[kind].value == "4":
+                                    basetype = "INTEGER"
+                            else:
+                                raise TypeError("Derived type not supported")
 
-                #if derived_type:
+                # if derived_type:
                 #    raise TypeError("Derived type not supported")
         if not derived_type:
             testtype = self.types[basetype]
@@ -953,15 +947,14 @@ class InternalFortranAst:
         # get the names of the variables being defined
         names_list = get_child(node, ["Entity_Decl_List", "Component_Decl_List"])
 
-        #get the names out of the name list
+        # get the names out of the name list
         names = get_children(names_list, [f03.Entity_Decl, f03.Component_Decl])
 
-
-        #get the attributes of the variables being defined
+        # get the attributes of the variables being defined
         # alloc relates to whether it is statically (False) or dynamically (True) allocated
-        # parameter means its a constant, so we should transform it into a symbol
+        # parameter means it's a constant, so we should transform it into a symbol
         attributes = get_children(node, "Attr_Spec_List")
-        comp_attributes=get_children(node, "Component_Attr_Spec_List")
+        comp_attributes = get_children(node, "Component_Attr_Spec_List")
         if len(attributes) != 0 and len(comp_attributes) != 0:
             raise TypeError("Attributes must be either in Attr_Spec_List or Component_Attr_Spec_List not both")
 
@@ -971,7 +964,7 @@ class InternalFortranAst:
         attr_size = None
         attr_offset = None
         assumed_vardecls = []
-        for i in attributes+comp_attributes:
+        for i in attributes + comp_attributes:
 
             if i.string.lower() == "allocatable":
                 alloc = True
@@ -1004,7 +997,8 @@ class InternalFortranAst:
                     attr_size = [attr_size] * len(names)
                     attr_offset = [attr_offset] * len(names)
                 else:
-                    attr_size, assumed_vardecls,attr_offset = self.assumed_array_shape(dimension_spec[0], names, node.item.span)
+                    attr_size, assumed_vardecls, attr_offset = self.assumed_array_shape(dimension_spec[0], names,
+                                                                                        node.item.span)
 
                     if attr_size is None:
                         raise RuntimeError("Couldn't parse the dimension attribute specification!")
@@ -1023,7 +1017,7 @@ class InternalFortranAst:
                 attr_size = []
                 attr_offset = []
                 sizes = get_child(dimension_spec[0], ["Explicit_Shape_Spec_List"])
-                #if sizes is None:
+                # if sizes is None:
                 #    sizes = get_child(dimension_spec[0], ["Deferred_Shape_Spec_List"])
 
                 if sizes is not None:
@@ -1033,38 +1027,39 @@ class InternalFortranAst:
                     attr_size = [attr_size] * len(names)
                     attr_offset = [attr_offset] * len(names)
                 else:
-                    attr_size, assumed_vardecls, attr_offset = self.assumed_array_shape(dimension_spec[0], names, node.item.span)
+                    attr_size, assumed_vardecls, attr_offset = self.assumed_array_shape(dimension_spec[0], names,
+                                                                                        node.item.span)
                     if attr_size is None:
                         raise RuntimeError("Couldn't parse the dimension attribute specification!")
 
         vardecls = [*assumed_vardecls]
 
         for idx, var in enumerate(names):
-            #print(self.name_list)
-            #first handle dimensions
+            # print(self.name_list)
+            # first handle dimensions
             size = None
             offset = None
             var_components = self.create_children(var)
             array_sizes = get_children(var, "Explicit_Shape_Spec_List")
             actual_name = get_child(var_components, ast_internal_classes.Name_Node)
-            #if actual_name.name not in self.name_list:
+            # if actual_name.name not in self.name_list:
             #    return
             if len(array_sizes) == 1:
                 array_sizes = array_sizes[0]
                 size = []
                 offset = []
                 for dim in array_sizes.children:
-                    #sanity check
+                    # sanity check
                     if isinstance(dim, f03.Explicit_Shape_Spec):
                         self.parse_shape_specification(dim, size, offset)
 
-            #handle initializiation
+            # handle initializiation
             init = None
 
             initialization = get_children(var, f03.Initialization)
             if len(initialization) == 1:
                 initialization = initialization[0]
-                #if there is an initialization, the actual expression is in the second child, with the first being the equals sign
+                # if there is an initialization, the actual expression is in the second child, with the first being the equals sign
                 if len(initialization.children) < 2:
                     raise ValueError("Initialization must have an expression")
                 raw_init = initialization.children[1]
@@ -1074,46 +1069,46 @@ class InternalFortranAst:
                 if len(comp_init) == 1:
                     raw_init = comp_init[0].children[1]
                     init = self.create_ast(raw_init)
-            #if size_later:
+            # if size_later:
             #    size.append(len(init))
-            if testtype!="INTEGER": symbol=False
+            if testtype != "INTEGER": symbol = False
             if symbol == False:
 
                 if attr_size is None:
 
                     if size is None:
 
-                        size, assumed_vardecls ,offset = self.assumed_array_shape(var, actual_name.name, node.item.span)
+                        size, assumed_vardecls, offset = self.assumed_array_shape(var, actual_name.name, node.item.span)
                         if size is None:
                             offset = None
                         else:
                             # only one array
                             size = size[0]
                             offset = offset[0]
-                            #offset = [1] * len(size)
+                            # offset = [1] * len(size)
                         vardecls.extend(assumed_vardecls)
 
                     vardecls.append(
                         ast_internal_classes.Var_Decl_Node(name=actual_name.name,
-                                                        type=testtype,
-                                                        alloc=alloc,
-                                                        sizes=size,
-                                                        offsets=offset,
-                                                        kind=kind,
-                                                        init=init,
-                                                        optional=optional,
-                                                        line_number=node.item.span))
+                                                           type=testtype,
+                                                           alloc=alloc,
+                                                           sizes=size,
+                                                           offsets=offset,
+                                                           kind=kind,
+                                                           init=init,
+                                                           optional=optional,
+                                                           line_number=node.item.span))
                 else:
                     vardecls.append(
                         ast_internal_classes.Var_Decl_Node(name=actual_name.name,
-                                                        type=testtype,
-                                                        alloc=alloc,
-                                                        sizes=attr_size[idx],
-                                                        offsets=attr_offset[idx],
-                                                        kind=kind,
-                                                        init=init,
-                                                        optional=optional,
-                                                        line_number=node.item.span))
+                                                           type=testtype,
+                                                           alloc=alloc,
+                                                           sizes=attr_size[idx],
+                                                           offsets=attr_offset[idx],
+                                                           kind=kind,
+                                                           init=init,
+                                                           optional=optional,
+                                                           line_number=node.item.span))
             else:
                 if size is None and attr_size is None:
                     self.symbols[actual_name.name] = init
@@ -1173,7 +1168,7 @@ class InternalFortranAst:
 
     def access_spec(self, node: FASTNode):
         print("access spec. Fix me")
-        #raise NotImplementedError("Access spec is not supported yet")
+        # raise NotImplementedError("Access spec is not supported yet")
         return node
 
     def allocatable_stmt(self, node: FASTNode):
@@ -1186,7 +1181,7 @@ class InternalFortranAst:
 
     def bind_stmt(self, node: FASTNode):
         print("bind stmt. Fix me")
-        #raise NotImplementedError("Bind stmt is not supported yet")
+        # raise NotImplementedError("Bind stmt is not supported yet")
         return node
 
     def common_stmt(self, node: FASTNode):
@@ -1195,7 +1190,7 @@ class InternalFortranAst:
 
     def data_stmt(self, node: FASTNode):
         print("data stmt! fix me!")
-        #raise NotImplementedError("Data stmt is not supported yet")
+        # raise NotImplementedError("Data stmt is not supported yet")
         return node
 
     def dimension_stmt(self, node: FASTNode):
@@ -1238,7 +1233,7 @@ class InternalFortranAst:
         return node
 
     def execution_part(self, node: FASTNode):
-        children =[child for child in self.create_children(node) if child is not None]
+        children = [child for child in self.create_children(node) if child is not None]
         return ast_internal_classes.Execution_Part_Node(execution=children)
 
     def execution_part_construct(self, node: FASTNode):
@@ -1250,24 +1245,29 @@ class InternalFortranAst:
     def level_2_expr(self, node: FASTNode):
         children = self.create_children(node)
         line = get_line(node)
-        if children[1]=="==": type="LOGICAL"
+        if children[1] == "==":
+            type = "LOGICAL"
         else:
-            type="VOID"
-            if hasattr(children[0],"type"):
-                type=children[0].type
+            type = "VOID"
+            if hasattr(children[0], "type"):
+                type = children[0].type
         if len(children) == 3:
-            return ast_internal_classes.BinOp_Node(lval=children[0], op=children[1], rval=children[2], line_number=line, type=type)
+            return ast_internal_classes.BinOp_Node(lval=children[0], op=children[1], rval=children[2], line_number=line,
+                                                   type=type)
         else:
-            return ast_internal_classes.UnOp_Node(lval=children[1], op=children[0], line_number=line,type=children[1].type)
+            return ast_internal_classes.UnOp_Node(lval=children[1], op=children[0], line_number=line,
+                                                  type=children[1].type)
 
     def assignment_stmt(self, node: FASTNode):
         children = self.create_children(node)
         line = get_line(node)
 
         if len(children) == 3:
-            return ast_internal_classes.BinOp_Node(lval=children[0], op=children[1], rval=children[2], line_number=line,type=children[0].type)
+            return ast_internal_classes.BinOp_Node(lval=children[0], op=children[1], rval=children[2], line_number=line,
+                                                   type=children[0].type)
         else:
-            return ast_internal_classes.UnOp_Node(lval=children[1], op=children[0], line_number=line,type=children[1].type)
+            return ast_internal_classes.UnOp_Node(lval=children[1], op=children[0], line_number=line,
+                                                  type=children[1].type)
 
     def pointer_assignment_stmt(self, node: FASTNode):
         children = self.create_children(node)
@@ -1320,8 +1320,8 @@ class InternalFortranAst:
         line = get_line(node)
         cond = children[0]
         body = children[1:]
-        #!THIS IS HACK
-        body= [i for i in body if i is not None]
+        # !THIS IS HACK
+        body = [i for i in body if i is not None]
         return ast_internal_classes.If_Stmt_Node(cond=cond,
                                                  body=ast_internal_classes.Execution_Part_Node(execution=body),
                                                  body_else=ast_internal_classes.Execution_Part_Node(execution=[]),
@@ -1381,17 +1381,19 @@ class InternalFortranAst:
     def case_construct(self, node: FASTNode):
         children = self.create_children(node)
         cond_start = children[0]
-        cond_end= children[1] 
+        cond_end = children[1]
         body = []
         body_else = []
         else_mode = False
         line = get_line(node)
         if line is None:
             line = "Unknown:TODO"
-        cond=ast_internal_classes.BinOp_Node(op=cond_end.op[0],lval=cond_start,rval=cond_end.cond[0],line_number=line)
-        for j in range(1,len(cond_end.op)):
-            cond_add=ast_internal_classes.BinOp_Node(op=cond_end.op[j],lval=cond_start,rval=cond_end.cond[j],line_number=line)
-            cond=ast_internal_classes.BinOp_Node(op=".AND.",lval=cond,rval=cond_add,line_number=line)    
+        cond = ast_internal_classes.BinOp_Node(op=cond_end.op[0], lval=cond_start, rval=cond_end.cond[0],
+                                               line_number=line)
+        for j in range(1, len(cond_end.op)):
+            cond_add = ast_internal_classes.BinOp_Node(op=cond_end.op[j], lval=cond_start, rval=cond_end.cond[j],
+                                                       line_number=line)
+            cond = ast_internal_classes.BinOp_Node(op=".AND.", lval=cond, rval=cond_add, line_number=line)
 
         toplevelIf = ast_internal_classes.If_Stmt_Node(cond=cond, line_number=line)
         currentIf = toplevelIf
@@ -1399,10 +1401,11 @@ class InternalFortranAst:
             if i is None:
                 continue
             if isinstance(i, ast_internal_classes.Case_Cond_Node):
-                cond=ast_internal_classes.BinOp_Node(op=i.op[0],lval=cond_start,rval=i.cond[0],line_number=line)    
-                for j in range(1,len(i.op)):
-                    cond_add=ast_internal_classes.BinOp_Node(op=i.op[j],lval=cond_start,rval=i.cond[j],line_number=line)
-                    cond=ast_internal_classes.BinOp_Node(op=".AND.",lval=cond,rval=cond_add,line_number=line)    
+                cond = ast_internal_classes.BinOp_Node(op=i.op[0], lval=cond_start, rval=i.cond[0], line_number=line)
+                for j in range(1, len(i.op)):
+                    cond_add = ast_internal_classes.BinOp_Node(op=i.op[j], lval=cond_start, rval=i.cond[j],
+                                                               line_number=line)
+                    cond = ast_internal_classes.BinOp_Node(op=".AND.", lval=cond, rval=cond_add, line_number=line)
 
                 newif = ast_internal_classes.If_Stmt_Node(cond=cond, line_number=line)
                 currentIf.body = ast_internal_classes.Execution_Part_Node(execution=body)
@@ -1410,13 +1413,13 @@ class InternalFortranAst:
                 currentIf = newif
                 body = []
                 continue
-            if isinstance(i, str) and i=="__default__":
+            if isinstance(i, str) and i == "__default__":
                 else_mode = True
                 continue
             if else_mode:
                 body_else.append(i)
             else:
-                
+
                 body.append(i)
         currentIf.body = ast_internal_classes.Execution_Part_Node(execution=body)
         currentIf.body_else = ast_internal_classes.Execution_Part_Node(execution=body_else)
@@ -1424,27 +1427,27 @@ class InternalFortranAst:
 
     def select_case_stmt(self, node: FASTNode):
         children = self.create_children(node)
-        if len(children)!=1:
+        if len(children) != 1:
             raise ValueError("CASE should have only 1 child")
         return children[0]
 
     def case_stmt(self, node: FASTNode):
         children = self.create_children(node)
-        children=[i for i in children if i is not None]
-        if len(children)==1:
+        children = [i for i in children if i is not None]
+        if len(children) == 1:
             return children[0]
-        elif len(children)==0:
+        elif len(children) == 0:
             return "__default__"
         else:
             raise ValueError("Can't parse case statement")
-        
-    def case_selector(self, node:FASTNode):
+
+    def case_selector(self, node: FASTNode):
         children = self.create_children(node)
-        if len(children)==1:
+        if len(children) == 1:
             if children[0] is None:
                 return None
-            returns=ast_internal_classes.Case_Cond_Node(op=[],cond=[])
-            
+            returns = ast_internal_classes.Case_Cond_Node(op=[], cond=[])
+
             for i in children[0]:
                 returns.op.append(i[0])
                 returns.cond.append(i[1])
@@ -1452,13 +1455,13 @@ class InternalFortranAst:
         else:
             raise ValueError("Can't parse case selector")
 
-    def case_value_range_list(self, node:FASTNode):        
+    def case_value_range_list(self, node: FASTNode):
         children = self.create_children(node)
-        if len(children)==1:
+        if len(children) == 1:
             return [[".EQ.", children[0]]]
-        if len(children)==2:
-            return [[".EQ.", children[0]],[".EQ.", children[1]]]
-        
+        if len(children) == 2:
+            return [[".EQ.", children[0]], [".EQ.", children[1]]]
+
         else:
             raise ValueError("Can't parse case range list")
 
@@ -1475,11 +1478,11 @@ class InternalFortranAst:
         children = self.create_children(node)
         loop_control = get_child(children, ast_internal_classes.Loop_Control_Node)
         if loop_control is None:
-            if node.string=="DO":
-                return ast_internal_classes.While_True_Control(name=node.item.name,line_number=node.item.span)
+            if node.string == "DO":
+                return ast_internal_classes.While_True_Control(name=node.item.name, line_number=node.item.span)
             else:
-                while_control=get_child(children,ast_internal_classes.While_Control)
-                return ast_internal_classes.While_Control(cond=while_control.cond,line_number=node.item.span)
+                while_control = get_child(children, ast_internal_classes.While_Control)
+                return ast_internal_classes.While_Control(cond=while_control.cond, line_number=node.item.span)
         return ast_internal_classes.Nonlabel_Do_Stmt_Node(iter=loop_control.iter,
                                                           cond=loop_control.cond,
                                                           init=loop_control.init,
@@ -1518,15 +1521,14 @@ class InternalFortranAst:
 
     def procedure_declaration_stmt(self, node: FASTNode):
         return node
-    
+
     def specific_binding(self, node: FASTNode):
         children = self.create_children(node)
-        return ast_internal_classes.Specific_Binding_Node(name=children[3], args=children[0:2]+[children[4]])
-
+        return ast_internal_classes.Specific_Binding_Node(name=children[3], args=children[0:2] + [children[4]])
 
     def type_bound_procedure_part(self, node: FASTNode):
         children = self.create_children(node)
-        return ast_internal_classes.Bound_Procedures_Node(procedures= children[1:])
+        return ast_internal_classes.Bound_Procedures_Node(procedures=children[1:])
 
     def contains_stmt(self, node: FASTNode):
         return node
@@ -1536,21 +1538,21 @@ class InternalFortranAst:
         name = get_child(children, ast_internal_classes.Name_Node)
         arg_addition = None
         if name is None:
-            proc_ref = get_child(children, ast_internal_classes.Procedure_Separator_Node)   
+            proc_ref = get_child(children, ast_internal_classes.Procedure_Separator_Node)
             name = proc_ref.part_ref
             arg_addition = proc_ref.parent_ref
-            
+
         args = get_child(children, ast_internal_classes.Arg_List_Node)
-        if args==None:
+        if args is None:
             ret_args = []
         else:
-            ret_args = args.args  
+            ret_args = args.args
         if arg_addition is not None:
-            ret_args.insert(0,arg_addition)
-        line_number = get_line(node)     
-        #if node.item is None:
+            ret_args.insert(0, arg_addition)
+        line_number = get_line(node)
+        # if node.item is None:
         #    line_number = 42
-        #else:
+        # else:
         #    line_number = node.item.span
         return ast_internal_classes.Call_Expr_Node(name=name, args=ret_args, type="VOID", line_number=line_number)
 
@@ -1585,9 +1587,9 @@ class InternalFortranAst:
 
     def loop_control(self, node: FASTNode):
         children = self.create_children(node)
-        #Structure of loop control is:
+        # Structure of loop control is:
         if children[1] is None:
-            return ast_internal_classes.While_Control(cond=children[0],line_number=node.parent.item.span)
+            return ast_internal_classes.While_Control(cond=children[0], line_number=node.parent.item.span)
         # child[1]. Loop control variable
         # child[1][0] Loop start
         # child[1][1] Loop end
@@ -1598,33 +1600,40 @@ class InternalFortranAst:
             loop_step = children[1][1][2]
         else:
             loop_step = ast_internal_classes.Int_Literal_Node(value="1")
-        init_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable, op="=", rval=loop_start,type="INTEGER")
+        init_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable, op="=", rval=loop_start, type="INTEGER")
         if isinstance(loop_step, ast_internal_classes.UnOp_Node):
             if loop_step.op == "-":
-                cond_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable, op=">=", rval=loop_end,type="INTEGER")
+                cond_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable, op=">=", rval=loop_end,
+                                                            type="INTEGER")
         else:
-            cond_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable, op="<=", rval=loop_end,type="INTEGER")
+            cond_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable, op="<=", rval=loop_end, type="INTEGER")
         iter_expr = ast_internal_classes.BinOp_Node(lval=iteration_variable,
                                                     op="=",
                                                     rval=ast_internal_classes.BinOp_Node(lval=iteration_variable,
                                                                                          op="+",
-                                                                                         rval=loop_step,type="INTEGER"),type="INTEGER")
+                                                                                         rval=loop_step,
+                                                                                         type="INTEGER"),
+                                                    type="INTEGER")
         return ast_internal_classes.Loop_Control_Node(init=init_expr, cond=cond_expr, iter=iter_expr)
 
     def block_nonlabel_do_construct(self, node: FASTNode):
         children = self.create_children(node)
         do = get_child(children, ast_internal_classes.Nonlabel_Do_Stmt_Node)
         body = children[1:-1]
-        body= [i for i in body if i is not None]
+        body = [i for i in body if i is not None]
         if do is None:
-            while_true_header=get_child(children, ast_internal_classes.While_True_Control)
+            while_true_header = get_child(children, ast_internal_classes.While_True_Control)
             if while_true_header is not None:
-                return ast_internal_classes.While_Stmt_Node(name=while_true_header.name,body=ast_internal_classes.Execution_Part_Node(execution=body),
-                                                  line_number=while_true_header.line_number)
-            while_header=get_child(children, ast_internal_classes.While_Control)
+                return ast_internal_classes.While_Stmt_Node(name=while_true_header.name,
+                                                            body=ast_internal_classes.Execution_Part_Node(
+                                                                execution=body),
+                                                            line_number=while_true_header.line_number)
+            while_header = get_child(children, ast_internal_classes.While_Control)
             if while_header is not None:
-                return ast_internal_classes.While_Stmt_Node(cond=while_header.cond,body=ast_internal_classes.Execution_Part_Node(execution=body),
-                                                  line_number=while_header.line_number)
+                return ast_internal_classes.While_Stmt_Node(cond=while_header.cond,
+                                                            body=ast_internal_classes.Execution_Part_Node(
+                                                                execution=body),
+                                                            line_number=while_header.line_number)
         return ast_internal_classes.For_Stmt_Node(init=do.init,
                                                   cond=do.cond,
                                                   iter=do.iter,
@@ -1643,17 +1652,17 @@ class InternalFortranAst:
 
     def specification_part(self, node: FASTNode):
 
-        #TODO this can be refactored to consider more fortran declaration options. Currently limited to what is encountered in code.
+        # TODO this can be refactored to consider more fortran declaration options. Currently limited to what is encountered in code.
         others = [self.create_ast(i) for i in node.children if not isinstance(i, f08.Type_Declaration_Stmt)]
 
         decls = [self.create_ast(i) for i in node.children if isinstance(i, f08.Type_Declaration_Stmt)]
         enums = [self.create_ast(i) for i in node.children if isinstance(i, f03.Enum_Def)]
-        #decls = list(filter(lambda x: x is not None, decls))
+        # decls = list(filter(lambda x: x is not None, decls))
         uses = [self.create_ast(i) for i in node.children if isinstance(i, f03.Use_Stmt)]
         tmp = [self.create_ast(i) for i in node.children]
         typedecls = [
             i for i in tmp if isinstance(i, ast_internal_classes.Type_Decl_Node)
-            or isinstance(i, ast_internal_classes.Derived_Type_Def_Node)
+                              or isinstance(i, ast_internal_classes.Derived_Type_Def_Node)
         ]
         symbols = []
         iblocks = []
@@ -1700,14 +1709,14 @@ class InternalFortranAst:
         return node
 
     def int_literal_constant(self, node: FASTNode):
-        value=node.string
-        if value.find("_")!=-1:
-            x=value.split("_")
-            value=x[0]
-        return ast_internal_classes.Int_Literal_Node(value=value,type="INTEGER")
+        value = node.string
+        if value.find("_") != -1:
+            x = value.split("_")
+            value = x[0]
+        return ast_internal_classes.Int_Literal_Node(value=value, type="INTEGER")
 
     def hex_constant(self, node: FASTNode):
-        return ast_internal_classes.Int_Literal_Node(value=str(int(node.string[2:-1],16)),type="INTEGER")
+        return ast_internal_classes.Int_Literal_Node(value=str(int(node.string[2:-1], 16)), type="INTEGER")
 
     def logical_literal_constant(self, node: FASTNode):
         if node.string in [".TRUE.", ".true.", ".True."]:
@@ -1717,26 +1726,25 @@ class InternalFortranAst:
         raise ValueError("Unknown logical literal constant")
 
     def real_literal_constant(self, node: FASTNode):
-        value=node.children[0].lower()
-        if len(node.children) == 2 and node.children[1] is not None and node.children[1].lower()=="wp":
-            return ast_internal_classes.Double_Literal_Node(value=value,type="DOUBLE")
-        if value.find("_")!=-1:
-            x=value.split("_")
-            value=x[0]
+        value = node.children[0].lower()
+        if len(node.children) == 2 and node.children[1] is not None and node.children[1].lower() == "wp":
+            return ast_internal_classes.Double_Literal_Node(value=value, type="DOUBLE")
+        if value.find("_") != -1:
+            x = value.split("_")
+            value = x[0]
             print(x[1])
-            if (x[1]=="wp"):
-                return ast_internal_classes.Double_Literal_Node(value=value,type="DOUBLE")
-        return ast_internal_classes.Real_Literal_Node(value=value,type="REAL")
-
+            if x[1] == "wp":
+                return ast_internal_classes.Double_Literal_Node(value=value, type="DOUBLE")
+        return ast_internal_classes.Real_Literal_Node(value=value, type="REAL")
 
     def char_literal_constant(self, node: FASTNode):
-        return ast_internal_classes.Char_Literal_Node(value=node.string,type="CHAR")
+        return ast_internal_classes.Char_Literal_Node(value=node.string, type="CHAR")
 
     def actual_arg_spec(self, node: FASTNode):
         children = self.create_children(node)
         if len(children) != 2:
             raise ValueError("Actual arg spec must have two children")
-        return ast_internal_classes.Actual_Arg_Spec_Node(arg_name=children[0], arg=children[1],type="VOID")
+        return ast_internal_classes.Actual_Arg_Spec_Node(arg_name=children[0], arg=children[1], type="VOID")
 
     def actual_arg_spec_list(self, node: FASTNode):
         children = self.create_children(node)
@@ -1746,11 +1754,11 @@ class InternalFortranAst:
         return node
 
     def name(self, node: FASTNode):
-        return ast_internal_classes.Name_Node(name=node.string.lower(),type="VOID")
-
+        return ast_internal_classes.Name_Node(name=node.string.lower(), type="VOID")
 
     def rename(self, node: FASTNode):
-        return ast_internal_classes.Rename_Node(oldname=node.children[2].string.lower(),newname=node.children[1].string.lower())
+        return ast_internal_classes.Rename_Node(oldname=node.children[2].string.lower(),
+                                                newname=node.children[1].string.lower())
 
     def type_name(self, node: FASTNode):
         return ast_internal_classes.Type_Name_Node(name=node.string.lower())

--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -106,7 +106,7 @@ class InternalFortranAst:
     for each entry in the dictionary, the key is the name of the class in the fparser AST and the value
     is the name of the function that will be used to translate the fparser AST to our AST
     """
-    def __init__(self, ast: FASTNode, tables: symbol_table.SymbolTable):
+    def __init__(self):
         """
         Initialization of the AST converter
         :param ast: the fparser AST
@@ -310,10 +310,6 @@ class InternalFortranAst:
 
     def fortran_intrinsics(self) -> "FortranIntrinsics":
         return self.intrinsic_handler
-
-    def list_tables(self):
-        for i in self.tables._symbol_tables:
-            print(i)
 
     def data_pointer_object(self, node: FASTNode):
         children = self.create_children(node)

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -2764,7 +2764,7 @@ def recursive_ast_improver(ast, source_list: Union[List, Dict], include_list, pa
     dep_graph = nx.DiGraph()
     asts = {}
     interface_blocks: Dict[str, Dict[str, List[Name]]] = {}
-    exclude_list = set()
+    exclude = set()
     missing_modules = set()
 
     NAME_REPLACEMENTS = {
@@ -2795,8 +2795,7 @@ def recursive_ast_improver(ast, source_list: Union[List, Dict], include_list, pa
         else:
             parent_module = _ast.children[0].children[0].children[1].string
         for mod in defined_modules:
-            if mod not in exclude_list:
-                exclude_list.add(mod)
+            exclude.add(mod)
             dep_graph.add_node(mod.lower(), info_list=fandsl)
         for mod in used_modules:
             if mod not in dep_graph.nodes:
@@ -2808,7 +2807,7 @@ def recursive_ast_improver(ast, source_list: Union[List, Dict], include_list, pa
 
         modules_to_parse = []
         for mod in used_modules:
-            if mod not in chain(defined_modules, exclude_list):
+            if mod not in chain(defined_modules, exclude):
                 modules_to_parse.append(mod)
         added_modules = []
         for mod in modules_to_parse:
@@ -2819,8 +2818,7 @@ def recursive_ast_improver(ast, source_list: Union[List, Dict], include_list, pa
             mod_file = [srcf for srcf in source_list if os.path.basename(srcf).lower() == f"{name}.f90"]
             assert len(mod_file) <= 1, f"Found multiple files for the same module `{mod}`: {mod_file}"
             if not mod_file:
-                if mod not in missing_modules:
-                    missing_modules.add(mod)
+                missing_modules.add(mod)
                 continue
             mod_file = mod_file[0]
 
@@ -2839,8 +2837,7 @@ def recursive_ast_improver(ast, source_list: Union[List, Dict], include_list, pa
                 added_modules.append(c)
                 c_stmt = c.children[0]
                 c_name = ast_utils.singular(ast_utils.children_of_type(c_stmt, Name)).string
-                if c_name not in exclude_list:
-                    exclude_list.add(c_name)
+                exclude.add(c_name)
 
         for mod in reversed(added_modules):
             mod_stmt = mod.children[0]

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -2487,7 +2487,7 @@ def create_ast_from_string(
     reader = fsr(source_string)
     ast = parser(reader)
     tables = SymbolTable
-    own_ast = ast_components.InternalFortranAst(ast, tables)
+    own_ast = ast_components.InternalFortranAst()
     program = own_ast.create_ast(ast)
 
     structs_lister = ast_transforms.StructLister()
@@ -2555,8 +2555,7 @@ def create_sdfg_from_string(
 
     name_dict, rename_dict = prune_unused_children(ast, parse_order, simple_graph, actually_used_in_module)
 
-    tables = SymbolTable
-    own_ast = ast_components.InternalFortranAst(ast, tables)
+    own_ast = ast_components.InternalFortranAst()
     functions_to_rename = {}
     for i in parse_order:
         own_ast.current_ast = i
@@ -2735,7 +2734,7 @@ def create_sdfg_from_fortran_file(source_string: str):
     reader = ffr(source_string)
     ast = parser(reader)
     tables = SymbolTable
-    own_ast = ast_components.InternalFortranAst(ast, tables)
+    own_ast = ast_components.InternalFortranAst()
     program = own_ast.create_ast(ast)
     functions_and_subroutines_builder = ast_transforms.FindFunctionAndSubroutines()
     functions_and_subroutines_builder.visit(program)
@@ -3281,7 +3280,7 @@ def create_sdfg_from_fortran_file_with_options(source_string: str, source_list, 
     #                         changes=True
 
     tables = SymbolTable
-    partial_ast = ast_components.InternalFortranAst(top_level_ast, tables)
+    partial_ast = ast_components.InternalFortranAst()
     partial_modules = {}
     partial_ast.symbols["c_int"] = ast_internal_classes.Int_Literal_Node(value=4)
     partial_ast.symbols["c_int8_t"] = ast_internal_classes.Int_Literal_Node(value=1)

--- a/tests/fortran/prune_unused_children.py
+++ b/tests/fortran/prune_unused_children.py
@@ -18,18 +18,7 @@ def parse_improve_and_simplify(sources: Dict[str, str]):
     ast = parser(reader)
     assert isinstance(ast, Program)
 
-    dep_graph = nx.DiGraph()
-    asts = {}
-    interface_blocks = {}
-    ast = recursive_ast_improver(ast,
-                                 sources,
-                                 [],
-                                 parser,
-                                 interface_blocks,
-                                 exclude_list=[],
-                                 missing_modules=[],
-                                 dep_graph=dep_graph,
-                                 asts=asts)
+    ast, dep_graph, interface_blocks, asts = recursive_ast_improver(ast, sources, [], parser)
     assert isinstance(ast, Program)
     assert not any(nx.simple_cycles(dep_graph))
 

--- a/tests/fortran/recursive_ast_improver_test.py
+++ b/tests/fortran/recursive_ast_improver_test.py
@@ -6,7 +6,8 @@ from fparser.common.readfortran import FortranStringReader
 from fparser.two.Fortran2003 import Program, Name
 from fparser.two.parser import ParserFactory
 
-from dace.frontend.fortran.fortran_parser import recursive_ast_improver, simplified_dependency_graph
+from dace.frontend.fortran.fortran_parser import recursive_ast_improver, simplified_dependency_graph, \
+    create_sdfg_from_string
 from tests.fortran.fotran_test_helper import SourceCodeBuilder
 
 
@@ -17,18 +18,7 @@ def parse_and_improve(sources: Dict[str, str]):
     ast = parser(reader)
     assert isinstance(ast, Program)
 
-    dep_graph = nx.DiGraph()
-    asts = {}
-    interface_blocks = {}
-    ast = recursive_ast_improver(ast,
-                                 sources,
-                                 [],
-                                 parser,
-                                 interface_blocks,
-                                 exclude_list=[],
-                                 missing_modules=[],
-                                 dep_graph=dep_graph,
-                                 asts=asts)
+    ast, dep_graph, interface_blocks, asts = recursive_ast_improver(ast, sources, [], parser)
     assert isinstance(ast, Program)
     assert not any(nx.simple_cycles(dep_graph))
     return ast, dep_graph, interface_blocks, asts


### PR DESCRIPTION
Additionally:
- Some minor data structure change: if all the operations that we're doing on `exclude_list` is to check if an item is in it, and add it if it isn't, then a `set` is probably a better container than a `list`.
- Formatting fixes in `ast_components.py`.