### PR TITLE
Rewrite type inference to reapply after expression size changes

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -1323,7 +1323,8 @@ class InternalFortranAst:
 
                         size, assumed_vardecls, offset = self.assumed_array_shape(var, actual_name.name, get_line(node))
                         if size is None:
-                            offset = None
+                            size = []
+                            offset = [1]
                         else:
                             # only one array
                             size = size[0]

--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -1359,8 +1359,8 @@ class InternalFortranAst:
                     vardecls.append(
                         ast_internal_classes.Symbol_Decl_Node(name=actual_name.name,
                                                               type=testtype,
-                                                              sizes=None,
-                                                              offsets=None,
+                                                              sizes=[],
+                                                              offsets=[1],
                                                               alloc=alloc,
                                                               init=init,
                                                               optional=optional))

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -2363,8 +2363,13 @@ class TypeInference(NodeTransformer):
         should_be_updated = False
         if node.lval.type == 'VOID':
             should_be_updated = True
+
         if self._get_sizes(node.lval) is None:
             should_be_updated = True
+
+        # We do NOT overwrite size of a varible if it has been defined by the user.
+        # We only do it for temporaries introduced by our transformations.
+        # At this moment, the only way to distinguish between them is the `tmp_` prefix.
         if isinstance(node.lval, ast_internal_classes.Name_Node) and node.lval.name.startswith("tmp_"):
             should_be_updated = True
 
@@ -3037,6 +3042,7 @@ class ReplaceStructArgsLibraryNodes(NodeTransformer):
                             ])
                         )
 
+                        # No need to create array subscript node - Array2Loop will catch that.
                         dest_node = ast_internal_classes.Name_Node(
                             name=tmp_var_name,
                             parent=call_node.parent,

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -2484,14 +2484,14 @@ class TypeInference(NodeTransformer):
 
     def visit_Call_Expr_Node(self, node: ast_internal_classes.Call_Expr_Node):
 
-        from dace.frontend.fortran.intrinsics import MathFunctions
+        from dace.frontend.fortran.intrinsics import FortranIntrinsics
 
         new_args = []
         for arg in node.args:
             new_args.append(self.visit(arg))
         node.args = new_args
 
-        sizes, offsets, return_type = MathFunctions.output_size(node)
+        sizes, offsets, return_type = FortranIntrinsics.output_size(node)
         if sizes is not None:
             node.sizes = sizes
             node.offsets = offsets

--- a/dace/frontend/fortran/icon_config_propagation.py
+++ b/dace/frontend/fortran/icon_config_propagation.py
@@ -56,13 +56,20 @@ if __name__ == "__main__":
     else:
         already_parsed_ast = None
 
+    if len(sys.argv) > 5:
+        entry_point_module = sys.argv[5]
+        entry_point_function = sys.argv[6]
+    else:
+        entry_point_module = 'radiation_interface'
+        entry_point_function = 'radiation'
+
     base_dir_ecrad = f"{base_icon_path}/externals/ecrad"
     fortran_files = find_path_recursive(base_dir_ecrad)
 
     # Construct the primary ECRAD AST.
     parse_cfg = ParseConfig(
         sources=[Path(f) for f in fortran_files],
-        entry_points=[('radiation_interface', 'radiation')],
+        entry_points=[(entry_point_module, entry_point_function)],
         config_injections=config_injection_list('dace/frontend/fortran/conf_files'),
     )
     if already_parsed_ast is None:

--- a/dace/frontend/fortran/intrinsics.py
+++ b/dace/frontend/fortran/intrinsics.py
@@ -1802,9 +1802,7 @@ class MathFunctions(IntrinsicTransformation):
             else:
                 sizes.append(arg.sizes)
 
-        print(sizes)
         sizes = size_func(node, sizes)
-        print(sizes)
 
         if isinstance(sizes, ast_internal_classes.Int_Literal_Node):
             return sizes, [1], return_type


### PR DESCRIPTION
It fixes the well-known issue of determining the size of a complex expression involving transposition. Required multiple changes across AST transformations.

No new tests broken, and `get_albedos` compiles. 