### PR TITLE
[f2dace/dev, Fortran] Copy `_replace_dict_keys()` implementation from `main` branch.

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -109,6 +109,8 @@ def _replace_dict_keys(d, old, new):
         warnings.warn(f"Trying to replace key with the same name {old} ... skipping.")
         return
     if old in d:
+        if new in d:
+            warnings.warn('"%s" already exists in SDFG' % new)
         d[new] = d[old]
         del d[old]
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -109,12 +109,8 @@ def _replace_dict_keys(d, old, new):
         warnings.warn(f"Trying to replace key with the same name {old} ... skipping.")
         return
     if old in d:
-        
         d[new] = d[old]
-        if new in d:
-            warnings.warn('"%s" already exists in SDFG' % new)
-        else:    
-            del d[old]
+        del d[old]
 
 
 def _replace_dict_values(d, old, new):


### PR DESCRIPTION
The logical mistake has been fixed there a long time ago.