### PR TITLE
Symbol redeclaration fix

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -334,7 +334,7 @@ class CPUCodeGen(TargetCodeGenerator):
 
             ctypedef = dtypes.pointer(nodedesc.dtype).ctype
 
-            declaration_stream.write(f'{nodedesc.dtype.ctype} *{name} = nullptr;\n', cfg, state_id, node)
+            declaration_stream.write(f'{nodedesc.dtype.ctype} *{name} = nullptr;//u2\n', cfg, state_id, node)
             self._dispatcher.declared_arrays.add(name, DefinedType.Pointer, ctypedef)
             return
         elif nodedesc.storage is dtypes.StorageType.CPU_ThreadLocal:
@@ -421,9 +421,9 @@ class CPUCodeGen(TargetCodeGenerator):
                                            allocation_stream)
         if isinstance(nodedesc, data.Scalar):
             if node.setzero:
-                declaration_stream.write("%s %s = 0;\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
+                declaration_stream.write("%s %s = 0; //u1\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
             else:
-                declaration_stream.write("%s %s;\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
+                declaration_stream.write("%s %s;//u1\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
             define_var(name, DefinedType.Scalar, nodedesc.dtype.ctype)
         elif isinstance(nodedesc, data.Stream):
             ###################################################################

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -421,9 +421,9 @@ class CPUCodeGen(TargetCodeGenerator):
                                            allocation_stream)
         if isinstance(nodedesc, data.Scalar):
             if node.setzero:
-                declaration_stream.write("%s %s = 0; //u1\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
+                declaration_stream.write("%s %s = 0;\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
             else:
-                declaration_stream.write("%s %s;//u1\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
+                declaration_stream.write("%s %s;\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
             define_var(name, DefinedType.Scalar, nodedesc.dtype.ctype)
         elif isinstance(nodedesc, data.Stream):
             ###################################################################

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -334,7 +334,7 @@ class CPUCodeGen(TargetCodeGenerator):
 
             ctypedef = dtypes.pointer(nodedesc.dtype).ctype
 
-            declaration_stream.write(f'{nodedesc.dtype.ctype} *{name} = nullptr;//u2\n', cfg, state_id, node)
+            declaration_stream.write(f'{nodedesc.dtype.ctype} *{name} = nullptr;\n', cfg, state_id, node)
             self._dispatcher.declared_arrays.add(name, DefinedType.Pointer, ctypedef)
             return
         elif nodedesc.storage is dtypes.StorageType.CPU_ThreadLocal:

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -896,7 +896,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
         # Allocate outer-level transients
         self.allocate_arrays_in_scope(sdfg, sdfg, sdfg, global_stream, callsite_stream)
 
-        global_args = sdfg.arglist()
+        outside_symbols = sdfg.free_symbols
 
         # Define constants as top-level-allocated
         for cname, (ctype, _) in sdfg.constants_prop.items():
@@ -956,7 +956,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
                 self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType.ctype)
             else:
                 # If the variable is passed as an input argument to the SDFG, do not need to declare it
-                if isvarName not in global_args:
+                if isvarName not in outside_symbols:
                     callsite_stream.write('%s;\n' % (isvar.as_arg(with_types=True, name=isvarName)), sdfg)
                     self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType.ctype)
         callsite_stream.write('\n', sdfg)

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -896,7 +896,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
         # Allocate outer-level transients
         self.allocate_arrays_in_scope(sdfg, sdfg, sdfg, global_stream, callsite_stream)
 
-        outside_symbols = sdfg.free_symbols
+        outside_symbols = sdfg.free_symbols if is_top_level else set()
 
         # Define constants as top-level-allocated
         for cname, (ctype, _) in sdfg.constants_prop.items():

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -959,8 +959,6 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
                 if isvarName not in outside_symbols:
                     callsite_stream.write('%s;\n' % (isvar.as_arg(with_types=True, name=isvarName)), sdfg)
                     self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType.ctype)
-                else:
-                    callsite_stream.write('//%s;\n' % (isvar.as_arg(with_types=True, name=isvarName)), sdfg)
         callsite_stream.write('\n', sdfg)
 
         #######################################################################

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -896,7 +896,7 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
         # Allocate outer-level transients
         self.allocate_arrays_in_scope(sdfg, sdfg, sdfg, global_stream, callsite_stream)
 
-        outside_symbols = sdfg.free_symbols if is_top_level else set()
+        outside_symbols = sdfg.arglist() if is_top_level else set()
 
         # Define constants as top-level-allocated
         for cname, (ctype, _) in sdfg.constants_prop.items():
@@ -959,6 +959,8 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
                 if isvarName not in outside_symbols:
                     callsite_stream.write('%s;\n' % (isvar.as_arg(with_types=True, name=isvarName)), sdfg)
                     self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType.ctype)
+                else:
+                    callsite_stream.write('//%s;\n' % (isvar.as_arg(with_types=True, name=isvarName)), sdfg)
         callsite_stream.write('\n', sdfg)
 
         #######################################################################

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -314,8 +314,6 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
                 symbols[str(sym)] = sym.dtype
         validate_control_flow_region(sdfg, sdfg, initialized_transients, symbols, references, **context)
 
-        # If a symbol used for the size of an array, but is assigned on an interstate edge, issue a warning
-        _check_symbol_assignments_and_array_size(sdfg)
 
     except InvalidSDFGError as ex:
         # If the SDFG is invalid, save it
@@ -323,30 +321,6 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
         sdfg.save(fpath, exception=ex, compress=True)
         ex.path = fpath
         raise
-
-def _check_symbol_assignments_and_array_size(sdfg):
-    arrs = sdfg.arrays.values()
-    symbols_used_for_size = set()
-    for arr in arrs:
-        for s in arr.shape:
-            if isinstance(s, symbolic.SymExpr) or isinstance(s, symbolic.symbol):
-                symbols_used_for_size.add(s)
-
-    symbol_assignments = defaultdict(int)
-    for e in sdfg.edges():
-        for key in e.data.assignments.keys():
-            symbol_assignments[key] += 1
-    for arg in sdfg.arglist():
-        symbol_assignments[arg] += 1
-
-    reassigned_symbols = {key: value for key, value in symbol_assignments.items() if value > 1}
-
-    reassigned_size_symbols = set.union(symbols_used_for_size, reassigned_symbols)
-
-    if len(reassigned_symbols) > 0:
-        warnings.warn(f'WARNING: The following symbols used to determine the sizes of arrays ({reassigned_size_symbols}) '
-                    f' are re-assigned (multiple interstate assignments and counts: {reassigned_symbols}) on interstate edges '
-                    f' if the symbol is passed to the SDFG it counts as one assignment')
 
 def _accessible(sdfg: 'dace.sdfg.SDFG', container: str, context: Dict[str, bool]):
     """
@@ -462,7 +436,6 @@ def validate_state(state: 'dace.sdfg.SDFGState',
         try:
             if isinstance(node, nd.NestedSDFG):
                 node.validate(sdfg, state, references, **context)
-                _check_symbol_assignments_and_array_size(node.sdfg)
             else:
                 node.validate(sdfg, state)
         except InvalidSDFGError:

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -335,11 +335,9 @@ def _check_symbol_assignments_and_array_size(sdfg):
     symbol_assignments = defaultdict(int)
     for e in sdfg.edges():
         for key in e.data.assignments.keys():
-            symbol = symbolic.symbol(key)
-            symbol_assignments[symbol] += 1
+            symbol_assignments[key] += 1
     for arg in sdfg.arglist():
-        symbol = symbolic.symbol(arg)
-        symbol_assignments[symbol] += 1
+        symbol_assignments[arg] += 1
 
     reassigned_symbols = {key: value for key, value in symbol_assignments.items() if value > 1}
 

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -337,13 +337,18 @@ def _check_symbol_assignments_and_array_size(sdfg):
         for key in e.data.assignments.keys():
             symbol = symbolic.symbol(key)
             symbol_assignments[symbol] += 1
+    for arg in sdfg.arglist():
+        symbol = symbolic.symbol(arg)
+        symbol_assignments[symbol] += 1
 
     reassigned_symbols = {key: value for key, value in symbol_assignments.items() if value > 1}
 
     reassigned_size_symbols = set.union(symbols_used_for_size, reassigned_symbols)
 
-    warnings.warn(f'WARNING: The following symbols used to determine the sizes of arrays ({reassigned_size_symbols}) '
-                  f' are re-assigned (multiple interstate assignments and counts: {reassigned_symbols}) on interstate edges')
+    if len(reassigned_symbols) > 0:
+        warnings.warn(f'WARNING: The following symbols used to determine the sizes of arrays ({reassigned_size_symbols}) '
+                    f' are re-assigned (multiple interstate assignments and counts: {reassigned_symbols}) on interstate edges '
+                    f' if the symbol is passed to the SDFG it counts as one assignment')
 
 def _accessible(sdfg: 'dace.sdfg.SDFG', container: str, context: Dict[str, bool]):
     """

--- a/tests/interstate_assignment_test.py
+++ b/tests/interstate_assignment_test.py
@@ -1,7 +1,5 @@
 from typing import Dict
-import warnings
 import dace
-import logging
 
 N = dace.symbol("N")
 
@@ -39,41 +37,14 @@ def _get_interstate_dependent_sdfg(assignments: Dict, symbols_at_start=False):
     sdfg.validate()
     return sdfg
 
-# Iteration space of maps
-# The number of maps
-# Number of nested maps
-# The number of loops
-# Volume to / out of maps
-# distribution of tasklets within maps
-# t
-
 def test_interstate_assignment():
     sdfg = _get_interstate_dependent_sdfg({"N": 5}, False)
-    with warnings.catch_warnings(record=True) as captured_warnings:
-        warnings.simplefilter("always")
-        sdfg.validate()
-        assert len(captured_warnings) > 0, "No warnings were raised"
-        matching_warnings = [
-            w for w in captured_warnings
-            if "symbols" in str(w.message) and issubclass(w.category, Warning)
-        ]
-        assert matching_warnings, "No warning with 'symbols' found"
-    sdfg.save("s0.sdfg")
+    sdfg.validate()
     sdfg()
-
 
 def test_interstate_assignment_on_sdfg_input():
     sdfg = _get_interstate_dependent_sdfg({"N": 5}, True)
-    with warnings.catch_warnings(record=True) as captured_warnings:
-        warnings.simplefilter("always")
-        sdfg.validate()
-        assert len(captured_warnings) > 0, "No warnings were raised"
-        matching_warnings = [
-            w for w in captured_warnings
-            if "symbols" in str(w.message) and issubclass(w.category, Warning)
-        ]
-        assert matching_warnings, "No warning with 'symbols' found"
-    sdfg.save("s1.sdfg")
+    sdfg.validate()
     sdfg(N=10)
 
 if __name__ == "__main__":

--- a/tests/interstate_assignment_test.py
+++ b/tests/interstate_assignment_test.py
@@ -33,7 +33,6 @@ def _get_interstate_dependent_sdfg(assignments: Dict, symbols_at_start=False):
         s.add_edge(map_exit, f"OUT_array{sid}", an2, None, dace.memlet.Memlet(f"array{sid}[0:N]"))
 
     sdfg.add_edge(s1, s2, dace.InterstateEdge(None, assignments=assignments))
-    sdfg.save("s1.sdfg")
     sdfg.validate()
     return sdfg
 

--- a/tests/interstate_assignment_test.py
+++ b/tests/interstate_assignment_test.py
@@ -1,0 +1,81 @@
+from typing import Dict
+import warnings
+import dace
+import logging
+
+N = dace.symbol("N")
+
+def _get_interstate_dependent_sdfg(assignments: Dict, symbols_at_start=False):
+    sdfg = dace.SDFG("interstate_dependent")
+    for k in assignments:
+        sdfg.add_symbol(k, dace.int32)
+
+    s1 = sdfg.add_state("s1")
+    s2 = sdfg.add_state("s2")
+
+    if not symbols_at_start:
+        s0 = sdfg.add_state("s0")
+        pre_assignments = dict()
+        for k,v in assignments.items():
+            pre_assignments[k] = v*2
+        sdfg.add_edge(s0, s1, dace.InterstateEdge(None, assignments=pre_assignments))
+
+    for sid, s in [("1", s1), ("2", s2)]:
+        sdfg.add_array(f"array{sid}", (N, ) , dace.int32, storage=dace.StorageType.CPU_Heap, transient=True)
+        an = s.add_access(f"array{sid}")
+        an2 = s.add_access(f"array{sid}")
+        t = s.add_tasklet(f"tasklet{sid}", {"_in"}, {"_out"}, "_out = _in * 2")
+        map_entry, map_exit = s.add_map(f"map{sid}", {"i":dace.subsets.Range([(0,N-1,1)])})
+        for m in [map_entry, map_exit]:
+            m.add_in_connector(f"IN_array{sid}")
+            m.add_out_connector(f"OUT_array{sid}")
+        s.add_edge(an, None, map_entry, f"IN_array{sid}", dace.memlet.Memlet(f"array{sid}[0:N]"))
+        s.add_edge(map_entry, f"OUT_array{sid}", t, "_in", dace.memlet.Memlet(f"array{sid}[i]"))
+        s.add_edge(t, "_out", map_exit, f"IN_array{sid}", dace.memlet.Memlet(f"array{sid}[i]"))
+        s.add_edge(map_exit, f"OUT_array{sid}", an2, None, dace.memlet.Memlet(f"array{sid}[0:N]"))
+
+    sdfg.add_edge(s1, s2, dace.InterstateEdge(None, assignments=assignments))
+    sdfg.save("s1.sdfg")
+    sdfg.validate()
+    return sdfg
+
+# Iteration space of maps
+# The number of maps
+# Number of nested maps
+# The number of loops
+# Volume to / out of maps
+# distribution of tasklets within maps
+# t
+
+def test_interstate_assignment():
+    sdfg = _get_interstate_dependent_sdfg({"N": 5}, False)
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        sdfg.validate()
+        assert len(captured_warnings) > 0, "No warnings were raised"
+        matching_warnings = [
+            w for w in captured_warnings
+            if "symbols" in str(w.message) and issubclass(w.category, Warning)
+        ]
+        assert matching_warnings, "No warning with 'symbols' found"
+    sdfg.save("s0.sdfg")
+    sdfg()
+
+
+def test_interstate_assignment_on_sdfg_input():
+    sdfg = _get_interstate_dependent_sdfg({"N": 5}, True)
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        sdfg.validate()
+        assert len(captured_warnings) > 0, "No warnings were raised"
+        matching_warnings = [
+            w for w in captured_warnings
+            if "symbols" in str(w.message) and issubclass(w.category, Warning)
+        ]
+        assert matching_warnings, "No warning with 'symbols' found"
+    sdfg.save("s1.sdfg")
+    sdfg(N=10)
+
+if __name__ == "__main__":
+    test_interstate_assignment()
+    test_interstate_assignment_on_sdfg_input()


### PR DESCRIPTION
If a symbol is passed as an argument to the SDFG and assigned on an interstate edge, the framecode declares the scalar symbol again. This PR fixes that issue.

The case: If there is an interstate assignment on a variable, `N=5`, but if 'N` is also an input argument to the SDFG, then the generated code does not compile because `N` is redeclared.