### PR TITLE
[Multi SDFG, Fortran] Make `functionStatementEliminator()` to modify the `node` itself and return it, so that it cannot forget to account for all the members of `node` when constructing a new one.

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -640,14 +640,10 @@ class InternalFortranAst:
 
     def program(self, node: FASTNode):
         children = self.create_children(node)
-
         main_program = get_child(children, ast_internal_classes.Main_Program_Node)
-
         function_definitions = [i for i in children if isinstance(i, ast_internal_classes.Function_Subprogram_Node)]
-
         subroutine_definitions = [i for i in children if isinstance(i, ast_internal_classes.Subroutine_Subprogram_Node)]
         modules = [node for node in children if isinstance(node, ast_internal_classes.Module_Node)]
-
         return ast_internal_classes.Program_Node(main_program=main_program,
                                                  function_definitions=function_definitions,
                                                  subroutine_definitions=subroutine_definitions,

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -195,26 +195,33 @@ class Name_Range_Node(FNode):
     _attributes = ('name', 'type', 'arrname', 'pos')
     _fields = ()
 
+
 class Where_Construct_Node(FNode):
     _attributes = ()
-    _fields = ('main_body', 'main_cond', 'else_body','elifs_body','elifs_cond')
+    _fields = ('main_body', 'main_cond', 'else_body', 'elifs_body', 'elifs_cond')
+
 
 class Type_Name_Node(FNode):
     _attributes = ('name', 'type')
     _fields = ()
 
+
 class Generic_Binding_Node(FNode):
     _attributes = ()
     _fields = ('name', 'binding')
 
+
 class Specification_Part_Node(FNode):
     _fields = ('specifications', 'symbols', 'interface_blocks', 'typedecls', 'enums')
+
 
 class Stop_Stmt_Node(FNode):
     _attributes = ('code')
 
+
 class Error_Stmt_Node(FNode):
     _fields = ('error')
+
 
 class Execution_Part_Node(FNode):
     _fields = ('execution',)
@@ -317,11 +324,14 @@ class Arg_List_Node(FNode):
 class Component_Spec_List_Node(FNode):
     _fields = ('args',)
 
+
 class Allocate_Object_List_Node(FNode):
-    _fields = ('list', )
+    _fields = ('list',)
+
 
 class Deallocate_Stmt_Node(FNode):
-    _fields = ('list', )
+    _fields = ('list',)
+
 
 class Decl_Stmt_Node(Statement_Node):
     _attributes = ()
@@ -475,69 +485,86 @@ class Procedure_Separator_Node(FNode):
     _attributes = ()
     _fields = ('parent_ref', 'part_ref')
 
+
 class Pointer_Object_List_Node(FNode):
     _attributes = ()
     _fields = ('list')
+
 
 class Read_Stmt_Node(FNode):
     _attributes = ()
     _fields = ('args')
 
+
 class Close_Stmt_Node(FNode):
     _attributes = ()
     _fields = ('args')
+
 
 class Open_Stmt_Node(FNode):
     _attributes = ()
     _fields = ('args')
 
+
 class Associate_Stmt_Node(FNode):
     _attributes = ()
     _fields = ('args')
+
 
 class Associate_Construct_Node(FNode):
     _attributes = ()
     _fields = ('associate', 'body')
 
+
 class Association_List_Node(FNode):
     _attributes = ()
     _fields = ('list')
+
 
 class Association_Node(FNode):
     _attributes = ()
     _fields = ('name', 'expr')
 
+
 class Connect_Spec_Node(FNode):
     _attributes = ('type')
     _fields = ('args')
+
 
 class Close_Spec_Node(FNode):
     _attributes = ('type')
     _fields = ('args')
 
+
 class Close_Spec_List_Node(FNode):
     _attributes = ()
     _fields = ('list')
+
 
 class IO_Control_Spec_Node(FNode):
     _attributes = ('type')
     _fields = ('args')
 
+
 class IO_Control_Spec_List_Node(FNode):
     _attributes = ()
     _fields = ('list')
+
 
 class Connect_Spec_List_Node(FNode):
     _attributes = ()
     _fields = ('list')
 
+
 class Nullify_Stmt_Node(FNode):
     _attributes = ()
     _fields = ('list')
 
+
 class Namelist_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('list','name' )
+    _fields = ('list', 'name')
+
 
 class Namelist_Group_Object_List_Node(FNode):
     _attributes = ()

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
-from typing import Any, List, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import List, Optional, Tuple, Union, Dict
+
 
 # The node class is the base class for all nodes in the AST. It provides attributes including the line number and fields.
 # Attributes are not used when walking the tree, but are useful for debugging and for code generation.
@@ -7,46 +8,59 @@ from typing import Any, List, Optional, Tuple, Type, TypeVar, Union, overload
 
 
 class FNode(object):
-    def __init__(self, *args, **kwargs):  # real signature unknown
-        self.integrity_exceptions = []
-        self.read_vars = []
-        self.written_vars = []
-        self.parent: Optional[
-            Union[
-                Subroutine_Subprogram_Node,
-                Function_Subprogram_Node,
-                Main_Program_Node,
-                Module_Node
-            ]
+    def __init__(self, line_number: int = -1, **kwargs):  # real signature unknown
+        self.line_number = line_number
+        self.parent: Union[
+            None,
+            Subroutine_Subprogram_Node,
+            Function_Subprogram_Node,
+            Main_Program_Node,
+            Module_Node
         ] = None
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    _attributes = ("line_number", )
-    _fields = ()
-    integrity_exceptions: List
-    read_vars: List
-    written_vars: List
+    _attributes: Tuple[str, ...] = ("line_number",)
+    _fields: Tuple[str, ...] = ()
 
     def __eq__(self, o: object) -> bool:
-        if type(self) is type(o):
-            # check that all fields and attributes match
-            self_field_vals = list(map(lambda name: getattr(self, name, None), self._fields))
-            self_attr_vals = list(map(lambda name: getattr(self, name, None), self._attributes))
-            o_field_vals = list(map(lambda name: getattr(o, name, None), o._fields))
-            o_attr_vals = list(map(lambda name: getattr(o, name, None), o._attributes))
-
-            return self_field_vals == o_field_vals and self_attr_vals == o_attr_vals
-        return False
+        if not isinstance(o, type(self)):
+            return False
+        # check that all fields and attributes match
+        self_field_vals = list(map(lambda name: getattr(self, name, None), self._fields))
+        self_attr_vals = list(map(lambda name: getattr(self, name, None), self._attributes))
+        o_field_vals = list(map(lambda name: getattr(o, name, None), o._fields))
+        o_attr_vals = list(map(lambda name: getattr(o, name, None), o._attributes))
+        return self_field_vals == o_field_vals and self_attr_vals == o_attr_vals
 
 
 class Program_Node(FNode):
+    def __init__(self,
+                 main_program: 'Main_Program_Node',
+                 function_definitions: List,
+                 subroutine_definitions: List,
+                 modules: List,
+                 module_declarations: Dict,
+                 placeholders: Optional[List] = None,
+                 placeholders_offsets: Optional[List] = None,
+                 structures: Optional['Structures'] = None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.main_program = main_program
+        self.function_definitions = function_definitions
+        self.subroutine_definitions = subroutine_definitions
+        self.modules = modules
+        self.module_declarations = module_declarations
+        self.structures = structures
+        self.placeholders = placeholders
+        self.placeholders_offsets = placeholders_offsets
+
     _attributes = ()
     _fields = (
-        "main_program",
-        "function_definitions",
-        "subroutine_definitions",
-        "modules",
+        'main_program',
+        'function_definitions',
+        'subroutine_definitions',
+        'modules',
     )
 
 
@@ -67,25 +81,28 @@ class UnOp_Node(FNode):
         'postfix',
         'type',
     )
-    _fields = ('lval', )
+    _fields = ('lval',)
+
 
 class Exit_Node(FNode):
     _attributes = ()
     _fields = ()
 
+
 class Main_Program_Node(FNode):
-    _attributes = ("name", )
+    _attributes = ("name",)
     _fields = ("execution_part", "specification_part")
 
 
 class Module_Node(FNode):
-    _attributes = ('name', )
+    _attributes = ('name',)
     _fields = (
         'specification_part',
         'subroutine_definitions',
         'function_definitions',
         'interface_blocks'
     )
+
 
 class Module_Subprogram_Part_Node(FNode):
     _attributes = ()
@@ -94,11 +111,13 @@ class Module_Subprogram_Part_Node(FNode):
         'function_definitions',
     )
 
+
 class Actual_Arg_Spec_Node(FNode):
     _fields = (
         'arg_name'
         'arg',
     )
+
 
 class Function_Subprogram_Node(FNode):
     _attributes = ('name', 'type', 'ret_name')
@@ -119,45 +138,53 @@ class Subroutine_Subprogram_Node(FNode):
         'execution_part',
     )
 
+
 class Interface_Block_Node(FNode):
     _attributes = ('name')
     _fields = (
         'subroutines',
     )
 
+
 class Interface_Stmt_Node(FNode):
     _attributes = ()
     _fields = ()
+
 
 class Procedure_Name_List_Node(FNode):
     _attributes = ()
     _fields = ('subroutines')
 
+
 class Procedure_Statement_Node(FNode):
     _attributes = ()
     _fields = ('namelists')
+
 
 class Module_Stmt_Node(FNode):
     _attributes = ()
     _fields = ('functions')
 
+
 class Program_Stmt_Node(FNode):
-    _attributes = ('name', )
+    _attributes = ('name',)
     _fields = ()
 
 
 class Subroutine_Stmt_Node(FNode):
-    _attributes = ('name', )
-    _fields = ('args', )
+    _attributes = ('name',)
+    _fields = ('args',)
 
 
 class Function_Stmt_Node(FNode):
-    _attributes = ('name', )
+    _attributes = ('name',)
     _fields = ('args', 'ret')
 
+
 class Prefix_Node(FNode):
-    _attributes = ('elemental', )
+    _attributes = ('elemental',)
     _fields = ()
+
 
 class Name_Node(FNode):
     _attributes = ('name', 'type')
@@ -181,20 +208,20 @@ class Generic_Binding_Node(FNode):
     _fields = ('name', 'binding')
 
 class Specification_Part_Node(FNode):
-    _fields = ('specifications', 'symbols', 'interface_blocks', 'typedecls','enums')
+    _fields = ('specifications', 'symbols', 'interface_blocks', 'typedecls', 'enums')
 
 class Stop_Stmt_Node(FNode):
     _attributes = ('code')
 
 class Error_Stmt_Node(FNode):
-    _fields = ('error')    
+    _fields = ('error')
 
 class Execution_Part_Node(FNode):
-    _fields = ('execution', )
+    _fields = ('execution',)
 
 
 class Statement_Node(FNode):
-    _attributes = ('col_offset', )
+    _attributes = ('col_offset',)
     _fields = ()
 
 
@@ -203,7 +230,7 @@ class Array_Subscript_Node(FNode):
         'name',
         'type',
     )
-    _fields = ('indices', )
+    _fields = ('indices',)
 
 
 class Type_Decl_Node(Statement_Node):
@@ -216,25 +243,27 @@ class Type_Decl_Node(Statement_Node):
 
 class Allocate_Shape_Spec_Node(FNode):
     _attributes = ()
-    _fields = ('sizes', )
+    _fields = ('sizes',)
 
 
 class Allocate_Shape_Spec_List(FNode):
     _attributes = ()
-    _fields = ('shape_list', )
+    _fields = ('shape_list',)
 
 
 class Allocation_Node(FNode):
-    _attributes = ('name', )
-    _fields = ('shape', )
+    _attributes = ('name',)
+    _fields = ('shape',)
+
 
 class Continue_Node(FNode):
     _attributes = ()
     _fields = ()
 
+
 class Allocate_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('allocation_list', )
+    _fields = ('allocation_list',)
 
 
 class Symbol_Decl_Node(Statement_Node):
@@ -282,21 +311,21 @@ class Var_Decl_Node(Statement_Node):
 
 
 class Arg_List_Node(FNode):
-    _fields = ('args', )
+    _fields = ('args',)
 
 
 class Component_Spec_List_Node(FNode):
-    _fields = ('args', )
+    _fields = ('args',)
 
 class Allocate_Object_List_Node(FNode):
     _fields = ('list', )
 
 class Deallocate_Stmt_Node(FNode):
-    _fields = ('list', )    
+    _fields = ('list', )
 
 class Decl_Stmt_Node(Statement_Node):
     _attributes = ()
-    _fields = ('vardecl', )
+    _fields = ('vardecl',)
 
 
 class VarType:
@@ -308,31 +337,38 @@ class Void(VarType):
 
 
 class Literal(FNode):
-    _attributes = ('value', )
+    _attributes = ('value',)
     _fields = ()
 
 
 class Int_Literal_Node(Literal):
     pass
 
+
 class Real_Literal_Node(Literal):
     pass
+
 
 class Double_Literal_Node(Literal):
     pass
 
+
 class Bool_Literal_Node(Literal):
     pass
+
 
 class String_Literal_Node(Literal):
     pass
 
+
 class Char_Literal_Node(Literal):
     pass
+
 
 class Suffix_Node(FNode):
     _attributes = ()
     _fields = ('name')
+
 
 class Call_Expr_Node(FNode):
     _attributes = ('type', 'subroutine')
@@ -343,23 +379,23 @@ class Call_Expr_Node(FNode):
 
 
 class Derived_Type_Stmt_Node(FNode):
-    _attributes = ('name', )
-    _fields = ('args', )
+    _attributes = ('name',)
+    _fields = ('args',)
 
 
 class Derived_Type_Def_Node(FNode):
-    _attributes = ('name', )
-    _fields = ('component_part','procedure_part' )
+    _attributes = ('name',)
+    _fields = ('component_part', 'procedure_part')
 
 
 class Component_Part_Node(FNode):
     _attributes = ()
-    _fields = ('component_def_stmts', )
+    _fields = ('component_def_stmts',)
 
 
 class Data_Component_Def_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('vars', )
+    _fields = ('vars',)
 
 
 class Data_Ref_Node(FNode):
@@ -369,12 +405,12 @@ class Data_Ref_Node(FNode):
 
 class Array_Constructor_Node(FNode):
     _attributes = ()
-    _fields = ('value_list', )
+    _fields = ('value_list',)
 
 
 class Ac_Value_List_Node(FNode):
     _attributes = ()
-    _fields = ('value_list', )
+    _fields = ('value_list',)
 
 
 class Section_Subscript_List_Node(FNode):
@@ -414,21 +450,26 @@ class If_Stmt_Node(FNode):
         'body_else',
     )
 
+
 class Defer_Shape_Node(FNode):
     _attributes = ()
-    _fields = ()    
+    _fields = ()
+
 
 class Component_Initialization_Node(FNode):
     _attributes = ()
     _fields = ('init')
 
+
 class Case_Cond_Node(FNode):
     _fields = ('cond', 'op')
-    _attributes = ()    
+    _attributes = ()
+
 
 class Else_Separator_Node(FNode):
     _attributes = ()
     _fields = ()
+
 
 class Procedure_Separator_Node(FNode):
     _attributes = ()
@@ -444,7 +485,7 @@ class Read_Stmt_Node(FNode):
 
 class Close_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('args')   
+    _fields = ('args')
 
 class Open_Stmt_Node(FNode):
     _attributes = ()
@@ -456,15 +497,15 @@ class Associate_Stmt_Node(FNode):
 
 class Associate_Construct_Node(FNode):
     _attributes = ()
-    _fields = ('associate', 'body')    
+    _fields = ('associate', 'body')
 
-class Association_List_Node(FNode):    
+class Association_List_Node(FNode):
     _attributes = ()
     _fields = ('list')
 
 class Association_Node(FNode):
     _attributes = ()
-    _fields = ('name', 'expr')    
+    _fields = ('name', 'expr')
 
 class Connect_Spec_Node(FNode):
     _attributes = ('type')
@@ -476,23 +517,23 @@ class Close_Spec_Node(FNode):
 
 class Close_Spec_List_Node(FNode):
     _attributes = ()
-    _fields = ('list')      
+    _fields = ('list')
 
 class IO_Control_Spec_Node(FNode):
     _attributes = ('type')
-    _fields = ('args')    
+    _fields = ('args')
 
 class IO_Control_Spec_List_Node(FNode):
     _attributes = ()
-    _fields = ('list')    
+    _fields = ('list')
 
 class Connect_Spec_List_Node(FNode):
     _attributes = ()
-    _fields = ('list')    
+    _fields = ('list')
 
 class Nullify_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('list')    
+    _fields = ('list')
 
 class Namelist_Stmt_Node(FNode):
     _attributes = ()
@@ -507,9 +548,11 @@ class Bound_Procedures_Node(FNode):
     _attributes = ()
     _fields = ('procedures')
 
+
 class Specific_Binding_Node(FNode):
     _attributes = ()
-    _fields = ('name', 'args')    
+    _fields = ('name', 'args')
+
 
 class Parenthesis_Expr_Node(FNode):
     _attributes = ()
@@ -524,6 +567,7 @@ class Nonlabel_Do_Stmt_Node(FNode):
         'iter',
     )
 
+
 class While_True_Control(FNode):
     _attributes = ()
     _fields = (
@@ -537,12 +581,14 @@ class While_Control(FNode):
         'cond',
     )
 
+
 class While_Stmt_Node(FNode):
     _attributes = ('name')
     _fields = (
         'body',
         'cond',
     )
+
 
 class Loop_Control_Node(FNode):
     _attributes = ()
@@ -555,35 +601,38 @@ class Loop_Control_Node(FNode):
 
 class Else_If_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('cond', )
+    _fields = ('cond',)
 
 
 class Only_List_Node(FNode):
     _attributes = ()
-    _fields = ('names','renames', )
+    _fields = ('names', 'renames',)
+
 
 class Rename_Node(FNode):
     _attributes = ()
-    _fields = ('oldname', 'newname', )
+    _fields = ('oldname', 'newname',)
+
 
 class ParDecl_Node(FNode):
-    _attributes = ('type', )
-    _fields = ('range', )
+    _attributes = ('type',)
+    _fields = ('range',)
 
 
 class Structure_Constructor_Node(FNode):
-    _attributes = ('type', )
+    _attributes = ('type',)
     _fields = ('name', 'args')
 
 
 class Use_Stmt_Node(FNode):
-    _attributes = ('name','list_all' )
-    _fields = ('list', )
+    _attributes = ('name', 'list_all')
+    _fields = ('list',)
 
 
 class Write_Stmt_Node(FNode):
     _attributes = ()
-    _fields = ('args', )
+    _fields = ('args',)
+
 
 class Break_Node(FNode):
     _attributes = ()

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -1616,12 +1616,11 @@ def functionStatementEliminator(node=ast_internal_classes.Program_Node):
                 subroutine_definitions=module_subroutine_definitions,
                 function_definitions=module_function_definitions,
             ))
-    return ast_internal_classes.Program_Node(main_program=main_program,
-                                             function_definitions=function_definitions,
-                                             subroutine_definitions=subroutine_definitions,
-                                             modules=modules,
-                                             module_declarations=node.module_declarations,
-                                             structures=node.structures)
+    node.main_program = main_program
+    node.function_definitions = function_definitions
+    node.subroutine_definitions = subroutine_definitions
+    node.modules = modules
+    return node
 
 
 def localFunctionStatementEliminator(node: ast_internal_classes.FNode):

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -3474,7 +3474,6 @@ def create_sdfg_from_fortran_file_with_options(source_string: str, source_list, 
         if i in ["mtime", "ISO_C_BINDING", "iso_c_binding", "mo_cdi", "iso_fortran_env"]:
             continue
 
-        partial_ast.add_name_list_for_module(i, name_dict[i])
         # try:
         partial_module = partial_ast.create_ast(asts[i.lower()])
         partial_modules[partial_module.name.name] = partial_module


### PR DESCRIPTION
Additionally:
- Introduce explicit constructor for `Program_Node`, since it allows for better tracking of what are the member variables. We want to do this for all of the ~84 classes in the `ast_internal_classes.py`, but for now we start with just one.