### PR TITLE
Fix: DDE removing read from access_set in read/write nodes

### DIFF
--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -164,8 +164,10 @@ class DeadDataflowElimination(ppl.ControlFlowRegionPass):
                                             for code in leaf.src.code.code:
                                                 ast_find.generic_visit(code)
                                         except astutils.NameFound:
-                                            # then add the hint expression 
-                                            leaf.src.code.code = ast.parse(f'{leaf.src_conn}: dace.{ctype.to_string()}\n').body + leaf.src.code.code
+                                            # then add the hint expression
+                                            leaf.src.code.code = ast.parse(
+                                                f'{leaf.src_conn}: dace.{ctype.to_string()}\n'
+                                            ).body + leaf.src.code.code
                                 else:
                                     raise NotImplementedError(f'Cannot eliminate dead connector "{leaf.src_conn}" on '
                                                               'tasklet due to its code language.')
@@ -195,8 +197,10 @@ class DeadDataflowElimination(ppl.ControlFlowRegionPass):
 
             # Update read sets for the predecessor states to reuse
             remaining_access_nodes = set(n for n in (access_nodes - result[state]) if state.out_degree(n) > 0)
+            remaining_data_containers = set(node.data for node in remaining_access_nodes)
             removed_data_containers = set(n.data for n in result[state]
-                                          if isinstance(n, nodes.AccessNode) and n not in remaining_access_nodes)
+                                          if isinstance(n, nodes.AccessNode) and n not in remaining_access_nodes
+                                          and n.data not in remaining_data_containers)
             access_sets[state] = (access_sets[state][0] - removed_data_containers, access_sets[state][1])
 
         return result or None

--- a/tests/passes/dead_code_elimination_test.py
+++ b/tests/passes/dead_code_elimination_test.py
@@ -58,8 +58,8 @@ def test_dse_edge_condition_with_integer_as_boolean_regression():
     state_init = sdfg.add_state()
     state_middle = sdfg.add_state()
     state_end = sdfg.add_state()
-    sdfg.add_edge(state_init, state_end, dace.InterstateEdge(condition='(not ((N > 20) != 0))',
-                                                             assignments={'result': 'N'}))
+    sdfg.add_edge(state_init, state_end,
+                  dace.InterstateEdge(condition='(not ((N > 20) != 0))', assignments={'result': 'N'}))
     sdfg.add_edge(state_init, state_middle, dace.InterstateEdge(condition='((N > 20) != 0)'))
     sdfg.add_edge(state_middle, state_end, dace.InterstateEdge(assignments={'result': '20'}))
 
@@ -266,6 +266,54 @@ def test_dde_inout(libnode):
     sdfg.validate()
 
 
+def test_dde_inout_two_states():
+    """Test two states with read/write in second state."""
+
+    sdfg = dace.SDFG("dde_inout_two_states")
+    sdfg.add_scalar("tmp", dace.float32)
+    sdfg.add_scalar("computed", dace.float32, transient=True)
+
+    start_state = sdfg.add_state("start_state", is_start_block=True)
+    s1_read_tmp = start_state.add_read("tmp")
+    s1_write_computed = start_state.add_write("computed")
+
+    # upstream tasklet that writes a transient (to be read in a separate state)
+    first_tasklet = start_state.add_tasklet("write", {"read_tmp"}, {"write_computed"},
+                                            "write_computed = read_tmp * 2 + 1")
+    start_state.add_memlet_path(s1_read_tmp, first_tasklet, dst_conn="read_tmp", memlet=dace.Memlet(data="tmp"))
+    start_state.add_memlet_path(first_tasklet,
+                                s1_write_computed,
+                                src_conn="write_computed",
+                                memlet=dace.Memlet(data="computed"))
+
+    next_state = sdfg.add_state_after(start_state, "next_state")
+    s2_write_computed = next_state.add_write("computed")
+    s2_read_computed = next_state.add_read("computed")
+    s2_write_tmp = next_state.add_write("tmp")
+
+    # downstream tasklet that reads _and_ writes a transient
+    second_tasklet = next_state.add_tasklet(
+        "read_write", {"read_computed"}, {"write_tmp", "write_computed"},
+        "write_computed = 2 * read_computed\nwrite_tmp = write_computed + read_computed")
+    next_state.add_memlet_path(s2_read_computed,
+                               second_tasklet,
+                               dst_conn="read_computed",
+                               memlet=dace.Memlet(data="computed"))
+    next_state.add_memlet_path(second_tasklet, s2_write_tmp, src_conn="write_tmp", memlet=dace.Memlet(data="tmp"))
+    next_state.add_memlet_path(second_tasklet,
+                               s2_write_computed,
+                               src_conn="write_computed",
+                               memlet=dace.Memlet(data="computed"))
+
+    results = {}
+    Pipeline([DeadDataflowElimination()]).apply_pass(sdfg, results)
+
+    dde_results = results["DeadDataflowElimination"]
+    assert dde_results.get(start_state) is None, "No changes to `start_state` expected."
+    expected_cleanup = dde_results.get(next_state)
+    assert expected_cleanup == {s2_write_computed}, "Expected to clean up write to `computed` from `next_state`."
+
+
 def test_dce():
     """ End-to-end test evaluating both dataflow and state elimination. """
     # Code should end up as b[:] = a + 2; b += 1
@@ -448,6 +496,7 @@ if __name__ == '__main__':
     test_dde_scope_reconnect()
     test_dde_inout(False)
     test_dde_inout(True)
+    test_dde_inout_two_states()
     test_dce()
     test_dce_callback()
     test_dce_callback_manual()

--- a/tests/passes/dead_code_elimination_test.py
+++ b/tests/passes/dead_code_elimination_test.py
@@ -308,7 +308,7 @@ def test_dde_inout_two_states():
     results = {}
     Pipeline([DeadDataflowElimination()]).apply_pass(sdfg, results)
 
-    dde_results = results["DeadDataflowElimination"]
+    dde_results = results["DeadDataflowElimination"][0]
     assert dde_results.get(start_state) is None, "No changes to `start_state` expected."
     expected_cleanup = dde_results.get(next_state)
     assert expected_cleanup == {s2_write_computed}, "Expected to clean up write to `computed` from `next_state`."


### PR DESCRIPTION
Cherry picking fix to the data flow elimination path from V1/maintenance. Original PR: #1955 