### PR TITLE
`StateFusion` misses read-write conflict due to early return

### DIFF
--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -153,12 +153,15 @@ class StateFusion(transformation.MultiStateTransformation):
                 path_to = nx.has_path(first_state._nx, node, match)
                 if not path_to:
                     continue
-                path_found = True
+                path_found |= True
                 node2 = next(n for n in second_input if n.data == match.data)
                 if not all(nx.has_path(second_state._nx, node2, n) for n in nodes_second):
                     fail = True
                     break
-            if fail or path_found:
+            # We keep looking for a potential match with a path that fail to find
+            # a path to the second state to make sure we test memlet_intersections
+            # independant of the order of the access nodes in the lists
+            if fail:
                 break
 
         # Check for intersection (if None, fusion is ok)

--- a/tests/transformations/state_fusion_test.py
+++ b/tests/transformations/state_fusion_test.py
@@ -12,12 +12,12 @@ def test_fuse_assignments():
     Two states in which the interstate assignment depends on an interstate
     value going into the first state. Should fail.
     """
-    sdfg = dace.SDFG("state_fusion_test")
+    sdfg = dace.SDFG('state_fusion_test')
     state1 = sdfg.add_state()
     state2 = sdfg.add_state()
     state3 = sdfg.add_state()
     sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
-    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k="k + 1")))
+    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k='k + 1')))
     sdfg.apply_transformations_repeated(StateFusion)
     assert sdfg.number_of_nodes() == 3
 
@@ -27,194 +27,142 @@ def test_fuse_assignments_2():
     Two states in which the first's state's input assignment depends on a symbol assigned (again)
     on the common interstate edge. Should fail.
     """
-    sdfg = dace.SDFG("state_fusion_test")
+    sdfg = dace.SDFG('state_fusion_test')
     state1 = sdfg.add_state()
     state2 = sdfg.add_state()
     state3 = sdfg.add_state()
     state4 = sdfg.add_state()
     state5 = sdfg.add_state()
     sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
-    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k="k + 1")))
-    sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(l="k + 1")))
-    sdfg.add_edge(state4, state5, dace.InterstateEdge(assignments=dict(k="k + 1")))
+    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k='k + 1')))
+    sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(l='k + 1')))
+    sdfg.add_edge(state4, state5, dace.InterstateEdge(assignments=dict(k='k + 1')))
     sdfg.apply_transformations_repeated(StateFusion)
     assert sdfg.number_of_nodes() == 5
 
 
 def test_fuse_assignment_in_use():
-    """
+    """ 
     Two states with an interstate assignment in between, where the assigned
     value is used in the first state. Should fail.
     """
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [2], dace.int32)
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [2], dace.int32)
     state1, state2, state3, state4 = tuple(sdfg.add_state() for _ in range(4))
     sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
     sdfg.add_edge(state2, state3, dace.InterstateEdge())
     sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(k=2)))
 
-    state3.add_edge(
-        state3.add_tasklet("one", {}, {"a"}, "a = k"),
-        "a",
-        state3.add_write("A"),
-        None,
-        dace.Memlet("A[0]"),
-    )
+    state3.add_edge(state3.add_tasklet('one', {}, {'a'}, 'a = k'), 'a', state3.add_write('A'), None,
+                    dace.Memlet('A[0]'))
 
-    state4.add_edge(
-        state3.add_tasklet("two", {}, {"a"}, "a = k"),
-        "a",
-        state3.add_write("A"),
-        None,
-        dace.Memlet("A[1]"),
-    )
+    state4.add_edge(state3.add_tasklet('two', {}, {'a'}, 'a = k'), 'a', state3.add_write('A'), None,
+                    dace.Memlet('A[1]'))
 
     try:
         StateFusion.apply_to(sdfg, first_state=state3, second_state=state4)
-        raise AssertionError("States fused, test failed")
+        raise AssertionError('States fused, test failed')
     except ValueError:
-        print("Exception successfully caught")
+        print('Exception successfully caught')
 
 
 # Connected components tests
 def test_two_to_one_cc_fusion():
-    """Two states, first with two connected components, second with one."""
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [1], dace.int32)
-    sdfg.add_array("B", [1], dace.int32)
-    sdfg.add_array("C", [1], dace.int32)
+    """ Two states, first with two connected components, second with one. """
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [1], dace.int32)
+    sdfg.add_array('B', [1], dace.int32)
+    sdfg.add_array('C', [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    state1.add_edge(
-        state1.add_tasklet("one", {}, {"a"}, "a = 1"),
-        "a",
-        state1.add_write("A"),
-        None,
-        dace.Memlet("A"),
-    )
+    state1.add_edge(state1.add_tasklet('one', {}, {'a'}, 'a = 1'), 'a', state1.add_write('A'), None, dace.Memlet('A'))
 
-    t2 = state1.add_tasklet("two", {}, {"b", "c"}, "b = 2; c = 3")
-    state1.add_edge(t2, "b", state1.add_write("B"), None, dace.Memlet("B"))
-    state1.add_edge(t2, "c", state1.add_write("C"), None, dace.Memlet("C"))
+    t2 = state1.add_tasklet('two', {}, {'b', 'c'}, 'b = 2; c = 3')
+    state1.add_edge(t2, 'b', state1.add_write('B'), None, dace.Memlet('B'))
+    state1.add_edge(t2, 'c', state1.add_write('C'), None, dace.Memlet('C'))
 
     # Second state
-    t2 = state2.add_tasklet("three", {"a", "b", "c"}, {"out"}, "out = a+b+c")
-    state2.add_edge(state2.add_read("A"), None, t2, "a", dace.Memlet("A"))
-    state2.add_edge(state2.add_read("B"), None, t2, "b", dace.Memlet("B"))
-    state2.add_edge(state2.add_read("C"), None, t2, "c", dace.Memlet("C"))
-    state2.add_edge(t2, "out", state2.add_write("C"), None, dace.Memlet("C"))
+    t2 = state2.add_tasklet('three', {'a', 'b', 'c'}, {'out'}, 'out = a+b+c')
+    state2.add_edge(state2.add_read('A'), None, t2, 'a', dace.Memlet('A'))
+    state2.add_edge(state2.add_read('B'), None, t2, 'b', dace.Memlet('B'))
+    state2.add_edge(state2.add_read('C'), None, t2, 'c', dace.Memlet('C'))
+    state2.add_edge(t2, 'out', state2.add_write('C'), None, dace.Memlet('C'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
 
 def test_one_to_two_cc_fusion():
-    """Two states, first with one connected component, second with two."""
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [1], dace.int32)
-    sdfg.add_array("B", [1], dace.int32)
+    """ Two states, first with one connected component, second with two. """
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [1], dace.int32)
+    sdfg.add_array('B', [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    t1 = state1.add_tasklet("one", {}, {"a", "b"}, "a = 1; b = 2")
-    state1.add_edge(t1, "a", state1.add_write("A"), None, dace.Memlet("A"))
-    state1.add_edge(t1, "b", state1.add_write("B"), None, dace.Memlet("B"))
+    t1 = state1.add_tasklet('one', {}, {'a', 'b'}, 'a = 1; b = 2')
+    state1.add_edge(t1, 'a', state1.add_write('A'), None, dace.Memlet('A'))
+    state1.add_edge(t1, 'b', state1.add_write('B'), None, dace.Memlet('B'))
 
     # Second state
-    state2.add_edge(
-        state2.add_read("A"),
-        None,
-        state2.add_tasklet("one", {"a"}, {}, ""),
-        "a",
-        dace.Memlet("A"),
-    )
-    state2.add_edge(
-        state2.add_read("B"),
-        None,
-        state2.add_tasklet("two", {"b"}, {}, ""),
-        "b",
-        dace.Memlet("B"),
-    )
+    state2.add_edge(state2.add_read('A'), None, state2.add_tasklet('one', {'a'}, {}, ''), 'a', dace.Memlet('A'))
+    state2.add_edge(state2.add_read('B'), None, state2.add_tasklet('two', {'b'}, {}, ''), 'b', dace.Memlet('B'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
 
 def test_two_cc_fusion_separate():
-    """Two states, both with two connected components, fused separately."""
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [1], dace.int32)
-    sdfg.add_array("B", [1], dace.int32)
-    sdfg.add_array("C", [1], dace.int32)
+    """ Two states, both with two connected components, fused separately. """
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [1], dace.int32)
+    sdfg.add_array('B', [1], dace.int32)
+    sdfg.add_array('C', [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    state1.add_edge(
-        state1.add_tasklet("one", {}, {"a"}, "a = 1"),
-        "a",
-        state1.add_write("A"),
-        None,
-        dace.Memlet("A"),
-    )
+    state1.add_edge(state1.add_tasklet('one', {}, {'a'}, 'a = 1'), 'a', state1.add_write('A'), None, dace.Memlet('A'))
 
-    t2 = state1.add_tasklet("two", {}, {"b", "c"}, "b = 2; c = 3")
-    state1.add_edge(t2, "b", state1.add_write("B"), None, dace.Memlet("B"))
-    state1.add_edge(t2, "c", state1.add_write("C"), None, dace.Memlet("C"))
+    t2 = state1.add_tasklet('two', {}, {'b', 'c'}, 'b = 2; c = 3')
+    state1.add_edge(t2, 'b', state1.add_write('B'), None, dace.Memlet('B'))
+    state1.add_edge(t2, 'c', state1.add_write('C'), None, dace.Memlet('C'))
 
     # Second state
-    state2.add_edge(
-        state2.add_read("A"),
-        None,
-        state2.add_tasklet("one", {"a"}, {}, ""),
-        "a",
-        dace.Memlet("A"),
-    )
+    state2.add_edge(state2.add_read('A'), None, state2.add_tasklet('one', {'a'}, {}, ''), 'a', dace.Memlet('A'))
 
-    t2 = state2.add_tasklet("two", {"b", "c"}, {}, "")
-    state2.add_edge(state2.add_read("B"), None, t2, "b", dace.Memlet("B"))
-    state2.add_edge(state2.add_read("C"), None, t2, "c", dace.Memlet("C"))
+    t2 = state2.add_tasklet('two', {'b', 'c'}, {}, '')
+    state2.add_edge(state2.add_read('B'), None, t2, 'b', dace.Memlet('B'))
+    state2.add_edge(state2.add_read('C'), None, t2, 'c', dace.Memlet('C'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
 
 def test_two_cc_fusion_together():
-    """Two states, both with two connected components, fused to one CC."""
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [1], dace.int32)
-    sdfg.add_array("B", [1], dace.int32)
-    sdfg.add_array("C", [1], dace.int32)
+    """ Two states, both with two connected components, fused to one CC. """
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [1], dace.int32)
+    sdfg.add_array('B', [1], dace.int32)
+    sdfg.add_array('C', [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    state1.add_edge(
-        state1.add_tasklet("one", {}, {"a"}, "a = 1"),
-        "a",
-        state1.add_write("A"),
-        None,
-        dace.Memlet("A"),
-    )
+    state1.add_edge(state1.add_tasklet('one', {}, {'a'}, 'a = 1'), 'a', state1.add_write('A'), None, dace.Memlet('A'))
 
-    t2 = state1.add_tasklet("two", {}, {"b", "c"}, "b = 2; c = 3")
-    state1.add_edge(t2, "b", state1.add_write("B"), None, dace.Memlet("B"))
-    state1.add_edge(t2, "c", state1.add_write("C"), None, dace.Memlet("C"))
+    t2 = state1.add_tasklet('two', {}, {'b', 'c'}, 'b = 2; c = 3')
+    state1.add_edge(t2, 'b', state1.add_write('B'), None, dace.Memlet('B'))
+    state1.add_edge(t2, 'c', state1.add_write('C'), None, dace.Memlet('C'))
 
     # Second state
-    state2.add_edge(
-        state2.add_read("B"),
-        None,
-        state2.add_tasklet("one", {"a"}, {}, ""),
-        "a",
-        dace.Memlet("B"),
-    )
+    state2.add_edge(state2.add_read('B'), None, state2.add_tasklet('one', {'a'}, {}, ''), 'a', dace.Memlet('B'))
 
-    t2 = state2.add_tasklet("two", {"b", "c"}, {"d", "e"}, "d = b + c; e = b")
-    state2.add_edge(state2.add_read("A"), None, t2, "b", dace.Memlet("A"))
-    state2.add_edge(state2.add_read("C"), None, t2, "c", dace.Memlet("C"))
-    state2.add_edge(t2, "d", state2.add_write("A"), None, dace.Memlet("A"))
-    state2.add_edge(t2, "e", state2.add_write("C"), None, dace.Memlet("C"))
+    t2 = state2.add_tasklet('two', {'b', 'c'}, {'d', 'e'}, 'd = b + c; e = b')
+    state2.add_edge(state2.add_read('A'), None, t2, 'b', dace.Memlet('A'))
+    state2.add_edge(state2.add_read('C'), None, t2, 'c', dace.Memlet('C'))
+    state2.add_edge(t2, 'd', state2.add_write('A'), None, dace.Memlet('A'))
+    state2.add_edge(t2, 'e', state2.add_write('C'), None, dace.Memlet('C'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
@@ -225,7 +173,6 @@ def test_write_write_path():
     Two states where both write to the same range of an array, but there is
     a path between the write and the second write.
     """
-
     @dace.program
     def state_fusion_test(A: dace.int32[20, 20]):
         A += 1
@@ -241,11 +188,11 @@ def test_write_write_no_overlap():
     """
     Two states where both write to different ranges of an array.
     """
-    N = dace.symbol("N", positive=True)
+    N = dace.symbol('N', positive=True)
 
     @dace.program
     def state_fusion_test(A: dace.int32[N, N]):
-        A[0 : N - 1, :] = 1
+        A[0:N - 1, :] = 1
         A[N - 1, :] = 2
 
     sdfg = state_fusion_test.to_sdfg(simplify=False)
@@ -258,7 +205,7 @@ def test_read_write_no_overlap():
     Two states where two separate CCs write and read to/from an array, but
     in different ranges.
     """
-    N = dace.symbol("N")
+    N = dace.symbol('N')
 
     @dace.program
     def state_fusion_test(A: dace.int32[N, N], B: dace.int32[N, N]):
@@ -271,92 +218,92 @@ def test_read_write_no_overlap():
 
 
 def test_array_in_middle_no_overlap():
-    """
+    """ 
     Two states that write and read from an array without overlap. Should be
     fused to two separate components.
     """
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [10, 10], dace.int32)
-    sdfg.add_array("B", [5, 5], dace.int32)
-    sdfg.add_array("C", [5, 5], dace.int32)
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [10, 10], dace.int32)
+    sdfg.add_array('B', [5, 5], dace.int32)
+    sdfg.add_array('C', [5, 5], dace.int32)
     state = sdfg.add_state()
-    t1 = state.add_tasklet("init_a1", {}, {"a"}, "")
-    rw1 = state.add_access("A")
-    t2 = state.add_tasklet("a2b", {"a"}, {"b"}, "")
-    wb = state.add_write("B")
-    state.add_edge(t1, "a", rw1, None, dace.Memlet("A[0:5, 0:5]"))
-    state.add_edge(rw1, None, t2, "a", dace.Memlet("A[0:5, 0:5]"))
-    state.add_edge(t2, "b", wb, None, dace.Memlet("B"))
+    t1 = state.add_tasklet('init_a1', {}, {'a'}, '')
+    rw1 = state.add_access('A')
+    t2 = state.add_tasklet('a2b', {'a'}, {'b'}, '')
+    wb = state.add_write('B')
+    state.add_edge(t1, 'a', rw1, None, dace.Memlet('A[0:5, 0:5]'))
+    state.add_edge(rw1, None, t2, 'a', dace.Memlet('A[0:5, 0:5]'))
+    state.add_edge(t2, 'b', wb, None, dace.Memlet('B'))
 
     state2 = sdfg.add_state_after(state)
-    t1 = state2.add_tasklet("init_a2", {}, {"a"}, "")
-    rw2 = state2.add_access("A")
-    t2 = state2.add_tasklet("a2c", {"a"}, {"c"}, "")
-    wc = state2.add_write("C")
-    state2.add_edge(t1, "a", rw2, None, dace.Memlet("A[5:10, 5:10]"))
-    state2.add_edge(rw2, None, t2, "a", dace.Memlet("A[5:10, 5:10]"))
-    state2.add_edge(t2, "c", wc, None, dace.Memlet("C"))
+    t1 = state2.add_tasklet('init_a2', {}, {'a'}, '')
+    rw2 = state2.add_access('A')
+    t2 = state2.add_tasklet('a2c', {'a'}, {'c'}, '')
+    wc = state2.add_write('C')
+    state2.add_edge(t1, 'a', rw2, None, dace.Memlet('A[5:10, 5:10]'))
+    state2.add_edge(rw2, None, t2, 'a', dace.Memlet('A[5:10, 5:10]'))
+    state2.add_edge(t2, 'c', wc, None, dace.Memlet('C'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
     assert len(list(nx.weakly_connected_components(sdfg.node(0).nx))) == 2
 
 
 def test_array_in_middle_overlap():
-    """
+    """ 
     Two states that write and read from an array with overlap. Should not be
     fused.
     """
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [10, 10], dace.int32)
-    sdfg.add_array("B", [5, 5], dace.int32)
-    sdfg.add_array("C", [5, 5], dace.int32)
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [10, 10], dace.int32)
+    sdfg.add_array('B', [5, 5], dace.int32)
+    sdfg.add_array('C', [5, 5], dace.int32)
     state = sdfg.add_state()
-    t1 = state.add_tasklet("init_a1", {}, {"a"}, "")
-    rw1 = state.add_access("A")
-    t2 = state.add_tasklet("a2b", {"a"}, {"b"}, "")
-    wb = state.add_write("B")
-    state.add_edge(t1, "a", rw1, None, dace.Memlet("A[0:5, 0:5]"))
-    state.add_edge(rw1, None, t2, "a", dace.Memlet("A[0:5, 0:5]"))
-    state.add_edge(t2, "b", wb, None, dace.Memlet("B"))
+    t1 = state.add_tasklet('init_a1', {}, {'a'}, '')
+    rw1 = state.add_access('A')
+    t2 = state.add_tasklet('a2b', {'a'}, {'b'}, '')
+    wb = state.add_write('B')
+    state.add_edge(t1, 'a', rw1, None, dace.Memlet('A[0:5, 0:5]'))
+    state.add_edge(rw1, None, t2, 'a', dace.Memlet('A[0:5, 0:5]'))
+    state.add_edge(t2, 'b', wb, None, dace.Memlet('B'))
 
     state2 = sdfg.add_state_after(state)
-    t1 = state2.add_tasklet("init_a2", {}, {"a"}, "")
-    rw2 = state2.add_access("A")
-    t2 = state2.add_tasklet("a2c", {"a"}, {"c"}, "")
-    wc = state2.add_write("C")
-    state2.add_edge(t1, "a", rw2, None, dace.Memlet("A[0:5, 0:5]"))
-    state2.add_edge(rw2, None, t2, "a", dace.Memlet("A[0:5, 0:5]"))
-    state2.add_edge(t2, "c", wc, None, dace.Memlet("C"))
+    t1 = state2.add_tasklet('init_a2', {}, {'a'}, '')
+    rw2 = state2.add_access('A')
+    t2 = state2.add_tasklet('a2c', {'a'}, {'c'}, '')
+    wc = state2.add_write('C')
+    state2.add_edge(t1, 'a', rw2, None, dace.Memlet('A[0:5, 0:5]'))
+    state2.add_edge(rw2, None, t2, 'a', dace.Memlet('A[0:5, 0:5]'))
+    state2.add_edge(t2, 'c', wc, None, dace.Memlet('C'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 0
 
 
 def test_two_outputs_same_name():
-    """
-    First state writes to the same array twice, second state updates one value.
+    """ 
+    First state writes to the same array twice, second state updates one value. 
     Should be fused to the right node in the second state or a data race will
     occur.
     """
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [2], dace.int32)
-    sdfg.add_scalar("scal", dace.int32)
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [2], dace.int32)
+    sdfg.add_scalar('scal', dace.int32)
     state = sdfg.add_state()
-    r = state.add_read("scal")
-    t1 = state.add_tasklet("init_a1", {"s"}, {"a"}, "a = 1 + s")
-    w1 = state.add_write("A")
-    t2 = state.add_tasklet("init_a2", {"s"}, {"a"}, "a = 2 + s")
-    w2 = state.add_write("A")
-    state.add_edge(r, None, t1, "s", dace.Memlet("scal"))
-    state.add_edge(t1, "a", w1, None, dace.Memlet("A[0]"))
-    state.add_edge(r, None, t2, "s", dace.Memlet("scal"))
-    state.add_edge(t2, "a", w2, None, dace.Memlet("A[1]"))
+    r = state.add_read('scal')
+    t1 = state.add_tasklet('init_a1', {'s'}, {'a'}, 'a = 1 + s')
+    w1 = state.add_write('A')
+    t2 = state.add_tasklet('init_a2', {'s'}, {'a'}, 'a = 2 + s')
+    w2 = state.add_write('A')
+    state.add_edge(r, None, t1, 's', dace.Memlet('scal'))
+    state.add_edge(t1, 'a', w1, None, dace.Memlet('A[0]'))
+    state.add_edge(r, None, t2, 's', dace.Memlet('scal'))
+    state.add_edge(t2, 'a', w2, None, dace.Memlet('A[1]'))
 
     state2 = sdfg.add_state_after(state)
-    r1 = state2.add_read("A")
-    t1 = state2.add_tasklet("update_a2", {"a"}, {"b"}, "b = a + 2")
-    w1 = state2.add_write("A")
-    state2.add_edge(r1, None, t1, "a", dace.Memlet("A[1]"))
-    state2.add_edge(t1, "b", w1, None, dace.Memlet("A[1]"))
+    r1 = state2.add_read('A')
+    t1 = state2.add_tasklet('update_a2', {'a'}, {'b'}, 'b = a + 2')
+    w1 = state2.add_write('A')
+    state2.add_edge(r1, None, t1, 'a', dace.Memlet('A[1]'))
+    state2.add_edge(t1, 'b', w1, None, dace.Memlet('A[1]'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
@@ -366,32 +313,32 @@ def test_two_outputs_same_name():
 
 
 def test_inout_read_after_write():
-    """
+    """ 
     First state ends with a computation that reads an array, while the second
     state both reads and writes to that same array. Fusion will then cause
     a RAW conflict.
     """
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [1], dace.int32)
-    sdfg.add_array("B", [1], dace.int32)
-    sdfg.add_array("C", [1], dace.int32)
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [1], dace.int32)
+    sdfg.add_array('B', [1], dace.int32)
+    sdfg.add_array('C', [1], dace.int32)
     state = sdfg.add_state()
-    r = state.add_read("A")
-    t1 = state.add_tasklet("init_b", {"a"}, {"b"}, "b = a + 1")
-    rw = state.add_access("B")
-    t2 = state.add_tasklet("init_c", {"b"}, {"c"}, "c = 2 + b")
-    w = state.add_access("C")
-    state.add_edge(r, None, t1, "a", dace.Memlet("A[0]"))
-    state.add_edge(t1, "b", rw, None, dace.Memlet("B[0]"))
-    state.add_edge(rw, None, t2, "b", dace.Memlet("B[0]"))
-    state.add_edge(t2, "c", w, None, dace.Memlet("C[0]"))
+    r = state.add_read('A')
+    t1 = state.add_tasklet('init_b', {'a'}, {'b'}, 'b = a + 1')
+    rw = state.add_access('B')
+    t2 = state.add_tasklet('init_c', {'b'}, {'c'}, 'c = 2 + b')
+    w = state.add_access('C')
+    state.add_edge(r, None, t1, 'a', dace.Memlet('A[0]'))
+    state.add_edge(t1, 'b', rw, None, dace.Memlet('B[0]'))
+    state.add_edge(rw, None, t2, 'b', dace.Memlet('B[0]'))
+    state.add_edge(t2, 'c', w, None, dace.Memlet('C[0]'))
 
     state2 = sdfg.add_state_after(state)
-    r1 = state2.add_read("B")
-    t1 = state2.add_tasklet("update_b", {"bin"}, {"bout"}, "bout = bin + bin")
-    w1 = state2.add_write("B")
-    state2.add_edge(r1, None, t1, "bin", dace.Memlet("B[0]"))
-    state2.add_edge(t1, "bout", w1, None, dace.Memlet("B[0]"))
+    r1 = state2.add_read('B')
+    t1 = state2.add_tasklet('update_b', {'bin'}, {'bout'}, 'bout = bin + bin')
+    w1 = state2.add_write('B')
+    state2.add_edge(r1, None, t1, 'bin', dace.Memlet('B[0]'))
+    state2.add_edge(t1, 'bout', w1, None, dace.Memlet('B[0]'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 0
 
@@ -404,27 +351,27 @@ def test_inout_read_after_write():
 
 
 def test_inout_second_state():
-    """
-    Second state has a computation that reads and writes to the same array,
-    while the first state also reads from that same array. Fusion will then
+    """ 
+    Second state has a computation that reads and writes to the same array, 
+    while the first state also reads from that same array. Fusion will then 
     cause a potential data race.
     """
-    sdfg = dace.SDFG("state_fusion_test")
-    sdfg.add_array("A", [1], dace.int32)
-    sdfg.add_array("B", [1], dace.int32)
+    sdfg = dace.SDFG('state_fusion_test')
+    sdfg.add_array('A', [1], dace.int32)
+    sdfg.add_array('B', [1], dace.int32)
     state = sdfg.add_state()
-    r = state.add_read("A")
-    t1 = state.add_tasklet("init_b", {"a"}, {"b"}, "b = a + 1")
-    w = state.add_write("B")
-    state.add_edge(r, None, t1, "a", dace.Memlet("A[0]"))
-    state.add_edge(t1, "b", w, None, dace.Memlet("B[0]"))
+    r = state.add_read('A')
+    t1 = state.add_tasklet('init_b', {'a'}, {'b'}, 'b = a + 1')
+    w = state.add_write('B')
+    state.add_edge(r, None, t1, 'a', dace.Memlet('A[0]'))
+    state.add_edge(t1, 'b', w, None, dace.Memlet('B[0]'))
 
     state2 = sdfg.add_state_after(state)
-    r1 = state2.add_read("A")
-    t1 = state2.add_tasklet("update_a", {"a"}, {"aout"}, "aout = a + 5")
-    w1 = state2.add_write("A")
-    state2.add_edge(r1, None, t1, "a", dace.Memlet("A[0]"))
-    state2.add_edge(t1, "aout", w1, None, dace.Memlet("A[0]"))
+    r1 = state2.add_read('A')
+    t1 = state2.add_tasklet('update_a', {'a'}, {'aout'}, 'aout = a + 5')
+    w1 = state2.add_write('A')
+    state2.add_edge(r1, None, t1, 'a', dace.Memlet('A[0]'))
+    state2.add_edge(t1, 'aout', w1, None, dace.Memlet('A[0]'))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 0
 

--- a/tests/transformations/state_fusion_test.py
+++ b/tests/transformations/state_fusion_test.py
@@ -12,12 +12,12 @@ def test_fuse_assignments():
     Two states in which the interstate assignment depends on an interstate
     value going into the first state. Should fail.
     """
-    sdfg = dace.SDFG('state_fusion_test')
+    sdfg = dace.SDFG("state_fusion_test")
     state1 = sdfg.add_state()
     state2 = sdfg.add_state()
     state3 = sdfg.add_state()
     sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
-    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k='k + 1')))
+    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k="k + 1")))
     sdfg.apply_transformations_repeated(StateFusion)
     assert sdfg.number_of_nodes() == 3
 
@@ -27,142 +27,194 @@ def test_fuse_assignments_2():
     Two states in which the first's state's input assignment depends on a symbol assigned (again)
     on the common interstate edge. Should fail.
     """
-    sdfg = dace.SDFG('state_fusion_test')
+    sdfg = dace.SDFG("state_fusion_test")
     state1 = sdfg.add_state()
     state2 = sdfg.add_state()
     state3 = sdfg.add_state()
     state4 = sdfg.add_state()
     state5 = sdfg.add_state()
     sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
-    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k='k + 1')))
-    sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(l='k + 1')))
-    sdfg.add_edge(state4, state5, dace.InterstateEdge(assignments=dict(k='k + 1')))
+    sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k="k + 1")))
+    sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(l="k + 1")))
+    sdfg.add_edge(state4, state5, dace.InterstateEdge(assignments=dict(k="k + 1")))
     sdfg.apply_transformations_repeated(StateFusion)
     assert sdfg.number_of_nodes() == 5
 
 
 def test_fuse_assignment_in_use():
-    """ 
+    """
     Two states with an interstate assignment in between, where the assigned
     value is used in the first state. Should fail.
     """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [2], dace.int32)
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [2], dace.int32)
     state1, state2, state3, state4 = tuple(sdfg.add_state() for _ in range(4))
     sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(k=1)))
     sdfg.add_edge(state2, state3, dace.InterstateEdge())
     sdfg.add_edge(state3, state4, dace.InterstateEdge(assignments=dict(k=2)))
 
-    state3.add_edge(state3.add_tasklet('one', {}, {'a'}, 'a = k'), 'a', state3.add_write('A'), None,
-                    dace.Memlet('A[0]'))
+    state3.add_edge(
+        state3.add_tasklet("one", {}, {"a"}, "a = k"),
+        "a",
+        state3.add_write("A"),
+        None,
+        dace.Memlet("A[0]"),
+    )
 
-    state4.add_edge(state3.add_tasklet('two', {}, {'a'}, 'a = k'), 'a', state3.add_write('A'), None,
-                    dace.Memlet('A[1]'))
+    state4.add_edge(
+        state3.add_tasklet("two", {}, {"a"}, "a = k"),
+        "a",
+        state3.add_write("A"),
+        None,
+        dace.Memlet("A[1]"),
+    )
 
     try:
         StateFusion.apply_to(sdfg, first_state=state3, second_state=state4)
-        raise AssertionError('States fused, test failed')
+        raise AssertionError("States fused, test failed")
     except ValueError:
-        print('Exception successfully caught')
+        print("Exception successfully caught")
 
 
 # Connected components tests
 def test_two_to_one_cc_fusion():
-    """ Two states, first with two connected components, second with one. """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [1], dace.int32)
-    sdfg.add_array('B', [1], dace.int32)
-    sdfg.add_array('C', [1], dace.int32)
+    """Two states, first with two connected components, second with one."""
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [1], dace.int32)
+    sdfg.add_array("B", [1], dace.int32)
+    sdfg.add_array("C", [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    state1.add_edge(state1.add_tasklet('one', {}, {'a'}, 'a = 1'), 'a', state1.add_write('A'), None, dace.Memlet('A'))
+    state1.add_edge(
+        state1.add_tasklet("one", {}, {"a"}, "a = 1"),
+        "a",
+        state1.add_write("A"),
+        None,
+        dace.Memlet("A"),
+    )
 
-    t2 = state1.add_tasklet('two', {}, {'b', 'c'}, 'b = 2; c = 3')
-    state1.add_edge(t2, 'b', state1.add_write('B'), None, dace.Memlet('B'))
-    state1.add_edge(t2, 'c', state1.add_write('C'), None, dace.Memlet('C'))
+    t2 = state1.add_tasklet("two", {}, {"b", "c"}, "b = 2; c = 3")
+    state1.add_edge(t2, "b", state1.add_write("B"), None, dace.Memlet("B"))
+    state1.add_edge(t2, "c", state1.add_write("C"), None, dace.Memlet("C"))
 
     # Second state
-    t2 = state2.add_tasklet('three', {'a', 'b', 'c'}, {'out'}, 'out = a+b+c')
-    state2.add_edge(state2.add_read('A'), None, t2, 'a', dace.Memlet('A'))
-    state2.add_edge(state2.add_read('B'), None, t2, 'b', dace.Memlet('B'))
-    state2.add_edge(state2.add_read('C'), None, t2, 'c', dace.Memlet('C'))
-    state2.add_edge(t2, 'out', state2.add_write('C'), None, dace.Memlet('C'))
+    t2 = state2.add_tasklet("three", {"a", "b", "c"}, {"out"}, "out = a+b+c")
+    state2.add_edge(state2.add_read("A"), None, t2, "a", dace.Memlet("A"))
+    state2.add_edge(state2.add_read("B"), None, t2, "b", dace.Memlet("B"))
+    state2.add_edge(state2.add_read("C"), None, t2, "c", dace.Memlet("C"))
+    state2.add_edge(t2, "out", state2.add_write("C"), None, dace.Memlet("C"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
 
 def test_one_to_two_cc_fusion():
-    """ Two states, first with one connected component, second with two. """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [1], dace.int32)
-    sdfg.add_array('B', [1], dace.int32)
+    """Two states, first with one connected component, second with two."""
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [1], dace.int32)
+    sdfg.add_array("B", [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    t1 = state1.add_tasklet('one', {}, {'a', 'b'}, 'a = 1; b = 2')
-    state1.add_edge(t1, 'a', state1.add_write('A'), None, dace.Memlet('A'))
-    state1.add_edge(t1, 'b', state1.add_write('B'), None, dace.Memlet('B'))
+    t1 = state1.add_tasklet("one", {}, {"a", "b"}, "a = 1; b = 2")
+    state1.add_edge(t1, "a", state1.add_write("A"), None, dace.Memlet("A"))
+    state1.add_edge(t1, "b", state1.add_write("B"), None, dace.Memlet("B"))
 
     # Second state
-    state2.add_edge(state2.add_read('A'), None, state2.add_tasklet('one', {'a'}, {}, ''), 'a', dace.Memlet('A'))
-    state2.add_edge(state2.add_read('B'), None, state2.add_tasklet('two', {'b'}, {}, ''), 'b', dace.Memlet('B'))
+    state2.add_edge(
+        state2.add_read("A"),
+        None,
+        state2.add_tasklet("one", {"a"}, {}, ""),
+        "a",
+        dace.Memlet("A"),
+    )
+    state2.add_edge(
+        state2.add_read("B"),
+        None,
+        state2.add_tasklet("two", {"b"}, {}, ""),
+        "b",
+        dace.Memlet("B"),
+    )
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
 
 def test_two_cc_fusion_separate():
-    """ Two states, both with two connected components, fused separately. """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [1], dace.int32)
-    sdfg.add_array('B', [1], dace.int32)
-    sdfg.add_array('C', [1], dace.int32)
+    """Two states, both with two connected components, fused separately."""
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [1], dace.int32)
+    sdfg.add_array("B", [1], dace.int32)
+    sdfg.add_array("C", [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    state1.add_edge(state1.add_tasklet('one', {}, {'a'}, 'a = 1'), 'a', state1.add_write('A'), None, dace.Memlet('A'))
+    state1.add_edge(
+        state1.add_tasklet("one", {}, {"a"}, "a = 1"),
+        "a",
+        state1.add_write("A"),
+        None,
+        dace.Memlet("A"),
+    )
 
-    t2 = state1.add_tasklet('two', {}, {'b', 'c'}, 'b = 2; c = 3')
-    state1.add_edge(t2, 'b', state1.add_write('B'), None, dace.Memlet('B'))
-    state1.add_edge(t2, 'c', state1.add_write('C'), None, dace.Memlet('C'))
+    t2 = state1.add_tasklet("two", {}, {"b", "c"}, "b = 2; c = 3")
+    state1.add_edge(t2, "b", state1.add_write("B"), None, dace.Memlet("B"))
+    state1.add_edge(t2, "c", state1.add_write("C"), None, dace.Memlet("C"))
 
     # Second state
-    state2.add_edge(state2.add_read('A'), None, state2.add_tasklet('one', {'a'}, {}, ''), 'a', dace.Memlet('A'))
+    state2.add_edge(
+        state2.add_read("A"),
+        None,
+        state2.add_tasklet("one", {"a"}, {}, ""),
+        "a",
+        dace.Memlet("A"),
+    )
 
-    t2 = state2.add_tasklet('two', {'b', 'c'}, {}, '')
-    state2.add_edge(state2.add_read('B'), None, t2, 'b', dace.Memlet('B'))
-    state2.add_edge(state2.add_read('C'), None, t2, 'c', dace.Memlet('C'))
+    t2 = state2.add_tasklet("two", {"b", "c"}, {}, "")
+    state2.add_edge(state2.add_read("B"), None, t2, "b", dace.Memlet("B"))
+    state2.add_edge(state2.add_read("C"), None, t2, "c", dace.Memlet("C"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
 
 def test_two_cc_fusion_together():
-    """ Two states, both with two connected components, fused to one CC. """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [1], dace.int32)
-    sdfg.add_array('B', [1], dace.int32)
-    sdfg.add_array('C', [1], dace.int32)
+    """Two states, both with two connected components, fused to one CC."""
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [1], dace.int32)
+    sdfg.add_array("B", [1], dace.int32)
+    sdfg.add_array("C", [1], dace.int32)
     state1, state2 = tuple(sdfg.add_state() for _ in range(2))
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
 
     # First state
-    state1.add_edge(state1.add_tasklet('one', {}, {'a'}, 'a = 1'), 'a', state1.add_write('A'), None, dace.Memlet('A'))
+    state1.add_edge(
+        state1.add_tasklet("one", {}, {"a"}, "a = 1"),
+        "a",
+        state1.add_write("A"),
+        None,
+        dace.Memlet("A"),
+    )
 
-    t2 = state1.add_tasklet('two', {}, {'b', 'c'}, 'b = 2; c = 3')
-    state1.add_edge(t2, 'b', state1.add_write('B'), None, dace.Memlet('B'))
-    state1.add_edge(t2, 'c', state1.add_write('C'), None, dace.Memlet('C'))
+    t2 = state1.add_tasklet("two", {}, {"b", "c"}, "b = 2; c = 3")
+    state1.add_edge(t2, "b", state1.add_write("B"), None, dace.Memlet("B"))
+    state1.add_edge(t2, "c", state1.add_write("C"), None, dace.Memlet("C"))
 
     # Second state
-    state2.add_edge(state2.add_read('B'), None, state2.add_tasklet('one', {'a'}, {}, ''), 'a', dace.Memlet('B'))
+    state2.add_edge(
+        state2.add_read("B"),
+        None,
+        state2.add_tasklet("one", {"a"}, {}, ""),
+        "a",
+        dace.Memlet("B"),
+    )
 
-    t2 = state2.add_tasklet('two', {'b', 'c'}, {'d', 'e'}, 'd = b + c; e = b')
-    state2.add_edge(state2.add_read('A'), None, t2, 'b', dace.Memlet('A'))
-    state2.add_edge(state2.add_read('C'), None, t2, 'c', dace.Memlet('C'))
-    state2.add_edge(t2, 'd', state2.add_write('A'), None, dace.Memlet('A'))
-    state2.add_edge(t2, 'e', state2.add_write('C'), None, dace.Memlet('C'))
+    t2 = state2.add_tasklet("two", {"b", "c"}, {"d", "e"}, "d = b + c; e = b")
+    state2.add_edge(state2.add_read("A"), None, t2, "b", dace.Memlet("A"))
+    state2.add_edge(state2.add_read("C"), None, t2, "c", dace.Memlet("C"))
+    state2.add_edge(t2, "d", state2.add_write("A"), None, dace.Memlet("A"))
+    state2.add_edge(t2, "e", state2.add_write("C"), None, dace.Memlet("C"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
@@ -173,6 +225,7 @@ def test_write_write_path():
     Two states where both write to the same range of an array, but there is
     a path between the write and the second write.
     """
+
     @dace.program
     def state_fusion_test(A: dace.int32[20, 20]):
         A += 1
@@ -188,11 +241,11 @@ def test_write_write_no_overlap():
     """
     Two states where both write to different ranges of an array.
     """
-    N = dace.symbol('N', positive=True)
+    N = dace.symbol("N", positive=True)
 
     @dace.program
     def state_fusion_test(A: dace.int32[N, N]):
-        A[0:N - 1, :] = 1
+        A[0 : N - 1, :] = 1
         A[N - 1, :] = 2
 
     sdfg = state_fusion_test.to_sdfg(simplify=False)
@@ -205,7 +258,7 @@ def test_read_write_no_overlap():
     Two states where two separate CCs write and read to/from an array, but
     in different ranges.
     """
-    N = dace.symbol('N')
+    N = dace.symbol("N")
 
     @dace.program
     def state_fusion_test(A: dace.int32[N, N], B: dace.int32[N, N]):
@@ -218,92 +271,92 @@ def test_read_write_no_overlap():
 
 
 def test_array_in_middle_no_overlap():
-    """ 
+    """
     Two states that write and read from an array without overlap. Should be
     fused to two separate components.
     """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [10, 10], dace.int32)
-    sdfg.add_array('B', [5, 5], dace.int32)
-    sdfg.add_array('C', [5, 5], dace.int32)
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [10, 10], dace.int32)
+    sdfg.add_array("B", [5, 5], dace.int32)
+    sdfg.add_array("C", [5, 5], dace.int32)
     state = sdfg.add_state()
-    t1 = state.add_tasklet('init_a1', {}, {'a'}, '')
-    rw1 = state.add_access('A')
-    t2 = state.add_tasklet('a2b', {'a'}, {'b'}, '')
-    wb = state.add_write('B')
-    state.add_edge(t1, 'a', rw1, None, dace.Memlet('A[0:5, 0:5]'))
-    state.add_edge(rw1, None, t2, 'a', dace.Memlet('A[0:5, 0:5]'))
-    state.add_edge(t2, 'b', wb, None, dace.Memlet('B'))
+    t1 = state.add_tasklet("init_a1", {}, {"a"}, "")
+    rw1 = state.add_access("A")
+    t2 = state.add_tasklet("a2b", {"a"}, {"b"}, "")
+    wb = state.add_write("B")
+    state.add_edge(t1, "a", rw1, None, dace.Memlet("A[0:5, 0:5]"))
+    state.add_edge(rw1, None, t2, "a", dace.Memlet("A[0:5, 0:5]"))
+    state.add_edge(t2, "b", wb, None, dace.Memlet("B"))
 
     state2 = sdfg.add_state_after(state)
-    t1 = state2.add_tasklet('init_a2', {}, {'a'}, '')
-    rw2 = state2.add_access('A')
-    t2 = state2.add_tasklet('a2c', {'a'}, {'c'}, '')
-    wc = state2.add_write('C')
-    state2.add_edge(t1, 'a', rw2, None, dace.Memlet('A[5:10, 5:10]'))
-    state2.add_edge(rw2, None, t2, 'a', dace.Memlet('A[5:10, 5:10]'))
-    state2.add_edge(t2, 'c', wc, None, dace.Memlet('C'))
+    t1 = state2.add_tasklet("init_a2", {}, {"a"}, "")
+    rw2 = state2.add_access("A")
+    t2 = state2.add_tasklet("a2c", {"a"}, {"c"}, "")
+    wc = state2.add_write("C")
+    state2.add_edge(t1, "a", rw2, None, dace.Memlet("A[5:10, 5:10]"))
+    state2.add_edge(rw2, None, t2, "a", dace.Memlet("A[5:10, 5:10]"))
+    state2.add_edge(t2, "c", wc, None, dace.Memlet("C"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
     assert len(list(nx.weakly_connected_components(sdfg.node(0).nx))) == 2
 
 
 def test_array_in_middle_overlap():
-    """ 
+    """
     Two states that write and read from an array with overlap. Should not be
     fused.
     """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [10, 10], dace.int32)
-    sdfg.add_array('B', [5, 5], dace.int32)
-    sdfg.add_array('C', [5, 5], dace.int32)
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [10, 10], dace.int32)
+    sdfg.add_array("B", [5, 5], dace.int32)
+    sdfg.add_array("C", [5, 5], dace.int32)
     state = sdfg.add_state()
-    t1 = state.add_tasklet('init_a1', {}, {'a'}, '')
-    rw1 = state.add_access('A')
-    t2 = state.add_tasklet('a2b', {'a'}, {'b'}, '')
-    wb = state.add_write('B')
-    state.add_edge(t1, 'a', rw1, None, dace.Memlet('A[0:5, 0:5]'))
-    state.add_edge(rw1, None, t2, 'a', dace.Memlet('A[0:5, 0:5]'))
-    state.add_edge(t2, 'b', wb, None, dace.Memlet('B'))
+    t1 = state.add_tasklet("init_a1", {}, {"a"}, "")
+    rw1 = state.add_access("A")
+    t2 = state.add_tasklet("a2b", {"a"}, {"b"}, "")
+    wb = state.add_write("B")
+    state.add_edge(t1, "a", rw1, None, dace.Memlet("A[0:5, 0:5]"))
+    state.add_edge(rw1, None, t2, "a", dace.Memlet("A[0:5, 0:5]"))
+    state.add_edge(t2, "b", wb, None, dace.Memlet("B"))
 
     state2 = sdfg.add_state_after(state)
-    t1 = state2.add_tasklet('init_a2', {}, {'a'}, '')
-    rw2 = state2.add_access('A')
-    t2 = state2.add_tasklet('a2c', {'a'}, {'c'}, '')
-    wc = state2.add_write('C')
-    state2.add_edge(t1, 'a', rw2, None, dace.Memlet('A[0:5, 0:5]'))
-    state2.add_edge(rw2, None, t2, 'a', dace.Memlet('A[0:5, 0:5]'))
-    state2.add_edge(t2, 'c', wc, None, dace.Memlet('C'))
+    t1 = state2.add_tasklet("init_a2", {}, {"a"}, "")
+    rw2 = state2.add_access("A")
+    t2 = state2.add_tasklet("a2c", {"a"}, {"c"}, "")
+    wc = state2.add_write("C")
+    state2.add_edge(t1, "a", rw2, None, dace.Memlet("A[0:5, 0:5]"))
+    state2.add_edge(rw2, None, t2, "a", dace.Memlet("A[0:5, 0:5]"))
+    state2.add_edge(t2, "c", wc, None, dace.Memlet("C"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 0
 
 
 def test_two_outputs_same_name():
-    """ 
-    First state writes to the same array twice, second state updates one value. 
+    """
+    First state writes to the same array twice, second state updates one value.
     Should be fused to the right node in the second state or a data race will
     occur.
     """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [2], dace.int32)
-    sdfg.add_scalar('scal', dace.int32)
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [2], dace.int32)
+    sdfg.add_scalar("scal", dace.int32)
     state = sdfg.add_state()
-    r = state.add_read('scal')
-    t1 = state.add_tasklet('init_a1', {'s'}, {'a'}, 'a = 1 + s')
-    w1 = state.add_write('A')
-    t2 = state.add_tasklet('init_a2', {'s'}, {'a'}, 'a = 2 + s')
-    w2 = state.add_write('A')
-    state.add_edge(r, None, t1, 's', dace.Memlet('scal'))
-    state.add_edge(t1, 'a', w1, None, dace.Memlet('A[0]'))
-    state.add_edge(r, None, t2, 's', dace.Memlet('scal'))
-    state.add_edge(t2, 'a', w2, None, dace.Memlet('A[1]'))
+    r = state.add_read("scal")
+    t1 = state.add_tasklet("init_a1", {"s"}, {"a"}, "a = 1 + s")
+    w1 = state.add_write("A")
+    t2 = state.add_tasklet("init_a2", {"s"}, {"a"}, "a = 2 + s")
+    w2 = state.add_write("A")
+    state.add_edge(r, None, t1, "s", dace.Memlet("scal"))
+    state.add_edge(t1, "a", w1, None, dace.Memlet("A[0]"))
+    state.add_edge(r, None, t2, "s", dace.Memlet("scal"))
+    state.add_edge(t2, "a", w2, None, dace.Memlet("A[1]"))
 
     state2 = sdfg.add_state_after(state)
-    r1 = state2.add_read('A')
-    t1 = state2.add_tasklet('update_a2', {'a'}, {'b'}, 'b = a + 2')
-    w1 = state2.add_write('A')
-    state2.add_edge(r1, None, t1, 'a', dace.Memlet('A[1]'))
-    state2.add_edge(t1, 'b', w1, None, dace.Memlet('A[1]'))
+    r1 = state2.add_read("A")
+    t1 = state2.add_tasklet("update_a2", {"a"}, {"b"}, "b = a + 2")
+    w1 = state2.add_write("A")
+    state2.add_edge(r1, None, t1, "a", dace.Memlet("A[1]"))
+    state2.add_edge(t1, "b", w1, None, dace.Memlet("A[1]"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 1
 
@@ -313,32 +366,32 @@ def test_two_outputs_same_name():
 
 
 def test_inout_read_after_write():
-    """ 
+    """
     First state ends with a computation that reads an array, while the second
     state both reads and writes to that same array. Fusion will then cause
     a RAW conflict.
     """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [1], dace.int32)
-    sdfg.add_array('B', [1], dace.int32)
-    sdfg.add_array('C', [1], dace.int32)
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [1], dace.int32)
+    sdfg.add_array("B", [1], dace.int32)
+    sdfg.add_array("C", [1], dace.int32)
     state = sdfg.add_state()
-    r = state.add_read('A')
-    t1 = state.add_tasklet('init_b', {'a'}, {'b'}, 'b = a + 1')
-    rw = state.add_access('B')
-    t2 = state.add_tasklet('init_c', {'b'}, {'c'}, 'c = 2 + b')
-    w = state.add_access('C')
-    state.add_edge(r, None, t1, 'a', dace.Memlet('A[0]'))
-    state.add_edge(t1, 'b', rw, None, dace.Memlet('B[0]'))
-    state.add_edge(rw, None, t2, 'b', dace.Memlet('B[0]'))
-    state.add_edge(t2, 'c', w, None, dace.Memlet('C[0]'))
+    r = state.add_read("A")
+    t1 = state.add_tasklet("init_b", {"a"}, {"b"}, "b = a + 1")
+    rw = state.add_access("B")
+    t2 = state.add_tasklet("init_c", {"b"}, {"c"}, "c = 2 + b")
+    w = state.add_access("C")
+    state.add_edge(r, None, t1, "a", dace.Memlet("A[0]"))
+    state.add_edge(t1, "b", rw, None, dace.Memlet("B[0]"))
+    state.add_edge(rw, None, t2, "b", dace.Memlet("B[0]"))
+    state.add_edge(t2, "c", w, None, dace.Memlet("C[0]"))
 
     state2 = sdfg.add_state_after(state)
-    r1 = state2.add_read('B')
-    t1 = state2.add_tasklet('update_b', {'bin'}, {'bout'}, 'bout = bin + bin')
-    w1 = state2.add_write('B')
-    state2.add_edge(r1, None, t1, 'bin', dace.Memlet('B[0]'))
-    state2.add_edge(t1, 'bout', w1, None, dace.Memlet('B[0]'))
+    r1 = state2.add_read("B")
+    t1 = state2.add_tasklet("update_b", {"bin"}, {"bout"}, "bout = bin + bin")
+    w1 = state2.add_write("B")
+    state2.add_edge(r1, None, t1, "bin", dace.Memlet("B[0]"))
+    state2.add_edge(t1, "bout", w1, None, dace.Memlet("B[0]"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 0
 
@@ -351,27 +404,27 @@ def test_inout_read_after_write():
 
 
 def test_inout_second_state():
-    """ 
-    Second state has a computation that reads and writes to the same array, 
-    while the first state also reads from that same array. Fusion will then 
+    """
+    Second state has a computation that reads and writes to the same array,
+    while the first state also reads from that same array. Fusion will then
     cause a potential data race.
     """
-    sdfg = dace.SDFG('state_fusion_test')
-    sdfg.add_array('A', [1], dace.int32)
-    sdfg.add_array('B', [1], dace.int32)
+    sdfg = dace.SDFG("state_fusion_test")
+    sdfg.add_array("A", [1], dace.int32)
+    sdfg.add_array("B", [1], dace.int32)
     state = sdfg.add_state()
-    r = state.add_read('A')
-    t1 = state.add_tasklet('init_b', {'a'}, {'b'}, 'b = a + 1')
-    w = state.add_write('B')
-    state.add_edge(r, None, t1, 'a', dace.Memlet('A[0]'))
-    state.add_edge(t1, 'b', w, None, dace.Memlet('B[0]'))
+    r = state.add_read("A")
+    t1 = state.add_tasklet("init_b", {"a"}, {"b"}, "b = a + 1")
+    w = state.add_write("B")
+    state.add_edge(r, None, t1, "a", dace.Memlet("A[0]"))
+    state.add_edge(t1, "b", w, None, dace.Memlet("B[0]"))
 
     state2 = sdfg.add_state_after(state)
-    r1 = state2.add_read('A')
-    t1 = state2.add_tasklet('update_a', {'a'}, {'aout'}, 'aout = a + 5')
-    w1 = state2.add_write('A')
-    state2.add_edge(r1, None, t1, 'a', dace.Memlet('A[0]'))
-    state2.add_edge(t1, 'aout', w1, None, dace.Memlet('A[0]'))
+    r1 = state2.add_read("A")
+    t1 = state2.add_tasklet("update_a", {"a"}, {"aout"}, "aout = a + 5")
+    w1 = state2.add_write("A")
+    state2.add_edge(r1, None, t1, "a", dace.Memlet("A[0]"))
+    state2.add_edge(t1, "aout", w1, None, dace.Memlet("A[0]"))
 
     assert sdfg.apply_transformations_repeated(StateFusion) == 0
 
@@ -397,7 +450,98 @@ def test_inout_second_state_2():
     assert sdfg.number_of_nodes() == 2
 
 
-if __name__ == '__main__':
+def test_check_paths():
+    # Test extracted from NASA GFDL_1M microphysics
+
+    # Case of:
+    #   qm -> q -> qm, m1 in Block_0
+    #   qm -> q and m1 -> m1 in Block_5
+    # m1 has a write in both cases, leading to state not being fusable
+    # but original code would exist early if qm was tested _before_ m1
+
+    sdfg = dace.SDFG("state_fusion_check_path_test")
+    sdfg.add_array("m1", [1], dace.int32)
+    sdfg.add_array("precip_fall", [1], dace.int32)
+    sdfg.add_array("q", [1], dace.int32)
+    sdfg.add_array("qm", [1], dace.int32)
+    sdfg.add_array("dp1", [1], dace.int32)
+
+    block_0 = sdfg.add_state()
+    q_b0_w = block_0.add_write("q")
+    qm_b0 = block_0.add_read("qm")
+    qm_b0_w = block_0.add_write("qm")
+    tasklet_b0_on_q = block_0.add_tasklet(
+        "tasklet_b0_on_q",
+        {"p_qm"},
+        {"p_q_w"},
+        "p_q_w = p_qm",
+    )
+    block_0.add_edge(qm_b0, None, tasklet_b0_on_q, "p_qm", dace.Memlet("qm[0]"))
+    block_0.add_edge(tasklet_b0_on_q, "p_q_w", q_b0_w, None, dace.Memlet("q[0]"))
+
+    m1_b0_w = block_0.add_write("m1")
+    tasklet_b0_on_m1 = block_0.add_tasklet(
+        "tasklet_b0_on_m1_qm",
+        {"p_q"},
+        {"p_m1_w", "p_qm_w"},
+        "p_m1_w = p_q",
+    )
+    block_0.add_edge(q_b0_w, None, tasklet_b0_on_m1, "p_q", dace.Memlet("q[0]"))
+    block_0.add_edge(tasklet_b0_on_m1, "p_m1_w", m1_b0_w, None, dace.Memlet("m1[0]"))
+    block_0.add_edge(tasklet_b0_on_m1, "p_qm_w", qm_b0_w, None, dace.Memlet("qm[0]"))
+
+    block_5 = sdfg.add_state_after(block_0)
+    precip_fall_b5 = block_5.add_read("precip_fall")
+    qm_b5 = block_5.add_read("qm")
+    q_b5_w = block_5.add_write("q")
+    tasklet_b5_on_q = block_5.add_tasklet(
+        "tasklet_b5_on_q",
+        {"p_precip_fall", "p_qm"},
+        {"p_q_w"},
+        "p_q_w = p_dp1 + 1",
+    )
+    block_5.add_edge(
+        precip_fall_b5,
+        None,
+        tasklet_b5_on_q,
+        "p_precip_fall",
+        dace.Memlet("precip_fall[0]"),
+    )
+    block_5.add_edge(qm_b5, None, tasklet_b5_on_q, "p_qm", dace.Memlet("qm[0]"))
+    block_5.add_edge(tasklet_b5_on_q, "p_q_w", q_b5_w, None, dace.Memlet("q[0]"))
+
+    m1_b5 = block_5.add_read("m1")
+    m1_b5_w = block_5.add_write("m1")
+    tasklet_b5_on_m1 = block_5.add_tasklet(
+        "tasklet_b5_on_m1",
+        {"p_m1", "p_precip_fall"},
+        {"p_m1_w"},
+        "m1_w = p_m1 + 1",
+    )
+    block_5.add_edge(m1_b5, None, tasklet_b5_on_m1, "p_m1", dace.Memlet("m1[0]"))
+    block_5.add_edge(
+        precip_fall_b5,
+        None,
+        tasklet_b5_on_m1,
+        "p_precip_fall",
+        dace.Memlet("precip_fall[0]"),
+    )
+    block_5.add_edge(tasklet_b5_on_m1, "p_m1_w", m1_b5_w, None, dace.Memlet("m1[0]"))
+
+    do_fuse = StateFusion()._check_paths(
+        first_state=block_0,
+        second_state=block_5,
+        match_nodes={qm_b0_w: qm_b5, m1_b0_w: m1_b5},
+        nodes_first=[q_b0_w],
+        nodes_second=[q_b5_w],
+        second_input={precip_fall_b5, m1_b5, qm_b5},
+        first_read=False,
+        second_read=False,
+    )
+    assert not do_fuse
+
+
+if __name__ == "__main__":
     test_fuse_assignments()
     test_fuse_assignments_2()
     test_fuse_assignment_in_use()
@@ -414,3 +558,4 @@ if __name__ == '__main__':
     test_inout_read_after_write()
     test_inout_second_state()
     test_inout_second_state_2()
+    test_check_paths()


### PR DESCRIPTION
Check for all potential match in `_check_paths` to not miss potential `memlets_intersect` failure.

Unit tests for checks the internal `_check_paths` function since it triggers on a non deterministic networkx search.


:warning:  This code exists as-is in `main` as of Feb 26 and showcase the same issue, cherry-picking fix will have to happen :warning: 