### PR TITLE
[f2dace/dev, fortran] 1) Handle more Fortran language constructs in the preprocessors, e.g., bindings, operators, includes 2) Right after constructing the full AST, run a coarse pruning to discard completely unused modules.

### DIFF
--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -96,6 +96,9 @@ def find_name_of_stmt(node: NAMED_STMTS_OF_INTEREST_TYPES) -> Optional[str]:
         # Ref: https://github.com/stfc/fparser/blob/8c870f84edbf1a24dfbc886e2f7226d1b158d50b/src/fparser/two/Fortran2003.py#L2504
         _, _, _, bname, _ = node.children
         name = bname
+    elif isinstance(node, Generic_Binding):
+        _, bname, _ = node.children
+        name = bname
     elif isinstance(node, Interface_Stmt):
         name, = node.children
     else:

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -26,7 +26,7 @@ from fparser.two.Fortran2003 import Program_Stmt, Module_Stmt, Function_Stmt, Su
     Contains_Stmt, Implicit_Part, End_Module_Stmt, Data_Stmt, Data_Stmt_Set, Data_Stmt_Value, \
     Block_Nonlabel_Do_Construct, Block_Label_Do_Construct, Label_Do_Stmt, Nonlabel_Do_Stmt, End_Do_Stmt, Return_Stmt, \
     Write_Stmt, Data_Component_Def_Stmt, Exit_Stmt, Allocate_Stmt, Deallocate_Stmt, Close_Stmt, Goto_Stmt, \
-    Continue_Stmt, Format_Stmt, Stmt_Function_Stmt, Internal_Subprogram_Part, Private_Components_Stmt
+    Continue_Stmt, Format_Stmt, Stmt_Function_Stmt, Internal_Subprogram_Part, Private_Components_Stmt, Generic_Spec
 from fparser.two.Fortran2008 import Procedure_Stmt, Type_Declaration_Stmt, Error_Stop_Stmt
 from fparser.two.utils import Base, walk, BinaryOpBase, UnaryOpBase, NumberBase
 
@@ -102,8 +102,7 @@ def find_name_of_stmt(node: NAMED_STMTS_OF_INTEREST_TYPES) -> Optional[str]:
         # TODO: Test out other type specific ways of finding names.
         name = singular(children_of_type(node, Name))
     if name:
-        assert isinstance(name, Name)
-        name = name.string
+        name = f"{name}"
     return name
 
 
@@ -298,12 +297,14 @@ def alias_specs(ast: Program):
         else:
             # Otherwise, only specific identifiers are aliased.
             for c in olist.children:
-                assert isinstance(c, (Name, Rename))
+                assert isinstance(c, (Name, Rename, Generic_Spec))
                 if isinstance(c, Name):
                     src, tgt = c, c
                 elif isinstance(c, Rename):
                     _, src, tgt = c.children
-                src, tgt = src.string, tgt.string
+                elif isinstance(c, Generic_Spec):
+                    src, tgt = c, c
+                src, tgt = f"{src}", f"{tgt}"
                 src_spec, tgt_spec = scope_spec + (src,), mod_spec + (tgt,)
                 # `tgt_spec` must have already been resolved if we have sorted the modules properly.
                 assert tgt_spec in alias_map, f"{src_spec} => {tgt_spec}"

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -265,7 +265,7 @@ def identifier_specs(ast: Program) -> SPEC_TABLE:
         if isinstance(stmt, Stmt_Function_Stmt):
             # An exception is statement-functions, which must have a dummy variable already declared in the same scope.
             continue
-        assert spec not in ident_map, f"{spec} / {stmt.parent.parent.parent.parent} / {ident_map[spec].parent.parent.parent.parent}"
+        assert spec not in ident_map, f"{spec}"
         ident_map[spec] = stmt
     return ident_map
 

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -1094,7 +1094,7 @@ def keep_sorted_used_modules(ast: Program, entry_points: Optional[Iterable[SPEC]
             return TOPLEVEL
         else:
             p = singular(children_of_type(p, (Module_Stmt, Program_Stmt)))
-            return find_name_of_stmt(p)
+            return find_name_of_stmt(p).lower()
 
     g = nx.DiGraph()  # An edge u->v means u should come before v, i.e., v depends on u.
     for c in ast.children:
@@ -1121,10 +1121,10 @@ def keep_sorted_used_modules(ast: Program, entry_points: Optional[Iterable[SPEC]
     top_ord[TOPLEVEL] = g.number_of_nodes() + 1
 
     # Discard the unused modules.
-    ast.content = [n for n in ast.children if _get_module(n) in used_modules]
+    set_children(ast, [n for n in ast.children if _get_module(n) in used_modules])
     assert all(_get_module(n) in top_ord for n in ast.children)
     # Sort the rest.
-    ast.content = sorted(ast.children, key=lambda x: top_ord[_get_module(x)])
+    set_children(ast, sorted(ast.children, key=lambda x: top_ord[_get_module(x)]))
 
     return ast
 

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -1110,7 +1110,7 @@ def keep_sorted_used_modules(ast: Program, entry_points: Optional[Iterable[SPEC]
         # If there was no option given, then keep all the modules.
         entry_modules: Set[str] = set(g.nodes) | {TOPLEVEL}
     else:
-        entry_modules: Set[str] = {ep[0] if len(ep) > 1 else TOPLEVEL for ep in entry_points} | {TOPLEVEL}
+        entry_modules: Set[str] = {ep[0] for ep in entry_points if ep[0] in g.nodes} | {TOPLEVEL}
 
     assert all(g.has_node(em) for em in entry_modules)
     used_modules: Set[str] = {anc for em in entry_modules for anc in nx.ancestors(g, em)} | entry_modules

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -3134,7 +3134,7 @@ def construct_full_ast(sources: Dict[str, str], parser,
 
     tops = {}
 
-    for path, f90 in tqdm.tqdm(sources.items()):
+    for path, f90 in sources.items():
         ctops = _get_toplevel_objects((path, f90), parser=parser, sources=sources)
         if ctops.keys() & tops.keys():
             print(f"Found duplicate names for top-level objects: {ctops.keys() & tops.keys()}", file=sys.stderr)

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -37,7 +37,7 @@ from dace.frontend.fortran.ast_desugaring import ENTRY_POINT_OBJECT_CLASSES, NAM
     make_practically_constant_arguments_constants, make_practically_constant_global_vars_constants, \
     exploit_locally_constant_variables, assign_globally_unique_subprogram_names, \
     create_global_initializers, convert_data_statements_into_assignments, deconstruct_statement_functions, \
-    assign_globally_unique_variable_names, deconstuct_goto_statements, remove_self
+    assign_globally_unique_variable_names, deconstuct_goto_statements
 from dace.frontend.fortran.ast_internal_classes import FNode, Main_Program_Node
 from dace.frontend.fortran.ast_utils import children_of_type, mywalk, atmost_one
 from dace.frontend.fortran.intrinsics import IntrinsicSDFGTransformation, NeedsTypeInferenceException
@@ -2732,7 +2732,7 @@ def top_level_objects_map(ast: Program, path: str) -> Dict[str, Base]:
 
 def create_fparser_ast(cfg: ParseConfig) -> Program:
     parser = ParserFactory().create(std="f2008")
-    ast = construct_full_ast(cfg.sources, parser, cfg.entry_points, cfg.main)
+    ast = construct_full_ast(cfg.sources, parser, cfg.entry_points or None, cfg.main)
     ast = lower_identifier_names(ast)
     assert isinstance(ast, Program)
     return ast

--- a/dace/frontend/fortran/gen_serde.py
+++ b/dace/frontend/fortran/gen_serde.py
@@ -219,7 +219,7 @@ def generate_serde_module(serde_base: Module, ast: Program) -> Module:
         for c in dtdef.children:
             if isinstance(c, Private_Components_Stmt):
                 private_access = True
-            assert 'PUBLIC' != f"{c}".strip(),\
+            assert 'PUBLIC' != f"{c}".strip(), \
                 f"We need to access public access statements in derived type defintions; got one in: {dtdef}"
             if not isinstance(c, Component_Part):
                 # We care only about serialising components.
@@ -276,8 +276,8 @@ def generate_serde_module(serde_base: Module, ast: Program) -> Module:
 
                     ops.append(f"s = s // '# {cname}' // new_line('A')")
                     if ptr:
-                        # TODO: pointer types have a whole bunch of different, best-effort strategies. For our purposes, we
-                        #  will only populate this when it points to a different component of the same structure.
+                        # TODO: pointer types have a whole bunch of different, best-effort strategies. For our purposes,
+                        #  we will only populate this when it points to a different component of the same structure.
                         ops.append(
                             f"s = s // '# assoc' // new_line('A') // serialize(associated(x%{cname})) // new_line('A')")
                         candidates = {f"x%{v[0]}": v[1].children for k, v in array_map.items()
@@ -344,6 +344,7 @@ def minimal_preprocessing(ast: Program) -> Program:
     ast = correct_for_function_calls(ast)
     ast = const_eval_nodes(ast)
     return ast
+
 
 def main():
     argp = argparse.ArgumentParser()

--- a/dace/frontend/fortran/gen_serde.py
+++ b/dace/frontend/fortran/gen_serde.py
@@ -16,6 +16,9 @@ from dace.frontend.fortran.ast_utils import singular, children_of_type, atmost_o
 from dace.frontend.fortran.fortran_parser import ParseConfig, create_fparser_ast
 
 
+NEW_LINE = "new_line('A')"
+
+
 def gen_serde_module_skeleton() -> Module:
     return Module(get_reader("""
 module serde
@@ -36,12 +39,20 @@ contains
     close (UNIT=io)
   end subroutine write_to
 
+  ! Given a string `r`, adds a line it to with the content `l`, and returns as `r`.
+  function add_line(r, l) result(s)
+    character(len=*), intent(in) :: r
+    character(len=*), intent(in) :: l
+    character(len=:), allocatable :: s
+    s = r // trim(l) // NEW_LINE('A')
+  end function add_line
+
   ! Given a string `x`, returns a string where `x` has been serialised
   function character_2s(x) result(s)
-    character(len = *), intent(in) :: x
-    character(len = :), allocatable :: s
-    allocate(character(len = len(x))::s)
-    write (s, *) x
+    character(len=*), intent(in) :: x
+    character(len=:), allocatable :: s
+    allocate(character(len = len(x) + 1)::s)
+    write (s, *) trim(x)
     s = trim(s)
   end function character_2s
 end module serde
@@ -60,11 +71,11 @@ def gen_base_type_serializer(typ: str, kind: Optional[int] = None) -> Function_S
     kind = f"(kind={kind})" if kind else ''
     return Function_Subprogram(get_reader(f"""
 function {fn_name}(x) result(s)
-{typ}{kind}, intent(in) :: x
-character(len=:), allocatable :: s
-allocate (character(len=50) :: s)
-write (s, *) x
-s = trim(s)
+  {typ}{kind}, intent(in) :: x
+  character(len=:), allocatable :: s
+  allocate (character(len=50) :: s)
+  write (s, *) x
+  s = trim(s)
 end function {fn_name}
 """))
 
@@ -73,14 +84,15 @@ def generate_array_meta(arr: str, rank: int) -> List[str]:
     # Assumes there is `arr` is an array in local scope with rank `rank`.
     # Also assumes there is a serialization sink `s` and an integer `kmeta` that can be used as an iterator.
     return f"""
-s = s // "# rank" // new_line('A') // serialize({rank}) // new_line('A')
-s = s // "# size" // new_line('A')
+s = add_line(s, "# rank")
+s = add_line(s, serialize({rank}))
+s = add_line(s, "# size")
 do kmeta = 1, {rank}
-  s = s // serialize(size({arr}, kmeta)) // new_line('A')
+  s = add_line(s, serialize(size({arr}, kmeta)))
 end do
-s = s // "# lbound" // new_line('A')
+s = add_line(s, "# lbound")
 do kmeta = 1, {rank}
-  s = s // serialize(lbound({arr}, kmeta)) // new_line('A')
+  s = add_line(s, serialize(lbound({arr}, kmeta)))
 end do
 """.strip().split('\n')
 
@@ -112,7 +124,7 @@ if (associated({ptr}, {c}({subsc_str}))) then
 kmeta = 1
 s = s // "=> {c}("
 {subsc_str_serialized_ops}
-s = s // "))" // new_line('A')
+s = s // "))" // {NEW_LINE}
 end if
 """)
             ops.extend(end_dos)
@@ -120,12 +132,14 @@ end if
         cand_checks.append('\n'.join(sub_checks))
 
     cand_checks: str = '\n'.join(cand_checks)
+    # TODO: We are essentially disabling all slice detection with this line. Enable back when it's performant enough.
+    cand_checks: str = ''
     return f"""
 if (associated({ptr})) then
     kmeta = 0
     {cand_checks}
     if (kmeta == 0) then
-    s = s // "=> missing" // new_line('A')
+    s = add_line(s, "=> missing")
     end if
 end if
 """.strip().split('\n')
@@ -141,16 +155,17 @@ integer :: k, {iter_vars}
     loop_ops = []
     for k in range(1, rank + 1):
         loop_ops.append(f"do k{k} = lbound(a, {k}), ubound(a, {k})")
-    loop_ops.append(f"s = s // serialize(a({iter_vars})) // new_line('A')")
+    loop_ops.append(f"s = add_line(s, serialize(a({iter_vars})))")
     loop_ops.extend(['end do'] * rank)
     loop = '\n'.join(loop_ops)
 
     return Function_Subprogram(get_reader(f"""
 function {tag}_2s{rank}(a) result(s)
-{use or ''}
-{decls}
-s = "# entries" // new_line('A')
-{loop}
+  {use or ''}
+  {decls}
+  s = ""  ! Start with an empty string.
+  s = add_line(s, "# entries")
+  {loop}
 end function {tag}_2s{rank}
 """.strip()))
 
@@ -192,7 +207,7 @@ def generate_serde_module(serde_base: Module, ast: Program) -> Module:
             # Convert to canonical types.
             if isinstance(ctyp, Intrinsic_Type_Spec):
                 dtyp, kind = ctyp.children
-                dtyp = f"{dtyp}".lower()
+                dtyp = f"{dtyp}"
                 if dtyp == 'DOUBLE PRECISION':
                     dtyp, kind = 'REAL', '(KIND = 8)'
                 dtyp = f"{dtyp}{kind or ''}"
@@ -248,9 +263,16 @@ def generate_serde_module(serde_base: Module, ast: Program) -> Module:
                     if rank:
                         if isinstance(ctyp, Intrinsic_Type_Spec):
                             dtyp, kind = ctyp.children
-                            dtyp = f"{dtyp}".lower()
+                            dtyp = f"{dtyp}"
                             if dtyp == 'DOUBLE PRECISION':
                                 dtyp, kind = 'REAL', '(KIND = 8)'
+                            if kind is None:
+                                assert dtyp in {'INTEGER', 'REAL', 'LOGICAL', 'CHAR'}, f"Unexpected type: {dtyp}"
+                                DEFAULT_KINDS = {
+                                    'INTEGER': '(KIND = 4)',
+                                    'REAL': '(KIND = 4)',
+                                }
+                                kind = DEFAULT_KINDS.get(dtyp)
                             dtyp = f"{dtyp}{kind or ''}"
                             use = None
                         else:
@@ -274,23 +296,23 @@ def generate_serde_module(serde_base: Module, ast: Program) -> Module:
                         if (tag, rank) not in array_serializers:
                             array_serializers[(tag, rank)] = generate_array_serializer(dtyp, rank, tag, use)
 
-                    ops.append(f"s = s // '# {cname}' // new_line('A')")
+                    ops.append(f"s = add_line(s , '# {cname}')")
                     if ptr:
                         # TODO: pointer types have a whole bunch of different, best-effort strategies. For our purposes,
                         #  we will only populate this when it points to a different component of the same structure.
-                        ops.append(
-                            f"s = s // '# assoc' // new_line('A') // serialize(associated(x%{cname})) // new_line('A')")
+                        ops.append(f"s = add_line(s, '# assoc')")
+                        ops.append(f"s = add_line(s, serialize(associated(x%{cname})))")
                         candidates = {f"x%{v[0]}": v[1].children for k, v in array_map.items()
                                       if k[0] == dtyp and rank <= k[1]}
                         ops.extend(generate_pointer_meta(f"x%{cname}", rank, candidates))
                     else:
                         if alloc:
-                            ops.append(
-                                f"s = s // '# alloc' // new_line('A') // serialize(allocated(x%{cname})) // new_line('A')")
+                            ops.append(f"s = add_line(s, '# alloc')")
+                            ops.append(f"s = add_line(s, serialize(allocated(x%{cname})))")
                             ops.append(f"if (allocated(x%{cname})) then")
                         if rank:
                             ops.extend(generate_array_meta(f"x%{cname}", rank))
-                        ops.append(f"s = s // new_line('A') // serialize(x%{cname}) // new_line('A')")
+                        ops.append(f"s = add_line(s, serialize(x%{cname}))")
 
                         if alloc:
                             ops.append("end if")
@@ -298,14 +320,15 @@ def generate_serde_module(serde_base: Module, ast: Program) -> Module:
         ops = '\n'.join(ops)
         kmetas = ', '.join(f"kmeta_{k}" for k in range(10))
         impl_fn = Function_Subprogram(get_reader(f"""
-    function {dtname}_2s(x) result(s)
-      use {tspec[0]}, only: {dtname}
-      type({dtname}), target, intent(in) :: x
-      character(len=:), allocatable :: s
-      integer :: kmeta, {kmetas}
-      {ops}
-    end function {dtname}_2s
-    """.strip()))
+function {dtname}_2s(x) result(s)
+  use {tspec[0]}, only: {dtname}
+  type({dtname}), target, intent(in) :: x
+  character(len=:), allocatable :: s
+  integer :: kmeta, {kmetas}
+  s = ""  ! Start with an empty string.
+  {ops}
+end function {dtname}_2s
+""".strip()))
         proc_names.append(f"{dtname}_2s")
         append_children(impls, impl_fn)
 

--- a/tests/fortran/serde_test.py
+++ b/tests/fortran/serde_test.py
@@ -173,7 +173,7 @@ T
 # cCP
 # assoc
 T
-=> x%cC(:           5))
+=> missing
 # d
 T
 # dD


### PR DESCRIPTION
1. This mostly affects the ability to process rest of ICON (e.g., for velocity tendencies). ECRAD did not have these constructs, so we didn't have them before.
2. This also is more useful for rest of the ICON, where it is really easy to pull in a lot of code in the AST just by giving a wide filter, but those additional codes sometimes contain language constructs we cannot process, and in some cases may even be broken.