### PR TITLE
[f2dace/dev, fortran] Avoid writing into (constantly reallocated) strings before writing into file. Also, improve the interface.

### DIFF
--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -3145,13 +3145,6 @@ def name_and_rename_dict_creator(parse_order: list, dep_graph: nx.DiGraph) \
     return name_dict, rename_dict
 
 
-@dataclass
-class FindUsedFunctionsConfig:
-    root: str
-    needed_functions: List[str]
-    skip_functions: List[str]
-
-
 def create_sdfg_from_fortran_file_with_options(
         cfg: ParseConfig,
         ast: Program,
@@ -3272,12 +3265,10 @@ def create_sdfg_from_fortran_file_with_options(
             if (i.name.name, j.name.name) not in cfg.entry_points:
                 continue
             candidates.append(j)
-    assert len(candidates) == 1, "Multiple SDFG generation from multiple entry points not supported yet."
 
     for j in candidates:
         print(f"Building SDFG {j.name.name}")
-        startpoint = j
-        ast2sdfg = AST_translator(__file__, multiple_sdfgs=False, startpoint=startpoint, sdfg_path=sdfgs_dir,
+        ast2sdfg = AST_translator(__file__, multiple_sdfgs=False, startpoint=j, sdfg_path=sdfgs_dir,
                                   normalize_offsets=normalize_offsets, do_not_make_internal_variables_argument=True)
         sdfg = SDFG(j.name.name)
         ast2sdfg.functions_and_subroutines = functions_and_subroutines_builder.names

--- a/dace/frontend/fortran/gen_serde.py
+++ b/dace/frontend/fortran/gen_serde.py
@@ -6,116 +6,138 @@ from typing import Generator, Dict, Tuple, List, Optional, Union, Any
 
 from fparser.api import get_reader
 from fparser.two.Fortran2003 import Module, Derived_Type_Stmt, Module_Subprogram_Part, Data_Component_Def_Stmt, \
-    Procedure_Stmt, Function_Subprogram, Interface_Block, Program, Intrinsic_Type_Spec, \
-    Function_Stmt, Dimension_Component_Attr_Spec, Declaration_Type_Spec, Private_Components_Stmt, Component_Part, \
-    Derived_Type_Def
+    Procedure_Stmt, Interface_Block, Program, Intrinsic_Type_Spec, \
+    Dimension_Component_Attr_Spec, Declaration_Type_Spec, Private_Components_Stmt, Component_Part, \
+    Derived_Type_Def, Subroutine_Subprogram, Subroutine_Stmt
 from fparser.two.utils import walk
 
 import dace
 from dace import SDFG
 from dace.frontend.fortran.ast_desugaring import identifier_specs, append_children, set_children, \
-    SPEC_TABLE, SPEC
+    SPEC_TABLE, SPEC, ConstTypeInjection, find_name_of_node
 from dace.frontend.fortran.ast_utils import singular, children_of_type, atmost_one
 from dace.frontend.fortran.fortran_parser import ParseConfig, create_fparser_ast, run_fparser_transformations
 
-NEW_LINE = "new_line('A')"
+NEW_LINE = "NEW_LINE('A')"
 
 
 def gen_f90_serde_module_skeleton() -> Module:
-    return Module(get_reader("""
+    return Module(get_reader(f"""
 module serde
   implicit none
 
+  ! ALWAYS: First argument should be an integer `io` that is an **opened** writeable stream.
+  ! ALWAYS: Second argument should be a **specialization type** to be serialized.
+  ! ALWAYS: Third argument should be an optional logical about whether to close `io` afterward (default true).
+  ! ALWAYS: Fourth argument should be an optional logical about whether add a new line afterward (default true).
   interface serialize
-    module procedure :: character_2s
+    module procedure :: W_string
   end interface serialize
+
+  ! A counter for versioning data files.
+  integer :: generation = 0
 contains
 
-  ! Given a string `s`, writes it to a file `path`.
-  subroutine write_to(path, s)
-    character(len=*), intent(in) :: path
-    character(len=*), intent(in) ::  s
+  ! Call `tic()` to switch to a new version of data files.
+  subroutine tic()
+    generation = generation + 1
+  end subroutine tic
+
+  ! Constructs a versioned file name for data file.
+  function cat(prefix, asis) result(path)
+    character(len=*), intent(in) :: prefix
+    character(len=:), allocatable :: path
+    character(len=50) :: gen
+    logical, optional, intent(in) :: asis
+    logical :: asis_local = .false.
+    if (present(asis)) asis_local = asis
+    if (asis_local) then
+      path = prefix
+    else
+      ! NOTE: SINCE WE ARE WRITING TO STRING, WE DON'T ADVANCE.
+      write (gen, '(g0)') generation
+      path = prefix // '.' // trim(gen) // ".data"
+    endif
+  end function cat
+
+  ! Constructs a versioned file name for data file, opens it for (over)writing, and returns the handler.
+  function at(prefix, asis) result(io)
+    character(len=*), intent(in) :: prefix
     integer :: io
-    open (NEWUNIT=io, FILE=path, STATUS="replace", ACTION="write")
-    write (io, *) s
-    close (UNIT=io)
-  end subroutine write_to
+    logical, optional, intent(in) :: asis
+    logical :: asis_local = .false.
+    if (present(asis)) asis_local = asis
+    open (NEWUNIT=io, FILE=cat(prefix, asis_local), STATUS="replace", ACTION="write")
+  end function at
 
-  ! Given a string `r`, adds a line it to with the content `l`, and returns as `r`.
-  function add_line(r, l) result(s)
-    character(len=*), intent(in) :: r
-    character(len=*), intent(in) :: l
-    character(len=:), allocatable :: s
-    s = r // trim(l) // NEW_LINE('A')
-  end function add_line
-
-  ! Given a string `x`, returns a string where `x` has been serialised
-  function character_2s(x) result(s)
+  subroutine W_string(io, x, cleanup, nline)
+    integer :: io
     character(len=*), intent(in) :: x
-    character(len=:), allocatable :: s
-    allocate(character(len = len(x) + 1)::s)
-    write (s, '(g0)') trim(x)
-    s = trim(s)
-  end function character_2s
+    logical, optional, intent(in) :: cleanup
+    logical, optional, intent(in) :: nline
+    logical :: cleanup_local = .true., nline_local = .true.
+    if (present(cleanup)) cleanup_local = cleanup
+    if (present(nline)) nline_local = nline
+    write (io, '(g0)', advance='no') trim(x)
+    if (nline_local)  write (io, '(g0)', advance='no') {NEW_LINE}
+    if (cleanup_local) close(UNIT=io)
+  end subroutine W_string
 end module serde
 """))
 
 
-def gen_base_type_serializer(typ: str, kind: Optional[int] = None) -> Function_Subprogram:
+def gen_base_type_serializer(typ: str, kind: Optional[int] = None) -> Subroutine_Subprogram:
     assert typ in {'logical', 'integer', 'real'}
     if typ == 'logical':
         assert kind is None
     elif typ == 'integer':
         assert kind in {1, 2, 4, 8}
-    elif type == 'real':
+    elif typ == 'real':
         assert kind in {4, 8}
-    fn_name = f"{typ}{kind or ''}_2s"
+    fn_name = f"W_{typ}{kind or ''}"
     kind = f"(kind={kind})" if kind else ''
-
     if typ == 'logical':
-        return Function_Subprogram(get_reader(f"""
-function {fn_name}(x) result(s)
+        op = '\n'.join(['y = merge(1, 0, x)', "write (io, '(g0)', advance='no') y"])
+    else:
+        op = "write (io, '(g0)', advance='no') x"
+
+    return Subroutine_Subprogram(get_reader(f"""
+subroutine {fn_name}(io, x, cleanup, nline)
+  integer :: io
   {typ}{kind}, intent(in) :: x
   integer :: y
-  character(len=:), allocatable :: s
-  allocate (character(len=50) :: s)
-  y = x
-  write (s, '(g0)') y
-  s = trim(s)
-end function {fn_name}
-"""))
-    else:
-        return Function_Subprogram(get_reader(f"""
-function {fn_name}(x) result(s)
-  {typ}{kind}, intent(in) :: x
-  character(len=:), allocatable :: s
-  allocate (character(len=50) :: s)
-  write (s, '(g0)') x
-  s = trim(s)
-end function {fn_name}
+  logical, optional, intent(in) :: cleanup
+  logical, optional, intent(in) :: nline
+  logical :: cleanup_local = .true., nline_local = .true.
+  if (present(cleanup)) cleanup_local = cleanup
+  if (present(nline)) nline_local = nline
+  {op}
+  if (nline_local)  write (io, '(g0)', advance='no') {NEW_LINE}
+  if (cleanup_local) close(UNIT=io)
+end subroutine {fn_name}
 """))
 
 
 def generate_array_meta_f90(arr: str, rank: int) -> List[str]:
     # Assumes there is `arr` is an array in local scope with rank `rank`.
-    # Also assumes there is a serialization sink `s` and an integer `kmeta` that can be used as an iterator.
+    # Also assumes there is a serialization sink `io` and an integer `kmeta` that can be used as an iterator.
     return f"""
-s = add_line(s, "# rank")
-s = add_line(s, serialize({rank}))
-s = add_line(s, "# size")
+call serialize(io, "# rank", .false.)
+call serialize(io, {rank}, .false.)
+call serialize(io, "# size", .false.)
 do kmeta = 1, {rank}
-  s = add_line(s, serialize(size({arr}, kmeta)))
+  call serialize(io, size({arr}, kmeta), .false.)
 end do
-s = add_line(s, "# lbound")
+call serialize(io, "# lbound", .false.)
 do kmeta = 1, {rank}
-  s = add_line(s, serialize(lbound({arr}, kmeta)))
+  call serialize(io, lbound({arr}, kmeta), .false.)
 end do
 """.strip().split('\n')
 
 
 def generate_pointer_meta_f90(ptr: str, rank: int, candidates: Dict[str, Tuple]) -> List[str]:
     # Assumes there is `ptr` is a pointer to an array in local scope with rank `rank`.
-    # Also assumes there is a serialization sink `s` and integers `kmeta` and `kmeta_n` that can be used as iterators.
+    # Also assumes there is a serialization sink `io` and integers `kmeta` and `kmeta_n` that can be used as iterators.
     cand_checks: List[str] = []
     for c, c_shape in candidates.items():
         c_rank = len(c_shape)
@@ -127,20 +149,20 @@ def generate_pointer_meta_f90(ptr: str, rank: int, candidates: Dict[str, Tuple])
             for k in range(c_rank):
                 if k not in subsc:
                     subsc_str.append(':')
-                    subsc_str_serialized.append(f"':'")
+                    subsc_str_serialized.append('call serialize(io, ":", .false., .false.)')
                     continue
                 subsc_str.append(f"kmeta_{k}")
-                subsc_str_serialized.append(f"serialize(kmeta_{k})")
+                subsc_str_serialized.append(f"call serialize(io, kmeta_{k}, .false., .false.)")
                 ops.append(f"do kmeta_{k} = lbound({c}, {k + 1}), ubound({c}, {k + 1})")
             end_dos = ['end do'] * len(ops)
             subsc_str = ', '.join(subsc_str)
-            subsc_str_serialized = "// ',' // ".join(subsc_str_serialized)
+            subsc_str_serialized = '\n call serialize(io, ",", .false., .false.) \n'.join(subsc_str_serialized)
             ops.append(f"""
 if (associated({ptr}, {c}({subsc_str}))) then
-kmeta = 1
-s = s // "=> {c}("
-s = s // {subsc_str_serialized}
-s = s // "))" // {NEW_LINE}
+  kmeta = 1
+  call serialize(io, "=> {c}(", .false., .false.)
+  {subsc_str_serialized}
+  call serialize(io, "))", .false.)
 end if
 """)
             ops.extend(end_dos)
@@ -150,38 +172,45 @@ end if
     cand_checks: str = '\n'.join(cand_checks)
     return f"""
 if (associated({ptr})) then
-    kmeta = 0
-    {cand_checks}
-    if (kmeta == 0) then
-    s = add_line(s, "=> missing")
-    end if
+  kmeta = 0
+  {cand_checks}
+  if (kmeta == 0) then
+    call serialize(io, "=> missing", .false.)
+  end if
 end if
 """.strip().split('\n')
 
 
-def generate_array_serializer_f90(dtyp: str, rank: int, tag: str, use: Optional[str] = None) -> Function_Subprogram:
+def generate_array_serializer_f90(dtyp: str, rank: int, tag: str, use: Optional[str] = None) -> Subroutine_Subprogram:
     iter_vars = ', '.join([f"k{k}" for k in range(1, rank + 1)])
     decls = f"""
-{dtyp}, intent(in) :: a({', '.join([':'] * rank)})
-character(len=:), allocatable :: s
+{dtyp}, intent(in) :: x({', '.join([':'] * rank)})
 integer :: k, {iter_vars}
 """
     loop_ops = []
     for k in range(1, rank + 1):
-        loop_ops.append(f"do k{k} = lbound(a, {k}), ubound(a, {k})")
-    loop_ops.append(f"s = add_line(s, serialize(a({iter_vars})))")
+        loop_ops.append(f"do k{k} = lbound(x, {k}), ubound(x, {k})")
+    loop_ops.append(f"call serialize(io, x({iter_vars}), .false.)")
     loop_ops.extend(['end do'] * rank)
     loop = '\n'.join(loop_ops)
+    fn_name = f"W_{tag}_R_{rank}"
 
-    return Function_Subprogram(get_reader(f"""
-function {tag}_2s{rank}(a) result(s)
+    return Subroutine_Subprogram(get_reader(f"""
+subroutine {fn_name}(io, x, cleanup, nline)
   {use or ''}
+  integer :: io
   {decls}
-  s = ""  ! Start with an empty string.
-  s = add_line(s, "# entries")
+  logical, optional, intent(in) :: cleanup
+  logical, optional, intent(in) :: nline
+  logical :: cleanup_local = .true., nline_local = .true.
+  if (present(cleanup)) cleanup_local = cleanup
+  if (present(nline)) nline_local = nline
+  call serialize(io, "# entries", .false.)
   {loop}
-  if (len(s) > 0) s = s(:len(s)-1)  ! Remove the trailing new line.
-end function {tag}_2s{rank}
+  ! NOTE: THIS CONDITIONAL IS INTENTIONALLY COMMENTED OUT, BECAUSE EACH ELEMENT ADD NEW LINE ANYWAY.
+  ! if (nline_local)  write (io, '(g0)', advance='no') {NEW_LINE}
+  if (cleanup_local) close(UNIT=io)
+end subroutine {fn_name}
 """.strip()))
 
 
@@ -273,7 +302,7 @@ def generate_serde_code(ast: Program, g: SDFG) -> SerdeCode:
     f90_mod = gen_f90_serde_module_skeleton()
     proc_names = []
     impls = singular(sp for sp in walk(f90_mod, Module_Subprogram_Part))
-    base_serializers: List[Function_Subprogram] = [
+    base_serializers: List[Subroutine_Subprogram] = [
         gen_base_type_serializer('logical'),
         gen_base_type_serializer('integer', 1),
         gen_base_type_serializer('integer', 2),
@@ -282,7 +311,7 @@ def generate_serde_code(ast: Program, g: SDFG) -> SerdeCode:
         gen_base_type_serializer('real', 4),
         gen_base_type_serializer('real', 8),
     ]
-    array_serializers: Dict[Tuple[str, int], Function_Subprogram] = {}
+    array_serializers: Dict[Tuple[str, int], Subroutine_Subprogram] = {}
     # Generate basic array serializers for ranks 1 to 4.
     for rank in range(1, 5):
         typez = ['LOGICAL', 'INTEGER(KIND = 1)', 'INTEGER(KIND = 2)', 'INTEGER(KIND = 4)', 'INTEGER(KIND = 8)',
@@ -420,7 +449,7 @@ std::string serialize(bool x) {{
             if z.name not in sdfg_structs[dt.name]:
                 # The component is not present in the final SDFG, so we don't care for it.
                 continue
-            f90_ser_ops.append(f"s = add_line(s , '# {z.name}')")
+            f90_ser_ops.append(f"call serialize(io , '# {z.name}', .false.)")
             cpp_ser_ops.append(f"""add_line("# {z.name}", s);""")
             cpp_deser_ops.append(f"""read_line(s, {{"# {z.name}"}});  // Should contain '# {z.name}'""")
 
@@ -451,8 +480,8 @@ std::string serialize(bool x) {{
                 # TODO: pointer types have a whole bunch of different, best-effort strategies. For our purposes,
                 #  we will only populate this when it points to a different component of the same structure.
                 f90_ser_ops.append(f"""
-s = add_line(s, '# assoc')
-s = add_line(s, serialize(associated(x%{z.name})))
+call serialize(io, '# assoc', .false.)
+call serialize(io, associated(x%{z.name}), .false.)
 """)
                 cpp_ser_ops.append(f"""
 add_line("# assoc", s);
@@ -477,8 +506,8 @@ x->{z.name} = nullptr;
             else:
                 if z.alloc:
                     f90_ser_ops.append(f"""
-s = add_line(s, '# alloc')
-s = add_line(s, serialize(allocated(x%{z.name})))
+call serialize(io, '# alloc', .false.)
+call serialize(io, allocated(x%{z.name}), .false.)
 if (allocated(x%{z.name})) then  ! BEGINNING IF
 """)
                     cpp_ser_ops.append(f"""
@@ -493,7 +522,7 @@ if (yep) {{  // BEGINING IF
 """)
                 if z.rank:
                     f90_ser_ops.extend(generate_array_meta_f90(f"x%{z.name}", z.rank))
-                    f90_ser_ops.append(f"s = add_line(s, serialize(x%{z.name}))")
+                    f90_ser_ops.append(f"call serialize(io, x%{z.name}, .false.)")
                     assert '***' not in sdfg_structs[dt.name][z.name]
                     ptrptr = '**' in sdfg_structs[dt.name][z.name]
                     if z.alloc:
@@ -548,14 +577,14 @@ for (int i=0; i<m.volume(); ++i) {{
 }}
 """)
                 elif '*' in sdfg_structs[dt.name][z.name]:
-                    f90_ser_ops.append(f"s = add_line(s, serialize(x%{z.name}))")
+                    f90_ser_ops.append(f"call serialize(io, x%{z.name}, .false.)")
                     cpp_ser_ops.append(f"add_line(serialize(x->{z.name}), s);")
                     cpp_deser_ops.append(f"""
 x ->{z.name} = new std::remove_pointer<decltype(x ->{z.name})>::type;
 deserialize(x->{z.name}, s);
 """)
                 else:
-                    f90_ser_ops.append(f"s = add_line(s, serialize(x%{z.name}))")
+                    f90_ser_ops.append(f"call serialize(io, x%{z.name}, .false.)")
                     cpp_ser_ops.append(f"add_line(serialize(x->{z.name}), s);")
                     cpp_deser_ops.append(f"""
 deserialize(&(x->{z.name}), s);
@@ -569,18 +598,23 @@ deserialize(&(x->{z.name}), s);
         # Conclude the F90 serializer of the type.
         f90_ser_ops: str = '\n'.join(f90_ser_ops)
         kmetas = ', '.join(f"kmeta_{k}" for k in range(10))
-        impl_fn = Function_Subprogram(get_reader(f"""
-function {dt.name}_2s(x) result(s)
+        impl_fn = Subroutine_Subprogram(get_reader(f"""
+subroutine W_{dt.name}(io, x, cleanup, nline)
   use {dt.spec[0]}, only: {dt.name}
+  integer :: io
   type({dt.name}), target, intent(in) :: x
-  character(len=:), allocatable :: s
+  logical, optional, intent(in) :: cleanup
+  logical, optional, intent(in) :: nline
   integer :: kmeta, {kmetas}
-  s = ""  ! Start with an empty string.
+  logical :: cleanup_local = .true., nline_local = .true.
+  if (present(cleanup)) cleanup_local = cleanup
+  if (present(nline)) nline_local = nline
   {f90_ser_ops}
-  if (len(s) > 0) s = s(:len(s)-1)  ! Remove the trailing new line.
-end function {dt.name}_2s
+  if (nline_local)  write (io, '(g0)', advance='no') {NEW_LINE}
+  if (cleanup_local) close(UNIT=io)
+end subroutine W_{dt.name}
 """.strip()))
-        proc_names.append(f"{dt.name}_2s")
+        proc_names.append(f"W_{dt.name}")
         append_children(impls, impl_fn)
 
         # Conclude the C++ serializer of the type.
@@ -626,10 +660,10 @@ std::string config_injection(const {dt.name}& x) {{
 
     # Conclude the F90 serializer code.
     for fn in chain(array_serializers.values(), base_serializers):
-        _, name, _, _ = singular(children_of_type(fn, Function_Stmt)).children
+        _, name, _, _ = singular(children_of_type(fn, Subroutine_Stmt)).children
         proc_names.append(f"{name}")
         append_children(impls, fn)
-    iface = singular(p for p in walk(f90_mod, Interface_Block))
+    iface = singular(p for p in walk(f90_mod, Interface_Block) if find_name_of_node(p) == 'serialize')
     proc_names = Procedure_Stmt(f"module procedure {', '.join(proc_names)}")
     set_children(iface, iface.children[:-1] + [proc_names] + iface.children[-1:])
     f90_code = f90_mod.tofortran()

--- a/tests/fortran/serde_test.py
+++ b/tests/fortran/serde_test.py
@@ -127,7 +127,7 @@ end subroutine f2
         y = singular(y for p in walk(ast, Main_Program) for y in walk(p, Specification_Part))
         x = singular(x for p in walk(ast, Main_Program) for x in walk(p, Execution_Part))
         prepend_children(y, Use_Stmt(f"use serde"))
-        append_children(x, Call_Stmt(f'call write_to("{s_data.name}", trim(serialize(s)))'))
+        append_children(x, Call_Stmt(f'call serialize(at("{s_data.name}", .true.), s)'))
 
         # Now reconstruct the AST again, this time with serde module in place. Then we will run the test and ensure that
         # the serialization is as expected.

--- a/tests/fortran/serde_test.py
+++ b/tests/fortran/serde_test.py
@@ -128,6 +128,7 @@ end subroutine f2
         x = singular(x for p in walk(ast, Main_Program) for x in walk(p, Execution_Part))
         prepend_children(y, Use_Stmt(f"use serde"))
         append_children(x, Call_Stmt(f'call serialize(at("{s_data.name}", .true.), s)'))
+        append_children(x, Call_Stmt(f'call serialize(at("{s_data.name}.bbz", .true.), s%name%w%bBZ)'))
 
         # Now reconstruct the AST again, this time with serde module in place. Then we will run the test and ensure that
         # the serialization is as expected.
@@ -225,9 +226,13 @@ end subroutine f2
 
 int main() {{
     std::ifstream data("{s_data.name}");
+    std::ifstream data_bbz("{s_data.name}.bbz");
+
 
     t x;
     serde::deserialize(&x, data);
+    // Just checking if we can read the plain array too.
+    auto [m, y] = serde::read_array<float>(data_bbz);
 
     auto* h = __dace_init_f2(&x);
     __program_f2(h, &x);


### PR DESCRIPTION
Now the F90 instrumentation is:
- As before, generate `serde.F90` and put it in ECRAD codebase.
- Add a `use serde` statement inside the `radiation` subroutine from `radiation_interface` module. This will import the following functions/subroutines: `tic()`, `at()`, `serialize()`.
- Add a `call tic()` at the beginning of the execution of `radiation`. This will increase the internal version counter.
- Add `call serialize(at("some/absolute/or/relative/pathprefix"), my_obj)` whenever we need to serialize `my_obj` into a file `some/absolute/or/relative/pathprefix.{VERSION}.data`.  The `at()` function will automatically open a versioned file and return the handler, leaving it open. Then `serialize()` subroutine will write into it, then close it before returning.
- NOTE: serializing arrays directly will also write metadata now.

And the C++ instrumentation is:
- Mostly as before, but now there is a `auto [m, arr] = read_array<T>(data);` will  first read the metadata from `data`, then read the actual array content based on that metadata.