### PR TITLE
Fully implement NumPy advanced indexing for reads

### DIFF
--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -15,7 +15,6 @@ from dace.frontend.python.common import DaceSyntaxError
 
 MemletType = Union[ast.Call, ast.Attribute, ast.Subscript, ast.Name]
 
-
 if sys.version_info < (3, 8):
     _simple_ast_nodes = (ast.Constant, ast.Name, ast.NameConstant, ast.Num)
     BytesConstant = ast.Bytes
@@ -107,6 +106,11 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
     idx = 0
     new_idx = 0
     has_ellipsis = False
+
+    # Count new axes
+    num_new_axes = sum(1 for dim in ast_ndslice
+                       if (dim is None or (isinstance(dim, (ast.Constant, NameConstant)) and dim.value is None)))
+
     for dim in ast_ndslice:
         if isinstance(dim, (str, list, slice)):
             dim = ast.Name(id=dim)
@@ -136,7 +140,7 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
             if has_ellipsis:
                 raise IndexError('an index can only have a single ellipsis ("...")')
             has_ellipsis = True
-            remaining_dims = len(ast_ndslice) - idx - 1
+            remaining_dims = len(ast_ndslice) - num_new_axes - idx - 1
             for j in range(idx, len(ndslice) - remaining_dims):
                 ndslice[j] = (0, array.shape[j] - 1, 1)
                 idx += 1
@@ -170,7 +174,7 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
             if desc.dtype == dtypes.bool:
                 # Boolean array indexing
                 if len(ast_ndslice) > 1:
-                    raise IndexError(f'Invalid indexing into array "{dim.id}". ' 'Only one boolean array is allowed.')
+                    raise IndexError(f'Invalid indexing into array "{dim.id}". Only one boolean array is allowed.')
                 if tuple(desc.shape) != tuple(array.shape):
                     raise IndexError(f'Invalid indexing into array "{dim.id}". '
                                      'Shape of boolean index must match original array.')
@@ -251,9 +255,9 @@ def parse_memlet_subset(array: data.Data,
             # Loop over the N dimensions
             ndslice, offsets, new_extra_dims, arrdims = _fill_missing_slices(das, ast_ndslice, narray, offsets)
             if new_extra_dims and idx != (len(ast_ndslices) - 1):
-                raise NotImplementedError('New axes only implemented for last ' 'slice')
+                raise NotImplementedError('New axes only implemented for last slice')
             if arrdims and len(ast_ndslices) != 1:
-                raise NotImplementedError('Array dimensions not implemented ' 'for consecutive subscripts')
+                raise NotImplementedError('Array dimensions not implemented for consecutive subscripts')
             extra_dims = new_extra_dims
             subset_array.append(_ndslice_to_subset(ndslice))
 
@@ -304,8 +308,9 @@ def ParseMemlet(visitor,
     try:
         subset, new_axes, arrdims = parse_memlet_subset(array, node, das, parsed_slice)
     except IndexError:
-        raise DaceSyntaxError(visitor, node, 'Failed to parse memlet expression due to dimensionality. '
-                              f'Array dimensions: {array.shape}, expression in code: {astutils.unparse(node)}')
+        raise DaceSyntaxError(
+            visitor, node, 'Failed to parse memlet expression due to dimensionality. '
+            f'Array dimensions: {array.shape}, expression in code: {astutils.unparse(node)}')
 
     # If undefined, default number of accesses is the slice size
     if num_accesses is None:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3439,6 +3439,8 @@ class ProgramVisitor(ExtNodeVisitor):
 
                 defined_arrays = dace.sdfg.NestedDict({**self.sdfg.arrays, **self.scope_arrays, **self.defined})
                 expr: MemletExpr = ParseMemlet(self, defined_arrays, true_target, nslice)
+                
+                # TODO: Use _create_output_shape_from_advanced_indexing
                 rng = expr.subset
                 if isinstance(rng, subsets.Indices):
                     rng = subsets.Range.from_indices(rng)
@@ -5385,6 +5387,15 @@ class ProgramVisitor(ExtNodeVisitor):
             dim_position = 0
         else:
             dim_position = advanced_dims[0]
+
+        # Add new axes
+        for new_axis in expr.new_axes:
+            if prefix_dims:
+                output_shape.insert(new_axis + 1, 1)
+            else:
+                output_shape.insert(new_axis, 1)
+                if new_axis <= dim_position:
+                    dim_position += 1
 
         # Contract contiguous None dimensions that appear multiple times in a row
         output_shape = [

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2496,7 +2496,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     if astr not in self.defined:
                         raise DaceSyntaxError(self, node, 'Undefined variable "%s"' % atom)
                     # Add to global SDFG symbols if not a scalar
-                    if (astr not in self.sdfg.symbols and astr not in self.variables):
+                    if (astr not in self.sdfg.symbols and astr not in self.variables and astr not in self.sdfg.arrays):
                         self.sdfg.add_symbol(astr, atom.dtype)
 
         # Handle else clause
@@ -3439,7 +3439,7 @@ class ProgramVisitor(ExtNodeVisitor):
 
                 defined_arrays = dace.sdfg.NestedDict({**self.sdfg.arrays, **self.scope_arrays, **self.defined})
                 expr: MemletExpr = ParseMemlet(self, defined_arrays, true_target, nslice)
-                
+
                 # TODO: Use _create_output_shape_from_advanced_indexing
                 rng = expr.subset
                 if isinstance(rng, subsets.Indices):
@@ -5255,7 +5255,8 @@ class ProgramVisitor(ExtNodeVisitor):
         # Obtain array/tuple
         node_parsed = self._gettype(node.value)
 
-        if len(node_parsed) > 1:
+        if len(node_parsed) > 1 or (len(node_parsed) == 1 and isinstance(node_parsed[0], tuple)
+                                    and node_parsed[0][1] in ('symbol', 'NumConstant')):
             # If the value is a tuple of constants (e.g., array.shape) and the
             # slice is constant, return the value itself
             nslice = self.visit(node.slice)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -5178,7 +5178,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 if isinstance(res, (ast.Constant, NumConstant)):
                     res = res.value
         elif sys.version_info < (3, 9) and isinstance(s, ast.Index):
-            res = self._parse_subscript_slice(s.value)
+            res = self._parse_subscript_slice(s.value, multidim=multidim)
         elif isinstance(s, ast.Slice):
             lower = s.lower
             if isinstance(lower, ast.AST):

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -40,7 +40,7 @@ import sympy
 
 # register replacements in oprepo
 import dace.frontend.python.replacements
-from dace.frontend.python.replacements import _sym_type, _broadcast_to, _broadcast_together
+from dace.frontend.python.replacements import _sym_type, broadcast_to, broadcast_together
 
 # Type hints
 Size = Union[int, dace.symbolic.symbol]
@@ -2711,7 +2711,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 if (indirect_indices or boolarr or len(ssize) != len(osize)
                         or any(inequal_symbols(s, o) for s, o in zip(ssize, osize)) or op):
 
-                    _, all_idx_tuples, _, _, inp_idx = _broadcast_to(squeezed.size(), op_subset.size())
+                    _, all_idx_tuples, _, _, inp_idx = broadcast_to(squeezed.size(), op_subset.size())
 
                     idx = iter(i for i, _ in all_idx_tuples)
                     target_index = ','.join(
@@ -2927,7 +2927,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 wsqz = sqz_wsub.squeeze()
                 sqz_rsub = copy.deepcopy(rtarget_subset)
                 rsqz = sqz_rsub.squeeze()
-                _, all_idx_tuples, _, out_idx, inp_idx = _broadcast_to(sqz_wsub.size(), sqz_osub.size())
+                _, all_idx_tuples, _, out_idx, inp_idx = broadcast_to(sqz_wsub.size(), sqz_osub.size())
                 # Re-add squeezed dimensions from original subset so that memlets match original arrays
                 osqueezed = [i for i in range(len(op_subset)) if i not in osqz]
                 wsqueezed = [i for i in range(len(wtarget_subset)) if i not in wsqz]
@@ -5409,7 +5409,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 shape = carr.shape
 
             if chunk_shape is not None:
-                chunk_shape, *_ = _broadcast_together(shape, chunk_shape)
+                chunk_shape, *_ = broadcast_together(shape, chunk_shape)
             else:
                 chunk_shape = tuple(shape)
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -5656,6 +5656,7 @@ class ProgramVisitor(ExtNodeVisitor):
             code=f'__out = __arr[{access_str}]',
             external_edges=True,
             debuginfo=self.current_lineinfo,
+            input_nodes={rnode.data: rnode},
         )
 
         return outname

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -175,8 +175,7 @@ class InterstateEdge(object):
         loop iterates).
     """
 
-    assignments = Property(dtype=dict,
-                           desc="Assignments to perform upon transition (e.g., 'x=x+1; y = 0')")
+    assignments = Property(dtype=dict, desc="Assignments to perform upon transition (e.g., 'x=x+1; y = 0')")
     condition = CodeProperty(desc="Transition condition", default=CodeBlock("1"))
     guid = Property(dtype=str, allow_none=False)
 
@@ -214,7 +213,7 @@ class InterstateEdge(object):
         result = cls.__new__(cls)
         memo[id(self)] = result
         for k, v in self.__dict__.items():
-            if k == 'guid': # Skip ID
+            if k == 'guid':  # Skip ID
                 continue
             setattr(result, k, copy.deepcopy(v, memo))
         return result
@@ -416,7 +415,11 @@ class SDFG(ControlFlowRegion):
 
     name = Property(dtype=str, desc="Name of the SDFG")
     arg_names = ListProperty(element_type=str, desc='Ordered argument names (used for calling conventions).')
-    constants_prop = Property(dtype=dict, default={}, desc="Compile-time constants")
+    constants_prop: Dict[str, Tuple[dt.Data, Any]] = Property(
+        dtype=dict,
+        default={},
+        desc='Compile-time constants. The dictionary maps between a constant name to '
+        'a tuple of its type and the actual constant data.')
     _arrays = Property(dtype=NestedDict,
                        desc="Data descriptors for this SDFG",
                        to_json=_arrays_to_json,
@@ -463,7 +466,8 @@ class SDFG(ControlFlowRegion):
                                     desc='Mapping between callback name and its original callback '
                                     '(for when the same callback is used with a different signature)')
 
-    using_explicit_control_flow = Property(dtype=bool, default=False,
+    using_explicit_control_flow = Property(dtype=bool,
+                                           default=False,
                                            desc="Whether the SDFG contains explicit control flow constructs")
 
     def __init__(self,
@@ -612,9 +616,7 @@ class SDFG(ControlFlowRegion):
 
         ret = SDFG(name=attrs['name'], constants=constants_prop, parent=context['sdfg'])
 
-        dace.serialize.set_properties_from_json(ret,
-                                                json_obj,
-                                                ignore_properties={'constants_prop', 'name', 'hash'})
+        dace.serialize.set_properties_from_json(ret, json_obj, ignore_properties={'constants_prop', 'name', 'hash'})
 
         nodelist = []
         for n in nodes:
@@ -741,7 +743,6 @@ class SDFG(ControlFlowRegion):
         repldict = {k: v for k, v in repldict.items() if k != v}
         if symrepl:
             symrepl = {k: v for k, v in symrepl.items() if str(k) != str(v)}
-
 
         symrepl = symrepl or {
             symbolic.pystr_to_symbolic(k): symbolic.pystr_to_symbolic(v) if isinstance(k, str) else v
@@ -2318,8 +2319,7 @@ class SDFG(ControlFlowRegion):
         dll = cs.ReloadableDLL(binary_filename, self.name)
         return dll.is_loaded()
 
-    def compile(self, output_file=None, validate=True,
-                return_program_handle=True) -> 'CompiledSDFG':
+    def compile(self, output_file=None, validate=True, return_program_handle=True) -> 'CompiledSDFG':
         """ Compiles a runnable binary from this SDFG.
 
             :param output_file: If not None, copies the output library file to

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1609,9 +1609,9 @@ def traverse_sdfg_with_defined_symbols(
 
     :return: A generator that yields tuples of (state, node in state, currently-defined symbols)
     """
-    # Start with global symbols
+    # Start with global symbols and scalar constants
     symbols = copy.copy(sdfg.symbols)
-    symbols.update({k: dt.create_datadescriptor(v).dtype for k, v in sdfg.constants.items()})
+    symbols.update({k: desc.dtype for k, (desc, _) in sdfg.constants_prop.items() if isinstance(desc, dt.Scalar)})
     for desc in sdfg.arrays.values():
         symbols.update({str(s): s.dtype for s in desc.free_symbols})
 

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -257,7 +257,7 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
         # Ensure that there is a mentioning of constants in either the array or symbol.
         for const_name, (const_type, _) in sdfg.constants_prop.items():
             if const_name in sdfg.arrays:
-                if const_type != sdfg.arrays[const_name].dtype:
+                if const_type.dtype != sdfg.arrays[const_name].dtype:
                     # This should actually be an error, but there is a lots of code that depends on it.
                     warnings.warn(f'Mismatch between constant and data descriptor of "{const_name}", '
                                   f'expected to find "{const_type}" but found "{sdfg.arrays[const_name]}".')

--- a/dace/transformation/passes/scalar_to_symbol.py
+++ b/dace/transformation/passes/scalar_to_symbol.py
@@ -342,10 +342,11 @@ class TaskletIndirectionPromoter(ast.NodeTransformer):
         """
         arrname, tasklet_slice = astutils.subscript_to_ast_slice(node)
         arrname = arrname if arrname in self.arrays else None
-        # Unsqueeze all index dimensions from orig_subset into tasklet_subset
-        for i, (start, end, _) in reversed(list(enumerate(memlet_subset.ndrange()))):
-            if start == end:
-                tasklet_slice.insert(i, (None, None, None))
+        if len(tasklet_slice) < len(memlet_subset):
+            # Unsqueeze all index dimensions from orig_subset into tasklet_subset
+            for i, (start, end, _) in reversed(list(enumerate(memlet_subset.ndrange()))):
+                if start == end:
+                    tasklet_slice.insert(i, (None, None, None))
         tasklet_subset = subsets.Range(astutils.astrange_to_symrange(tasklet_slice, self.arrays, arrname))
         return memlet_subset.compose(tasklet_subset)
 

--- a/dace/transformation/passes/scalar_to_symbol.py
+++ b/dace/transformation/passes/scalar_to_symbol.py
@@ -331,6 +331,24 @@ class TaskletIndirectionPromoter(ast.NodeTransformer):
         self.out_mapping: Dict[str, Tuple[str, subsets.Range]] = {}
         self.do_not_remove: Set[str] = set()
 
+    def _get_requested_range(self, node: ast.Subscript, memlet_subset: subsets.Subset) -> subsets.Subset:
+        """
+        Returns the requested range from a subscript node, which consists of the memlet subset composed with the
+        tasklet subset.
+
+        :param node: The subscript node.
+        :param memlet_subset: The memlet subset.
+        :return: The requested range.
+        """
+        arrname, tasklet_slice = astutils.subscript_to_ast_slice(node)
+        arrname = arrname if arrname in self.arrays else None
+        # Unsqueeze all index dimensions from orig_subset into tasklet_subset
+        for i, (start, end, _) in reversed(list(enumerate(memlet_subset.ndrange()))):
+            if start == end:
+                tasklet_slice.insert(i, (None, None, None))
+        tasklet_subset = subsets.Range(astutils.astrange_to_symrange(tasklet_slice, self.arrays, arrname))
+        return memlet_subset.compose(tasklet_subset)
+
     def visit_Subscript(self, node: ast.Subscript) -> Any:
         # Convert subscript to symbol name
         node = self.generic_visit(node)
@@ -339,8 +357,7 @@ class TaskletIndirectionPromoter(ast.NodeTransformer):
             new_name = dt.find_new_name(node_name, self.connector_names)
             self.connector_names.add(new_name)
 
-            orig_subset = self.in_edges[node_name].subset
-            subset = orig_subset.compose(subsets.Range(astutils.subscript_to_slice(node, self.arrays)[1]))
+            subset = self._get_requested_range(node, self.in_edges[node_name].subset)
             # Check if range can be collapsed
             if _range_is_promotable(subset, self.defined):
                 self.in_mapping[new_name] = (node_name, subset)
@@ -351,8 +368,7 @@ class TaskletIndirectionPromoter(ast.NodeTransformer):
             new_name = dt.find_new_name(node_name, self.connector_names)
             self.connector_names.add(new_name)
 
-            orig_subset = self.out_edges[node_name].subset
-            subset = orig_subset.compose(subsets.Range(astutils.subscript_to_slice(node, self.arrays)[1]))
+            subset = self._get_requested_range(node, self.out_edges[node_name].subset)
             # Check if range can be collapsed
             if _range_is_promotable(subset, self.defined):
                 self.out_mapping[new_name] = (node_name, subset)
@@ -750,4 +766,4 @@ class ScalarToSymbolPromotion(passes.Pass):
         return to_promote or None
 
     def report(self, pass_retval: Set[str]) -> str:
-        return f'Promoted {len(pass_retval)} scalars to symbols.'
+        return f'Promoted {len(pass_retval)} scalars to symbols: {pass_retval}'

--- a/dace/transformation/passes/simplification/prune_empty_conditional_branches.py
+++ b/dace/transformation/passes/simplification/prune_empty_conditional_branches.py
@@ -55,7 +55,7 @@ class PruneEmptyConditionalBranches(ppl.ControlFlowRegionPass):
                     region.remove_branch(branch)
                 removed_branches += 1
         # If the else branch remains, make sure it now has the new negate-all condition.
-        if new_else_cond is not None and region.branches[-1][0] is None:
+        if region.branches and new_else_cond is not None and region.branches[-1][0] is None:
             region._branches[-1] = (new_else_cond, region._branches[-1][1])
 
         if len(region.branches) == 0:

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -57,6 +57,17 @@ def test_ellipsis_and_newaxis():
     assert np.allclose(A[None, 1:5, ..., 0], res)
 
 
+def test_ellipsis_and_newaxis_2():
+
+    @dace.program
+    def indexing_test(A: dace.float64[5, 5, 5, 5, 5]):
+        return A[None, 1:5, ..., None, 2]
+
+    A = np.random.rand(5, 5, 5, 5, 5)
+    res = indexing_test(A)
+    assert np.allclose(A[None, 1:5, ..., None, 2], res)
+
+
 def test_aug_implicit():
 
     @dace.program
@@ -520,6 +531,7 @@ if __name__ == '__main__':
     test_flat_noncontiguous()
     test_ellipsis()
     test_ellipsis_and_newaxis()
+    test_ellipsis_and_newaxis_2()
     test_aug_implicit()
     test_ellipsis_aug()
     test_newaxis()

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -519,7 +519,7 @@ def test_combining_basic_and_advanced_indexing_with_newaxes_2():
 
     # Advanced indexing dimensions should be prepended to the shape
     sdfg = indexing_test.to_sdfg()
-    assert tuple(sdfg.arrays['__return'].shape) == (1, 5, 3, 3, 3, N, N, 2, 1)
+    assert tuple(sdfg.arrays['__return'].shape) == (1, 5, 3, 3, 3, N, N, N, 2, 1)
 
     res = indexing_test(A, indices, indices2)
 

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -288,7 +288,6 @@ def test_out_index_intarr_aug_bcast():
 
     assert np.allclose(A, ref)
 
-
 def test_out_index_intarr_multidim():
 
     @dace.program
@@ -299,6 +298,20 @@ def test_out_index_intarr_multidim():
     indices = [1, 10, 15]
     ref = np.copy(A)
     ref[1:2, indices, 3:4] = 2
+    indexing_test(A, indices, M=3)
+
+    assert np.allclose(A, ref)
+
+def test_out_index_intarr_multidim_range():
+
+    @dace.program
+    def indexing_test(A: dace.float64[N, N, N], indices: dace.int32[M]):
+        A[1:2, indices, 3:10] = 2
+
+    A = np.random.rand(20, 20, 20)
+    indices = [1, 10, 15]
+    ref = np.copy(A)
+    ref[1:2, indices, 3:10] = 2
     indexing_test(A, indices, M=3)
 
     assert np.allclose(A, ref)
@@ -425,6 +438,24 @@ def test_combining_basic_and_advanced_indexing():
     assert np.allclose(res, ref)
 
 
+def test_combining_basic_and_advanced_indexing_write():
+
+    @dace.program
+    def indexing_test(A: dace.float64[N, N, N, N, N, N, N], indices: dace.int32[3, 3], indices2: dace.int32[3, 3, 3]):
+        A[:5, indices, indices2, ..., 1:3, 4] = 2
+
+    n = 6
+    A = np.random.rand(n, n, n, n, n, n, n)
+    indices = np.random.randint(0, n, size=(3, 3))
+    indices2 = np.random.randint(0, n, size=(3, 3, 3))
+    ref = np.copy(A)
+    A[:5, indices, indices2, ..., 1:3, 4] = 2
+
+    # Advanced indexing dimensions should be prepended to the shape
+    res = indexing_test(A, indices, indices2)
+
+    assert np.allclose(res, ref)
+
 if __name__ == '__main__':
     test_flat()
     test_flat_noncontiguous()
@@ -447,6 +478,7 @@ if __name__ == '__main__':
     test_out_index_intarr_aug()
     test_out_index_intarr_aug_bcast()
     test_out_index_intarr_multidim()
+    test_out_index_intarr_multidim_range()
     test_advanced_indexing_syntax(False)
     test_advanced_indexing_syntax(True)
     test_multidim_tuple_index(False)
@@ -455,3 +487,4 @@ if __name__ == '__main__':
     test_multidim_tuple_multidim_index()
     test_advanced_index_broadcasting()
     test_combining_basic_and_advanced_indexing()
+    test_combining_basic_and_advanced_indexing_write()

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -46,6 +46,17 @@ def test_ellipsis():
     assert np.allclose(A[1:5, ..., 0], res)
 
 
+def test_ellipsis_and_newaxis():
+
+    @dace.program
+    def indexing_test(A: dace.float64[5, 5, 5, 5, 5]):
+        return A[None, 1:5, ..., 0]
+
+    A = np.random.rand(5, 5, 5, 5, 5)
+    res = indexing_test(A)
+    assert np.allclose(A[None, 1:5, ..., 0], res)
+
+
 def test_aug_implicit():
 
     @dace.program
@@ -508,6 +519,7 @@ if __name__ == '__main__':
     test_flat()
     test_flat_noncontiguous()
     test_ellipsis()
+    test_ellipsis_and_newaxis()
     test_aug_implicit()
     test_ellipsis_aug()
     test_newaxis()

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -161,10 +161,9 @@ def test_index_intarr_1d_multi():
         return A[indices, 2:7:2, [15, 10, 1]]
 
     A = np.random.rand(20, 10, 30)
-    indices = [1, 10, 15]
+    indices = np.array([1, 10, 15], dtype=np.int32)
     res = indexing_test(A, indices)
-    # FIXME: NumPy behavior is unclear in this case
-    assert np.allclose(np.diag(A[indices, 2:7:2, [15, 10, 1]]), res)
+    assert np.allclose(A[indices, 2:7:2, [15, 10, 1]], res)
 
 
 def test_index_intarr_nd():
@@ -429,7 +428,7 @@ def test_multidim_tuple_multidim_index_write():
 def test_advanced_index_broadcasting():
 
     @dace.program
-    def indexing_test(A: dace.float64[N, N, N], indices: dace.int32[3, 3]):
+    def indexing_test(A: dace.float64[N, M, N], indices: dace.int32[3, 3]):
         return A[indices, (1, 2, 4), :]
 
     sdfg = indexing_test.to_sdfg()
@@ -452,8 +451,8 @@ def test_combining_basic_and_advanced_indexing():
 
     n = 6
     A = np.random.rand(n, n, n, n, n, n, n)
-    indices = np.random.randint(0, n, size=(3, 3))
-    indices2 = np.random.randint(0, n, size=(3, 3, 3))
+    indices = np.random.randint(0, n, size=(3, 3)).astype(np.int32)
+    indices2 = np.random.randint(0, n, size=(3, 3, 3)).astype(np.int32)
     ref = A[:5, indices, indices2, ..., 1:3, 4]
 
     # Advanced indexing dimensions should be prepended to the shape
@@ -473,8 +472,8 @@ def test_combining_basic_and_advanced_indexing_write():
 
     n = 6
     A = np.random.rand(n, n, n, n, n, n, n)
-    indices = np.random.randint(0, n, size=(3, 3))
-    indices2 = np.random.randint(0, n, size=(3, 3, 3))
+    indices = np.random.randint(0, n, size=(3, 3)).astype(np.int32)
+    indices2 = np.random.randint(0, n, size=(3, 3, 3)).astype(np.int32)
     ref = np.copy(A)
     A[:5, indices, indices2, ..., 1:3, 4] = 2
 
@@ -492,8 +491,8 @@ def test_combining_basic_and_advanced_indexing_with_newaxes():
 
     n = 6
     A = np.random.rand(n, n, n, n, n, n, n)
-    indices = np.random.randint(0, n, size=(3, 3))
-    indices2 = np.random.randint(0, n, size=(3, 3, 3))
+    indices = np.random.randint(0, n, size=(3, 3)).astype(np.int32)
+    indices2 = np.random.randint(0, n, size=(3, 3, 3)).astype(np.int32)
     ref = A[None, :5, indices, indices2, ..., 1:3, 4, np.newaxis]
 
     # Advanced indexing dimensions should be prepended to the shape
@@ -513,8 +512,8 @@ def test_combining_basic_and_advanced_indexing_with_newaxes_2():
 
     n = 6
     A = np.random.rand(n, n, n, n, n, n, n)
-    indices = np.random.randint(0, n, size=(3, 3))
-    indices2 = np.random.randint(0, n, size=(3, 3, 3))
+    indices = np.random.randint(0, n, size=(3, 3)).astype(np.int32)
+    indices2 = np.random.randint(0, n, size=(3, 3, 3)).astype(np.int32)
     ref = A[None, :5, indices, indices2, ..., 1:3, np.newaxis]
 
     # Advanced indexing dimensions should be prepended to the shape

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -385,7 +385,7 @@ def test_multidim_tuple_index_longer():
 
 
 def test_multidim_tuple_multidim_index():
-    with pytest.raises(SyntaxError, match='could not be broadcast together'):
+    with pytest.raises(IndexError, match='could not be broadcast together'):
 
         @dace.program
         def indexing_test(A: dace.float64[N, M, N]):
@@ -395,7 +395,7 @@ def test_multidim_tuple_multidim_index():
 
 
 def test_multidim_tuple_multidim_index_write():
-    with pytest.raises(SyntaxError, match='could not be broadcast together'):
+    with pytest.raises(IndexError, match='could not be broadcast together'):
 
         @dace.program
         def indexing_test(A: dace.float64[N, M, N]):

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -487,13 +487,13 @@ def test_combining_basic_and_advanced_indexing_with_newaxes():
 
     @dace.program
     def indexing_test(A: dace.float64[N, N, N, N, N, N, N], indices: dace.int32[3, 3], indices2: dace.int32[3, 3, 3]):
-        return A[None, :5, indices, indices2, ..., 1:3, 4, np.newaxis]
+        return A[None, :5, indices, indices2, ..., 1:6:3, 4, np.newaxis]
 
     n = 6
     A = np.random.rand(n, n, n, n, n, n, n)
     indices = np.random.randint(0, n, size=(3, 3)).astype(np.int32)
     indices2 = np.random.randint(0, n, size=(3, 3, 3)).astype(np.int32)
-    ref = A[None, :5, indices, indices2, ..., 1:3, 4, np.newaxis]
+    ref = A[None, :5, indices, indices2, ..., 1:6:3, 4, np.newaxis]
 
     # Advanced indexing dimensions should be prepended to the shape
     sdfg = indexing_test.to_sdfg()
@@ -508,13 +508,13 @@ def test_combining_basic_and_advanced_indexing_with_newaxes_2():
 
     @dace.program
     def indexing_test(A: dace.float64[N, N, N, N, N, N, N], indices: dace.int32[3, 3], indices2: dace.int32[3, 3, 3]):
-        return A[None, :5, indices, indices2, ..., 1:3, np.newaxis]
+        return A[None, :5, indices, indices2, ..., 1:6:3, np.newaxis]
 
     n = 6
     A = np.random.rand(n, n, n, n, n, n, n)
     indices = np.random.randint(0, n, size=(3, 3)).astype(np.int32)
     indices2 = np.random.randint(0, n, size=(3, 3, 3)).astype(np.int32)
-    ref = A[None, :5, indices, indices2, ..., 1:3, np.newaxis]
+    ref = A[None, :5, indices, indices2, ..., 1:6:3, np.newaxis]
 
     # Advanced indexing dimensions should be prepended to the shape
     sdfg = indexing_test.to_sdfg()

--- a/tests/numpy/advanced_indexing_test.py
+++ b/tests/numpy/advanced_indexing_test.py
@@ -429,6 +429,7 @@ def test_multidim_tuple_multidim_index():
         indexing_test.to_sdfg()
 
 
+@pytest.mark.skip("Combined basic and advanced indexing with writes is not supported")
 def test_multidim_tuple_multidim_index_write():
     with pytest.raises(IndexError, match='could not be broadcast together'):
 
@@ -477,7 +478,7 @@ def test_combining_basic_and_advanced_indexing():
 
     assert np.allclose(res, ref)
 
-
+@pytest.mark.skip("Combined basic and advanced indexing with writes is not supported")
 def test_combining_basic_and_advanced_indexing_write():
 
     @dace.program
@@ -571,9 +572,9 @@ if __name__ == '__main__':
     test_multidim_tuple_index(True)
     test_multidim_tuple_index_longer()
     test_multidim_tuple_multidim_index()
-    test_multidim_tuple_multidim_index_write()
+    # test_multidim_tuple_multidim_index_write()
     test_advanced_index_broadcasting()
     test_combining_basic_and_advanced_indexing()
-    test_combining_basic_and_advanced_indexing_write()
+    # test_combining_basic_and_advanced_indexing_write()
     test_combining_basic_and_advanced_indexing_with_newaxes()
     test_combining_basic_and_advanced_indexing_with_newaxes_2()

--- a/tests/numpy/split_test.py
+++ b/tests/numpy/split_test.py
@@ -137,9 +137,9 @@ def test_compiletime_split():
         y[:, o:o + 1] = factor * (-(x1 + x2) + (x0 + x1) - (x0 + x4) + (x3 + x4) + (x2 + x5) - (x3 + x5))
 
     x = np.random.rand(1000, 8)
-    y = np.empty_like(x)
+    y = np.zeros_like(x)
     tester(x, y, (1, 2, 3, 4, 5, 7), 0)
-    ref = np.empty_like(y)
+    ref = np.zeros_like(y)
     tester.f(x, ref, (1, 2, 3, 4, 5, 7), 0)
 
     assert np.allclose(y, ref)

--- a/tests/numpy/split_test.py
+++ b/tests/numpy/split_test.py
@@ -127,6 +127,24 @@ def test_dsplit_4d():
     return a, b, c
 
 
+def test_compiletime_split():
+
+    @dace.program
+    def tester(x, y, in_indices: dace.compiletime, out_index: dace.compiletime):
+        x0, x1, x2, x3, x4, x5 = np.split(x[:, in_indices], 6, axis=1)
+        factor = 1 / 12
+        o = out_index
+        y[:, o:o + 1] = factor * (-(x1 + x2) + (x0 + x1) - (x0 + x4) + (x3 + x4) + (x2 + x5) - (x3 + x5))
+
+    x = np.random.rand(1000, 8)
+    y = np.empty_like(x)
+    tester(x, y, (1, 2, 3, 4, 5, 7), 0)
+    ref = np.empty_like(y)
+    tester.f(x, ref, (1, 2, 3, 4, 5, 7), 0)
+
+    assert np.allclose(y, ref)
+
+
 if __name__ == "__main__":
     test_split()
     test_uneven_split_fail()
@@ -140,3 +158,4 @@ if __name__ == "__main__":
     test_vsplit()
     test_hsplit()
     test_dsplit_4d()
+    test_compiletime_split()

--- a/tests/python_frontend/callee_autodetect_test.py
+++ b/tests/python_frontend/callee_autodetect_test.py
@@ -325,7 +325,7 @@ def test_explicit_type_hints_in_nested_call(decorated):
     a_ref = A * 2
 
     if decorated:
-        with pytest.raises(SyntaxError):
+        with pytest.raises(IndexError):
             outer(A)
     else:
         outer(A)


### PR DESCRIPTION
* Adds support for multi-dimensional integer arrays as indices
* Adds support for mixing advanced and basic indexing (see https://numpy.org/doc/stable/user/basics.indexing.html#combining-advanced-and-basic-indexing)
* Adds support for `newaxis` in conjunction with advanced indexing
* Fixes array indirection promotion for multidimensional slices with offset dimensions