### PR TITLE
Implement numpy.any/all, more descriptive Python frontend errors

### DIFF
--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -398,7 +398,7 @@ class DaceProgram(pycommon.SDFGConvertible):
         # Start with default arguments, then add other arguments
         result = {**self.default_args}
         # Reconstruct keyword arguments
-        result.update({aname: arg for aname, arg in zip(self.argnames, args)})
+        result.update({aname: arg for aname, arg in zip(self.argnames, args) if aname not in self.constant_args})
         result.update(kwargs)
 
         # Add closure arguments to the call

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -1052,26 +1052,28 @@ def _mean(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None):
 
 @oprepo.replaces('numpy.max')
 @oprepo.replaces('numpy.amax')
-def _max(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None):
+def _max(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None, initial=None):
+    initial = initial if initial is not None else dtypes.min_value(sdfg.arrays[a].dtype)
     return _reduce(pv,
                    sdfg,
                    state,
                    "lambda x, y: max(x, y)",
                    a,
                    axis=axis,
-                   identity=dtypes.min_value(sdfg.arrays[a].dtype))
+                   identity=initial)
 
 
 @oprepo.replaces('numpy.min')
 @oprepo.replaces('numpy.amin')
-def _min(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None):
+def _min(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None, initial=None):
+    initial = initial if initial is not None else dtypes.max_value(sdfg.arrays[a].dtype)
     return _reduce(pv,
                    sdfg,
                    state,
                    "lambda x, y: min(x, y)",
                    a,
                    axis=axis,
-                   identity=dtypes.max_value(sdfg.arrays[a].dtype))
+                   identity=initial)
 
 
 def _minmax2(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, b: str, ismin=True):

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -1021,6 +1021,16 @@ def _sum_array(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, a: str):
     return _reduce(pv, sdfg, state, "lambda x, y: x + y", a, axis=0, identity=0)
 
 
+@oprepo.replaces('numpy.any')
+def _any(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None):
+    return _reduce(pv, sdfg, state, "lambda x, y: x or y", a, axis=axis, identity=0)
+
+
+@oprepo.replaces('numpy.all')
+def _all(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None):
+    return _reduce(pv, sdfg, state, "lambda x, y: x and y", a, axis=axis, identity=0)
+
+
 @oprepo.replaces('numpy.mean')
 def _mean(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, a: str, axis=None):
 

--- a/tests/numpy/reductions_test.py
+++ b/tests/numpy/reductions_test.py
@@ -227,6 +227,16 @@ def test_degenerate_reduction_implicit(A: dace.float64[1, 20]):
     return np.sum(A, axis=0)
 
 
+@compare_numpy_output()
+def test_any(A: dace.float64[20]):
+    return np.any(A > 0.8, axis=0)
+
+
+@compare_numpy_output()
+def test_all(A: dace.float64[20]):
+    return np.all(A > 0.8, axis=0)
+
+
 if __name__ == '__main__':
 
     # generated with cat tests/numpy/reductions_test.py | grep -oP '(?<=^def ).*(?=\()' | awk '{print $0 "()"}'
@@ -271,3 +281,6 @@ if __name__ == '__main__':
     test_scalar_reduction()
     test_degenerate_reduction_explicit()
     test_degenerate_reduction_implicit()
+
+    test_any()
+    test_all()


### PR DESCRIPTION
* Implement `numpy.any` and `numpy.all`
* More descriptive errors when slicing and using non-annotated callbacks
* Remove `dace.compiletime` arguments from symbolic analysis