### PR TITLE
Fix tutorial codegen

### DIFF
--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -15,7 +15,7 @@ from .frontend.operations import reduce, elementwise
 from . import data, hooks, subsets
 from .codegen.compiled_sdfg import CompiledSDFG
 from .config import Config
-from .sdfg import SDFG, SDFGState, InterstateEdge, nodes
+from .sdfg import SDFG, SDFGState, InterstateEdge, nodes, ControlFlowRegion
 from .sdfg.propagation import propagate_memlets_sdfg, propagate_memlet
 from .memlet import Memlet
 from .symbolic import symbol
@@ -30,6 +30,7 @@ hooks._install_hooks_from_config()
 # Hack that enables using @dace as a decorator
 # See https://stackoverflow.com/a/48100440/6489142
 class DaceModule(sys.modules[__name__].__class__):
+    breakpoint()
     def __call__(self, *args, **kwargs):
         return function(*args, **kwargs)
 

--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -31,6 +31,7 @@ hooks._install_hooks_from_config()
 # See https://stackoverflow.com/a/48100440/6489142
 class DaceModule(sys.modules[__name__].__class__):
     breakpoint()
+
     def __call__(self, *args, **kwargs):
         return function(*args, **kwargs)
 

--- a/dace/__init__.py
+++ b/dace/__init__.py
@@ -30,8 +30,6 @@ hooks._install_hooks_from_config()
 # Hack that enables using @dace as a decorator
 # See https://stackoverflow.com/a/48100440/6489142
 class DaceModule(sys.modules[__name__].__class__):
-    breakpoint()
-
     def __call__(self, *args, **kwargs):
         return function(*args, **kwargs)
 

--- a/dace/sdfg/__init__.py
+++ b/dace/sdfg/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 from dace.sdfg.sdfg import SDFG, InterstateEdge, LogicalGroup, NestedDict
 
-from dace.sdfg.state import SDFGState
+from dace.sdfg.state import SDFGState, ControlFlowRegion
 
 from dace.sdfg.scope import (scope_contains_scope, is_devicelevel_gpu, devicelevel_block_size, ScopeSubgraphView)
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='dace',
           'pyreadline;platform_system=="Windows"', 'typing-compat; python_version < "3.8"', 'packaging'
       ] + cmake_requires,
       extras_require={
-          'testing': ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'nbconvert'],
+          'testing': ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'ipykernel', 'nbconvert'],
           'docs': ['jinja2<3.2.0', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme>=0.5.1']
       },
       entry_points={

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='dace',
           'pyreadline;platform_system=="Windows"', 'typing-compat; python_version < "3.8"', 'packaging'
       ] + cmake_requires,
       extras_require={
-          'testing': ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click'],
+          'testing': ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'nbconvert'],
           'docs': ['jinja2<3.2.0', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme>=0.5.1']
       },
       entry_points={

--- a/tests/tutorials/tutorials.py
+++ b/tests/tutorials/tutorials.py
@@ -1,0 +1,17 @@
+import nbformat
+import pytest
+from nbconvert.preprocessors import ExecutePreprocessor
+
+BASE_PATH = "tutorials/"
+NOTEBOOK_PATHS = [f"{BASE_PATH}getting_started.ipynb",
+                  f"{BASE_PATH}codegen.ipynb", ]
+
+@pytest.mark.parametrize("notebook", NOTEBOOK_PATHS)
+def test_notebook_exec(notebook):
+  with open(notebook) as f:
+      nb = nbformat.read(f, as_version=4)
+      ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+      try:
+        assert ep.preprocess(nb) is not None, f"Got empty notebook for {notebook}"
+      except Exception:
+          assert False, f"Failed executing {notebook}"

--- a/tests/tutorials/tutorials.py
+++ b/tests/tutorials/tutorials.py
@@ -3,15 +3,18 @@ import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
 
 BASE_PATH = "tutorials/"
-NOTEBOOK_PATHS = [f"{BASE_PATH}getting_started.ipynb",
-                  f"{BASE_PATH}codegen.ipynb", ]
+NOTEBOOK_PATHS = [
+    f"{BASE_PATH}getting_started.ipynb",
+    f"{BASE_PATH}codegen.ipynb",
+]
+
 
 @pytest.mark.parametrize("notebook", NOTEBOOK_PATHS)
 def test_notebook_exec(notebook):
-  with open(notebook) as f:
-      nb = nbformat.read(f, as_version=4)
-      ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
-      try:
-        assert ep.preprocess(nb) is not None, f"Got empty notebook for {notebook}"
-      except Exception:
-          assert False, f"Failed executing {notebook}"
+    with open(notebook) as f:
+        nb = nbformat.read(f, as_version=4)
+        ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+        try:
+            assert ep.preprocess(nb) is not None, f"Got empty notebook for {notebook}"
+        except Exception:
+            assert False, f"Failed executing {notebook}"

--- a/tests/tutorials/tutorials_test.py
+++ b/tests/tutorials/tutorials_test.py
@@ -13,7 +13,7 @@ NOTEBOOK_PATHS = [
 def test_notebook_exec(notebook):
     with open(notebook) as f:
         nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+        ep = ExecutePreprocessor(timeout=600)
         try:
             assert ep.preprocess(nb) is not None, f"Got empty notebook for {notebook}"
         except Exception:

--- a/tests/tutorials/tutorials_test.py
+++ b/tests/tutorials/tutorials_test.py
@@ -18,3 +18,7 @@ def test_notebook_exec(notebook):
             assert ep.preprocess(nb) is not None, f"Got empty notebook for {notebook}"
         except Exception:
             assert False, f"Failed executing {notebook}"
+
+
+if __name__ == '__main__':
+    pytest.main(["-v", __file__])

--- a/tests/tutorials/tutorials_test.py
+++ b/tests/tutorials/tutorials_test.py
@@ -1,6 +1,6 @@
 import nbformat
 import pytest
-from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 
 BASE_PATH = "tutorials/"
 NOTEBOOK_PATHS = [
@@ -15,9 +15,12 @@ def test_notebook_exec(notebook):
         nb = nbformat.read(f, as_version=4)
         ep = ExecutePreprocessor(timeout=600)
         try:
-            assert ep.preprocess(nb) is not None, f"Got empty notebook for {notebook}"
-        except Exception:
-            assert False, f"Failed executing {notebook}"
+            out = ep.preprocess(nb)
+        except CellExecutionError:
+            out = None
+            msg = 'Error executing the notebook "%s".\n\n' % notebook
+            print(msg)
+            raise
 
 
 if __name__ == '__main__':

--- a/tutorials/getting_started.ipynb
+++ b/tutorials/getting_started.ipynb
@@ -404,25 +404,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "dace_dev",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.0"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
The tutorial `codegen.ipynb` has a small bug, namely the  `ControlFlowRegion`  is not in the correct namespace (as used in the tutorial).
This PR fixes the issue by importing `ControlFlowRegion` in the `dace` namespace.

Additionally I  added a test for the notebook tutorials to make sure they are not broken.
At the moment I added only the "getting started" and "codegen" notebooks.
These tests require new dependencies `ipykernel` and `nbconvert`.

The above may or may not be the preferred solutions!