### PR TITLE
Fix: DDE removing read from access_set in read/write nodes

### DIFF
--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -192,8 +192,10 @@ class DeadDataflowElimination(ppl.Pass):
 
             # Update read sets for the predecessor states to reuse
             remaining_access_nodes = set(n for n in (access_nodes - result[state]) if state.out_degree(n) > 0)
+            remaining_data_containers = set(node.data for node in remaining_access_nodes)
             removed_data_containers = set(n.data for n in result[state]
-                                          if isinstance(n, nodes.AccessNode) and n not in remaining_access_nodes)
+                                          if isinstance(n, nodes.AccessNode) and n not in remaining_access_nodes
+                                          and n.data not in remaining_data_containers)
             access_sets[state] = (access_sets[state][0] - removed_data_containers, access_sets[state][1])
 
         return result or None

--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -159,8 +159,10 @@ class DeadDataflowElimination(ppl.Pass):
                                             for code in leaf.src.code.code:
                                                 ast_find.generic_visit(code)
                                         except astutils.NameFound:
-                                            # then add the hint expression 
-                                            leaf.src.code.code = ast.parse(f'{leaf.src_conn}: dace.{ctype.to_string()}\n').body + leaf.src.code.code
+                                            # then add the hint expression
+                                            leaf.src.code.code = ast.parse(
+                                                f'{leaf.src_conn}: dace.{ctype.to_string()}\n'
+                                            ).body + leaf.src.code.code
                                 else:
                                     raise NotImplementedError(f'Cannot eliminate dead connector "{leaf.src_conn}" on '
                                                               'tasklet due to its code language.')

--- a/tests/passes/dead_code_elimination_test.py
+++ b/tests/passes/dead_code_elimination_test.py
@@ -210,6 +210,54 @@ def test_dde_inout(libnode):
     sdfg.validate()
 
 
+def test_dde_inout_two_states():
+    """Test two states with read/write in second state."""
+
+    sdfg = dace.SDFG("dde_inout_two_states")
+    sdfg.add_scalar("tmp", dace.float32)
+    sdfg.add_scalar("computed", dace.float32, transient=True)
+
+    start_state = sdfg.add_state("start_state", is_start_block=True)
+    s1_read_tmp = start_state.add_read("tmp")
+    s1_write_computed = start_state.add_write("computed")
+
+    # upstream tasklet that writes a transient (to be read in a separate state)
+    first_tasklet = start_state.add_tasklet("write", {"read_tmp"}, {"write_computed"},
+                                            "write_computed = read_tmp * 2 + 1")
+    start_state.add_memlet_path(s1_read_tmp, first_tasklet, dst_conn="read_tmp", memlet=dace.Memlet(data="tmp"))
+    start_state.add_memlet_path(first_tasklet,
+                                s1_write_computed,
+                                src_conn="write_computed",
+                                memlet=dace.Memlet(data="computed"))
+
+    next_state = sdfg.add_state_after(start_state, "next_state")
+    s2_write_computed = next_state.add_write("computed")
+    s2_read_computed = next_state.add_read("computed")
+    s2_write_tmp = next_state.add_write("tmp")
+
+    # downstream tasklet that reads _and_ writes a transient
+    second_tasklet = next_state.add_tasklet(
+        "read_write", {"read_computed"}, {"write_tmp", "write_computed"},
+        "write_computed = 2 * read_computed\nwrite_tmp = write_computed + read_computed")
+    next_state.add_memlet_path(s2_read_computed,
+                               second_tasklet,
+                               dst_conn="read_computed",
+                               memlet=dace.Memlet(data="computed"))
+    next_state.add_memlet_path(second_tasklet, s2_write_tmp, src_conn="write_tmp", memlet=dace.Memlet(data="tmp"))
+    next_state.add_memlet_path(second_tasklet,
+                               s2_write_computed,
+                               src_conn="write_computed",
+                               memlet=dace.Memlet(data="computed"))
+
+    results = {}
+    Pipeline([DeadDataflowElimination()]).apply_pass(sdfg, results)
+
+    dde_results = results["DeadDataflowElimination"]
+    assert dde_results.get(start_state) is None, "No changes to `start_state` expected."
+    expected_cleanup = dde_results.get(next_state)
+    assert expected_cleanup == {s2_write_computed}, "Expected to clean up write to `computed` from `next_state`."
+
+
 def test_dce():
     """ End-to-end test evaluating both dataflow and state elimination. """
     # Code should end up as b[:] = a + 2; b += 1
@@ -336,6 +384,7 @@ if __name__ == '__main__':
     test_dde_scope_reconnect()
     test_dde_inout(False)
     test_dde_inout(True)
+    test_dde_inout_two_states()
     test_dce()
     test_dce_callback()
     test_dce_callback_manual()

--- a/tests/passes/dead_code_elimination_test.py
+++ b/tests/passes/dead_code_elimination_test.py
@@ -56,8 +56,8 @@ def test_dse_edge_condition_with_integer_as_boolean_regression():
     state_init = sdfg.add_state()
     state_middle = sdfg.add_state()
     state_end = sdfg.add_state()
-    sdfg.add_edge(state_init, state_end, dace.InterstateEdge(condition='(not ((N > 20) != 0))',
-                                                             assignments={'result': 'N'}))
+    sdfg.add_edge(state_init, state_end,
+                  dace.InterstateEdge(condition='(not ((N > 20) != 0))', assignments={'result': 'N'}))
     sdfg.add_edge(state_init, state_middle, dace.InterstateEdge(condition='((N > 20) != 0)'))
     sdfg.add_edge(state_middle, state_end, dace.InterstateEdge(assignments={'result': '20'}))
 


### PR DESCRIPTION
## Description

For this bug to show, we need two separate states with a transient produced in one and subsequently read and written (but not read again). It is important that `StateFusion` isn't able to merge these two state. I've put a dummy if/else in the middle. Before DDE this might look like

![image](https://github.com/user-attachments/assets/4ac52b3d-8cd8-4035-bc20-fba2258a7fd7)

where `tmp_computed` is transient and `tmp` is a given variable. DDE will now go and see that `tmp_computed` can be removed as an output of the `read_write` tasklet. The currently faulty update of `access_set` will remove `tmp_computed` from the list of reads in `block` state. This will then propagate (badly) up to the `start` state where `tmp_computed` is marked as never read again, removing the whole tasklet, leaving the `block` state to read an uninitialized `tmp_computed` (if we were to codegen).

![image](https://github.com/user-attachments/assets/64892133-1f2f-4bf5-bee6-8a80c192a0cc)



### Repro

```python
import dace
import os

# Create an empty SDFG
sdfg = dace.SDFG(os.path.basename(__file__).removesuffix(".py").replace("-", "_"))

sdfg.add_scalar("tmp", dace.float32)
sdfg.add_scalar("tmp_computed", dace.float32, transient=True)

start_state = sdfg.add_state("start", is_start_block=True)

read_tmp = start_state.add_read("tmp")
write_computed = start_state.add_write("tmp_computed")

# upstream tasklet that writes a transient (to be read in a separate state)
write = start_state.add_tasklet("write", {"IN_tmp"}, {"OUT_computed"}, "OUT_computed = IN_tmp * 2 + 1")
start_state.add_memlet_path(read_tmp, write, dst_conn="IN_tmp", memlet=dace.Memlet(data="tmp"))
start_state.add_memlet_path(write, write_computed, src_conn="OUT_computed", memlet=dace.Memlet(data="tmp_computed"))

# Add a condition to avoid fusing next_state and start_state separate
guard = sdfg.add_state_after(start_state, "guard_state")
true_state = sdfg.add_state("true_state")
false_state = sdfg.add_state("false_state")
fs_read = false_state.add_read("tmp")
fs_write = false_state.add_write("tmp")
fs_tasklet = false_state.add_tasklet("abs", {"IN_tmp"}, {"OUT_tmp"}, "OUT_tmp = -IN_tmp")
false_state.add_memlet_path(fs_read, fs_tasklet, dst_conn="IN_tmp", memlet=dace.Memlet("tmp"))
false_state.add_memlet_path(fs_tasklet, fs_write, src_conn="OUT_tmp", memlet=dace.Memlet("tmp"))
merge = sdfg.add_state("merge_state")

sdfg.add_edge(guard, true_state, dace.InterstateEdge("tmp >= 0"))
sdfg.add_edge(guard, false_state, dace.InterstateEdge("tmp < 0"))
sdfg.add_edge(true_state, merge, dace.InterstateEdge())
sdfg.add_edge(false_state, merge, dace.InterstateEdge())

next_state = sdfg.add_state_after(merge)

write_computed = next_state.add_write("tmp_computed")
read_computed = next_state.add_read("tmp_computed")
write_tmp = next_state.add_write("tmp")

# downstream tasklet that reads _and_ writes a transient
consume = next_state.add_tasklet("read_write", {"IN_computed"}, {"OUT_tmp", "OUT_computed"}, "OUT_computed = 2 * IN_computed\nOUT_tmp = OUT_computed + IN_computed")
next_state.add_memlet_path(read_computed, consume, dst_conn="IN_computed", memlet=dace.Memlet(data="tmp_computed"))
next_state.add_memlet_path(consume, write_tmp, src_conn="OUT_tmp", memlet=dace.Memlet(data="tmp"))
next_state.add_memlet_path(consume, write_computed, src_conn="OUT_computed", memlet=dace.Memlet(data="tmp_computed"))

sdfg.validate()

sdfg.simplify(verbose=True, validate=True)

assert len(list(filter(lambda node: isinstance(node, dace.sdfg.nodes.Tasklet), sdfg.start_block.nodes()))) == 1, "write tasklet in start_block is gone"
```

### Finishing this PR

I'll need help to evaluate whether or not the proposed solution is a good one. Questions that I have:

- Is this the right place to fix it?
- Should we manually change `access_sets` or would it be simpler/more reliable to redo the analysis step?
- The repro case translates to a unit test. Is it a good one or should I e.g. call DDE directly and write assertions for the output of the pass?