### PR TITLE
Size in `new[]` explicitly casted to `size_t`

### DIFF
--- a/dace/codegen/instrumentation/data/data_dump.py
+++ b/dace/codegen/instrumentation/data/data_dump.py
@@ -45,7 +45,7 @@ class DataInstrumentationProviderMixin:
         # Emit synchronous memcpy
         preamble = f'''
         {{
-        {new_desc.as_arg(name=new_ptr)} = new {desc.dtype.ctype}[{csize}];
+        {new_desc.as_arg(name=new_ptr)} = new {desc.dtype.ctype}[std::size_t({csize})];
         {self.backend}Memcpy({new_ptr}, {ptr}, sizeof({desc.dtype.ctype}) * ({csize}), {self.backend}MemcpyDeviceToHost);
         '''
 
@@ -65,7 +65,7 @@ class DataInstrumentationProviderMixin:
         # Emit synchronous memcpy
         preamble = f'''
         {{
-        {new_desc.as_arg(name=new_ptr)} = new {desc.dtype.ctype}[{csize}];
+        {new_desc.as_arg(name=new_ptr)} = new {desc.dtype.ctype}[std::size_t({csize})];
         '''
 
         postamble = f'''

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -498,7 +498,7 @@ class CPUCodeGen(TargetCodeGenerator):
             if not declared:
                 declaration_stream.write(f'{nodedesc.dtype.ctype} *{name};\n', cfg, state_id, node)
             allocation_stream.write(
-                "%s = new %s DACE_ALIGN(64)[%s];\n" % (alloc_name, nodedesc.dtype.ctype, cpp.sym2cpp(arrsize)), cfg,
+                    "%s = new %s DACE_ALIGN(64)[std::size_t(%s)];\n" % (alloc_name, nodedesc.dtype.ctype, cpp.sym2cpp(arrsize)), cfg,
                 state_id, node)
             define_var(name, DefinedType.Pointer, ctypedef)
 
@@ -548,7 +548,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 """
                 #pragma omp parallel
                 {{
-                    {name} = new {ctype} DACE_ALIGN(64)[{arrsize}];""".format(ctype=nodedesc.dtype.ctype,
+                    {name} = new {ctype} DACE_ALIGN(64)[std::size_t({arrsize})];""".format(ctype=nodedesc.dtype.ctype,
                                                                               name=alloc_name,
                                                                               arrsize=cpp.sym2cpp(arrsize)),
                 cfg,

--- a/dace/codegen/targets/snitch.py
+++ b/dace/codegen/targets/snitch.py
@@ -408,7 +408,7 @@ class SnitchCodeGen(TargetCodeGenerator):
                     #pragma omp parallel
                     {{
                         #error "malloc is not threadsafe"
-                        {name} = new {ctype} [{arrsize}];""".format(ctype=nodedesc.dtype.ctype,
+                        {name} = new {ctype} [std::size_t({arrsize})];""".format(ctype=nodedesc.dtype.ctype,
                                                                     name=alloc_name,
                                                                     arrsize=cpp.sym2cpp(arrsize)),
                     cfg,
@@ -1108,6 +1108,7 @@ class SnitchCodeGen(TargetCodeGenerator):
 
         # change new/delete to malloc/free
         code._code = re.sub(r"new (.+) \[(\d*)\];", r"(\1*)malloc(\2*sizeof(\1));", code._code)
+        code._code = re.sub(r"new (.+) \[std::size_t\((\d*)\)\];", r"(\1*)malloc(\2*sizeof(\1));", code._code)
         code._code = re.sub(r"new ([a-zA-Z0-9 _]*);", r"(\1*)malloc(sizeof(\1));", code._code)
         code._code = re.sub(r"delete (.*);", r"free(\1);", code._code)
         code._code = re.sub(r"delete\[\] (.*);", r"free(\1);", code._code)

--- a/tests/npbench/misc/stockham_fft_test.py
+++ b/tests/npbench/misc/stockham_fft_test.py
@@ -155,12 +155,10 @@ def run_stockham_fft(device_type: dace.dtypes.DeviceType):
     return sdfg
 
 
-@pytest.mark.skip(reason="Assertion error in read_and_write_sets")
 def test_cpu():
     run_stockham_fft(dace.dtypes.DeviceType.CPU)
 
 
-@pytest.mark.skip(reason="Assertion error in read_and_write_sets")
 @pytest.mark.gpu
 def test_gpu():
     run_stockham_fft(dace.dtypes.DeviceType.GPU)


### PR DESCRIPTION
In [PR#1748](https://github.com/spcl/dace/pull/1748) we tried to enable the Stockham FFT tests.
Their problem is that the size of an array is given as `b**e` which the code generator translates to
```c++
new double [dace::math::pow(b, e)
```
currently, `pow` will generate a float, which leads to a compilation error.
In PR#1748, the solution was to specialize `pow` to handle this case.
But it was concluded that this was the wrong approach.
This is now the second attempt.