### PR TITLE
[Multi SDFG, Fortran] Track down `allocated()` calls on Fparser and resolve them to constants with config injection if possible.

### DIFF
--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -2403,6 +2403,11 @@ def inject_const_evals(ast: Program,
             replace_node(al, _val_2_lit(item.value, ('LOGICAL',)))
 
         for dr in drefs:
+            if isinstance(dr.parent, Assignment_Stmt):
+                # We cannot replace on the LHS of an assignment.
+                lv, _, _ = dr.parent.children
+                if lv == dr:
+                    continue
             item = _find_matching_item(items, dr, alias_map)
             if not item:
                 continue

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -2284,6 +2284,67 @@ def _val_2_lit(val: str, type_spec: SPEC) -> LITERAL_TYPES:
     return numpy_type_to_literal(val)
 
 
+def _find_real_ident_spec(node: Name, alias_map: SPEC_TABLE) -> SPEC:
+    loc = search_real_local_alias_spec(node, alias_map)
+    assert loc
+    return ident_spec(alias_map[loc])
+
+
+def _lookup_dataref(dr: Data_Ref, alias_map: SPEC_TABLE) -> Optional[Tuple[Name, SPEC]]:
+    scope_spec = find_scope_spec(dr)
+    root, root_tspec, rest = _dataref_root(dr, scope_spec, alias_map)
+    while not isinstance(root, Name):
+        root, root_tspec, nurest = _dataref_root(root, scope_spec, alias_map)
+        rest += nurest
+    # NOTE: We should replace only when it is not an output of the function. However, here we pass the responsibilty to
+    # the user to provide valid injections.
+    if not all(isinstance(c, Name) for c in rest):
+        return None
+    return root, rest
+
+
+def _find_matching_item(items: List[ConstInjection], dr: Data_Ref, alias_map: SPEC_TABLE) -> Optional[ConstInjection]:
+    dr_info = _lookup_dataref(dr, alias_map)
+    if not dr_info:
+        return None
+    root, rest = dr_info
+    root_id_spec = _find_real_ident_spec(root, alias_map)
+    scope_spec = find_scope_spec(dr)
+    comp_tspec = find_type_dataref(dr, scope_spec, alias_map)
+    for item in items:
+        if isinstance(item, ConstTypeInjection):
+            # `item.component_spec` must be a precise suffix in the data-ref, and everything before that must
+            # precisely match `item.type_spec`.
+            if len(item.component_spec) > len(rest):
+                continue
+            pre, c_rest = rest[:-len(item.component_spec)], rest[-len(item.component_spec):]
+            comp_spec: SPEC = tuple(c.string for c in c_rest)
+            if comp_spec[:-1] != item.component_spec[:-1]:
+                # All but the last component must exactly match in all case.
+                continue
+            if comp_tspec.alloc:
+                if f"{comp_spec[-1]}_a" != item.component_spec[-1]:
+                    # Allocatable array's special variable didn't match either.
+                    continue
+            else:
+                if comp_spec[-1] != item.component_spec[-1]:
+                    # Otherwise the last component must exactly match too.
+                    continue
+            comp = Data_Ref(' % '.join(tuple(p.string for p in (root,) + pre)))
+            ctspec = find_type_dataref(comp, scope_spec, alias_map)
+            if ctspec.spec != item.type_spec:
+                continue
+        elif isinstance(item, ConstInstanceInjection):
+            # This is a simpler case, where the object must match `item.root_spec`, and the entire component
+            # parts of the data-ref must precisely match `item.component_spec`.
+            comp_spec: SPEC = tuple(c.string for c in rest)
+            if root_id_spec != item.root_spec or comp_spec != item.component_spec:
+                continue
+
+        return item
+    return None
+
+
 def inject_const_evals(ast: Program,
                        inject_consts: Optional[List[ConstInjection]] = None) -> Program:
     inject_consts = inject_consts or []
@@ -2316,56 +2377,36 @@ def inject_const_evals(ast: Program,
         else:
             scope = alias_map[scope_spec].parent
 
-        drefs: List[Data_Ref] = walk(scope, Data_Ref)
+        drefs: List[Data_Ref] = [dr for dr in walk(scope, Data_Ref)
+                                 if find_type_dataref(dr, find_scope_spec(dr), alias_map).spec != ('CHARACTER',)]
         names: List[Name] = walk(scope, Name)
+        allocateds: List[Intrinsic_Function_Reference] = [c for c in walk(scope, Intrinsic_Function_Reference)
+                                                          if c.children[0].string == 'ALLOCATED']
 
         # Ignore the special variables related to array dimensions, since we don't handle them here.
+        alloc_items = [item for item in items if item.component_spec[-1].endswith('_a')]
         items = [item for item in items
                  if not (item.component_spec[-1].endswith('_s') or item.component_spec[-1].endswith('_a'))]
         item_inst_root_specs: Set[SPEC] = {item.root_spec for item in items
                                            if isinstance(item, ConstInstanceInjection)}  # For speedup later.
 
+        for al in allocateds:
+            _, args = al.children
+            assert args and len(args.children) == 1
+            arr, = args.children
+            if not isinstance(arr, Data_Ref):
+                # TODO: We don't support anything else for now.
+                continue
+            item = _find_matching_item(alloc_items, arr, alias_map)
+            if not item:
+                continue
+            replace_node(al, _val_2_lit(item.value, ('LOGICAL',)))
+
         for dr in drefs:
-            scope_spec = find_scope_spec(dr)
-            root, root_tspec, rest = _dataref_root(dr, scope_spec, alias_map)
-            while not isinstance(root, Name):
-                root, root_tspec, nurest = _dataref_root(root, scope_spec, alias_map)
-                rest += nurest
-            loc = search_real_local_alias_spec(root, alias_map)
-            assert loc
-            root_id_spec = ident_spec(alias_map[loc])
-            if root_tspec.out:
-                # We replace only when it is not an output of the function.
+            item = _find_matching_item(items, dr, alias_map)
+            if not item:
                 continue
-            if not all(isinstance(c, Name) for c in rest):
-                continue
-            comp_tspec = find_type_dataref(dr, scope_spec, alias_map)
-            if comp_tspec.spec == ('CHARACTER',):
-                continue
-
-            for item in items:
-                if isinstance(item, ConstTypeInjection):
-                    # `item.component_spec` must be a precise suffix in the data-ref, and everything before that must
-                    # precisely match `item.type_spec`.
-                    if len(item.component_spec) > len(rest):
-                        continue
-                    pre, c_rest = rest[:-len(item.component_spec)], rest[-len(item.component_spec):]
-                    comp_spec: SPEC = tuple(c.string for c in c_rest)
-                    if comp_spec != item.component_spec:
-                        continue
-                    comp = Data_Ref(' % '.join(tuple(p.string for p in (root,) + pre)))
-                    ctspec = find_type_dataref(comp, scope_spec, alias_map)
-                    if ctspec.spec != item.type_spec:
-                        continue
-                elif isinstance(item, ConstInstanceInjection):
-                    # This is a simpler case, where the object must match `item.root_spec`, and the entire component
-                    # parts of the data-ref must precisely match `item.component_spec`.
-                    comp_spec: SPEC = tuple(c.string for c in rest)
-                    if root_id_spec != item.root_spec or comp_spec != item.component_spec:
-                        continue
-
-                replace_node(dr, _val_2_lit(item.value, comp_tspec.spec))
-                break
+            replace_node(dr, _val_2_lit(item.value, find_type_dataref(dr, find_scope_spec(dr), alias_map).spec))
 
         for nm in names:
             # We can also directly inject variables' values with `ConstInstanceInjection`.
@@ -2387,9 +2428,8 @@ def inject_const_evals(ast: Program,
                     # to the (scalar) variable identified by `nm`.
                     continue
                 tspec = find_type_of_entity(alias_map[loc], alias_map)
-                if tspec.out:
-                    # We replace only when it is not an output of the function.
-                    continue
+                # NOTE: We should replace only when it is not an output of the function. However, here we pass the
+                # responsibilty to the user to provide valid injections.
                 replace_node(nm, _val_2_lit(item.value, tspec.spec))
                 break
     return ast

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -3340,11 +3340,11 @@ def create_sdfg_from_fortran_file_with_options(
         ast = deconstruct_enums(ast)
         ast = deconstruct_associations(ast)
         ast = remove_access_statements(ast)
-        ast = inject_const_evals(ast, cfg.config_injections)
         ast = correct_for_function_calls(ast)
         ast = deconstruct_procedure_calls(ast)
         ast = deconstruct_interface_calls(ast)
 
+        ast = inject_const_evals(ast, cfg.config_injections)
         # Prune things once.
         ast = const_eval_nodes(ast)
         ast = prune_branches(ast)

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1590,7 +1590,7 @@ contains
   real function fun(this)
     implicit none
     type(config), intent(inout) :: this
-    if (allocated(this%a)) then
+    if (allocated(this%a)) then  ! This will be replaced even though it is an out (i.e., beware of invalid injections).
       fun = 5.1
     else
       fun = -1
@@ -1612,7 +1612,6 @@ end subroutine main
     ])
 
     got = ast.tofortran()
-    print(got)
     want = """
 MODULE lib
   IMPLICIT NONE
@@ -1623,7 +1622,7 @@ MODULE lib
   REAL FUNCTION fun(this)
     IMPLICIT NONE
     TYPE(config), INTENT(INOUT) :: this
-    IF (ALLOCATED(this % a)) THEN
+    IF (.TRUE.) THEN
       fun = 5.1
     ELSE
       fun = - 1


### PR DESCRIPTION
Turns out this is enough to remove all `allocated()` calls that remains after pruning.