### PR TITLE
[f2dace-dev, fortran] 1) Simplify and improve `call2sdfg()` 2) Do not drop internal subprograms in internal AST transforms.

### DIFF
--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -701,6 +701,9 @@ class pointer(typeclass):
     def ocltype(self):
         return f"{self.base_type.ocltype}*"
 
+    def to_string(self):
+        return f"{self.type.__name__}_ptr"
+
 
 class vector(typeclass):
     """

--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -751,6 +751,7 @@ class InternalFortranAst:
 
         specification_part = get_child(children, ast_internal_classes.Specification_Part_Node)
         execution_part = get_child(children, ast_internal_classes.Execution_Part_Node)
+        internal_subprogram_part = get_child(children, ast_internal_classes.Internal_Subprogram_Part_Node)
 
         name = get_child(children, ast_internal_classes.Function_Stmt_Node)
         return_var: Name_Node = name.ret.name if name.ret else name.name
@@ -769,6 +770,7 @@ class InternalFortranAst:
             ret=return_var,
             specification_part=specification_part,
             execution_part=execution_part,
+            internal_subprogram_part=internal_subprogram_part,
             type=return_type,
             line_number=name.line_number,
             elemental=name.elemental,

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -190,8 +190,9 @@ class Function_Subprogram_Node(FNode):
                  name: 'Name_Node',
                  args: List,
                  ret: 'Name_Node',
-                 specification_part: 'Specification_Part_Node',
-                 execution_part: 'Execution_Part_Node',
+                 specification_part: Optional['Specification_Part_Node'],
+                 execution_part: Optional['Execution_Part_Node'],
+                 internal_subprogram_part: Optional[Internal_Subprogram_Part_Node],
                  type: str,
                  elemental: bool,
                  **kwargs):
@@ -203,6 +204,7 @@ class Function_Subprogram_Node(FNode):
         self.args = args
         self.specification_part = specification_part
         self.execution_part = execution_part
+        self.internal_subprogram_part = internal_subprogram_part
         self.elemental = elemental
 
     _attributes = ('name', 'type', 'ret')
@@ -217,8 +219,9 @@ class Subroutine_Subprogram_Node(FNode):
     def __init__(self,
                  name: 'Name_Node',
                  args: List,
-                 specification_part: 'Specification_Part_Node',
-                 execution_part: 'Execution_Part_Node',
+                 specification_part: Optional['Specification_Part_Node'],
+                 execution_part: Optional['Execution_Part_Node'],
+                 internal_subprogram_part: Optional[Internal_Subprogram_Part_Node],
                  mandatory_args_count: int = -1,
                  optional_args_count: int = -1,
                  type: Any = None,
@@ -233,6 +236,7 @@ class Subroutine_Subprogram_Node(FNode):
         self.elemental = elemental
         self.specification_part = specification_part
         self.execution_part = execution_part
+        self.internal_subprogram_part = internal_subprogram_part
 
     _attributes = ('name', 'type', 'elemental')
     _fields = (
@@ -241,6 +245,7 @@ class Subroutine_Subprogram_Node(FNode):
         'optional_args_count',
         'specification_part',
         'execution_part',
+        'internal_subprogram_part',
     )
 
 

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -243,6 +243,7 @@ class FindFunctionAndSubroutines(NodeVisitor):
         ret = node.name
         ret.elemental = node.elemental
         self.names.append(ret)
+        assert ret.name not in self.nodes
         self.nodes[ret.name] = node
         self.module_based_names[self.current_module].append(ret)
 
@@ -250,6 +251,7 @@ class FindFunctionAndSubroutines(NodeVisitor):
         ret = node.name
         ret.elemental = node.elemental
         self.names.append(ret)
+        assert ret.name not in self.nodes
         self.nodes[ret.name] = node
         self.module_based_names[self.current_module].append(ret)
 

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -243,6 +243,8 @@ class FindFunctionAndSubroutines(NodeVisitor):
         assert ret.name not in self.nodes
         self.nodes[ret.name] = node
         self.module_based_names[self.current_module].append(ret)
+        if node.internal_subprogram_part:
+            self.visit(node.internal_subprogram_part)
 
     def visit_Function_Subprogram_Node(self, node: ast_internal_classes.Function_Subprogram_Node):
         ret = node.name
@@ -251,6 +253,8 @@ class FindFunctionAndSubroutines(NodeVisitor):
         assert ret.name not in self.nodes
         self.nodes[ret.name] = node
         self.module_based_names[self.current_module].append(ret)
+        if node.internal_subprogram_part:
+            self.visit(node.internal_subprogram_part)
 
     def visit_Module_Node(self, node: ast_internal_classes.Module_Node):
         self.iblocks.update(node.interface_blocks)

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -177,51 +177,48 @@ class Flatten_Classes(NodeTransformer):
         return self.generic_visit(node)
 
     def visit_Subroutine_Subprogram_Node(self, node: ast_internal_classes.Subroutine_Subprogram_Node):
-        new_node = self.generic_visit(node)
+        node: ast_internal_classes.Subroutine_Subprogram_Node = self.generic_visit(node)
         print("Subroutine: ", node.name.name)
-        if self.current_class is not None:
-            for i in self.classes:
-                if i.is_class is True:
-                    if i.name.name == self.current_class.name.name:
-                        for j in i.procedure_part.procedures:
-                            if j.name.name == node.name.name:
-                                return ast_internal_classes.Subroutine_Subprogram_Node(
-                                    name=ast_internal_classes.Name_Node(name=i.name.name + "_" + node.name.name,
-                                                                        type=node.type),
-                                    args=new_node.args,
-                                    specification_part=new_node.specification_part,
-                                    execution_part=new_node.execution_part,
-                                    mandatory_args_count=new_node.mandatory_args_count,
-                                    optional_args_count=new_node.optional_args_count,
-                                    elemental=new_node.elemental,
-                                    line_number=new_node.line_number)
-                            elif hasattr(j, "args") and j.args[2] is not None:
-                                if j.args[2].name == node.name.name:
-                                    return ast_internal_classes.Subroutine_Subprogram_Node(
-                                        name=ast_internal_classes.Name_Node(name=i.name.name + "_" + j.name.name,
-                                                                            type=node.type),
-                                        args=new_node.args,
-                                        specification_part=new_node.specification_part,
-                                        execution_part=new_node.execution_part,
-                                        mandatory_args_count=new_node.mandatory_args_count,
-                                        optional_args_count=new_node.optional_args_count,
-                                        elemental=new_node.elemental,
-                                        line_number=new_node.line_number)
-        return new_node
+        if not self.current_class:
+            return node
+        for i in self.classes:
+            if not i.is_class or i.name.name != self.current_class.name.name:
+                continue
+            for j in i.procedure_part.procedures:
+                name = None
+                if j.name.name == node.name.name:
+                    name = i.name.name + "_" + node.name.name
+                elif hasattr(j, "args") and j.args[2] is not None:
+                    if j.args[2].name == node.name.name:
+                        name = i.name.name + "_" + j.name.name
+                if name:
+                    return ast_internal_classes.Subroutine_Subprogram_Node(
+                        name=ast_internal_classes.Name_Node(name=name, type=node.type),
+                        args=node.args,
+                        specification_part=node.specification_part,
+                        execution_part=node.execution_part,
+                        internal_subprogram_part=node.execution_part,
+                        mandatory_args_count=node.mandatory_args_count,
+                        optional_args_count=node.optional_args_count,
+                        elemental=node.elemental,
+                        line_number=node.line_number)
+
+        return node
 
     def visit_Call_Expr_Node(self, node: ast_internal_classes.Call_Expr_Node):
-        if self.current_class is not None:
-            for i in self.classes:
-                if i.is_class is True:
-                    if i.name.name == self.current_class.name.name:
-                        for j in i.procedure_part.procedures:
-                            if j.name.name == node.name.name:
-                                return ast_internal_classes.Call_Expr_Node(
-                                    name=ast_internal_classes.Name_Node(name=i.name.name + "_" + node.name.name,
-                                                                        type=node.type, args=node.args,
-                                                                        line_number=node.line_number), args=node.args,
-                                    type=node.type, subroutine=node.subroutine, line_number=node.line_number,
-                                    parent=node.parent)
+        if not self.current_class:
+            return self.generic_visit(node)
+        for i in self.classes:
+            if not i.is_class or i.name.name != self.current_class.name.name:
+                continue
+            for j in i.procedure_part.procedures:
+                if j.name.name == node.name.name:
+                    name = i.name.name + "_" + j.name.name
+                    return ast_internal_classes.Call_Expr_Node(
+                        name=ast_internal_classes.Name_Node(
+                            name=name, type=node.type, args=node.args, line_number=node.line_number),
+                        args=node.args, type=node.type, subroutine=node.subroutine,
+                        line_number=node.line_number, parent=node.parent)
         return self.generic_visit(node)
 
 
@@ -980,6 +977,7 @@ class FunctionToSubroutineDefiner(NodeTransformer):
             args=args,
             specification_part=node.specification_part,
             execution_part=execution_part,
+            internal_subprogram_part=node.internal_subprogram_part,
             subroutine=True,
             line_number=node.line_number,
             elemental=node.elemental)
@@ -1898,7 +1896,8 @@ class AllocatableReplacerTransformer(NodeTransformer):
             name=node.name,
             args=args,
             specification_part=node.specification_part,
-            execution_part=node.execution_part
+            execution_part=node.execution_part,
+            internal_subprogram_part=node.internal_subprogram_part,
         )
 
 
@@ -2963,11 +2962,17 @@ class PointerRemoval(NodeTransformer):
         else:
             specification_part = node.specification_part
 
+        if node.internal_subprogram_part is not None:
+            internal_subprogram_part = self.visit(node.internal_subprogram_part)
+        else:
+            internal_subprogram_part = node.internal_subprogram_part
+
         return ast_internal_classes.Subroutine_Subprogram_Node(
             name=node.name,
             args=node.args,
             specification_part=specification_part,
             execution_part=execution_part,
+            internal_subprogram_part=internal_subprogram_part,
             line_number=node.line_number,
             elemental=node.elemental
         )

--- a/tests/fortran/missing_func_test.py
+++ b/tests/fortran/missing_func_test.py
@@ -1,26 +1,8 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 
-from fparser.common.readfortran import FortranStringReader
-from fparser.common.readfortran import FortranFileReader
-from fparser.two.parser import ParserFactory
-import sys, os
 import numpy as np
-import pytest
-
-from dace import SDFG, SDFGState, nodes, dtypes, data, subsets, symbolic
-from dace.frontend.fortran import fortran_parser
-from fparser.two.symbol_table import SymbolTable
 
 from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_string
-from dace.sdfg import utils as sdutil
-
-import dace.frontend.fortran.ast_components as ast_components
-import dace.frontend.fortran.ast_transforms as ast_transforms
-import dace.frontend.fortran.ast_utils as ast_utils
-import dace.frontend.fortran.ast_internal_classes as ast_internal_classes
-
-from dace.transformation.passes.lift_struct_views import LiftStructViews
-from dace.transformation import pass_pipeline as ppl
 from tests.fortran.fortran_test_helper import SourceCodeBuilder
 
 
@@ -28,76 +10,54 @@ def test_fortran_frontend_missing_func():
     """
     Tests that the Fortran frontend can parse the simplest type declaration and make use of it in a computation.
     """
-    test_string = """
-        PROGRAM missing_test
-            implicit none
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine main(d)
+  real d(5, 5), z(5)
+  call init_zero_contiguous_dp(z, 5, opt_acc_async=.true., lacc=.false.)
+  d(2, 1) = 5.5 + z(1)
 
+contains
 
-            REAL :: d(5,5)
+  subroutine init_contiguous_dp(var, n, v, opt_acc_async, lacc)
+    integer, intent(in) :: n
+    real, intent(out) :: var(n)
+    real, intent(in) :: v
+    logical, intent(in), optional :: opt_acc_async
+    logical, intent(in), optional :: lacc
+    integer :: i
+    logical :: lzacc
 
-            CALL missing_test_function(d)            
-        end
-
-        
-  SUBROUTINE missing_test_function(d)
-                    REAL d(5,5)
-                    REAL z(5)
-                    
-                    CALL init_zero_contiguous_dp(z, 5, opt_acc_async=.TRUE.,lacc=.FALSE.)
-                    d(2,1) = 5.5 + z(1)
-
-    END SUBROUTINE missing_test_function     
-       
-  SUBROUTINE init_contiguous_dp(var, n, v, opt_acc_async, lacc)
-    INTEGER, INTENT(in) :: n
-    REAL, INTENT(out) :: var(n)
-    REAL, INTENT(in) :: v
-    LOGICAL, INTENT(in), OPTIONAL :: opt_acc_async
-    LOGICAL, INTENT(in), OPTIONAL :: lacc
-
-    INTEGER :: i
-    LOGICAL :: lzacc
-
-    CALL set_acc_host_or_device(lzacc, lacc)
-
-    DO i = 1, n
+    call set_acc_host_or_device(lzacc, lacc)
+    do i = 1, n
       var(i) = v
-    END DO
+    end do
+    call acc_wait_if_requested(1, opt_acc_async)
+  end subroutine init_contiguous_dp
 
-    CALL acc_wait_if_requested(1, opt_acc_async)
-  END SUBROUTINE init_contiguous_dp
+  subroutine init_zero_contiguous_dp(var, n, opt_acc_async, lacc)
+    integer, intent(in) :: n
+    real, intent(out) :: var(n)
+    logical, intent(IN), optional :: opt_acc_async
+    logical, intent(IN), optional :: lacc
 
-  SUBROUTINE init_zero_contiguous_dp(var, n, opt_acc_async, lacc)
-    INTEGER, INTENT(in) :: n
-    REAL, INTENT(out) :: var(n)
-    LOGICAL, INTENT(IN), OPTIONAL :: opt_acc_async
-    LOGICAL, INTENT(IN), OPTIONAL :: lacc
-    
-    
-    CALL init_contiguous_dp(var, n, 0.0, opt_acc_async, lacc)
-    var(1)=var(1)+1.0
+    call init_contiguous_dp(var, n, 0.0, opt_acc_async, lacc)
+    var(1) = var(1) + 1.0
+  end subroutine init_zero_contiguous_dp
 
-  END SUBROUTINE init_zero_contiguous_dp
+  subroutine set_acc_host_or_device(lzacc, lacc)
+    logical, intent(out) :: lzacc
+    logical, intent(in), optional :: lacc
 
-  
-    SUBROUTINE set_acc_host_or_device(lzacc, lacc)
-    LOGICAL, INTENT(out) :: lzacc
-    LOGICAL, INTENT(in), OPTIONAL :: lacc
+    lzacc = .false.
+  end subroutine set_acc_host_or_device
 
-    lzacc = .FALSE.
-
-     END SUBROUTINE set_acc_host_or_device
-
-  SUBROUTINE acc_wait_if_requested(acc_async_queue, opt_acc_async)
-    INTEGER, INTENT(IN) :: acc_async_queue
-    LOGICAL, INTENT(IN), OPTIONAL :: opt_acc_async
-
-
-  END SUBROUTINE acc_wait_if_requested
-    """
-    sources = {}
-    sources["missing_test"] = test_string
-    sdfg = fortran_parser.create_sdfg_from_string(test_string, "missing_test", True, sources=sources)
+  subroutine acc_wait_if_requested(acc_async_queue, opt_acc_async)
+    integer, intent(IN) :: acc_async_queue
+    logical, intent(IN), optional :: opt_acc_async
+  end subroutine acc_wait_if_requested
+end subroutine main
+""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main')
     sdfg.simplify(verbose=True)
     a = np.full([5, 5], 42, order="F", dtype=np.float32)
     sdfg(d=a)


### PR DESCRIPTION
1) During call translation, look harder for the subprogram defs (i.e.,  look into the whole AST, including internal subprograms if any).
2) Simplify that path of `call2sdfg()`.
3) Add `internal_subprogram_part` to the subprogram nodes consistently.
4) Make sure that other transforms don't accidentally drop the internal subprograms.