### PR TITLE
[f2dace/dev, fortran] Write "1" or "0" instead of "True" or "False" as preferred by dace semantics.

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -1,5 +1,5 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
-from typing import Any, List, Optional, Type, TypeVar, Union, overload, TYPE_CHECKING, Dict
+from typing import Any, List, Optional, Type, TypeVar, Union, overload, TYPE_CHECKING, Dict, Tuple
 
 import fparser
 import networkx as nx
@@ -8,6 +8,7 @@ from fparser.two import Fortran2008 as f08
 from fparser.two.Fortran2003 import Function_Subprogram, Function_Stmt, Prefix, Intrinsic_Type_Spec, \
     Assignment_Stmt, Logical_Literal_Constant, Real_Literal_Constant, Signed_Real_Literal_Constant, \
     Int_Literal_Constant, Signed_Int_Literal_Constant, Hex_Constant, Function_Reference
+from fparser.two.utils import Base
 
 from dace.frontend.fortran import ast_internal_classes
 from dace.frontend.fortran.ast_internal_classes import Name_Node, Program_Node, Decl_Stmt_Node, Var_Decl_Node
@@ -91,17 +92,14 @@ def get_children(node: Union[FASTNode, List[FASTNode]], child_type: Union[str, T
     return children_of_type
 
 
-def get_line(node: FASTNode):
+def get_line(node: Base) -> Tuple[int, int]:
     line = None
-    if node.item is not None and hasattr(node.item, "span"):
+    if node.item:
         line = node.item.span
-    else:
-        tmp = node
-        while tmp.parent is not None:
-            tmp = tmp.parent
-            if tmp.item is not None and hasattr(tmp.item, "span"):
-                line = tmp.item.span
-                break
+    if not line and node.parent:
+        line = get_line(node.parent)
+    if not line:
+        line = (0, 0)
     return line
 
 

--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -1988,9 +1988,9 @@ class InternalFortranAst:
 
     def logical_literal_constant(self, node: Logical_Literal_Constant):
         if node.string in [".TRUE.", ".true.", ".True."]:
-            return ast_internal_classes.Bool_Literal_Node(value="True")
+            return ast_internal_classes.Bool_Literal_Node(value="1")
         if node.string in [".FALSE.", ".false.", ".False."]:
-            return ast_internal_classes.Bool_Literal_Node(value="False")
+            return ast_internal_classes.Bool_Literal_Node(value="0")
         raise ValueError("Unknown logical literal constant")
 
     def real_literal_constant(self, node: Union[Real_Literal_Constant, Signed_Real_Literal_Constant]):

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -1785,6 +1785,10 @@ def make_practically_constant_arguments_constants(ast: Program, keepers: List[SP
             if not args:
                 # If we do not have supplied arguments anymore, the remaining arguments must be optional
                 assert atype.optional
+                # The absense should be noted even if it is a writable argument.
+                if aspec not in fnargs_optional_presence:
+                    fnargs_optional_presence[aspec] = set()
+                fnargs_optional_presence[aspec].add(False)
                 continue
             kwargs_zone = isinstance(args[0], Actual_Arg_Spec)  # Whether we are in keyword args territory.
             if kwargs_zone:
@@ -1847,7 +1851,8 @@ def make_practically_constant_arguments_constants(ast: Program, keepers: List[SP
             replace_node(pcall, numpy_type_to_literal(np.bool_(presence)))
 
     for aspec, vals in fnargs_possible_values.items():
-        if aspec in fnargs_undecidables or len(vals) > 1:
+        if (aspec in fnargs_undecidables or len(vals) > 1 or
+                (aspec in fnargs_optional_presence and False in fnargs_optional_presence[aspec])):
             # There are multiple possiblities for the argument: either some undecidables or multiple literals.
             continue
         fixed_val, = vals

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -564,6 +564,8 @@ class Double_Literal_Node(Literal):
 
 class Bool_Literal_Node(Literal):
     def __init__(self, value: str, type='LOGICAL', **kwargs):
+        assert value in {'0', '1'},\
+            f"`{value}` is not a valid respresentation: use `0` for falsey values, and `1` for truthy values."
         super().__init__(value, type, **kwargs)
 
 

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -51,13 +51,15 @@ class FNode(object):
 
         clsname = type(self).__name__.removesuffix('_Node')
         objname = self.name if hasattr(self, 'name') else '?'
-        fieldstrs = {f: _fieldstr(getattr(self, f)) for f in self._fields if hasattr(self, f)}
+        objtype = f"/{self.type}" if hasattr(self, 'type') else ''
+        fieldstrs = {f: _fieldstr(getattr(self, f)) for f in self._fields
+                     if hasattr(self, f) and f not in {'name', 'type'}}
         fieldstrs = [f"{k}:{_indent(v)}" for k, v in fieldstrs.items()]
         if fieldstrs:
             fieldstrs = '\n'.join(fieldstrs)
-            return f"{clsname} '{objname}':\n{_indent(fieldstrs)}"
+            return f"{clsname} '{objname}{objtype}':\n{_indent(fieldstrs)}"
         else:
-            return f"{clsname} '{objname}'"
+            return f"{clsname} '{objname}{objtype}'"
 
 
 class Program_Node(FNode):

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -65,8 +65,8 @@ class FNode(object):
 class Program_Node(FNode):
     def __init__(self,
                  main_program: 'Main_Program_Node',
-                 function_definitions: List,
-                 subroutine_definitions: List,
+                 function_definitions: List['Function_Subprogram_Node'],
+                 subroutine_definitions: List['Subroutine_Subprogram_Node'],
                  modules: List,
                  module_declarations: Dict,
                  placeholders: Optional[List] = None,

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -1559,32 +1559,24 @@ class OptionalArgsTransformer(NodeTransformer):
         return node
 
 
-def optionalArgsExpander(node=ast_internal_classes.Program_Node):
+def optionalArgsExpander(program: ast_internal_classes.Program_Node):
     """
     Adds to each optional arg a logical value specifying its status.
     Eliminates function statements from the AST
-    :param node: The AST to be transformed
+    :param program: The AST to be transformed
     :return: The transformed AST
     :note Should only be used on the program node
     """
-
     modified_functions = {}
+    for fn in mywalk(program, ast_internal_classes.Subroutine_Subprogram_Node):
+        if optionalArgsHandleFunction(fn):
+            modified_functions[fn.name.name] = fn
 
-    for func in node.subroutine_definitions:
-        if optionalArgsHandleFunction(func):
-            modified_functions[func.name.name] = func
-    for mod in node.modules:
-        for func in mod.subroutine_definitions:
-            if optionalArgsHandleFunction(func):
-                modified_functions[func.name.name] = func
-
-    node = OptionalArgsTransformer(modified_functions).visit(node)
-
-    return node
+    return OptionalArgsTransformer(modified_functions).visit(program)
 
 
 class AllocatableReplacerTransformer(NodeTransformer):
-    def __init__(self, program=ast_internal_classes.Program_Node):
+    def __init__(self, program: ast_internal_classes.Program_Node):
         ParentScopeAssigner().visit(program)
 
         # TODO: This assumes globally unique function names. We can make it more general by keeping track of the

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -1596,7 +1596,6 @@ class AllocatableReplacerTransformer(NodeTransformer):
         # `self.execution_preludes[-1]` will contain all the temporary variable assignments necessary for that node.
         self.execution_preludes: List[List[ast_internal_classes.BinOp_Node]] = []
 
-
     @staticmethod
     def _allocated_flag(var: ast_internal_classes.Var_Decl_Node) -> str:
         assert isinstance(var, ast_internal_classes.Var_Decl_Node) and var.alloc
@@ -1645,7 +1644,7 @@ class AllocatableReplacerTransformer(NodeTransformer):
                     continue
                 alloc_flag = self._allocated_flag(fvdecl)
                 decl = ast_internal_classes.Var_Decl_Node(
-                    name=alloc_flag, type='LOGICAL', init=ast_internal_classes.Bool_Literal_Node('False'),
+                    name=alloc_flag, type='LOGICAL', init=ast_internal_classes.Bool_Literal_Node('0'),
                     line_number=fn.line_number, parent=fn.parent)
                 fn.specification_part.specifications.append(ast_internal_classes.Decl_Stmt_Node(vardecl=[decl]))
         # Then, for each argument in order, we will add the extra argument in order. Note that we may not have updated
@@ -1672,7 +1671,7 @@ class AllocatableReplacerTransformer(NodeTransformer):
             #  e.g., setting the sizes, offsets, and the actual memory allocation itself.
             asgn = ast_internal_classes.BinOp_Node(
                 lval=ast_internal_classes.Name_Node(name=self._allocated_flag(avdecl)), op='=',
-                rval=ast_internal_classes.Bool_Literal_Node(value='True'),
+                rval=ast_internal_classes.Bool_Literal_Node(value='1'),
                 line_number=alloc.line_number, parent=alloc.parent)
             self.execution_preludes[-1].append(asgn)
 
@@ -1686,7 +1685,7 @@ class AllocatableReplacerTransformer(NodeTransformer):
             #  e.g., the actual memory deallocation itself.
             asgn = ast_internal_classes.BinOp_Node(
                 lval=ast_internal_classes.Name_Node(name=self._allocated_flag(dvdecl)), op='=',
-                rval=ast_internal_classes.Bool_Literal_Node(value='False'),
+                rval=ast_internal_classes.Bool_Literal_Node(value='0'),
                 line_number=dealloc.line_number, parent=dealloc.parent)
             self.execution_preludes[-1].append(asgn)
 

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -4,6 +4,7 @@ import copy
 import re
 import warnings
 from collections import namedtuple
+from itertools import chain
 from typing import Dict, List, Optional, Tuple, Set, Union, Type
 
 import sympy as sp
@@ -1425,64 +1426,35 @@ class SignToIf(NodeTransformer):
             return self.generic_visit(node)
 
 
-def optionalArgsHandleFunction(func):
-    func.optional_args = []
-    if func.specification_part is None:
+def optionalArgsHandleFunction(fn: ast_internal_classes.Subroutine_Subprogram_Node):
+    # TODO: Determine the arguments' optionality during construction and keep updated.
+    fn.optional_args = []
+    if fn.specification_part is None:
         return 0
-    for spec in func.specification_part.specifications:
+    for spec in fn.specification_part.specifications:
         for var in spec.vardecl:
-            if hasattr(var, "optional") and var.optional:
-                func.optional_args.append((var.name, var.type))
+            if var.optional:
+                fn.optional_args.append((var.name, var.type))
 
-    vardecls = []
-    new_args = []
-    for i in func.args:
-        new_args.append(i)
-    for arg in func.args:
+    vardecls, new_args = [], []
+    args_names = {a.name for a in fn.args}
+    optional_args_names = {a[0] for a in fn.optional_args}
+    for arg in fn.args:
+        if arg.name not in optional_args_names:
+            continue
+        name = f"__f2dace_OPTIONAL_{arg.name}"
+        if name in args_names:
+            continue
+        var = ast_internal_classes.Var_Decl_Node(
+            name=name, type='LOGICAL', alloc=False, sizes=None, offsets=None, kind=None, optional=False, init=None,
+            line_number=fn.line_number, parent=fn)
+        new_args.append(ast_internal_classes.Name_Node(name=name, line_number=fn.line_number, parent=fn))
+        vardecls.append(var)
 
-        found = False
-        for opt_arg in func.optional_args:
-            if opt_arg[0] == arg.name:
-                found = True
-                break
-
-        if found:
-
-            name = f'__f2dace_OPTIONAL_{arg.name}'
-            already_there = False
-            for i in func.args:
-                if hasattr(i, "name") and i.name == name:
-                    already_there = True
-                    break
-            if not already_there:
-                var = ast_internal_classes.Var_Decl_Node(name=name,
-                                                         type='LOGICAL',
-                                                         alloc=False,
-                                                         sizes=None,
-                                                         offsets=None,
-                                                         kind=None,
-                                                         optional=False,
-                                                         init=None,
-                                                         line_number=func.line_number)
-                new_args.append(ast_internal_classes.Name_Node(name=name))
-                vardecls.append(var)
-
-    if len(new_args) > len(func.args):
-        func.args.clear()
-        func.args = new_args
-
-    if len(vardecls) > 0:
-        specifiers = []
-        for i in func.specification_part.specifications:
-            specifiers.append(i)
-        specifiers.append(
-            ast_internal_classes.Decl_Stmt_Node(
-                vardecl=vardecls,
-                line_number=func.line_number
-            )
-        )
-        func.specification_part.specifications.clear()
-        func.specification_part.specifications = specifiers
+    if vardecls:
+        fn.args.extend(new_args)
+        fn.specification_part.specifications.append(
+            ast_internal_classes.Decl_Stmt_Node(vardecl=vardecls, line_number=fn.line_number, parent=fn))
 
     return len(new_args)
 
@@ -1491,56 +1463,47 @@ class OptionalArgsTransformer(NodeTransformer):
     def __init__(self, funcs_with_opt_args):
         self.funcs_with_opt_args = funcs_with_opt_args
 
-    def visit_Call_Expr_Node(self, node: ast_internal_classes.Call_Expr_Node):
-
-        if node.name.name not in self.funcs_with_opt_args:
-            return node
+    def visit_Call_Expr_Node(self, call: ast_internal_classes.Call_Expr_Node):
+        fn_def = self.funcs_with_opt_args.get(call.name.name)
+        if not fn_def:
+            return self.generic_visit(call)
+        assert fn_def.optional_args
 
         # Basic assumption for positioanl arguments
         # Optional arguments follow the mandatory ones
         # We use that to determine which optional arguments are missing
-        func_decl = self.funcs_with_opt_args[node.name.name]
-        optional_args = len(func_decl.optional_args)
-        if optional_args == 0:
-            return node
-
-        should_be_args = len(func_decl.args)
+        optional_args = len(fn_def.optional_args)
+        should_be_args = len(fn_def.args)
         mandatory_args = should_be_args - optional_args * 2
-
-        present_args = len(node.args)
+        present_args = len(call.args)
 
         # Remove the deduplicated variable entries acting as flags for optional args
         missing_args_count = should_be_args - present_args
-        present_optional_args = present_args - mandatory_args
-        new_args = [None] * should_be_args
-        print("Func len args: ", len(func_decl.args))
-        print("Func: ", func_decl.name.name, "Mandatory: ", mandatory_args, "Optional: ", optional_args, "Present: ",
-              present_args, "Missing: ", missing_args_count, "Present Optional: ", present_optional_args)
-        print("List: ", node.name.name, len(new_args), mandatory_args)
-
         if missing_args_count == 0:
-            return node
+            return self.generic_visit(call)
 
+        new_args: List[Optional[ast_internal_classes.FNode]] = [None] * should_be_args
+        # The mandatory arguments should be left as is.
         for i in range(mandatory_args):
-            new_args[i] = node.args[i]
-        for i in range(mandatory_args, len(node.args)):
-            if len(node.args) > i:
-                current_arg = node.args[i]
-                if not isinstance(current_arg, ast_internal_classes.Actual_Arg_Spec_Node):
-                    new_args[i] = current_arg
-                else:
-                    name = current_arg.arg_name
-                    index = 0
-                    for j in func_decl.optional_args:
-                        if j[0] == name.name:
-                            break
-                        index = index + 1
-                    new_args[mandatory_args + index] = current_arg.arg
+            new_args[i] = call.args[i]
+
+        optional_args_names = [a[0] for a in fn_def.optional_args]
+        for i in range(mandatory_args, len(call.args)):
+            current_arg = call.args[i]
+            if isinstance(current_arg, ast_internal_classes.Actual_Arg_Spec_Node):
+                # TODO: We are moving keyworded arguments into their new positions as positional arguments. But what
+                #  about the arguments that are not present in the call statement at all?
+                name = current_arg.arg_name
+                new_pos = mandatory_args + optional_args_names.index(name.name)
+                new_args[new_pos] = current_arg.arg
+            else:
+                # Positional arguments are left as is.
+                new_args[i] = current_arg
 
         for i in range(mandatory_args, mandatory_args + optional_args):
             relative_position = i - mandatory_args
             if new_args[i] is None:
-                dtype = func_decl.optional_args[relative_position][1]
+                dtype = fn_def.optional_args[relative_position][1]
                 if dtype == 'INTEGER':
                     new_args[i] = ast_internal_classes.Int_Literal_Node(value='0')
                 elif dtype == 'LOGICAL':
@@ -1555,8 +1518,8 @@ class OptionalArgsTransformer(NodeTransformer):
             else:
                 new_args[i + optional_args] = ast_internal_classes.Bool_Literal_Node(value='1')
 
-        node.args = new_args
-        return node
+        call.args = new_args
+        return self.generic_visit(call)
 
 
 def optionalArgsExpander(program: ast_internal_classes.Program_Node):

--- a/dace/frontend/fortran/ast_utils.py
+++ b/dace/frontend/fortran/ast_utils.py
@@ -364,8 +364,9 @@ class TaskletWriter:
         return "".join(map(str, node.value))
 
     def boollit2string(self, node: ast_internal_classes.Bool_Literal_Node):
-
-        return str(node.value)
+        assert node.value in {'0', '1'},\
+            f"`{node.value}` is not a valid respresentation: use `0` for falsey values, and `1` for truthy values."
+        return node.value
 
     def unop2string(self, node: ast_internal_classes.UnOp_Node):
         op = node.op

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -2895,10 +2895,9 @@ def create_sdfg_from_internal_ast(own_ast: ast_components.InternalFortranAst, pr
         if not mod and program.main_program and program.main_program.name.name.name == pt:
             # The main program can be a valid entry point, so include that when appropriate.
             fn.append(program.main_program)
-        assert len(fn) <= 1, f"found multiple subroutines with the same name {ep}"
+        fn = atmost_one(f for f in fn)
         if not fn:
             continue
-        fn = fn[0]
 
         # Do the actual translation.
         ast2sdfg = AST_translator(__file__, multiple_sdfgs=cfg.multiple_sdfgs, startpoint=fn, toplevel_subroutine=None,

--- a/tests/fortran/advanced_optional_args_test.py
+++ b/tests/fortran/advanced_optional_args_test.py
@@ -1,81 +1,60 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 
 import numpy as np
-import pytest
 
-from dace.frontend.fortran import fortran_parser
+from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_string
+from tests.fortran.fortran_test_helper import SourceCodeBuilder
+
 
 def test_fortran_frontend_optional_adv():
-    test_string = """
-                    PROGRAM adv_intrinsic_optional_test_function
-                    implicit none
-                    integer, dimension(4) :: res
-                    integer, dimension(4) :: res2
-                    integer :: a
-                    CALL intrinsic_optional_test_function(res, res2, a)
-                    end
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine main(res, res2, a)
+  integer, dimension(4) :: res, res2
+  integer :: a
+  integer, dimension(2) :: ret
 
-                    SUBROUTINE intrinsic_optional_test_function(res, res2, a)
-                    integer, dimension(4) :: res
-                    integer, dimension(4) :: res2
-                    integer :: a
-                    integer,dimension(2) :: ret
+  call fun(res, a)
+  call fun(res2)
+  call get_indices_c(1, 1, 1, ret(1), ret(2), 1, 2)
 
-                    CALL intrinsic_optional_test_function2(res, a)
-                    CALL intrinsic_optional_test_function2(res2)
-                    CALL get_indices_c(1, 1, 1, ret(1), ret(2), 1, 2)
+contains
 
-                    END SUBROUTINE intrinsic_optional_test_function
+  subroutine fun(res, a)
+    integer, dimension(2) :: res
+    integer, optional :: a
+    res(1) = a
+  end subroutine fun
 
-                    SUBROUTINE intrinsic_optional_test_function2(res, a)
-                    integer, dimension(2) :: res
-                    integer, optional :: a
-
-                    res(1) = a
-
-                    END SUBROUTINE intrinsic_optional_test_function2
-
-                    SUBROUTINE get_indices_c(i_blk, i_startblk, i_endblk, i_startidx, &
-                         i_endidx, irl_start, opt_rl_end)
-
-
-  INTEGER, INTENT(IN) :: i_blk      ! Current block (variable jb in do loops)
-  INTEGER, INTENT(IN) :: i_startblk ! Start block of do loop
-  INTEGER, INTENT(IN) :: i_endblk   ! End block of do loop
-  INTEGER, INTENT(IN) :: irl_start  ! refin_ctrl level where do loop starts
-
-  INTEGER, OPTIONAL, INTENT(IN) :: opt_rl_end ! refin_ctrl level where do loop ends
-
-  INTEGER, INTENT(OUT) :: i_startidx, i_endidx ! Start and end indices (jc loop)
-
-  ! Local variables
-
-  INTEGER :: irl_end
-
-  IF (PRESENT(opt_rl_end)) THEN
-    irl_end = opt_rl_end
-  ELSE
-    irl_end = 42
-  ENDIF
-
-  IF (i_blk == i_startblk) THEN
-    i_startidx = 1
-    i_endidx   = 42
-    IF (i_blk == i_endblk) i_endidx = irl_end 
-  ELSE IF (i_blk == i_endblk) THEN
-    i_startidx = 1
-    i_endidx   = irl_end
-  ELSE
-    i_startidx = 1
-    i_endidx = 42
-  ENDIF
-
-END SUBROUTINE get_indices_c
-
-                    """
-    sources={}
-    sources["adv_intrinsic_optional_test_function"]=test_string
-    sdfg = fortran_parser.create_sdfg_from_string(test_string, "intrinsic_optional_test", True,sources=sources)
+  subroutine get_indices_c(i_blk, i_startblk, i_endblk, i_startidx, &
+                           i_endidx, irl_start, opt_rl_end)
+    integer, intent(IN) :: i_blk      ! Current block (variable jb in do loops)
+    integer, intent(IN) :: i_startblk ! Start block of do loop
+    integer, intent(IN) :: i_endblk   ! End block of do loop
+    integer, intent(IN) :: irl_start  ! refin_ctrl level where do loop starts
+    integer, optional, intent(IN) :: opt_rl_end ! refin_ctrl level where do loop ends
+    integer, intent(OUT) :: i_startidx, i_endidx ! Start and end indices (jc loop)
+    ! Local variables
+    integer :: irl_end
+    if (present(opt_rl_end)) then
+      irl_end = opt_rl_end
+    else
+      irl_end = 42
+    end if
+    if (i_blk == i_startblk) then
+      i_startidx = 1
+      i_endidx = 42
+      if (i_blk == i_endblk) i_endidx = irl_end
+    else if (i_blk == i_endblk) then
+      i_startidx = 1
+      i_endidx = irl_end
+    else
+      i_startidx = 1
+      i_endidx = 42
+    end if
+  end subroutine get_indices_c
+end subroutine main
+    """, 'main').check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main')
     sdfg.simplify(verbose=True)
     sdfg.compile()
 
@@ -87,6 +66,6 @@ END SUBROUTINE get_indices_c
     assert res[0] == 5
     assert res2[0] == 0
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     test_fortran_frontend_optional_adv()

--- a/tests/fortran/allocate_test.py
+++ b/tests/fortran/allocate_test.py
@@ -3,7 +3,8 @@
 import numpy as np
 import pytest
 
-from dace.frontend.fortran import fortran_parser
+from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_string
+from tests.fortran.fortran_test_helper import SourceCodeBuilder
 
 
 @pytest.mark.skip(reason="This requires Deferred Allocation support on DaCe, which we do not have yet.")
@@ -11,22 +12,13 @@ def test_fortran_frontend_basic_allocate():
     """
     Tests that the Fortran frontend can parse array accesses and that the accessed indices are correct.
     """
-    test_string = """
-                    PROGRAM allocate_test
-                    implicit none
-                    double precision, allocatable :: d(:,:)
-                    allocate(d(4,5))
-                    CALL allocate_test_function(d)
-                    end
-
-                    SUBROUTINE allocate_test_function(d)
-                    double precision d(4,5)
-                    
-                    d(2,1)=5.5
-                    
-                    END SUBROUTINE allocate_test_function
-                    """
-    sdfg = fortran_parser.create_sdfg_from_string(test_string, "allocate_test")
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine main(d)
+  double precision, allocatable, intent(out) :: d(:, :)
+  allocate (d(4, 5))
+  d(2, 1) = 5.5
+end subroutine main""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main')
     sdfg.simplify(verbose=True)
     a = np.full([4, 5], 42, order="F", dtype=np.float64)
     sdfg(d=a)

--- a/tests/fortran/empty_test.py
+++ b/tests/fortran/empty_test.py
@@ -1,7 +1,6 @@
 # Copyright 2023 ETH Zurich and the DaCe authors. All rights reserved.
 
 import numpy as np
-import pytest
 
 from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_string
 from tests.fortran.fortran_test_helper import SourceCodeBuilder

--- a/tests/fortran/empty_test.py
+++ b/tests/fortran/empty_test.py
@@ -6,7 +6,6 @@ from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_strin
 from tests.fortran.fortran_test_helper import SourceCodeBuilder
 
 
-@pytest.mark.skip("Boolean conditional is broken after applying simplify")
 def test_fortran_frontend_empty():
     """ 
     Test that empty subroutines and functions are correctly parsed.

--- a/tests/fortran/intrinsic_basic_test.py
+++ b/tests/fortran/intrinsic_basic_test.py
@@ -141,35 +141,24 @@ def test_fortran_frontend_size_arbitrary():
 
 
 def test_fortran_frontend_present():
-    test_string = """
-                    PROGRAM intrinsic_basic_present
-                    implicit none
-                    integer, dimension(4) :: res
-                    integer, dimension(4) :: res2
-                    integer :: a
-                    CALL intrinsic_basic_present_test_function(res, res2, a)
-                    end
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine main(res, res2, a)
+  integer, dimension(4) :: res
+  integer, dimension(4) :: res2
+  integer :: a
+  call tf2(res, a=a)
+  call tf2(res2)
 
-                    SUBROUTINE intrinsic_basic_present_test_function(res, res2, a)
-                    integer, dimension(4) :: res
-                    integer, dimension(4) :: res2
-                    integer :: a
+contains
 
-                    CALL tf2(res, a=a)
-                    CALL tf2(res2)
-
-                    END SUBROUTINE intrinsic_basic_present_test_function
-
-                    SUBROUTINE tf2(res, a)
-                    integer, dimension(4) :: res
-                    integer, optional :: a
-
-                    res(1) = PRESENT(a)
-
-                    END SUBROUTINE tf2
-                    """
-
-    sdfg = fortran_parser.create_sdfg_from_string(test_string, "intrinsic_basic_present_test", True)
+  subroutine tf2(res, a)
+    integer, dimension(4) :: res
+    integer, optional :: a
+    res(1) = present(a)
+  end subroutine tf2
+end subroutine
+""", 'main').check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main')
     sdfg.simplify(verbose=True)
     sdfg.compile()
 


### PR DESCRIPTION
- Allows enabling `empty_test`: fixes writing "true" or "false" into SDFG branches.
- Fixes a bug in the fparser processing, where an optional argument might have been fixed to one value, even if it would not be present some of the times.
- Fixes mishandling of internal subprograms by the optional argument transform.