### PR TITLE
[Multi SDFG, Fortran] Deconstruct all the class procedures of a Fortran program, right after parsing it in.

### DIFF
--- a/dace/frontend/fortran/ast_utils.py
+++ b/dace/frontend/fortran/ast_utils.py
@@ -982,7 +982,7 @@ def singular(items: Iterator[T]) -> T:
     raise ValueError(f"`items` must have only 1 item, got: {it}, {nit}, ...")
 
 
-def children_of_type(node: Base, typ: Union[str, Type[T]]) -> Iterator[T]:
+def children_of_type(node: Base, typ: Union[str, Type[T], Tuple[Type, ...]]) -> Iterator[T]:
     """
     Returns a generator over the children of `node` that are of type `typ`.
     """

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -9,14 +9,18 @@ from pathlib import Path
 from typing import List, Optional, Set, Dict, Tuple, Union
 
 import networkx as nx
+from fparser.api import get_reader
 from fparser.common.readfortran import FortranFileReader as ffr, FortranStringReader, FortranFileReader
 from fparser.common.readfortran import FortranStringReader as fsr
-from fparser.two.Fortran2003 import Program, Entity_Decl, Declaration_Type_Spec, Derived_Type_Def, End_Module_Stmt, \
-    Contains_Stmt, Rename, Name, Subroutine_Subprogram, Function_Subprogram, Module, Main_Program, Module_Stmt, \
-    Specification_Part, Execution_Part, Program_Stmt, Module_Subprogram_Part, Subroutine_Stmt, Function_Stmt
+from fparser.two.Fortran2003 import Program, Entity_Decl, Declaration_Type_Spec, Derived_Type_Def, Rename, Name, \
+    Subroutine_Subprogram, Function_Subprogram, Module, Main_Program, Module_Stmt, \
+    Specification_Part, Execution_Part, Program_Stmt, Module_Subprogram_Part, Subroutine_Stmt, Function_Stmt, \
+    Procedure_Designator, Function_Reference, Call_Stmt, Use_Stmt, Actual_Arg_Spec_List, Specific_Binding, \
+    Derived_Type_Stmt, Type_Name
 from fparser.two.Fortran2008 import Type_Declaration_Stmt
 from fparser.two.parser import ParserFactory as pf, ParserFactory
 from fparser.two.symbol_table import SymbolTable
+from fparser.two.utils import Base, walk
 
 import dace.frontend.fortran.ast_components as ast_components
 import dace.frontend.fortran.ast_internal_classes as ast_internal_classes
@@ -30,7 +34,7 @@ from dace import subsets as subs
 from dace import symbolic as sym
 from dace.data import Scalar, Structure
 from dace.frontend.fortran.ast_internal_classes import FNode, Main_Program_Node
-from dace.frontend.fortran.ast_utils import UseAllPruneList
+from dace.frontend.fortran.ast_utils import UseAllPruneList, get_defined_modules
 from dace.frontend.fortran.intrinsics import IntrinsicSDFGTransformation
 from dace.properties import CodeBlock
 
@@ -2540,6 +2544,10 @@ def create_internal_ast(cfg: ParseConfig) -> Tuple[ast_components.InternalFortra
     assert isinstance(ast, Program)
     assert not any(nx.simple_cycles(dep_graph))
 
+    ast, dep_graph = deconstruct_procedure_calls(ast, dep_graph)
+    assert isinstance(ast, Program)
+    assert not any(nx.simple_cycles(dep_graph))
+
     simple_graph, actually_used_in_module = simplified_dependency_graph(dep_graph, interface_blocks)
     prune_unused_children(ast, simple_graph, actually_used_in_module)
     assert isinstance(ast, Program)
@@ -2868,7 +2876,104 @@ def create_sdfg_from_fortran_file(source_string: str):
     return sdfg
 
 
-def recursive_ast_improver(ast, source_list: Union[List, Dict], include_list, parser):
+def procedure_specs(ast: Program) -> Dict[Tuple[str, ...], Tuple[str, ...]]:
+    proc_map: Dict[Tuple[str, ...], Tuple[str, ...]] = {}
+    for pb in walk(ast, Specific_Binding):
+        # Ref: https://github.com/stfc/fparser/blob/8c870f84edbf1a24dfbc886e2f7226d1b158d50b/src/fparser/two/Fortran2003.py#L2504
+        iname, mylist, dcolon, bname, pname = pb.children
+
+        proc_spec, subp_spec = [bname.string], [pname.string if pname else bname.string]
+
+        typedef: Derived_Type_Def = pb.parent.parent
+        typedef_stmt: Derived_Type_Stmt = ast_utils.singular(ast_utils.children_of_type(typedef, Derived_Type_Stmt))
+        typedef_name: str = ast_utils.singular(ast_utils.children_of_type(typedef_stmt, Type_Name)).string
+        proc_spec.insert(0, typedef_name)
+
+        # TODO: Generalize.
+        # We assume that the type is defined inside a module (i.e., not another subprogram).
+        mod: Module = typedef.parent.parent
+        mod_stmt: Module_Stmt = ast_utils.singular(ast_utils.children_of_type(mod, Module_Stmt))
+        mod_name: str = ast_utils.singular(ast_utils.children_of_type(mod_stmt, Name)).string
+        proc_spec.insert(0, mod_name)
+        subp_spec.insert(0, mod_name)
+
+        # TODO: Is this assumption true?
+        # We assume that the type and the bound function exist in the same scope (i.e., module, subprogram etc.).
+        proc_map[tuple(proc_spec)] = tuple(subp_spec)
+    return proc_map
+
+
+def deconstruct_procedure_calls(ast: Program, dep_graph: nx.DiGraph) -> Program:
+    proc_map = procedure_specs(ast)
+    for pd in walk(ast, Procedure_Designator):
+        # TODO:
+        #  1. Find the specification part where `dref` would live and where we would insert `use`.
+        #  2. Find the type of `dref`.
+        #  3. Find the bound subprogram from the type of `dref`.
+        #  4. Insert an `use` for that bound subprogram.
+
+        # Ref: https://github.com/stfc/fparser/blob/master/src/fparser/two/Fortran2003.py#L12530
+        dref, op, bname = pd.children
+
+        callsite = pd.parent
+        assert isinstance(callsite, (Function_Reference, Call_Stmt))
+
+        cmod = callsite.parent
+        while cmod and not isinstance(cmod, (Module, Main_Program)):
+            cmod = cmod.parent
+        if cmod:
+            stmt, _, _, _ = _get_module_or_program_parts(cmod)
+            cmod = ast_utils.singular(ast_utils.children_of_type(stmt, Name)).string.lower()
+        else:
+            subp = list(ast_utils.children_of_type(ast, Subroutine_Subprogram))
+            assert subp
+            stmt = ast_utils.singular(ast_utils.children_of_type(subp[0], Subroutine_Stmt))
+            cmod = ast_utils.singular(ast_utils.children_of_type(stmt, Name)).string.lower()
+
+        # Find the nearest execution and its correpsonding specification parts.
+        execution_part = callsite.parent
+        while not isinstance(execution_part, Execution_Part):
+            execution_part = execution_part.parent
+        subprog = execution_part.parent
+        specification_part = list(ast_utils.children_of_type(subprog, Specification_Part))
+        assert len(specification_part) <= 1
+        if specification_part:
+            specification_part = specification_part[0]
+
+        # TODO: Current hacks:
+        #  1. Assume that there is only one procdecure named `bname` anywhere.
+        #  2. Assume that `pname` is not already an existing identifier (i.e., we can import it without renaming).
+        pname = [v for k, v in proc_map.items() if k[-1] == bname.string]
+        assert len(pname) == 1
+        pname = pname[0]
+        # We are assumping that it's a subprogram defined directly inside a module.
+        assert len(pname) == 2
+        mod, pname = pname
+
+        if not specification_part:
+            subprog.children.append(Specification_Part(get_reader(f"use {mod}, only: {pname}")))
+        else:
+            specification_part.children.insert(0, Use_Stmt(f"use {mod}, only: {pname}"))
+        obj_list = []
+        if dep_graph.has_edge(cmod, mod):
+            edge = dep_graph.get_edge_data(cmod, mod)
+            if 'obj_list' in edge:
+                obj_list = edge.get('obj_list')
+                assert isinstance(obj_list, list)
+        ast_utils.extend_with_new_items_from(obj_list, [Name(pname)])
+
+
+        # For both function and subroutine calls, we replace `bname` with `pname`, and add `dref` as the first arg.
+        _, args = callsite.children
+        if args is None:
+            args = Actual_Arg_Spec_List(f"{dref}")
+        else:
+            args = Actual_Arg_Spec_List(f"{dref}, {args}")
+        callsite.items = (pname, args)
+    return ast, dep_graph
+
+
+def recursive_ast_improver(ast: Base, source_list: Union[List, Dict], include_list, parser):
     dep_graph = nx.DiGraph()
     asts = {}
     interface_blocks: Dict[str, Dict[str, List[Name]]] = {}

--- a/tests/fortran/deconstruct_procedure_calls_test.py
+++ b/tests/fortran/deconstruct_procedure_calls_test.py
@@ -1,0 +1,133 @@
+from typing import Dict
+
+import networkx as nx
+from fparser.common.readfortran import FortranStringReader
+from fparser.two.Fortran2003 import Program, Name, Rename
+from fparser.two.parser import ParserFactory
+
+from dace.frontend.fortran.fortran_parser import deconstruct_procedure_calls, recursive_ast_improver, prune_unused_children, simplified_dependency_graph
+from tests.fortran.fotran_test_helper import SourceCodeBuilder
+
+
+def parse_and_improve(sources: Dict[str, str]):
+    parser = ParserFactory().create(std="f2008")
+    assert 'main.f90' in sources
+    reader = FortranStringReader(sources['main.f90'])
+    ast = parser(reader)
+    assert isinstance(ast, Program)
+
+    ast, dep_graph, interface_blocks, asts = recursive_ast_improver(ast, sources, [], parser)
+    assert isinstance(ast, Program)
+    assert not any(nx.simple_cycles(dep_graph))
+    return ast, dep_graph, interface_blocks, asts
+
+
+def test_procedure_replacer():
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+  type Square
+    real :: side
+  contains
+    procedure :: area
+    procedure :: area_alt => area
+    procedure :: get_area
+  end type Square
+contains
+  real function area(this, m)
+    implicit none
+    class(Square), intent(in) :: this
+    real, intent(in) :: m
+    area = m * this%side*this%side
+  end function area
+  subroutine get_area(this, a)
+    implicit none
+    class(Square), intent(in) :: this
+    real, intent(out) :: a
+    a = area(this, 1.0)
+  end subroutine get_area
+end module lib
+""").add_file("""
+subroutine main
+  use lib, only: Square
+  implicit none
+  type(Square) :: s
+  real :: a
+
+  s%side = 1.0
+  a = s%area(1.0)
+  a = s%area_alt(1.0)
+  call s%get_area(a)
+end subroutine main
+""").check_with_gfortran().get()
+    ast, dep_graph, interface_blocks, asts = parse_and_improve(sources)
+    ast, dep_graph = deconstruct_procedure_calls(ast, dep_graph)
+
+    got = ast.tofortran()
+    want = """
+MODULE lib
+  IMPLICIT NONE
+  TYPE :: Square
+    REAL :: side
+    CONTAINS
+    PROCEDURE :: area
+    PROCEDURE :: area_alt => area
+    PROCEDURE :: get_area
+  END TYPE Square
+  CONTAINS
+  REAL FUNCTION area(this, m)
+    IMPLICIT NONE
+    CLASS(Square), INTENT(IN) :: this
+    REAL, INTENT(IN) :: m
+    area = m * this % side * this % side
+  END FUNCTION area
+  SUBROUTINE get_area(this, a)
+    IMPLICIT NONE
+    CLASS(Square), INTENT(IN) :: this
+    REAL, INTENT(OUT) :: a
+    a = area(this, 1.0)
+  END SUBROUTINE get_area
+END MODULE lib
+SUBROUTINE main
+  USE lib, ONLY: get_area
+  USE lib, ONLY: area
+  USE lib, ONLY: area
+  USE lib, ONLY: Square
+  IMPLICIT NONE
+  TYPE(Square) :: s
+  REAL :: a
+  s % side = 1.0
+  a = area(s, 1.0)
+  a = area(s, 1.0)
+  CALL get_area(s, a)
+END SUBROUTINE main
+""".strip()
+    assert got == want
+    SourceCodeBuilder().add_file(got).check_with_gfortran()
+
+    assert set(dep_graph.nodes) == {'lib', 'main'}
+    assert set(dep_graph.edges) == {('main', 'lib')}
+    assert set(u.string for u in dep_graph.edges['main', 'lib']['obj_list']) == {'Square', 'area', 'get_area'}
+    assert not interface_blocks
+    assert set(asts.keys()) == {'lib'}
+
+    simple_graph, actually_used_in_module = simplified_dependency_graph(dep_graph, interface_blocks)
+
+    # Nothing changed here.
+    assert set(simple_graph.nodes) == {'lib', 'main'}
+    assert set(simple_graph.edges) == {('main', 'lib')}
+    assert set(u.string for u in simple_graph.edges['main', 'lib']['obj_list']) == {'Square', 'area', 'get_area'}
+    assert not interface_blocks
+    assert set(asts.keys()) == {'lib'}
+
+    assert ({k: set(v) for k, v in actually_used_in_module.items()}
+            == {'lib': {'get_area', 'area', 'Square'}, 'main': set()})
+
+    name_dict, rename_dict = prune_unused_children(ast, simple_graph, actually_used_in_module)
+    got = ast.tofortran()
+    # Still want the same program, because nothing should have been pruned.
+    assert got == want
+    SourceCodeBuilder().add_file(got).check_with_gfortran()
+
+    assert name_dict == {'lib': ['Square', 'area', 'get_area']}
+    assert not rename_dict == {'lib': []}

--- a/tests/fortran/prune_unused_children_test.py
+++ b/tests/fortran/prune_unused_children_test.py
@@ -7,7 +7,7 @@ from fparser.two.Fortran2003 import Program
 from fparser.two.parser import ParserFactory
 
 from dace.frontend.fortran.fortran_parser import recursive_ast_improver, simplified_dependency_graph, \
-    prune_unused_children
+    prune_unused_children, deconstruct_procedure_calls
 from tests.fortran.fotran_test_helper import SourceCodeBuilder
 
 
@@ -19,6 +19,10 @@ def parse_improve_and_simplify(sources: Dict[str, str]):
     assert isinstance(ast, Program)
 
     ast, dep_graph, interface_blocks, asts = recursive_ast_improver(ast, sources, [], parser)
+    assert isinstance(ast, Program)
+    assert not any(nx.simple_cycles(dep_graph))
+
+    ast, dep_graph = deconstruct_procedure_calls(ast, dep_graph)
     assert isinstance(ast, Program)
     assert not any(nx.simple_cycles(dep_graph))
 

--- a/tests/fortran/recursive_ast_improver_test.py
+++ b/tests/fortran/recursive_ast_improver_test.py
@@ -6,7 +6,8 @@ from fparser.common.readfortran import FortranStringReader
 from fparser.two.Fortran2003 import Program, Name
 from fparser.two.parser import ParserFactory
 
-from dace.frontend.fortran.fortran_parser import recursive_ast_improver, simplified_dependency_graph
+from dace.frontend.fortran.fortran_parser import recursive_ast_improver, simplified_dependency_graph, \
+    deconstruct_procedure_calls
 from tests.fortran.fotran_test_helper import SourceCodeBuilder
 
 
@@ -20,6 +21,11 @@ def parse_and_improve(sources: Dict[str, str]):
     ast, dep_graph, interface_blocks, asts = recursive_ast_improver(ast, sources, [], parser)
     assert isinstance(ast, Program)
     assert not any(nx.simple_cycles(dep_graph))
+
+    ast, dep_graph = deconstruct_procedure_calls(ast, dep_graph)
+    assert isinstance(ast, Program)
+    assert not any(nx.simple_cycles(dep_graph))
+
     return ast, dep_graph, interface_blocks, asts
 
 


### PR DESCRIPTION
This involves:
1. Find the bound subprogram for that procedure.
2. Replace the calls to the procedure with that subprogram (with the object as an extra argument).
3. Adding `use` statements as necessary.

This has many, many corner cases not addressed. Will be adding more tests as we refine it.