### PR TITLE
[Multi SDFG, Fortran, After PR#1774] New tests. In particular, now we can start testing the construction of internal SDFG.

### DIFF
--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -12,7 +12,7 @@ import networkx as nx
 from fparser.common.readfortran import FortranFileReader as ffr, FortranStringReader, FortranFileReader
 from fparser.common.readfortran import FortranStringReader as fsr
 from fparser.two.Fortran2003 import Program, Entity_Decl, Declaration_Type_Spec, Derived_Type_Def, End_Module_Stmt, \
-    Contains_Stmt, Rename, Name, Subroutine_Subprogram, Function_Subprogram
+    Contains_Stmt, Rename, Name, Subroutine_Subprogram, Function_Subprogram, Module, Main_Program
 from fparser.two.Fortran2008 import Type_Declaration_Stmt
 from fparser.two.parser import ParserFactory as pf, ParserFactory
 from fparser.two.symbol_table import SymbolTable
@@ -3040,6 +3040,10 @@ def prune_unused_children(ast: Program, simple_graph: nx.DiGraph, actually_used_
     top_level_ast: str = parse_order.pop() if parse_order else ast
     new_children = []
     for mod in ast.children:
+        if not isinstance(mod, (Module, Main_Program)):
+            # Leave it alone if it is not a module  or program node (e.g., a subroutine).
+            new_children.append(mod)
+            continue
         stmt, spec, exec = mod.children[0:3]
         mod_name = ast_utils.singular(ast_utils.children_of_type(stmt, Name)).string
         if mod_name not in parse_order and mod_name != top_level_ast:

--- a/tests/fortran/create_internal_ast_test.py
+++ b/tests/fortran/create_internal_ast_test.py
@@ -1,0 +1,228 @@
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+from typing import Dict
+
+from dace.frontend.fortran.ast_internal_classes import Program_Node, Main_Program_Node, Subroutine_Subprogram_Node, \
+    Module_Node
+from dace.frontend.fortran.ast_transforms import Structures
+from dace.frontend.fortran.fortran_parser import ParseConfig, create_internal_ast
+from tests.fortran.fotran_test_helper import SourceCodeBuilder, InternalASTMatcher as M
+
+
+def construct_internal_ast(sources: Dict[str, str]):
+    assert 'main.f90' in sources
+    cfg = ParseConfig(sources['main.f90'], sources, [])
+    iast, prog = create_internal_ast(cfg)
+    return iast, prog
+
+
+def test_minimal():
+    """
+    A simple program to just verify that we can produce compilable SDFGs.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+program main
+  implicit none
+  double precision d(4)
+  d(2) = 5.5
+end program main
+subroutine fun(d)
+  implicit none
+  double precision, intent(inout) :: d(4)
+  d(2) = 4.2
+end subroutine fun
+""").check_with_gfortran().get()
+    # Construct
+    iast, prog = construct_internal_ast(sources)
+
+    # Verify
+    assert not iast.fortran_intrinsics().transformations()
+    m = M(Program_Node, has_attr={
+        'main_program': M(Main_Program_Node),
+        'subroutine_definitions': [
+            M(Subroutine_Subprogram_Node, {
+                'name': M.NAMED('fun'),
+                'args': [M.NAMED('d')],
+            }),
+        ],
+        'structures': M(Structures, has_empty_attr={'structures'})
+    }, has_empty_attr={'function_definitions', 'modules', 'placeholders', 'placeholders_offsets'})
+    m.check(prog)
+
+
+def test_standalone_subroutines():
+    """
+    A standalone subroutine, with no program or module in sight.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine fun(d)
+  implicit none
+  double precision, intent(inout) :: d(4)
+  d(2) = 4.2
+end subroutine fun
+
+subroutine not_fun(d, val)
+  implicit none
+  double precision, intent(in) :: val
+  double precision, intent(inout) :: d(4)
+  d(4) = val
+end subroutine not_fun
+""").check_with_gfortran().get()
+    # Construct
+    iast, prog = construct_internal_ast(sources)
+
+    # Verify
+    assert not iast.fortran_intrinsics().transformations()
+    m = M(Program_Node, has_attr={
+        'subroutine_definitions': [
+            M(Subroutine_Subprogram_Node, {
+                'name': M.NAMED('fun'),
+                'args': [M.NAMED('d')],
+            }),
+            M(Subroutine_Subprogram_Node, {
+                'name': M.NAMED('not_fun'),
+                'args': [M.NAMED('d'), M.NAMED('val')],
+            }),
+        ],
+        'structures': M(Structures, has_empty_attr={'structures'})
+    }, has_empty_attr={'main_program', 'function_definitions', 'modules', 'placeholders', 'placeholders_offsets'})
+    m.check(prog)
+
+
+def test_subroutines_from_module():
+    """
+    A standalone subroutine, with no program or module in sight.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+contains
+  subroutine fun(d)
+    implicit none
+    double precision, intent(inout) :: d(4)
+    d(2) = 4.2
+  end subroutine fun
+
+  subroutine not_fun(d, val)
+    implicit none
+    double precision, intent(in) :: val
+    double precision, intent(inout) :: d(4)
+    d(4) = val
+  end subroutine not_fun
+end module lib
+""").add_file("""
+program main
+  use lib
+  implicit none
+end program main
+""").check_with_gfortran().get()
+    # Construct
+    iast, prog = construct_internal_ast(sources)
+
+    # Verify
+    assert not iast.fortran_intrinsics().transformations()
+    m = M(Program_Node, has_attr={
+        'main_program': M(Main_Program_Node),
+        'modules': [M(Module_Node, has_attr={
+            'subroutine_definitions': [
+                M(Subroutine_Subprogram_Node, {
+                    'name': M.NAMED('fun'),
+                    'args': [M.NAMED('d')],
+                }),
+                M(Subroutine_Subprogram_Node, {
+                    'name': M.NAMED('not_fun'),
+                    'args': [M.NAMED('d'), M.NAMED('val')],
+                }),
+            ],
+        }, has_empty_attr={'function_definitions', 'interface_blocks'})],
+        'structures': M(Structures, has_empty_attr={'structures'})
+    }, has_empty_attr={'function_definitions', 'subroutine_definitions', 'placeholders', 'placeholders_offsets'})
+    m.check(prog)
+
+
+def test_subroutine_with_local_variable():
+    """
+    A standalone subroutine, with no program or module in sight.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine fun(d)
+  implicit none
+  double precision, intent(inout) :: d(4)
+  double precision :: e(4)
+  e(:) = 1.0
+  e(2) = 4.2
+  d(:) = e(:)
+end subroutine fun
+""").check_with_gfortran().get()
+    # Construct
+    iast, prog = construct_internal_ast(sources)
+
+    # Verify
+    assert not iast.fortran_intrinsics().transformations()
+    m = M(Program_Node, has_attr={
+        'subroutine_definitions': [
+            M(Subroutine_Subprogram_Node, {
+                'name': M.NAMED('fun'),
+                'args': [M.NAMED('d')],
+            }),
+        ],
+        'structures': M(Structures, has_empty_attr={'structures'})
+    }, has_empty_attr={'main_program', 'function_definitions', 'modules', 'placeholders', 'placeholders_offsets'})
+    m.check(prog)
+
+
+def test_subroutine_contains_function():
+    """
+    A function is defined inside a subroutine that calls it. A main program uses the top-level subroutine.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+contains
+  subroutine fun(d)
+    implicit none
+    double precision d(4)
+    d(2) = fun2()
+
+  contains
+    real function fun2()
+      implicit none
+      fun2 = 5.5
+    end function fun2
+  end subroutine fun
+end module lib
+""").add_file("""
+program main
+  use lib, only: fun
+  implicit none
+
+  double precision d(4)
+  call fun(d)
+end program main
+""").check_with_gfortran().get()
+    # Construct
+    iast, prog = construct_internal_ast(sources)
+    # Verify
+    assert not iast.fortran_intrinsics().transformations()
+    m = M(Program_Node, has_attr={
+        'main_program': M(Main_Program_Node),
+        'modules': [M(Module_Node, has_attr={
+            'subroutine_definitions': [
+                M(Subroutine_Subprogram_Node, {
+                    'name': M.NAMED('fun'),
+                    'args': [M.NAMED('d')],
+                }),
+            ],
+        }, has_empty_attr={'function_definitions', 'interface_blocks'})],
+        'structures': M(Structures, has_empty_attr={'structures'})
+    }, has_empty_attr={'function_definitions', 'subroutine_definitions', 'placeholders', 'placeholders_offsets'})
+    m.check(prog)
+
+    # TODO: We cannot handle during the internal AST construction (it works just fine before during parsing etc.) when a
+    #  subroutine contains other subroutines. This needs to be fixed.
+    mod = prog.modules[0]
+    # Where could `fun2`'s definition could be?
+    assert not mod.function_definitions  # Not here!
+    assert 'fun2' not in [f.name.name for f in mod.subroutine_definitions]  # Not here!
+    fn = mod.subroutine_definitions[0]
+    assert not hasattr(fn, 'function_definitions')  # Not here!
+    assert not hasattr(fn, 'subroutine_definitions')  # Not here!

--- a/tests/fortran/fotran_test_helper.py
+++ b/tests/fortran/fotran_test_helper.py
@@ -54,7 +54,7 @@ class SourceCodeBuilder:
                     f.write(content)
             # Run `gfortran -Wall` to verify that it compiles.
             # Note: we're relying on the fact that python dictionaries keeps the insertion order when calling `keys()`.
-            cmd = ['gfortran', '-Wall', '-c', *self.sources.keys()]
+            cmd = ['gfortran', '-Wall', '-shared', *self.sources.keys()]
             subprocess.run(cmd, cwd=td, capture_output=True).check_returncode()
             return self
 
@@ -214,7 +214,7 @@ class InternalASTMatcher:
 
     def __init__(self,
                  is_type: Optional[Type] = None,
-                 has_attr: Optional[Dict[str, Union[Self, List[Self]]]] = None,
+                 has_attr: Optional[Dict[str, Union[Self, List[Self], Dict[str, Self]]]] = None,
                  has_empty_attr: Optional[Collection[str]] = None,
                  has_value: Optional[LiteralString] = None):
         # TODO: Include Set[Self] to `has_children` type?
@@ -243,6 +243,12 @@ class InternalASTMatcher:
                     assert len(attr) == len(subm), f"{attr} must have the same length as {subm}."
                     for (c, m) in zip(attr, subm):
                         m.check(c)
+                elif isinstance(subm, Dict):
+                    assert isinstance(attr, Dict)
+                    assert len(attr) == len(subm)
+                    assert subm.keys() <= attr.keys()
+                    for k in subm.keys():
+                        subm[k].check(attr[k])
                 else:
                     subm.check(attr)
 


### PR DESCRIPTION
Testing the internal SDFG construction will allow us to verify if the transforms that follow at least start from a valid input state. One of the added tests (`test_subroutine_contains_function()`) already demonstrates that the construction is not always correct.