### PR TITLE
Use typeclasses in code generator

### DIFF
--- a/dace/codegen/dispatcher.py
+++ b/dace/codegen/dispatcher.py
@@ -24,9 +24,9 @@ class DefinedType(aenum.AutoNumberEnum):
         :see: DefinedMemlets
     """
     Pointer = ()  # Pointer
-    Scalar = ()   # A copyable scalar moved by value (e.g., POD)
-    Object = ()   # An object moved by reference
-    Stream = ()   # A stream object moved by reference and accessed via a push/pop API
+    Scalar = ()  # A copyable scalar moved by value (e.g., POD)
+    Object = ()  # An object moved by reference
+    Stream = ()  # A stream object moved by reference and accessed via a push/pop API
     StreamArray = ()  # An array of Streams
     FPGA_ShiftRegister = ()  # A shift-register object used in FPGA code generation
     ArrayInterface = ()  # An object representing an interface to an array, used mostly in FPGA
@@ -56,7 +56,7 @@ class DefinedMemlets:
         except KeyError:
             return False
 
-    def get(self, name: str, ancestor: int = 0, is_global: bool = False) -> Tuple[DefinedType, str]:
+    def get(self, name: str, ancestor: int = 0, is_global: bool = False) -> Tuple[DefinedType, dtypes.typeclass]:
         for parent, scope, can_access_parent in reversed(self._scopes):
             last_parent = parent
             if ancestor > 0:
@@ -85,7 +85,14 @@ class DefinedMemlets:
 
         raise KeyError("Variable {} has not been defined".format(name))
 
-    def add(self, name: str, dtype: DefinedType, ctype: str, ancestor: int = 0, allow_shadowing: bool = False):
+    def add(self,
+            name: str,
+            dtype: DefinedType,
+            ctype: dtypes.typeclass,
+            ancestor: int = 0,
+            allow_shadowing: bool = False):
+        if not isinstance(ctype, dtypes.typeclass):
+            raise NotImplementedError('No longer supported')
         if not isinstance(name, str):
             raise TypeError('Variable name type cannot be %s' % type(name).__name__)
         if name.startswith('__state->'):
@@ -95,7 +102,7 @@ class DefinedMemlets:
             if name in scope:
                 err_str = "Shadowing variable {} from type {} to {}".format(name, scope[name], dtype)
                 if (allow_shadowing or config.Config.get_bool("compiler", "allow_shadowing")):
-                    if not allow_shadowing:
+                    if not allow_shadowing and scope[name][0] != dtype:
                         print("WARNING: " + err_str)
                 else:
                     raise cgx.CodegenError(err_str)
@@ -103,7 +110,7 @@ class DefinedMemlets:
                 break
         self._scopes[-1 - ancestor][1][name] = (dtype, ctype)
 
-    def add_global(self, name: str, dtype: DefinedType, ctype: str) -> None:
+    def add_global(self, name: str, dtype: DefinedType, ctype: dtypes.typeclass):
         """
         Adds a global variable (top scope)
         """
@@ -111,6 +118,15 @@ class DefinedMemlets:
             raise TypeError('Variable name type cannot be %s' % type(name).__name__)
 
         self._scopes[0][1][name] = (dtype, ctype)
+
+    def get_all_names(self, ancestor: int = 0) -> Set[str]:
+        global_vars = self._scopes[0][1].keys()
+        result = set(global_vars)
+        for _, scope, can_access_parent in self._scopes[1:len(self._scopes) - ancestor]:
+            if not can_access_parent:
+                result = set(global_vars)
+            result |= scope.keys()
+        return result
 
     def remove(self, name: str, ancestor: int = 0, is_global: bool = False) -> None:
         for parent, scope, can_access_parent in reversed(self._scopes):
@@ -244,7 +260,8 @@ class TargetDispatcher(object):
         """ Returns a list of state dispatchers with predicates. """
         return list(self._state_dispatchers)
 
-    def register_node_dispatcher(self, dispatcher: target.TargetCodeGenerator,
+    def register_node_dispatcher(self,
+                                 dispatcher: target.TargetCodeGenerator,
                                  predicate: Optional[Callable] = None) -> None:
         """ Registers a code generator that processes a single node, calling
             ``generate_node``.
@@ -272,8 +289,7 @@ class TargetDispatcher(object):
         """ Returns a list of node dispatchers with predicates. """
         return list(self._node_dispatchers)
 
-    def register_map_dispatcher(self,
-                                schedule_type: Union[List[dtypes.ScheduleType], dtypes.ScheduleType],
+    def register_map_dispatcher(self, schedule_type: Union[List[dtypes.ScheduleType], dtypes.ScheduleType],
                                 func: target.TargetCodeGenerator) -> None:
         """ Registers a function that processes a scope, used when calling
             ``dispatch_subgraph`` and ``dispatch_scope``.
@@ -315,8 +331,11 @@ class TargetDispatcher(object):
         if not isinstance(func, target.TargetCodeGenerator): raise TypeError
         self._array_dispatchers[storage_type] = func
 
-    def register_copy_dispatcher(self, src_storage: dtypes.StorageType, dst_storage: dtypes.StorageType,
-                                 dst_schedule: dtypes.ScheduleType, func: target.TargetCodeGenerator,
+    def register_copy_dispatcher(self,
+                                 src_storage: dtypes.StorageType,
+                                 dst_storage: dtypes.StorageType,
+                                 dst_schedule: dtypes.ScheduleType,
+                                 func: target.TargetCodeGenerator,
                                  predicate: Optional[Callable] = None) -> None:
         """ Registers code generation of data-to-data (or data from/to
             tasklet, if src/dst storage is StorageType.Register) copy
@@ -449,13 +468,8 @@ class TargetDispatcher(object):
     def get_scope_dispatcher(self, schedule: dtypes.ScheduleType) -> target.TargetCodeGenerator:
         return self._map_dispatchers[schedule]
 
-    def dispatch_scope(self,
-                       map_schedule: dtypes.ScheduleType,
-                       sdfg: SDFG,
-                       cfg: ControlFlowRegion,
-                       sub_dfg: StateSubgraphView,
-                       state_id: int,
-                       function_stream: CodeIOStream,
+    def dispatch_scope(self, map_schedule: dtypes.ScheduleType, sdfg: SDFG, cfg: ControlFlowRegion,
+                       sub_dfg: StateSubgraphView, state_id: int, function_stream: CodeIOStream,
                        callsite_stream: CodeIOStream) -> None:
         """ Dispatches a code generator function for a scope in an SDFG
             state. """
@@ -517,9 +531,9 @@ class TargetDispatcher(object):
 
     # Dispatches copy code for a memlet
     def get_copy_dispatcher(self, src_node: Union[nodes.CodeNode, nodes.AccessNode],
-                            dst_node: Union[nodes.CodeNode, nodes.AccessNode, nodes.EntryNode],
-                            edge: MultiConnectorEdge[Memlet],
-                            sdfg: SDFG, state: SDFGState) -> Optional[target.TargetCodeGenerator]:
+                            dst_node: Union[nodes.CodeNode, nodes.AccessNode,
+                                            nodes.EntryNode], edge: MultiConnectorEdge[Memlet], sdfg: SDFG,
+                            state: SDFGState) -> Optional[target.TargetCodeGenerator]:
         """
         (Internal) Returns a code generator that should be dispatched for a
         memory copy operation.

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -249,6 +249,7 @@ def ptr(name: str, desc: data.Data, sdfg: SDFG = None, framecode=None) -> str:
         root = name.split('.')[0]
         if root in sdfg.arrays and isinstance(sdfg.arrays[root], data.Structure):
             name = name.replace('.', '->')
+            name = name.replace('->->->', '...')  # Special case
 
     # Special case: If memory is persistent and defined in this SDFG, add state
     # struct to name
@@ -269,6 +270,16 @@ def ptr(name: str, desc: data.Data, sdfg: SDFG = None, framecode=None) -> str:
     return name
 
 
+def get_abs_base_type_and_ptr_count(dtype: dtypes.typeclass) -> Tuple[dtypes.typeclass, int]:
+    base_type = dtype
+    ptr_count = 0
+    while isinstance(base_type, (dace.pointer, dace.fixedlenarray)):
+        ptr_count += 1
+        base_type = base_type.base_type
+
+    return base_type, ptr_count
+
+
 def emit_memlet_reference(dispatcher: 'TargetDispatcher',
                           sdfg: SDFG,
                           memlet: mmlt.Memlet,
@@ -277,7 +288,7 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
                           ancestor: int = 1,
                           is_write: bool = None,
                           device_code: bool = False,
-                          decouple_array_interfaces: bool = False) -> Tuple[str, str, str]:
+                          decouple_array_interfaces: bool = False) -> Tuple[dtypes.typeclass, str, str]:
     """
     Returns a tuple of three strings with a definition of a reference to an
     existing memlet. Used in nested SDFG arguments.
@@ -288,7 +299,7 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
     :return: A tuple of the form (type, name, value).
     """
     desc = sdfg.arrays[memlet.data]
-    typedef = conntype.ctype
+    typedef = conntype
     offset = cpp_offset_expr(desc, memlet.subset)
     offset_expr = '[' + offset + ']'
     is_scalar = not isinstance(conntype, dtypes.pointer)
@@ -302,11 +313,11 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
         if (isinstance(desc, data.Array) and not isinstance(desc, data.View) and any(
                 str(s) not in dispatcher.frame.symbols_and_constants(sdfg)
                 for s in dispatcher.frame.free_symbols(desc))):
-            defined_types = dispatcher.declared_arrays.get(ptrname, ancestor)
+            defined_types: Tuple[DefinedType, dtypes.typeclass] = dispatcher.declared_arrays.get(ptrname, ancestor)
     except KeyError:
         pass
     if not defined_types:
-        defined_types = dispatcher.defined_vars.get(ptrname, ancestor)
+        defined_types: Tuple[DefinedType, dtypes.typeclass] = dispatcher.defined_vars.get(ptrname, ancestor)
     defined_type, defined_ctype = defined_types
 
     if fpga.is_fpga_array(desc):
@@ -324,12 +335,11 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
     else:
         datadef = ptr(memlet.data, desc, sdfg, dispatcher.frame)
 
-    def make_const(expr: str) -> str:
+    def make_const(expr: dtypes.typeclass) -> dtypes.typeclass:
         # check whether const has already been added before
-        if not expr.startswith("const "):
-            return "const " + expr
-        else:
-            return expr
+        if getattr(expr, 'const', False):
+            expr.const = True
+        return expr
 
     if (defined_type == DefinedType.Pointer
             or (defined_type == DefinedType.ArrayInterface and isinstance(desc, data.View))):
@@ -349,11 +359,11 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
                 typedef = make_const(typedef)
 
     elif defined_type == DefinedType.ArrayInterface:
-        base_ctype = conntype.base_type.ctype
-        typedef = f"{base_ctype}*" if is_write else f"const {base_ctype}*"
+        base_ctype = conntype.base_type
+        typedef = dtypes.pointer(base_ctype)
         is_scalar = False
     elif defined_type == DefinedType.Scalar:
-        typedef = defined_ctype if is_scalar else (defined_ctype + '*')
+        typedef = defined_ctype if is_scalar else dtypes.pointer(defined_ctype)
         if is_write is False and not isinstance(desc, data.Structure):
             typedef = make_const(typedef)
         ref = '&' if is_scalar else ''
@@ -397,7 +407,7 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
         ref = '&'
     else:
         # Cast as necessary
-        expr = make_ptr_vector_cast(datadef + offset_expr, desc.dtype, conntype, is_scalar, defined_type)
+        expr = make_ptr_vector_cast(datadef + offset_expr, defined_ctype, conntype, is_scalar, defined_type)
 
     # Register defined variable
     dispatcher.defined_vars.add(pointer_name, defined_type, typedef, allow_shadowing=True)
@@ -405,8 +415,9 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
     # NOTE: `expr` may only be a name or a sequence of names and dots. The latter indicates nested data and structures.
     # NOTE: Since structures are implemented as pointers, we replace dots with arrows.
     expr = expr.replace('.', '->')
+    expr = expr.replace('->->->', '...')  # Special case
 
-    return (typedef + ref, pointer_name, expr)
+    return (typedef, ref + pointer_name, expr)
 
 
 def reshape_strides(subset, strides, original_strides, copy_shape):
@@ -614,19 +625,34 @@ def cpp_array_expr(sdfg,
         return offset_cppstr
 
 
-def make_ptr_vector_cast(dst_expr, dst_dtype, src_dtype, is_scalar, defined_type):
+def make_ptr_vector_cast(dst_expr: str, dst_dtype: dtypes.typeclass, src_dtype: dtypes.typeclass, is_scalar: bool,
+                         defined_type: DefinedType):
     """
     If there is a type mismatch, cast pointer type. Used mostly in vector types.
     """
-    if src_dtype != dst_dtype:
+    src_base, src_ptrs = get_abs_base_type_and_ptr_count(src_dtype)
+    dst_base, dst_ptrs = get_abs_base_type_and_ptr_count(dst_dtype)
+    dst_ptrs -= dst_expr.count('[')  # Count dereferences
+
+    if src_base != dst_base:
         if is_scalar:
-            dst_expr = '*(%s *)(&%s)' % (src_dtype.ctype, dst_expr)
+            dst_expr = '*(%s)(&%s)' % (dtypes.pointer(src_dtype).as_arg(''), dst_expr)
         elif src_dtype.base_type != dst_dtype:
-            dst_expr = '(%s)(&%s)' % (src_dtype.ctype, dst_expr)
+            dst_expr = '(%s)(&%s)' % (src_dtype.as_arg(''), dst_expr)
         elif defined_type in [DefinedType.Pointer, DefinedType.ArrayInterface]:
-            dst_expr = '&' + dst_expr
-    elif not is_scalar:
-        dst_expr = '&' + dst_expr
+            if dst_expr.endswith('[0]'):  # Skip expressions of the kind "&x[0]"
+                dst_expr = dst_expr[:-3]
+            else:
+                dst_expr = '&' + dst_expr
+    elif src_ptrs < dst_ptrs:
+        dst_expr = '*' * (dst_ptrs - src_ptrs) + dst_expr
+    elif dst_ptrs < src_ptrs:
+        if dst_expr.endswith('[0]'):  # Skip expressions of the kind "&x[0]"
+            dst_expr = dst_expr[:-3]
+            dst_ptrs += 1
+
+        dst_expr = '&' * (src_ptrs - dst_ptrs) + dst_expr
+
     return dst_expr
 
 
@@ -1011,9 +1037,10 @@ def unparse_tasklet(sdfg, cfg, state_id, dfg, node, function_stream, callsite_st
     # To prevent variables-redefinition, build dictionary with all the previously defined symbols
     defined_symbols = state_dfg.symbols_defined_at(node)
 
-    defined_symbols.update(
-        {k: v.dtype if hasattr(v, 'dtype') else dtypes.typeclass(type(v))
-         for k, v in sdfg.constants.items()})
+    defined_symbols.update({
+        k: v.dtype if hasattr(v, 'dtype') else dtypes.typeclass(type(v))
+        for k, v in sdfg.constants.items()
+    })
 
     for connector, (memlet, _, _, conntype) in memlets.items():
         if connector is not None:
@@ -1196,6 +1223,44 @@ class DaCeKeywordRemover(ExtNodeTransformer):
         memlet, nc, wcr, dtype = self.memlets[target]
         value = self.visit(astutils.copy_tree(node.value))
 
+        # Count dereferences in node.value and if types mismatch, prepend the
+        # correct number of references
+        if isinstance(value, ast.Name):
+            src_derefs = 0
+            cur_node = node.value
+            while isinstance(cur_node, ast.Subscript):
+                cur_node = cur_node.value
+                src_derefs += 1
+
+            target_derefs = 0
+            cur_node = node.targets[-1]
+            while isinstance(cur_node, ast.Subscript):
+                cur_node = cur_node.value
+                target_derefs += 1
+
+            source = rname(node.value)
+            if source in self.memlets:
+                src_dtype = self.memlets[source][3]
+                src_ptrs = 0
+                curdtype = src_dtype
+                while isinstance(curdtype, (dace.pointer, dace.fixedlenarray)):
+                    src_ptrs += 1
+                    curdtype = curdtype.base_type
+                target_ptrs = 0
+                curdtype = dtype
+                while isinstance(curdtype, (dace.pointer, dace.fixedlenarray)):
+                    target_ptrs += 1
+                    curdtype = curdtype.base_type
+
+                src_ptrs -= src_derefs
+                target_ptrs -= target_derefs
+                if src_ptrs > target_ptrs:
+                    value.id = '*' * (src_ptrs - target_ptrs) + value.id
+                    node.value = value
+                elif src_ptrs < target_ptrs:
+                    value.id = '&' * (target_ptrs - src_ptrs) + value.id
+                    node.value = value
+
         if not isinstance(node.targets[-1], ast.Subscript):
             # Dynamic accesses or streams -> every access counts
             try:
@@ -1290,7 +1355,8 @@ class DaCeKeywordRemover(ExtNodeTransformer):
 
     def visit_Call(self, node: ast.Call):
         funcname = rname(node.func)
-        if (funcname in self.sdfg.symbols and isinstance(self.sdfg.symbols[funcname], dtypes.callback)):
+        if (funcname in self.sdfg.callback_mapping
+                or (funcname in self.sdfg.symbols and isinstance(self.sdfg.symbols[funcname], dtypes.callback))):
             # Visit arguments without changing their types
             self.allow_casts = False
             result = self.generic_visit(node)

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -42,7 +42,7 @@ class CPUCodeGen(TargetCodeGenerator):
             for k, v in struct.members.items():
                 if isinstance(v, data.Structure):
                     _visit_structure(v, args, f'{prefix}->{k}')
-                elif isinstance(v, data.ContainerArray):
+                elif isinstance(v, data.ContainerArray) and isinstance(v.stype, data.Structure):
                     _visit_structure(v.stype, args, f'{prefix}->{k}')
                 if isinstance(v, data.Data):
                     args[f'{prefix}->{k}'] = v
@@ -64,19 +64,20 @@ class CPUCodeGen(TargetCodeGenerator):
                 # GPU global memory is only accessed via pointers
                 # TODO(later): Fix workaround somehow
                 if arg_type.storage is dtypes.StorageType.GPU_Global:
-                    self._dispatcher.defined_vars.add(name, DefinedType.Pointer, dtypes.pointer(arg_type.dtype).ctype)
+                    self._dispatcher.defined_vars.add(name, DefinedType.Pointer, dtypes.pointer(arg_type.dtype))
                     continue
 
-                self._dispatcher.defined_vars.add(name, DefinedType.Scalar, arg_type.dtype.ctype)
+                self._dispatcher.defined_vars.add(name, DefinedType.Scalar, arg_type.dtype)
             elif isinstance(arg_type, data.Array):
-                self._dispatcher.defined_vars.add(name, DefinedType.Pointer, dtypes.pointer(arg_type.dtype).ctype)
+                self._dispatcher.defined_vars.add(name, DefinedType.Pointer, dtypes.pointer(arg_type.dtype))
             elif isinstance(arg_type, data.Stream):
                 if arg_type.is_stream_array():
-                    self._dispatcher.defined_vars.add(name, DefinedType.StreamArray, arg_type.as_arg(name=''))
+                    self._dispatcher.defined_vars.add(name, DefinedType.StreamArray,
+                                                      dtypes.opaque(arg_type.as_arg(name='')))
                 else:
-                    self._dispatcher.defined_vars.add(name, DefinedType.Stream, arg_type.as_arg(name=''))
+                    self._dispatcher.defined_vars.add(name, DefinedType.Stream, dtypes.opaque(arg_type.as_arg(name='')))
             elif isinstance(arg_type, data.Structure):
-                self._dispatcher.defined_vars.add(name, DefinedType.Pointer, arg_type.dtype.ctype)
+                self._dispatcher.defined_vars.add(name, DefinedType.Pointer, arg_type.dtype)
             else:
                 raise TypeError("Unrecognized argument type: {t} (value {v})".format(t=type(arg_type).__name__,
                                                                                      v=str(arg_type)))
@@ -102,7 +103,7 @@ class CPUCodeGen(TargetCodeGenerator):
         # Keep track of traversed nodes
         self._generated_nodes = set()
 
-        # Keep track of generated NestedSDG, and the name of the assigned function
+        # Keep track of generated NestedSDFG, and the name of the assigned function
         self._generated_nested_sdfg = dict()
 
         # Keeps track of generated connectors, so we know how to access them in nested scopes
@@ -211,11 +212,12 @@ class CPUCodeGen(TargetCodeGenerator):
         # write variation
         is_write = edge.src is node
 
-        # Allocate the viewed data before the view, if necessary
+        # Allocate the viewed view before the view, if necessary
         mpath = dfg.memlet_path(edge)
         viewed_dnode: nodes.AccessNode = mpath[-1].dst if is_write else mpath[0].src
-        self._dispatcher.dispatch_allocate(sdfg, cfg, dfg, state_id, viewed_dnode, viewed_dnode.desc(sdfg),
-                                           global_stream, allocation_stream)
+        if isinstance(viewed_dnode.desc(sdfg), (data.View, data.Reference)):
+            self._dispatcher.dispatch_allocate(sdfg, cfg, dfg, state_id, viewed_dnode, viewed_dnode.desc(sdfg),
+                                               global_stream, allocation_stream)
 
         # Memlet points to view, construct mirror memlet
         memlet = edge.data
@@ -226,12 +228,18 @@ class CPUCodeGen(TargetCodeGenerator):
             if memlet.subset is None:
                 memlet.subset = subsets.Range.from_array(viewed_dnode.desc(sdfg))
 
+        if isinstance(nodedesc, data.Structure) and not nodedesc.byval:
+            # dtype is already a pointer
+            view_dtype = nodedesc.dtype
+        else:
+            view_dtype = dtypes.pointer(nodedesc.dtype)
+
         # Emit memlet as a reference and register defined variable
         atype, aname, value = cpp.emit_memlet_reference(self._dispatcher,
                                                         sdfg,
                                                         memlet,
                                                         name,
-                                                        dtypes.pointer(nodedesc.dtype),
+                                                        view_dtype,
                                                         ancestor=0,
                                                         is_write=is_write)
 
@@ -246,7 +254,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 field_name = mpath[0].src_conn
 
             # Plain view into a container array
-            if isinstance(vdesc, data.ContainerArray) and not isinstance(vdesc.stype, data.Structure):
+            if isinstance(vdesc, data.ContainerArray) and not isinstance(vdesc.stype, data.Structure) and nodedesc.dtype == vdesc.dtype:
                 offset = cpp.cpp_offset_expr(vdesc, memlet.subset)
                 value = f'{ptrname}[{offset}]'
             else:
@@ -264,21 +272,20 @@ class CPUCodeGen(TargetCodeGenerator):
                         value = '&' + value
 
         if not declared:
-            ctypedef = dtypes.pointer(nodedesc.dtype).ctype
-            self._dispatcher.declared_arrays.add(aname, DefinedType.Pointer, ctypedef)
+            self._dispatcher.declared_arrays.add(aname, DefinedType.Pointer, atype)
             if isinstance(nodedesc, data.StructureView):
                 for k, v in nodedesc.members.items():
                     if isinstance(v, data.Data):
-                        ctypedef = dtypes.pointer(v.dtype).ctype if isinstance(v, data.Array) else v.dtype.ctype
+                        ctypedef = dtypes.pointer(v.dtype) if isinstance(v, data.Array) else v.dtype
                         defined_type = DefinedType.Scalar if isinstance(v, data.Scalar) else DefinedType.Pointer
                         self._dispatcher.declared_arrays.add(f"{name}->{k}", defined_type, ctypedef)
                         self._dispatcher.defined_vars.add(f"{name}->{k}", defined_type, ctypedef)
                 # TODO: Find a better way to do this (the issue is with pointers of pointers)
-                if atype.endswith('*'):
-                    atype = atype[:-1]
-                if value.startswith('&'):
-                    value = value[1:]
-            declaration_stream.write(f'{atype} {aname};', cfg, state_id, node)
+                # if isinstance(atype, dtypes.pointer):
+                #     atype = atype.base_type
+                # if value.startswith('&'):
+                #     value = value[1:]
+            declaration_stream.write(f'{atype.as_arg(aname)};', cfg, state_id, node)
         allocation_stream.write(f'{aname} = {value};', cfg, state_id, node)
 
     def allocate_reference(self, sdfg: SDFG, cfg: ControlFlowRegion, dfg: SDFGState, state_id: int,
@@ -292,8 +299,13 @@ class CPUCodeGen(TargetCodeGenerator):
         declared = self._dispatcher.declared_arrays.has(ptrname)
 
         if not declared:
-            declaration_stream.write(f'{nodedesc.dtype.ctype} *{ptrname};', cfg, state_id, node)
-            ctypedef = dtypes.pointer(nodedesc.dtype).ctype
+            if 'views' in node.out_connectors and not list(dfg.out_edges_by_connector(node, 'views'))[0].dst_conn:
+                # Reference and a view, but not setting a field
+                self.allocate_view(sdfg, cfg, dfg, state_id, node, global_stream, declaration_stream, allocation_stream)
+                return
+
+            declaration_stream.write(f'{nodedesc.as_arg(name=ptrname)};', cfg, state_id, node)
+            ctypedef = dtypes.pointer(nodedesc.dtype)
             self._dispatcher.declared_arrays.add(ptrname, DefinedType.Pointer, ctypedef)
             self._dispatcher.defined_vars.add(ptrname, DefinedType.Pointer, ctypedef)
 
@@ -332,22 +344,22 @@ class CPUCodeGen(TargetCodeGenerator):
 
         if (nodedesc.storage == dtypes.StorageType.CPU_Heap or nodedesc.storage == dtypes.StorageType.Register):
 
-            ctypedef = dtypes.pointer(nodedesc.dtype).ctype
+            ctypedef = dtypes.pointer(nodedesc.dtype)
 
-            declaration_stream.write(f'{nodedesc.dtype.ctype} *{name} = nullptr;\n', cfg, state_id, node)
+            declaration_stream.write(f'{ctypedef.as_arg(name)} = nullptr;\n', cfg, state_id, node)
             self._dispatcher.declared_arrays.add(name, DefinedType.Pointer, ctypedef)
             return
         elif nodedesc.storage is dtypes.StorageType.CPU_ThreadLocal:
             # Define pointer once
             # NOTE: OpenMP threadprivate storage MUST be declared globally.
             function_stream.write(
-                "{ctype} *{name} = nullptr;\n"
-                "#pragma omp threadprivate({name})".format(ctype=nodedesc.dtype.ctype, name=name),
-                cfg,
+                "{ctype} = nullptr;\n"
+                "#pragma omp threadprivate({name})".format(ctype=nodedesc.as_arg(name=name)),
+                sdfg,
                 state_id,
                 node,
             )
-            self._dispatcher.declared_arrays.add_global(name, DefinedType.Pointer, '%s *' % nodedesc.dtype.ctype)
+            self._dispatcher.declared_arrays.add_global(name, DefinedType.Pointer, dtypes.pointer(nodedesc.dtype))
         else:
             raise NotImplementedError("Unimplemented storage type " + str(nodedesc.storage))
 
@@ -398,20 +410,21 @@ class CPUCodeGen(TargetCodeGenerator):
             arrsize_bytes = arrsize * nodedesc.dtype.bytes
 
         if isinstance(nodedesc, data.Structure) and not isinstance(nodedesc, data.StructureView):
-            declaration_stream.write(f"{nodedesc.ctype} {name} = new {nodedesc.dtype.base_type};\n")
-            define_var(name, DefinedType.Pointer, nodedesc.ctype)
+            declaration_stream.write(f"{nodedesc.as_arg(name=name)} = new {nodedesc.dtype.base_type};\n")
+            define_var(name, DefinedType.Pointer, nodedesc.dtype)
             if allocate_nested_data:
                 for k, v in nodedesc.members.items():
                     if isinstance(v, data.Data):
-                        ctypedef = dtypes.pointer(v.dtype).ctype if isinstance(v, data.Array) else v.dtype.ctype
+                        ctypedef = dtypes.pointer(v.dtype) if isinstance(v, data.Array) else v.dtype
                         defined_type = DefinedType.Scalar if isinstance(v, data.Scalar) else DefinedType.Pointer
                         self._dispatcher.declared_arrays.add(f"{name}->{k}", defined_type, ctypedef)
                         if isinstance(v, data.Scalar):
                             # NOTE: Scalar members are already defined in the struct definition.
                             self._dispatcher.defined_vars.add(f"{name}->{k}", defined_type, ctypedef)
                         else:
-                            self.allocate_array(sdfg, cfg, dfg, state_id, nodes.AccessNode(f"{name}.{k}"), v,
-                                                function_stream, declaration_stream, allocation_stream)
+                            self.allocate_array(sdfg, cfg, dfg, state_id, nodes.AccessNode(f"{name}.{k}"), v, function_stream,
+                                                declaration_stream, allocation_stream)
+
             return
         if isinstance(nodedesc, data.View):
             return self.allocate_view(sdfg, cfg, dfg, state_id, node, function_stream, declaration_stream,
@@ -421,10 +434,10 @@ class CPUCodeGen(TargetCodeGenerator):
                                            allocation_stream)
         if isinstance(nodedesc, data.Scalar):
             if node.setzero:
-                declaration_stream.write("%s %s = 0;\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
+                declaration_stream.write(f'{nodedesc.as_arg(name=name)} = 0;\n', cfg, state_id, node)
             else:
-                declaration_stream.write("%s %s;\n" % (nodedesc.dtype.ctype, name), cfg, state_id, node)
-            define_var(name, DefinedType.Scalar, nodedesc.dtype.ctype)
+                declaration_stream.write(f'{nodedesc.as_arg(name=name)};\n', cfg, state_id, node)
+            define_var(name, DefinedType.Scalar, nodedesc.dtype)
         elif isinstance(nodedesc, data.Stream):
             ###################################################################
             # Stream directly connected to an array
@@ -460,7 +473,7 @@ class CPUCodeGen(TargetCodeGenerator):
                     state_id,
                     node,
                 )
-                define_var(name, DefinedType.Stream, ctype)
+                define_var(name, DefinedType.Stream, dtypes.opaque(ctype))
                 return
 
             ###################################################################
@@ -474,7 +487,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 definition = "{} {};".format(ctypedef, name)
 
             declaration_stream.write(definition, cfg, state_id, node)
-            define_var(name, DefinedType.Stream, ctypedef)
+            define_var(name, DefinedType.Stream, dtypes.opaque(ctypedef))
 
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or (nodedesc.storage == dtypes.StorageType.Register and
@@ -493,10 +506,10 @@ class CPUCodeGen(TargetCodeGenerator):
                                       name, cpp.sym2cpp(arrsize_bytes), nodedesc.storage,
                                       Config.get("compiler", "max_stack_array_size")))
 
-            ctypedef = dtypes.pointer(nodedesc.dtype).ctype
+            ctypedef = dtypes.pointer(nodedesc.dtype)
 
             if not declared:
-                declaration_stream.write(f'{nodedesc.dtype.ctype} *{name};\n', cfg, state_id, node)
+                declaration_stream.write(f'{ctypedef.as_arg(name=name)};\n', cfg, state_id, node)
             allocation_stream.write(
                 "%s = new %s DACE_ALIGN(64)[%s];\n" % (alloc_name, nodedesc.dtype.ctype, cpp.sym2cpp(arrsize)), cfg,
                 state_id, node)
@@ -511,20 +524,20 @@ class CPUCodeGen(TargetCodeGenerator):
 
             return
         elif (nodedesc.storage == dtypes.StorageType.Register):
-            ctypedef = dtypes.pointer(nodedesc.dtype).ctype
             if nodedesc.start_offset != 0:
                 raise NotImplementedError('Start offset unsupported for registers')
             if node.setzero:
                 declaration_stream.write(
-                    "%s %s[%s]  DACE_ALIGN(64) = {0};\n" % (nodedesc.dtype.ctype, name, cpp.sym2cpp(arrsize)),
+                    "%s DACE_ALIGN(64) = {0};\n" % (defdesc.as_arg(name=name)),
                     cfg,
                     state_id,
                     node,
                 )
                 define_var(name, DefinedType.Pointer, ctypedef)
                 return
+
             declaration_stream.write(
-                "%s %s[%s]  DACE_ALIGN(64);\n" % (nodedesc.dtype.ctype, name, cpp.sym2cpp(arrsize)),
+                "%s DACE_ALIGN(64);\n" % (defdesc.as_arg(name=name)),
                 cfg,
                 state_id,
                 node,
@@ -541,7 +554,7 @@ class CPUCodeGen(TargetCodeGenerator):
                     state_id,
                     node,
                 )
-                self._dispatcher.declared_arrays.add_global(name, DefinedType.Pointer, '%s *' % nodedesc.dtype.ctype)
+                self._dispatcher.declared_arrays.add_global(name, DefinedType.Pointer, dtypes.pointer(nodedesc.dtype))
 
             # Allocate in each OpenMP thread
             allocation_stream.write(
@@ -564,7 +577,7 @@ class CPUCodeGen(TargetCodeGenerator):
 
             # Close OpenMP parallel section
             allocation_stream.write('}')
-            self._dispatcher.defined_vars.add_global(name, DefinedType.Pointer, '%s *' % nodedesc.dtype.ctype)
+            self._dispatcher.defined_vars.add_global(name, DefinedType.Pointer, dtypes.pointer(nodedesc.dtype))
         else:
             raise NotImplementedError("Unimplemented storage type " + str(nodedesc.storage))
 
@@ -581,18 +594,23 @@ class CPUCodeGen(TargetCodeGenerator):
                                               dtypes.AllocationLifetime.External)
             self._dispatcher.declared_arrays.remove(alloc_name, is_global=is_global)
 
+        # Special case for structures
+        operator = 'delete[]'
+        if isinstance(nodedesc, data.Structure) and not isinstance(nodedesc, data.StructureView):
+            operator = 'delete'
+
         if isinstance(nodedesc, (data.Scalar, data.View, data.Stream, data.Reference)):
             return
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
               or (nodedesc.storage == dtypes.StorageType.Register and symbolic.issymbolic(arrsize, sdfg.constants))):
-            callsite_stream.write("delete[] %s;\n" % alloc_name, cfg, state_id, node)
+            callsite_stream.write(f'{operator} {alloc_name};\n', cfg, state_id, node)
         elif nodedesc.storage is dtypes.StorageType.CPU_ThreadLocal:
             # Deallocate in each OpenMP thread
             callsite_stream.write(
-                """#pragma omp parallel
+                f"""#pragma omp parallel
                 {{
-                    delete[] {name};
-                }}""".format(name=alloc_name),
+                    {operator} {alloc_name};
+                }}""",
                 cfg,
                 state_id,
                 node,
@@ -715,8 +733,31 @@ class CPUCodeGen(TargetCodeGenerator):
             if isinstance(dst_nodedesc, data.Reference) and orig_vconn == 'set':
                 srcptr = cpp.ptr(src_node.data, src_nodedesc, sdfg, self._frame)
                 defined_type, _ = self._dispatcher.defined_vars.get(srcptr)
+                if src_node.data == memlet.data:
+                    src_expr = cpp.cpp_ptr_expr(sdfg, memlet, defined_type)
+                else:
+                    src_expr = srcptr
+
+                if dst_nodedesc.dtype == dtypes.pointer(src_nodedesc.dtype):
+                    src_expr = '&' + src_expr
+                if src_nodedesc.dtype == dtypes.pointer(dst_nodedesc.dtype):
+                    src_expr = '*' + src_expr
+
                 stream.write(
-                    "%s = %s;" % (vconn, cpp.cpp_ptr_expr(sdfg, memlet, defined_type)),
+                    f"{dst_node.data} = {src_expr};",
+                    cfg,
+                    state_id,
+                    [src_node, dst_node],
+                )
+                return
+
+            # Setting a reference to a struct field
+            if (isinstance(src_nodedesc, data.Reference) and 'set' in src_node.in_connectors
+                    and isinstance(dst_nodedesc, data.Structure) and orig_vconn):
+                srcptr = cpp.ptr(src_node.data, src_nodedesc, sdfg, self._frame)
+                defined_type, _ = self._dispatcher.defined_vars.get(srcptr)
+                stream.write(
+                    f'{cpp.cpp_ptr_expr(sdfg, memlet, defined_type)}->{orig_vconn} = {srcptr};',
                     cfg,
                     state_id,
                     [src_node, dst_node],
@@ -1063,16 +1104,19 @@ class CPUCodeGen(TargetCodeGenerator):
                                                       dtypes.AllocationLifetime.Persistent,
                                                       dtypes.AllocationLifetime.External)
                         try:
-                            defined_type, _ = self._dispatcher.declared_arrays.get(ptrname, is_global=is_global)
+                            defined_type, defined_ctype = self._dispatcher.declared_arrays.get(ptrname, is_global=is_global)
                         except KeyError:
-                            defined_type, _ = self._dispatcher.defined_vars.get(ptrname, is_global=is_global)
+                            defined_type, defined_ctype = self._dispatcher.defined_vars.get(ptrname, is_global=is_global)
 
                         if defined_type == DefinedType.Scalar:
                             mname = cpp.ptr(memlet.data, desc, sdfg, self._frame)
                             write_expr = f"{mname} = {in_local_name};"
                         elif defined_type == DefinedType.Pointer and is_refset:
                             mname = cpp.ptr(memlet.data, desc, sdfg, self._frame)
-                            write_expr = f"{mname} = {in_local_name};"
+                            if isinstance(desc, data.ContainerArray) and desc.dtype == conntype:
+                                write_expr = f"*{mname} = {in_local_name};"
+                            else:
+                                write_expr = f"{mname} = {in_local_name};"
                         elif (defined_type == DefinedType.ArrayInterface and not isinstance(desc, data.View)):
                             # Special case: No need to write anything between
                             # array interfaces going out
@@ -1099,7 +1143,7 @@ class CPUCodeGen(TargetCodeGenerator):
                         else:
                             desc_dtype = desc.dtype
                             expr = cpp.cpp_array_expr(sdfg, memlet, codegen=self._frame)
-                            write_expr = codegen.make_ptr_assignment(in_local_name, conntype, expr, desc_dtype)
+                            write_expr = codegen.make_ptr_assignment(in_local_name, conntype, expr, defined_ctype)
 
                     # Write out
                     result.write(write_expr, cfg, state_id, node)
@@ -1224,6 +1268,30 @@ class CPUCodeGen(TargetCodeGenerator):
             ", ".join(memlet_params),
         )
 
+    def _make_pointer_difference(self, connector_type: dtypes.typeclass, defined_type: dtypes.typeclass):
+        """
+        Returns the prefix of an expression when converted from ``defined_type``
+        to ``connector_type``.
+        """
+        num_ptrs_in_connector = num_ptrs_in_defined = 0
+        curctype = connector_type
+        while isinstance(curctype, dtypes.pointer):
+            num_ptrs_in_connector += 1
+            curctype = curctype.base_type
+        curdtype = defined_type
+        while isinstance(curdtype, dtypes.pointer):
+            num_ptrs_in_defined += 1
+            curdtype = curdtype.base_type
+
+        if curctype != curdtype:  # Base types differ
+            return ''
+
+        if num_ptrs_in_defined > num_ptrs_in_connector:
+            return '*' * (num_ptrs_in_defined - num_ptrs_in_connector)
+        if num_ptrs_in_connector > num_ptrs_in_defined:
+            return '&' * (num_ptrs_in_connector - num_ptrs_in_defined)
+        return ''
+
     def memlet_definition(self,
                           sdfg: SDFG,
                           memlet: mmlt.Memlet,
@@ -1245,11 +1313,15 @@ class CPUCodeGen(TargetCodeGenerator):
 
         desc = sdfg.arrays[memlet.data]
 
-        is_scalar = not isinstance(conntype, dtypes.pointer) or desc.dtype == conntype
+        desc_dtype = desc.dtype
+        if isinstance(desc, data.Array):
+            desc_dtype = dtypes.pointer(desc_dtype)
+
+        is_scalar = not isinstance(conntype, dtypes.pointer) or desc_dtype == conntype
         is_pointer = isinstance(conntype, dtypes.pointer)
 
         # Allocate variable type
-        memlet_type = conntype.dtype.ctype
+        memlet_type = conntype.dtype
 
         ptr = cpp.ptr(memlet.data, desc, sdfg, self._frame)
         types = None
@@ -1285,40 +1357,45 @@ class CPUCodeGen(TargetCodeGenerator):
 
         if expr != ptr:
             expr = '%s[%s]' % (ptr, expr)
+
+        # Special case for pointer use as-is
+        if is_scalar and is_pointer and list(memlet.subset.size()) == list(desc.shape):
+            expr = ptr
+
         # If there is a type mismatch, cast pointer
-        expr = codegen.make_ptr_vector_cast(expr, desc.dtype, conntype, is_scalar, var_type)
+        expr = codegen.make_ptr_vector_cast(expr, ctypedef, conntype, is_scalar, var_type)
 
         defined = None
 
         if var_type in [DefinedType.Scalar, DefinedType.Pointer, DefinedType.ArrayInterface]:
             if output:
                 if is_pointer and var_type == DefinedType.ArrayInterface:
-                    result += "{} {} = {};".format(memlet_type, local_name, expr)
+                    result += "{} = {};".format(memlet_type.as_arg(local_name), expr)
                 elif not memlet.dynamic or (memlet.dynamic and memlet.wcr is not None):
                     # Dynamic WCR memlets start uninitialized
-                    result += "{} {};".format(memlet_type, local_name)
+                    result += "{};".format(memlet_type.as_arg(local_name))
                     defined = DefinedType.Scalar
 
             else:
                 if not memlet.dynamic:
                     if is_scalar:
                         # We can pre-read the value
-                        result += "{} {} = {};".format(memlet_type, local_name, expr)
+                        result += "{} = {};".format(memlet_type.as_arg(local_name), expr)
                     else:
                         # constexpr arrays
                         if memlet.data in self._frame.symbols_and_constants(sdfg):
-                            result += "const {} {} = {};".format(memlet_type, local_name, expr)
+                            result += "const {} = {};".format(memlet_type.as_arg(local_name), expr)
                         else:
                             # Pointer reference
-                            result += "{} {} = {};".format(ctypedef, local_name, expr)
+                            result += "{} = {};".format(conntype.as_arg(local_name), expr)
                 else:
                     # Variable number of reads: get a const reference that can
                     # be read if necessary
-                    memlet_type = 'const %s' % memlet_type
                     if is_pointer:
-                        result += "{} {} = {};".format(memlet_type, local_name, expr)
+                        # If it's a pointer, the reference is unnecessary
+                        result += "{} = {};".format(memlet_type.as_arg(local_name), expr)
                     else:
-                        result += "{} &{} = {};".format(memlet_type, local_name, expr)
+                        result += "{} = {};".format(memlet_type.as_arg('&' + local_name), expr)
                 defined = (DefinedType.Scalar if is_scalar else DefinedType.Pointer)
         elif var_type in [DefinedType.Stream, DefinedType.StreamArray]:
             if not memlet.dynamic and memlet.num_accesses == 1:
@@ -1326,12 +1403,12 @@ class CPUCodeGen(TargetCodeGenerator):
                     if isinstance(desc, data.Stream) and desc.is_stream_array():
                         index = cpp.cpp_offset_expr(desc, memlet.subset)
                         expr = f"{memlet.data}[{index}]"
-                    result += f'{memlet_type} {local_name} = ({expr}).pop();'
+                    result += f'{memlet_type.as_arg(local_name)} = ({expr}).pop();'
                     defined = DefinedType.Scalar
             else:
                 # Just forward actions to the underlying object
                 memlet_type = ctypedef
-                result += "{} &{} = {};".format(memlet_type, local_name, expr)
+                result += "{} = {};".format(memlet_type.as_arg('&' + local_name), expr)
                 defined = DefinedType.Stream
         else:
             raise TypeError("Unknown variable type: {}".format(var_type))
@@ -1400,7 +1477,7 @@ class CPUCodeGen(TargetCodeGenerator):
             if edge.dst_conn:  # Not (None or "")
                 if edge.dst_conn in arrays:  # Disallow duplicates
                     raise SyntaxError("Duplicates found in memlets")
-                ctype = node.in_connectors[edge.dst_conn].ctype
+                ctype: dtypes.typeclass = node.in_connectors[edge.dst_conn]
                 # Special case: code->code
                 if isinstance(src_node, nodes.CodeNode):
                     shared_data_name = edge.data.data
@@ -1412,11 +1489,11 @@ class CPUCodeGen(TargetCodeGenerator):
                     # Read variable from shared storage
                     defined_type, _ = self._dispatcher.defined_vars.get(shared_data_name)
                     if defined_type in (DefinedType.Scalar, DefinedType.Pointer):
-                        assign_str = (f"const {ctype} {edge.dst_conn} = {shared_data_name};")
+                        assign_str = (f"const {ctype.as_arg(edge.dst_conn)} = {shared_data_name};")
                     else:
-                        assign_str = (f"const {ctype} &{edge.dst_conn} = {shared_data_name};")
+                        assign_str = (f"const {ctype.as_arg('&' + edge.dst_conn)} = {shared_data_name};")
                     inner_stream.write(assign_str, cfg, state_id, [edge.src, edge.dst])
-                    self._dispatcher.defined_vars.add(edge.dst_conn, defined_type, f"const {ctype}")
+                    self._dispatcher.defined_vars.add(edge.dst_conn, defined_type, ctype)
 
                 else:
                     self._dispatcher.dispatch_copy(
@@ -1462,7 +1539,7 @@ class CPUCodeGen(TargetCodeGenerator):
             if edge.src_conn is None:
                 continue
             cdtype = node.out_connectors[edge.src_conn]
-            ctype = cdtype.ctype
+            ctype = cdtype
             # Convert dtype to data descriptor
             if isinstance(cdtype, dtypes.pointer):
                 arg_type = data.Array(cdtype._typeclass, [1])
@@ -1480,7 +1557,7 @@ class CPUCodeGen(TargetCodeGenerator):
                                                             dfg.node_id(dst_node), edge.src_conn)
 
                 # Allocate variable type
-                code = "%s %s;" % (ctype, local_name)
+                code = f'{ctype.as_arg(local_name)};'
                 outer_stream_begin.write(code, cfg, state_id, [edge.src, dst_node])
                 if (isinstance(arg_type, data.Scalar) or isinstance(arg_type, dtypes.typeclass)):
                     self._dispatcher.defined_vars.add(local_name, DefinedType.Scalar, ctype, ancestor=1)
@@ -1494,7 +1571,7 @@ class CPUCodeGen(TargetCodeGenerator):
                 else:
                     raise TypeError("Unrecognized argument type: {}".format(type(arg_type).__name__))
 
-                inner_stream.write("%s %s;" % (ctype, edge.src_conn), cfg, state_id, [edge.src, edge.dst])
+                inner_stream.write(f'{ctype.as_arg(edge.src_conn)};', cfg, state_id, [edge.src, edge.dst])
                 tasklet_out_connectors.add(edge.src_conn)
                 self._dispatcher.defined_vars.add(edge.src_conn, DefinedType.Scalar, ctype)
                 self._locals.define(edge.src_conn, -1, self._ldepth + 1, ctype)
@@ -1597,7 +1674,7 @@ class CPUCodeGen(TargetCodeGenerator):
                     return ''
 
             if aname in node.sdfg.arrays and not node.sdfg.arrays[aname].may_alias:
-                restrict_args.append(make_restrict(atype))
+                restrict_args.append(make_restrict(atype.ctype))
             else:
                 restrict_args.append('')
 
@@ -1667,6 +1744,7 @@ class CPUCodeGen(TargetCodeGenerator):
     ):
         inline = Config.get_bool('compiler', 'inline_sdfgs')
         self._dispatcher.defined_vars.enter_scope(sdfg, can_access_parent=inline)
+        self._dispatcher.declared_arrays.enter_scope(sdfg, can_access_parent=inline)
         state_dfg = cfg.nodes()[state_id]
 
         fsyms = self._frame.free_symbols(node.sdfg)
@@ -1822,6 +1900,7 @@ class CPUCodeGen(TargetCodeGenerator):
             function_stream.write(nested_stream.getvalue())
 
         self._dispatcher.defined_vars.exit_scope(sdfg)
+        self._dispatcher.declared_arrays.exit_scope(sdfg)
 
     def _generate_MapEntry(
         self,
@@ -2005,16 +2084,16 @@ class CPUCodeGen(TargetCodeGenerator):
 
         # Take chunks into account
         if node.consume.chunksize == 1:
-            ctype = 'const %s' % input_streamdesc.dtype.ctype
-            chunk = "%s& %s" % (ctype, "__dace_" + node.consume.label + "_element")
+            ctype = dtypes.pointer(input_streamdesc.dtype)
+            chunk = "const " + ctype.as_arg("&__dace_" + node.consume.label + "_element")
             self._dispatcher.defined_vars.add("__dace_" + node.consume.label + "_element", DefinedType.Scalar, ctype)
         else:
-            ctype = 'const %s *' % input_streamdesc.dtype.ctype
-            chunk = "%s %s, size_t %s" % (ctype, "__dace_" + node.consume.label + "_elements",
-                                          "__dace_" + node.consume.label + "_numelems")
+            ctype = dtypes.pointer(input_streamdesc.dtype)
+            chunk = "const %s, size_t %s" % (ctype.as_arg("__dace_" + node.consume.label + "_elements"),
+                                             "__dace_" + node.consume.label + "_numelems")
             self._dispatcher.defined_vars.add("__dace_" + node.consume.label + "_elements", DefinedType.Pointer, ctype)
             self._dispatcher.defined_vars.add("__dace_" + node.consume.label + "_numelems", DefinedType.Scalar,
-                                              'size_t')
+                                              dtypes.opaque('size_t'))
 
         # Take quiescence condition into account
         if node.consume.condition is not None:
@@ -2104,14 +2183,14 @@ class CPUCodeGen(TargetCodeGenerator):
                 # code->code edges
                 if (isinstance(edge.src, nodes.CodeNode) and isinstance(edge.dst, nodes.CodeNode)):
                     local_name = edge.data.data
-                    ctype = node.out_connectors[edge.src_conn].ctype
+                    ctype = node.out_connectors[edge.src_conn]
                     if not local_name:
                         # Very unique name. TODO: Make more intuitive
                         local_name = '__dace_%d_%d_%d_%d_%s' % (cfg.cfg_id, state_id, dfg.node_id(
                             edge.src), dfg.node_id(edge.dst), edge.src_conn)
 
                     # Allocate variable type
-                    code = '%s %s;' % (ctype, local_name)
+                    code = f'{ctype.as_arg(local_name)};'
                     result.write(code, cfg, state_id, [edge.src, edge.dst])
                     self._dispatcher.defined_vars.add(local_name, DefinedType.Scalar, ctype)
 

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -532,12 +532,12 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStr
             return
 
         result_decl = StringIO()
-        ctypedef = '%s *' % nodedesc.dtype.ctype
+        ctypedef = dtypes.pointer(nodedesc.dtype)
         dataname = node.data
 
         # Different types of GPU arrays
         if (nodedesc.storage == dtypes.StorageType.GPU_Global or nodedesc.storage == dtypes.StorageType.CPU_Pinned):
-            result_decl.write('%s %s;\n' % (ctypedef, dataname))
+            result_decl.write('%s;\n' % (ctypedef.as_arg(dataname)))
             self._dispatcher.declared_arrays.add(dataname, DefinedType.Pointer, ctypedef)
         elif nodedesc.storage == dtypes.StorageType.GPU_Shared:
             raise NotImplementedError('Dynamic shared memory unsupported')
@@ -585,12 +585,12 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStr
         arrsize = nodedesc.total_size
         is_dynamically_sized = symbolic.issymbolic(arrsize, sdfg.constants)
         arrsize_malloc = '%s * sizeof(%s)' % (sym2cpp(arrsize), nodedesc.dtype.ctype)
-        ctypedef = '%s *' % nodedesc.dtype.ctype
+        ctypedef = dtypes.pointer(nodedesc.dtype)
 
         # Different types of GPU arrays
         if nodedesc.storage == dtypes.StorageType.GPU_Global:
             if not declared:
-                result_decl.write('%s %s;\n' % (ctypedef, dataname))
+                result_decl.write('%s;\n' % (ctypedef.as_arg(dataname)))
             self._dispatcher.defined_vars.add(dataname, DefinedType.Pointer, ctypedef)
 
             if nodedesc.pool:
@@ -612,7 +612,7 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStr
                 result_alloc.write(f'{dataname} += {cpp.sym2cpp(nodedesc.start_offset)};\n')
         elif nodedesc.storage == dtypes.StorageType.CPU_Pinned:
             if not declared:
-                result_decl.write('%s %s;\n' % (ctypedef, dataname))
+                result_decl.write('%s;\n' % (ctypedef.as_arg(dataname)))
             self._dispatcher.defined_vars.add(dataname, DefinedType.Pointer, ctypedef)
 
             # Strides are left to the user's discretion
@@ -626,7 +626,7 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStr
                 raise NotImplementedError('Dynamic shared memory unsupported')
             if nodedesc.start_offset != 0:
                 raise NotImplementedError('Start offset unsupported for shared memory')
-            result_decl.write("__shared__ %s %s[%s];\n" % (nodedesc.dtype.ctype, dataname, sym2cpp(arrsize)))
+            result_decl.write("__shared__ %s[%s];\n" % (nodedesc.dtype.as_arg(dataname), sym2cpp(arrsize)))
             self._dispatcher.defined_vars.add(dataname, DefinedType.Pointer, ctypedef)
             if node.setzero:
                 result_alloc.write('dace::ResetShared<{type}, {block_size}, {elements}, '
@@ -640,7 +640,7 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStr
             if nodedesc.start_offset != 0:
                 raise NotImplementedError('Start offset unsupported for registers')
             szstr = ' = {0}' if node.setzero else ''
-            result_decl.write("%s %s[%s]%s;\n" % (nodedesc.dtype.ctype, dataname, sym2cpp(arrsize), szstr))
+            result_decl.write("%s[%s]%s;\n" % (nodedesc.dtype.as_arg(dataname), sym2cpp(arrsize), szstr))
             self._dispatcher.defined_vars.add(dataname, DefinedType.Pointer, ctypedef)
         else:
             raise NotImplementedError("CUDA: Unimplemented storage type " + str(nodedesc.storage))
@@ -663,7 +663,7 @@ DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStr
             }
 
             ctypedef = 'dace::GPUStream<{type}, {is_pow2}>'.format(**fmtargs)
-            self._dispatcher.defined_vars.add(allocname, DefinedType.Stream, ctypedef)
+            self._dispatcher.defined_vars.add(allocname, DefinedType.Stream, dtypes.opaque(ctypedef))
 
             if is_array_stream_view(sdfg, dfg, node):
                 edges = dfg.out_edges(node)
@@ -1474,7 +1474,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                     self.extra_nsdfg_args.append((desc.as_arg(name=''), inner_name, outer_name))
                     self._dispatcher.defined_vars.add(inner_name,
                                                       DefinedType.Pointer,
-                                                      desc.dtype.ctype,
+                                                      desc.dtype,
                                                       allow_shadowing=True)
                     extra_call_args.append(outer_name)
                     extra_call_args_typed.append(desc.as_arg(name=inner_name))
@@ -1535,7 +1535,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
 
                     self._dispatcher.defined_vars.add(inner_ptrname,
                                                       defined_type,
-                                                      'const %s' % ctype,
+                                                      ctype,
                                                       allow_shadowing=True)
 
                     # Rename argument in kernel prototype as necessary
@@ -2032,8 +2032,8 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
                 expr = _topy(bidx[i]).replace('__DAPB%d' % i, block_expr)
 
-                kernel_stream.write(f'{tidtype.ctype} {varname} = {expr};', cfg, state_id, node)
-                self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, tidtype.ctype)
+                kernel_stream.write(f'{tidtype.as_arg(varname)} = {expr};', cfg, state_id, node)
+                self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, tidtype)
 
             # Delinearize beyond the third dimension
             if len(krange) > 3:
@@ -2052,8 +2052,8 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                     )
 
                     expr = _topy(bidx[i]).replace('__DAPB%d' % i, block_expr)
-                    kernel_stream.write(f'{tidtype.ctype} {varname} = {expr};', cfg, state_id, node)
-                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, tidtype.ctype)
+                    kernel_stream.write(f'{tidtype.as_arg(varname)} = {expr};', cfg, state_id, node)
+                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, tidtype)
 
         # Dispatch internal code
         assert CUDACodeGen._in_device_code is False
@@ -2275,7 +2275,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
                     declarations.append((varname, expr))
 
-                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, dtypes.int32)
 
                 # Delinearize beyond the third dimension
                 if len(device_map_range) > 3:
@@ -2291,7 +2291,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
                         declarations.append((varname, expr))
 
-                        self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+                        self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, dtypes.int32)
 
                 kmap_min = subsets.Range(self._kernel_map.range[::-1]).min_element()
                 kmap_max = subsets.Range(self._kernel_map.range[::-1]).max_element()
@@ -2371,7 +2371,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
                     expr = _topy(tidx[i]).replace('__DAPT%d' % i, block_expr)
                     callsite_stream.write('int %s = %s;' % (varname, expr), cfg, state_id, scope_entry)
-                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, dtypes.int32)
 
                 # Generate conditions for this subgrid's execution using min and max
                 # element, e.g. skipping out-of-bounds threads
@@ -2440,7 +2440,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
                 expr = _topy(tidx[i]).replace('__DAPT%d' % i, block_expr)
                 callsite_stream.write('int %s = %s;' % (varname, expr), cfg, state_id, scope_entry)
-                self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+                self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, dtypes.int32)
 
             # Delinearize beyond the third dimension
             if len(brange) > 3:
@@ -2454,7 +2454,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
 
                     expr = _topy(tidx[i]).replace('__DAPT%d' % i, block_expr)
                     callsite_stream.write('int %s = %s;' % (varname, expr), cfg, state_id, scope_entry)
-                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+                    self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, dtypes.int32)
 
             # Generate conditions for this block's execution using min and max
             # element, e.g. skipping out-of-bounds threads in trailing block

--- a/dace/codegen/targets/fpga.py
+++ b/dace/codegen/targets/fpga.py
@@ -1163,7 +1163,7 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
                     nodedesc.dtype.ctype, ptrname))
                 self._dispatcher.declared_arrays.add(
                     ptrname, DefinedType.Pointer,
-                    'hlslib::ocl::Buffer <{}, hlslib::ocl::Access::readWrite>'.format(nodedesc.dtype.ctype))
+                    dtypes.opaque('hlslib::ocl::Buffer <{}, hlslib::ocl::Access::readWrite>'.format(nodedesc.dtype.ctype)))
         elif (nodedesc.storage in (dtypes.StorageType.FPGA_Local, dtypes.StorageType.FPGA_Registers,
                                    dtypes.StorageType.FPGA_ShiftRegister)):
 
@@ -1227,9 +1227,9 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
             # defined type: decide whether this is a stream array or a single stream
             def_type = (DefinedType.StreamArray if arrsize != 1 else DefinedType.Stream)
             if is_global:
-                self._dispatcher.defined_vars.add_global(dataname, def_type, ctype)
+                self._dispatcher.defined_vars.add_global(dataname, def_type, dtypes.opaque(ctype))
             else:
-                self._dispatcher.defined_vars.add(dataname, def_type, ctype)
+                self._dispatcher.defined_vars.add(dataname, def_type, dtypes.opaque(ctype))
 
         elif isinstance(nodedesc, dt.Array):
 
@@ -1285,7 +1285,7 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
 
                         self._dispatcher.defined_vars.add(
                             alloc_name, DefinedType.Pointer,
-                            'hlslib::ocl::Buffer <{}, hlslib::ocl::Access::readWrite>'.format(nodedesc.dtype.ctype))
+                            dtypes.opaque('hlslib::ocl::Buffer <{}, hlslib::ocl::Access::readWrite>'.format(nodedesc.dtype.ctype)))
 
             elif (nodedesc.storage in (dtypes.StorageType.FPGA_Local, dtypes.StorageType.FPGA_Registers,
                                        dtypes.StorageType.FPGA_ShiftRegister)):
@@ -1304,7 +1304,7 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
                     ctype = self.make_vector_type(nodedesc.dtype, False)
                     define_str = "{} {};".format(ctype, dataname)
                     result_decl.write(define_str)
-                    self._dispatcher.defined_vars.add(dataname, DefinedType.Scalar, ctype)
+                    self._dispatcher.defined_vars.add(dataname, DefinedType.Scalar, dtypes.opaque(ctype))
                 else:
                     # Language-specific
                     if (nodedesc.storage == dtypes.StorageType.FPGA_ShiftRegister):
@@ -1321,7 +1321,7 @@ std::cout << "FPGA program \\"{state.label}\\" executed in " << elapsed << " sec
 
             ctype = self.make_vector_type(nodedesc.dtype, False)
             result_decl.write("{} {};\n".format(ctype, dataname))
-            self._dispatcher.defined_vars.add(dataname, DefinedType.Scalar, ctype)
+            self._dispatcher.defined_vars.add(dataname, DefinedType.Scalar, dtypes.opaque(ctype))
 
         else:
             raise TypeError("Unhandled data type: {}".format(type(nodedesc).__name__))

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -906,9 +906,9 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
         # Define constants as top-level-allocated
         for cname, (ctype, _) in sdfg.constants_prop.items():
             if isinstance(ctype, data.Array):
-                self.dispatcher.defined_vars.add(cname, disp.DefinedType.Pointer, ctype.dtype.ctype)
+                self.dispatcher.defined_vars.add(cname, disp.DefinedType.Pointer, ctype.dtype)
             else:
-                self.dispatcher.defined_vars.add(cname, disp.DefinedType.Scalar, ctype.dtype.ctype)
+                self.dispatcher.defined_vars.add(cname, disp.DefinedType.Scalar, ctype.dtype)
 
         # Allocate inter-state variables
         global_symbols = copy.deepcopy(sdfg.symbols)
@@ -955,12 +955,13 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
                     and config.Config.get('compiler', 'fpga', 'vendor').lower() == 'intel_fpga'):
                 # Emit OpenCL type
                 callsite_stream.write(f'{isvarType.ocltype} {isvarName};\n', sdfg)
-                self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType.ctype)
+                self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType)
             else:
                 # If the variable is passed as an input argument to the SDFG, do not need to declare it
                 if isvarName not in outside_symbols:
                     callsite_stream.write('%s;\n' % (isvar.as_arg(with_types=True, name=isvarName)), sdfg)
-                    self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType.ctype)
+                    self.dispatcher.defined_vars.add(isvarName, disp.DefinedType.Scalar, isvarType)
+
         callsite_stream.write('\n', sdfg)
 
         #######################################################################

--- a/dace/codegen/targets/intel_fpga.py
+++ b/dace/codegen/targets/intel_fpga.py
@@ -281,7 +281,7 @@ DACE_EXPORTED int __dace_exit_intel_fpga({sdfg_state_name} *__state) {{
         else:
             attributes = ""
         kernel_stream.write("{}{} {}[{}];\n".format(vec_type, attributes, var_name, cpp.sym2cpp(array_size)))
-        self._dispatcher.defined_vars.add(var_name, DefinedType.Pointer, vec_type)
+        self._dispatcher.defined_vars.add(var_name, DefinedType.Pointer, dtypes.opaque(vec_type))
 
     def define_shift_register(self, *args, **kwargs):
         # Shift registers are just arrays on Intel
@@ -794,7 +794,7 @@ __kernel void \\
                 memlet_references.append((typedef, vconn, ref + expr))
                 # get the defined type (as defined in the parent)
                 # Register defined variable
-                self._dispatcher.defined_vars.add(vconn, DefinedType.Pointer, typedef, allow_shadowing=True)
+                self._dispatcher.defined_vars.add(vconn, DefinedType.Pointer, dtypes.opaque(typedef), allow_shadowing=True)
             elif isinstance(desc, dace.data.Stream):
                 # streams are defined as global variables
                 continue
@@ -804,11 +804,11 @@ __kernel void \\
                     # if this is a scalar and the argument passed is also a scalar
                     # then we have to pass it by value
                     ref = (typedef, vconn, ptrname)
-                    self._dispatcher.defined_vars.add(vconn, defined_type, typedef, allow_shadowing=True)
+                    self._dispatcher.defined_vars.add(vconn, defined_type, dtypes.opaque(typedef), allow_shadowing=True)
                 else:
                     # otherwise, pass it as a pointer (references do not exist in C99)
                     ref = (typedef, vconn, cpp.cpp_ptr_expr(sdfg, in_memlet, defined_type, codegen=self._frame))
-                self._dispatcher.defined_vars.add(vconn, defined_type, typedef, allow_shadowing=True)
+                self._dispatcher.defined_vars.add(vconn, defined_type, dtypes.opaque(typedef), allow_shadowing=True)
                 memlet_references.append(ref)
             else:
                 # all the other cases
@@ -845,7 +845,7 @@ __kernel void \\
                                                      False, defined_type)
                     memlet_references.append((typedef, uconn, ref + expr))
                     # Register defined variable
-                    self._dispatcher.defined_vars.add(uconn, DefinedType.Pointer, typedef, allow_shadowing=True)
+                    self._dispatcher.defined_vars.add(uconn, DefinedType.Pointer, dtypes.opaque(typedef), allow_shadowing=True)
                 elif isinstance(desc, dace.data.Stream):
                     # streams are defined as global variables
                     continue
@@ -858,7 +858,7 @@ __kernel void \\
                         typedef = typedef + "*"
                     memlet_references.append(
                         (typedef, uconn, cpp.cpp_ptr_expr(sdfg, out_memlet, defined_type, codegen=self._frame)))
-                    self._dispatcher.defined_vars.add(uconn, DefinedType.Pointer, typedef, allow_shadowing=True)
+                    self._dispatcher.defined_vars.add(uconn, DefinedType.Pointer, dtypes.opaque(typedef), allow_shadowing=True)
                 else:
                     memlet_references.append(
                         cpp.emit_memlet_reference(self._dispatcher,
@@ -917,7 +917,7 @@ __kernel void \\
             eptr = cpp.ptr(edge.data.data, viewed_desc, sdfg, self._frame)
             defined_type, _ = self._dispatcher.defined_vars.get(eptr, 0)
             # Register defined variable
-            self._dispatcher.defined_vars.add(aname, defined_type, atype, allow_shadowing=True)
+            self._dispatcher.defined_vars.add(aname, defined_type, dtypes.opaque(atype), allow_shadowing=True)
             _, _, value = cpp.emit_memlet_reference(self._dispatcher,
                                                     sdfg,
                                                     edge.data,
@@ -1002,11 +1002,11 @@ __kernel void \\
                     init = ""
 
                     result += "{} {}{};".format(memlet_type, connector, init)
-                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, memlet_type)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, dtypes.opaque(memlet_type))
             else:
                 # Variable number of reads or writes
                 result += "{} *{} = &{};".format(memlet_type, connector, rhs)
-                self._dispatcher.defined_vars.add(connector, DefinedType.Pointer, '%s *' % memlet_type)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Pointer, dtypes.opaque('%s *' % memlet_type))
         elif def_type == DefinedType.Pointer:
             if cast:
                 rhs = f"(({memlet_type} const *){data_name})"
@@ -1017,7 +1017,7 @@ __kernel void \\
                     result += "{} {};".format(memlet_type, connector)
                 else:
                     result += "{} {} = {}[{}];".format(memlet_type, connector, rhs, offset)
-                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, memlet_type)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, dtypes.opaque(memlet_type))
             else:
                 if data_desc.storage == dace.dtypes.StorageType.FPGA_Global:
                     qualifiers = "__global "
@@ -1025,7 +1025,7 @@ __kernel void \\
                     qualifiers = ""
                 ctype = '{}{} *'.format(qualifiers, memlet_type)
                 result += "{}{} = &{}[{}];".format(ctype, connector, rhs, offset)
-                self._dispatcher.defined_vars.add(connector, DefinedType.Pointer, ctype)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Pointer, dtypes.opaque(ctype))
         elif def_type == DefinedType.Stream:
             if cast:
                 raise TypeError("Cannot cast stream from {} to {}.".format(data_dtype, dtype))
@@ -1037,12 +1037,12 @@ __kernel void \\
                 else:
                     result += "{} {} = read_channel_intel({});".format(
                         memlet_type, connector, self.get_mangled_channel_name(data_name, self._kernel_count))
-                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, memlet_type)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, dtypes.opaque(memlet_type))
             else:
                 # Desperate times call for desperate measures
                 result += "#define {} {} // God save us".format(
                     connector, self.get_mangled_channel_name(data_name, self._kernel_count))
-                self._dispatcher.defined_vars.add(connector, DefinedType.Stream, ctypedef)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Stream, dtypes.opaque(ctypedef))
         elif def_type == DefinedType.StreamArray:
             if cast:
                 raise TypeError("Cannot cast stream array from {} to {}.".format(data_dtype, dtype))
@@ -1067,7 +1067,7 @@ __kernel void \\
 
                     result += "{} {} = read_channel_intel({}[{}]);".format(
                         memlet_type, connector, self.get_mangled_channel_name(data_name, self._kernel_count), offset)
-                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, memlet_type)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Scalar, dtypes.opaque(memlet_type))
             else:
                 # Must happen directly in the code
                 # Here we create a macro which take the proper channel
@@ -1077,7 +1077,7 @@ __kernel void \\
                     channel_idx = cpp.cpp_offset_expr(sdfg.arrays[data_name], memlet.subset)
                 result += "#define {} {}[{}] // God save us".format(
                     connector, self.get_mangled_channel_name(data_name, self._kernel_count), channel_idx)
-                self._dispatcher.defined_vars.add(connector, DefinedType.Stream, ctypedef)
+                self._dispatcher.defined_vars.add(connector, DefinedType.Stream, dtypes.opaque(ctypedef))
         else:
             raise TypeError("Unknown variable type: {}".format(def_type))
 

--- a/dace/codegen/targets/snitch.py
+++ b/dace/codegen/targets/snitch.py
@@ -301,7 +301,7 @@ class SnitchCodeGen(TargetCodeGenerator):
         is_pointer = isinstance(conntype, dtypes.pointer)
 
         # Allocate variable type
-        memlet_type = conntype.dtype.ctype
+        memlet_type = conntype.dtype
 
         desc = sdfg.arrays[memlet.data]
         ptr = cpp.ptr(memlet.data, desc)
@@ -327,25 +327,24 @@ class SnitchCodeGen(TargetCodeGenerator):
         if var_type in [DefinedType.Scalar, DefinedType.Pointer, DefinedType.ArrayInterface]:
             if output:
                 if is_pointer and var_type == DefinedType.ArrayInterface:
-                    result += "{} {} = {};".format(memlet_type, local_name, expr)
+                    result += "{} = {};".format(memlet_type.as_arg(local_name), expr)
                 elif not memlet.dynamic or (memlet.dynamic and memlet.wcr is not None):
                     # Dynamic WCR memlets start uninitialized
-                    result += "{} {};".format(memlet_type, local_name)
+                    result += "{};".format(memlet_type.as_arg(local_name))
                     defined = DefinedType.Scalar
 
             else:
                 if not memlet.dynamic:
                     if is_scalar:
                         # We can pre-read the value
-                        result += "{} {} = {};".format(memlet_type, local_name, expr)
+                        result += "{} = {};".format(memlet_type.as_arg(local_name), expr)
                     else:
                         # Pointer reference
-                        result += "{} {} = {};".format(ctypedef, local_name, expr)
+                        result += "{} = {};".format(ctypedef.as_arg(local_name), expr)
                 else:
                     # Variable number of reads: get a const reference that can
                     # be read if necessary
-                    memlet_type = '%s const' % memlet_type
-                    result += "{} &{} = {};".format(memlet_type, local_name, expr)
+                    result += "{} = {};".format(memlet_type.as_arg('const &' + local_name), expr)
                 defined = (DefinedType.Scalar if is_scalar else DefinedType.Pointer)
         elif var_type in [DefinedType.Stream, DefinedType.StreamArray]:
             if not memlet.dynamic and memlet.num_accesses == 1:
@@ -355,7 +354,7 @@ class SnitchCodeGen(TargetCodeGenerator):
             else:
                 # Just forward actions to the underlying object
                 memlet_type = ctypedef
-                result += "{} &{} = {};".format(memlet_type, local_name, expr)
+                result += "{} = {};".format(memlet_type.as_arg('&' + local_name), expr)
                 defined = DefinedType.Stream
         else:
             raise TypeError("Unknown variable type: {}".format(var_type))
@@ -387,7 +386,7 @@ class SnitchCodeGen(TargetCodeGenerator):
             arrsize, arrsize_bytes, alloc_name, nodedesc))
 
         if isinstance(nodedesc, data.Array):
-            ctypedef = dtypes.pointer(nodedesc.dtype).ctype
+            ctypedef = dtypes.pointer(nodedesc.dtype)
 
             # catch Threadlocal storage
             if nodedesc.storage is dtypes.StorageType.CPU_ThreadLocal:
@@ -401,7 +400,7 @@ class SnitchCodeGen(TargetCodeGenerator):
                         state_id,
                         node,
                     )
-                    self.dispatcher.defined_vars.add_global(name, DefinedType.Pointer, '%s *' % nodedesc.dtype.ctype)
+                    self.dispatcher.defined_vars.add_global(name, DefinedType.Pointer, dace.pointer(nodedesc.dtype))
                 # Allocate in each OpenMP thread
                 allocation_stream.write(
                     """

--- a/dace/codegen/targets/xilinx.py
+++ b/dace/codegen/targets/xilinx.py
@@ -290,7 +290,7 @@ DACE_EXPORTED int __dace_exit_xilinx({sdfg_state_name} *__state) {{
             pass
         else:
             raise ValueError("Unsupported storage type: {}".format(desc.storage.name))
-        self._dispatcher.defined_vars.add(var_name, DefinedType.Pointer, '%s *' % dtype.ctype)
+        self._dispatcher.defined_vars.add(var_name, DefinedType.Pointer, dtypes.pointer(dtype))
 
     def define_shift_register(*args, **kwargs):
         raise NotImplementedError("Xilinx shift registers NYI")
@@ -895,12 +895,12 @@ DACE_EXPORTED int __dace_exit_xilinx({sdfg_state_name} *__state) {{
                     # This is an external stream being passed to the module
                     # Add this to defined vars
                     if not self._dispatcher.defined_vars.has(argname):
-                        self._dispatcher.defined_vars.add(argname, DefinedType.Stream, arg.ctype)
+                        self._dispatcher.defined_vars.add(argname, DefinedType.Stream, arg)
                     continue
 
                 if (not (isinstance(arg, dt.Array) and arg.storage == dace.dtypes.StorageType.FPGA_Global)):
                     continue
-                ctype = dtypes.pointer(arg.dtype).ctype
+                ctype = dtypes.pointer(arg.dtype)
                 ptr_name = fpga.fpga_ptr(argname,
                                          arg,
                                          sdfg,
@@ -910,7 +910,7 @@ DACE_EXPORTED int __dace_exit_xilinx({sdfg_state_name} *__state) {{
                                          is_array_interface=True,
                                          decouple_array_interfaces=self._decouple_array_interfaces)
                 if not is_output and self._decouple_array_interfaces:
-                    ctype = f"const {ctype}"
+                    ctype.const = True
 
                 if self._decouple_array_interfaces:
                     self._dispatcher.defined_vars.add(ptr_name, DefinedType.Pointer, ctype)
@@ -1066,7 +1066,7 @@ DACE_EXPORTED int __dace_exit_xilinx({sdfg_state_name} *__state) {{
             buffer_size = dace.symbolic.evaluate(node.buffer_size, sdfg.constants)
             ctype = "dace::FIFO<{}, {}, {}>".format(node.dtype.base_type.ctype, node.dtype.veclen, buffer_size)
             num_streams = dace.symbolic.evaluate(node.shape[0], sdfg.constants)
-            self._dispatcher.defined_vars.add_global(name, DefinedType.Stream, ctype)
+            self._dispatcher.defined_vars.add_global(name, DefinedType.Stream, dtypes.opaque(ctype))
             key = 0 if is_output else 1
 
             # Define here external streams

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -684,6 +684,9 @@ class pointer(typeclass):
 
         return pointer(json_to_typeclass(json_obj['dtype'], context))
 
+    def as_arg(self, name):
+        return self._typeclass.as_arg('* ' + name)
+
     def as_ctypes(self):
         """ Returns the ctypes version of the typeclass. """
         if isinstance(self._typeclass, struct):
@@ -1047,6 +1050,10 @@ class callback(typeclass):
 
         retval = self.cfunc_return_type()
         return f'{retval} (*{name})({", ".join(input_type_cstring)})'
+
+    @property
+    def ctype(self):
+        return self.as_arg('')
 
     def get_trampoline(self, pyfunc, other_arguments, refs):
         from functools import partial


### PR DESCRIPTION
Modifies the code generator to use typeclasses instead of raw C type strings. Makes for a more robust pointer type analysis.