### PR TITLE
Fix read_and_write_sets() for ControlFlowRegion

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1385,8 +1385,8 @@ class SDFG(ControlFlowRegion):
         for edge in self.all_interstate_edges():
             read_set |= edge.data.free_symbols & array_names
 
-        # By definition, data that is referenced by the conditions (branching condition,
-        #  loop condition, ...) is not single use data, also remove that.
+        # By definition, data that is referenced by symbolic condition expressions
+        # (branching condition, loop condition, ...) is also part of the read set.
         for cfr in self.all_control_flow_regions():
             read_set |= cfr.used_symbols(all_symbols=True, with_contents=False) & array_names
 


### PR DESCRIPTION
The `PruneConnectors` transformation relies on `read_and_write_sets()` to identify connectors on a nested SDFG that refer to unused data containers. With the introduction of `ControlFlowRegion` nodes, the data containers can now be accessed by symbolic expressions used as conditions in such nodes. This case was not considered in baseline.