### PR TITLE
Enforce consistent formatting on CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,14 +16,21 @@ jobs:
     - name: Check repository
       uses: actions/checkout@v4
 
-    - name: Setup Python 3.13
+    - name: Setup Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.9'
         cache: 'pip'
 
     - name: Install linting tools
       run: pip install .[linting]
 
     - name: Run linting tools
+      id: lint
+      continue-on-error: true
       run: pre-commit run --all-files
+
+    - name: Show git diff
+      if: steps.lint.outcome == 'failure'
+      run: |
+        ./.github/workflows/scripts/show-git-diff.sh

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,29 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [ main, ci-fix ]
+  pull_request:
+    branches: [ main, ci-fix ]
+
+jobs:
+  linting:
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-ci')"
+    name: pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check repository
+      uses: actions/checkout@v4
+
+    - name: Setup Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+
+    - name: Install linting tools
+      run: pip install pre-commit yapf
+
+    - name: Run linting tools
+      run: pre-commit run --all-files

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
         cache: 'pip'
 
     - name: Install linting tools
-      run: pip install pre-commit yapf
+      run: pip install .[linting]
 
     - name: Run linting tools
       run: pre-commit run --all-files

--- a/.github/workflows/scripts/show-git-diff.sh
+++ b/.github/workflows/scripts/show-git-diff.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check for uncommitted changes in the working tree
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Linting tools found the following changes are needed to comply"
+    echo "with our automatic styling."
+    echo ""
+    echo "Please run \"pre-commit run --all-files\" locally to fix these."
+    echo "See also https://github.com/spcl/dace/blob/main/CONTRIBUTING.md"
+    echo ""
+    echo "git status"
+    echo "----------"
+    git status
+    echo ""
+    echo "git diff"
+    echo "--------"
+    git --no-pager diff
+    echo ""
+
+    exit 1
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+default_language_version:
+  python: python3
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-merge-conflict
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+- repo: https://github.com/google/yapf
+  rev: v0.43.0
+  hooks:
+    - id: yapf
+      name: yapf
+      language: python
+      entry: yapf
+      args: [-i]
+      types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,4 @@ repos:
       name: yapf
       language: python
       entry: yapf
-      args: [-i]
       types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,28 @@ def example_function(param_a: str, *args: Optional[SDFG]) -> bool:
     ...
 ```
 
+For automatic styling, we rely on [pre-commit](https://pre-commit.com/) and use the [yapf](https://github.com/google/yapf) file formatter.
+**Please run `pre-commit` before making your pull request ready for review.**
 
-For automatic styling, we use the [yapf](https://github.com/google/yapf) file formatter.
-**Please run `yapf` before making your pull request ready for review.**
+```bash
+pre-commit run --all-files
+```
+
+Formatting will be evaluated as part of CI and you won't be able to merge unless formatting issues are resolved. To get `pre-commit` and `yapf`, be sure to install the `linting` extra, e.g. for contributors we recommend
+
+```bash
+pip install -e ".[testing,linting]"
+```
+
+to get testing and linting extras in an editable install.
+
+One way to always ensure consistency with our coding standards is to install pre-commit hooks, which will check formatting issues of changed files before every commit. If you wish to do so, run
+
+```bash
+pre-commit install
+```
+
+to install the `git` hooks for this repository.
 
 ## Tests
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(name='dace',
       extras_require={
           'testing':
           ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'ipykernel', 'nbconvert'],
-          'docs': ['jinja2<3.2.0', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme>=0.5.1']
+          'docs': ['jinja2<3.2.0', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme>=0.5.1'],
+          'linting': ['pre-commit', 'yapf'],
       },
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(name='dace',
           'testing':
           ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'ipykernel', 'nbconvert'],
           'docs': ['jinja2<3.2.0', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme>=0.5.1'],
-          'linting': ['pre-commit', 'yapf'],
+          'linting': ['pre-commit==4.1.0', 'yapf==0.43.0'],
       },
       entry_points={
           'console_scripts': [

--- a/tests/transformations/state_fusion_test.py
+++ b/tests/transformations/state_fusion_test.py
@@ -480,7 +480,10 @@ def test_check_paths():
     do_fuse = StateFusion()._check_paths(
         first_state=block_0,
         second_state=block_5,
-        match_nodes={qm_b0_w: qm_b5, m1_b0_w: m1_b5},
+        match_nodes={
+            qm_b0_w: qm_b5,
+            m1_b0_w: m1_b5
+        },
         nodes_first=[q_b0_w],
         nodes_second=[q_b5_w],
         second_input={precip_fall_b5, m1_b5, qm_b5},


### PR DESCRIPTION
## Description

As discussed in the weekly DaCe meeting today, we'd like to go ahead with enforcing consistent formatting as part of CI. As a reminder, this started with a discussion[^1] in December and there was no pushback on the discussion page and also not in the meeting today.

We decided to proceed in the following way.

1. @tbennun will run `pre-commit` / `yapf`  locally on the codebase and push that, see https://github.com/spcl/dace/pull/1966
2. This PR wil then be merged afterwards and just contain the changes needed to add the new CI job.

<!--
Tal, you might wanna a couple manual guards in places like

https://github.com/spcl/dace/blob/6a485cf310940d3299ca48bcc4357d207ae67d04/tests/codegen/codegen_used_symbols_test.py#L17-L30

and other outlined below to keep beautiful manual formatting that makes sense in some (very limited) cases.
-->

[^1]: https://github.com/spcl/dace/discussions/1804