### PR TITLE
Additional intrinsics for Fortran frontend

### DIFF
--- a/tests/fortran/fortran_test_helper.py
+++ b/tests/fortran/fortran_test_helper.py
@@ -55,8 +55,14 @@ class SourceCodeBuilder:
             # Run `gfortran -Wall` to verify that it compiles.
             # Note: we're relying on the fact that python dictionaries keeps the insertion order when calling `keys()`.
             cmd = ['gfortran', '-Wall', '-shared', *self.sources.keys()]
-            subprocess.run(cmd, cwd=td, capture_output=True).check_returncode()
-            return self
+
+            try:
+                subprocess.run(cmd, cwd=td, capture_output=True).check_returncode()
+                return self
+            except subprocess.CalledProcessError as e:
+                print("Fortran compilation failed!")
+                print(e.stderr.decode())
+                raise e
 
     def get(self) -> Tuple[Dict[str, str], Optional[str]]:
         """Get a dictionary mapping file names (possibly auto-inferred) to their content."""

--- a/tests/fortran/intrinsic_blas_test.py
+++ b/tests/fortran/intrinsic_blas_test.py
@@ -85,7 +85,40 @@ end subroutine main
 
     assert np.all(np.transpose(res1) == arg1)
 
+def test_fortran_frontend_matmul():
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine main(arg1, arg2, res1)
+  double precision, dimension(5,3) :: arg1
+  double precision, dimension(3,7) :: arg2
+  double precision, dimension(5,7) :: res1
+  res1 = matmul(arg1, arg2)
+end subroutine main
+""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main', normalize_offsets=False)
+    # TODO: We should re-enable `simplify()` once we merge it.
+    # sdfg.simplify()
+    sdfg.compile()
+
+    size_x = 5
+    size_y = 3
+    size_z = 7
+    arg1 = np.full([size_x, size_y], 42, order="F", dtype=np.float64)
+    arg2 = np.full([size_y, size_z], 42, order="F", dtype=np.float64)
+    res1 = np.full([size_x, size_z], 42, order="F", dtype=np.float64)
+
+    for i in range(size_x):
+        for j in range(size_y):
+            arg1[i, j] = i + j + 1
+    for i in range(size_y):
+        for j in range(size_z):
+            arg2[i, j] = i + j + 7
+
+    sdfg(arg1=arg1, arg2=arg2, res1=res1)
+
+    assert np.all(np.matmul(arg1, arg2) == res1)
+
 if __name__ == "__main__":
     test_fortran_frontend_dot()
     test_fortran_frontend_dot_range()
     test_fortran_frontend_transpose()
+    test_fortran_frontend_matmul()


### PR DESCRIPTION
Added two intrinsics needed by ICON: gemm & transpose. Both use DaCe's library node, so they should generate optimal code.