### PR TITLE
Various Fixes and QOL improvements

### DIFF
--- a/dace/cli/sdfv.py
+++ b/dace/cli/sdfv.py
@@ -22,7 +22,7 @@ def partialclass(cls, *args, **kwds):
     return NewCls
 
 
-def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None, verbose: bool = True):
+def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None, verbose: bool = True, compress: bool = True):
     """
     View an sdfg in the system's HTML viewer
 
@@ -33,6 +33,7 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None, verbose: b
                     served using a basic web server on that port,
                     blocking the current thread.
     :param verbose: Be verbose.
+    :param compress: Use compression for the temporary file.
     """
     # If vscode is open, try to open it inside vscode
     if filename is None:
@@ -41,8 +42,9 @@ def view(sdfg: dace.SDFG, filename: Optional[Union[str, int]] = None, verbose: b
             or 'VSCODE_IPC_HOOK_CLI' in os.environ
             or 'VSCODE_GIT_IPC_HANDLE' in os.environ
         ):
-            fd, filename = tempfile.mkstemp(suffix='.sdfg')
-            sdfg.save(filename)
+            suffix = '.sdfgz' if compress else '.sdfg'
+            fd, filename = tempfile.mkstemp(suffix=suffix)
+            sdfg.save(filename, compress=compress)
             if platform.system() == 'Darwin':
                 # Special case for MacOS
                 os.system(f'open {filename}')

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -55,6 +55,7 @@ class DaCeCodeGenerator(object):
 
         # resolve all symbols and constants
         # first handle root
+        sdfg.reset_cfg_list()
         self._symbols_and_constants[sdfg.cfg_id] = sdfg.free_symbols.union(sdfg.constants_prop.keys())
         # then recurse
         for nested, state in sdfg.all_nodes_recursive():
@@ -66,7 +67,7 @@ class DaCeCodeGenerator(object):
                 # found a new nested sdfg: resolve symbols and constants
                 result = nsdfg.free_symbols.union(nsdfg.constants_prop.keys())
 
-                parent_constants = self._symbols_and_constants[nsdfg._parent_sdfg.cfg_id]
+                parent_constants = self._symbols_and_constants[nsdfg.parent_sdfg.cfg_id]
                 result |= parent_constants
 
                 # check for constant inputs

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -2350,7 +2350,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     if symbolic.issymbolic(atom, self.sdfg.constants):
                         astr = str(atom)
                         # Check for undefined variables
-                        if astr not in self.defined:
+                        if astr not in self.defined and not ('.' in astr and astr in self.sdfg.arrays):
                             raise DaceSyntaxError(self, node, 'Undefined variable "%s"' % atom)
                         # Add to global SDFG symbols if not a scalar
                         if (astr not in self.sdfg.symbols and not (astr in self.variables or astr in self.sdfg.arrays)):

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3944,6 +3944,10 @@ class ProgramVisitor(ExtNodeVisitor):
         else:
             required_args.extend(symbols)
         required_args = dtypes.deduplicate(required_args)
+        gargs = set(a[0] for a in args)
+        for rarg in required_args:
+            if rarg not in gargs and rarg in self.sdfg.symbols:
+                args.append((rarg, rarg))
 
         # Argument checks
         for aname, arg in kwargs:

--- a/dace/frontend/python/replacements.py
+++ b/dace/frontend/python/replacements.py
@@ -1294,8 +1294,14 @@ def _array_array_where(visitor: ProgramVisitor,
         raise ValueError('numpy.where is only supported for the case where x and y are given')
 
     cond_arr = sdfg.arrays[cond_operand]
-    left_arr = sdfg.arrays.get(left_operand, None)
-    right_arr = sdfg.arrays.get(right_operand, None)
+    try:
+        left_arr = sdfg.arrays[left_operand]
+    except KeyError:
+        left_arr = None
+    try:
+        right_arr = sdfg.arrays[right_operand]
+    except KeyError:
+        right_arr = None
 
     left_type = left_arr.dtype if left_arr else dtypes.dtype_to_typeclass(type(left_operand))
     right_type = right_arr.dtype if right_arr else dtypes.dtype_to_typeclass(type(right_operand))

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -1575,7 +1575,7 @@ class Reduce(dace.sdfg.nodes.LibraryNode):
         super().__init__(name=name, **kwargs)
         self.wcr = wcr
         self.axes = axes
-        self.identity = str(identity)
+        self.identity = str(identity) if identity is not None else None
         self.debuginfo = debuginfo
         self.schedule = schedule
 

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -1562,7 +1562,7 @@ class Reduce(dace.sdfg.nodes.LibraryNode):
     # Properties
     axes = ListProperty(element_type=int, allow_none=True)
     wcr = LambdaProperty(default='lambda a, b: a')
-    identity = Property(allow_none=True, dtype=str)
+    identity = Property(allow_none=True, to_json=lambda x: str(x))
 
     def __init__(self,
                  name,
@@ -1575,7 +1575,7 @@ class Reduce(dace.sdfg.nodes.LibraryNode):
         super().__init__(name=name, **kwargs)
         self.wcr = wcr
         self.axes = axes
-        self.identity = str(identity) if identity is not None else None
+        self.identity = identity
         self.debuginfo = debuginfo
         self.schedule = schedule
 

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -1562,7 +1562,7 @@ class Reduce(dace.sdfg.nodes.LibraryNode):
     # Properties
     axes = ListProperty(element_type=int, allow_none=True)
     wcr = LambdaProperty(default='lambda a, b: a')
-    identity = Property(allow_none=True)
+    identity = Property(allow_none=True, dtype=str)
 
     def __init__(self,
                  name,
@@ -1575,7 +1575,7 @@ class Reduce(dace.sdfg.nodes.LibraryNode):
         super().__init__(name=name, **kwargs)
         self.wcr = wcr
         self.axes = axes
-        self.identity = identity
+        self.identity = str(identity)
         self.debuginfo = debuginfo
         self.schedule = schedule
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2509,7 +2509,7 @@ class SDFG(ControlFlowRegion):
         warnings.warn('SDFG.apply_strict_transformations is deprecated, use SDFG.simplify instead.', DeprecationWarning)
         return self.simplify(validate, validate_all)
 
-    def simplify(self, validate=True, validate_all=False, verbose=False):
+    def simplify(self, validate=True, validate_all=False, verbose=False, options=None):
         """ Applies safe transformations (that will surely increase the
             performance) on the SDFG. For example, this fuses redundant states
             (safely) and removes redundant arrays.
@@ -2517,7 +2517,8 @@ class SDFG(ControlFlowRegion):
             :note: This is an in-place operation on the SDFG.
         """
         from dace.transformation.passes.simplify import SimplifyPass
-        return SimplifyPass(validate=validate, validate_all=validate_all, verbose=verbose).apply_pass(self, {})
+        return SimplifyPass(validate=validate, validate_all=validate_all, verbose=verbose,
+                            pass_options=options).apply_pass(self, {})
 
     def auto_optimize(self,
                       device: dtypes.DeviceType,

--- a/dace/transformation/passes/fusion_inline.py
+++ b/dace/transformation/passes/fusion_inline.py
@@ -88,6 +88,16 @@ class InlineSDFGs(ppl.Pass):
     def report(self, pass_retval: int) -> str:
         return f'Inlined {pass_retval} SDFGs.'
 
+    def set_opts(self, opts):
+        opt_keys = [
+            'multistate',
+        ]
+
+        for k in opt_keys:
+            attr_k = InlineSDFGs.__name__ + '.' + k
+            if attr_k in opts:
+                setattr(self, k, opts[attr_k])
+
 
 @dataclass(unsafe_hash=True)
 @properties.make_properties


### PR DESCRIPTION
- Allow the use of compression when using `SDFG.view`, allowing large SDFGs to be viewed
- Fix codegen issues related to out-of-date CFG lists
- Allow pass options to be passed to `SDFG.simplify`, passing them along to passes
- Implement the pass options API for `InlineSDFGs`
- Fix serialization issues for reduction library nodes where the identity function is `np.inf` or similar non-numeric numbers, which cause issues with other JSON deserializers that do not treat 'Infinity' (or similar) as a number.
- Fix missing symbol arguments when parsing a nested SDFG which takes a structure argument where a member's size is defined by a symbol not explicitly passed to the NSDFG, using symbol mappings
- Fix an error where the frontend reports missing symbols when a scalar struct member is being used in the range of a loop
- Fix replacements for `np.where` when using a member of a structure