### PR TITLE
Add skip to sdfg dot simplify

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2517,7 +2517,9 @@ class SDFG(ControlFlowRegion):
             :note: This is an in-place operation on the SDFG.
         """
         from dace.transformation.passes.simplify import SimplifyPass
-        return SimplifyPass(validate=validate, validate_all=validate_all, verbose=verbose,
+        return SimplifyPass(validate=validate,
+                            validate_all=validate_all,
+                            verbose=verbose,
                             skip=options.get('skip', None),
                             pass_options=options).apply_pass(self, {})
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2509,7 +2509,7 @@ class SDFG(ControlFlowRegion):
         warnings.warn('SDFG.apply_strict_transformations is deprecated, use SDFG.simplify instead.', DeprecationWarning)
         return self.simplify(validate, validate_all)
 
-    def simplify(self, validate=True, validate_all=False, verbose=False, options=None):
+    def simplify(self, validate=True, validate_all=False, verbose=False, skip:Optional[Set[str]]=None, options=None):
         """ Applies safe transformations (that will surely increase the
             performance) on the SDFG. For example, this fuses redundant states
             (safely) and removes redundant arrays.
@@ -2520,7 +2520,7 @@ class SDFG(ControlFlowRegion):
         return SimplifyPass(validate=validate,
                             validate_all=validate_all,
                             verbose=verbose,
-                            skip=options.get('skip', None),
+                            skip=skip,
                             pass_options=options).apply_pass(self, {})
 
     def auto_optimize(self,

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2518,6 +2518,7 @@ class SDFG(ControlFlowRegion):
         """
         from dace.transformation.passes.simplify import SimplifyPass
         return SimplifyPass(validate=validate, validate_all=validate_all, verbose=verbose,
+                            skip=options.get('skip', None),
                             pass_options=options).apply_pass(self, {})
 
     def auto_optimize(self,


### PR DESCRIPTION
I think this change would be convenient, allows us to skip some passes even if we call sdfg.simplify()