### PR TITLE
Fix handling of MERGE with data references

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -477,7 +477,7 @@ class CPUCodeGen(TargetCodeGenerator):
                             # NOTE: Scalar members are already defined in the struct definition.
                             self._dispatcher.defined_vars.add(f"{name}->{k}", defined_type, ctypedef)
                         else:
-                            self.allocate_array(sdfg, cfg, dfg, state_id, nodes.AccessNode(f"{name}.{k}"), v,
+                            self.allocate_array(sdfg, cfg, dfg, state_id, nodes.AccessNode(f"{node.data}.{k}"), v,
                                                 function_stream, declaration_stream, allocation_stream)
             return
         if isinstance(nodedesc, data.View):

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -1741,7 +1741,7 @@ def par_Decl_Range_Finder(node: ast_internal_classes.Array_Subscript_Node,
                 lower_boundary = None
                 if offsets[idx] != 1:
                     # support symbols and integer literals
-                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.BinOp_Node)):
+                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node, ast_internal_classes.BinOp_Node)):
                         lower_boundary = offsets[idx]
                     else:
                         # check if offset is a number
@@ -1777,7 +1777,7 @@ def par_Decl_Range_Finder(node: ast_internal_classes.Array_Subscript_Node,
                 if offsets[idx] != 1:
 
                     # support symbols and integer literals
-                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.BinOp_Node)):
+                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node, ast_internal_classes.BinOp_Node)):
                         offset = offsets[idx]
                     else:
                         try:

--- a/dace/frontend/fortran/ast_utils.py
+++ b/dace/frontend/fortran/ast_utils.py
@@ -985,3 +985,7 @@ class TempName(object):
         tmp = TempName()
         name, tmp._counter = f"{tag}_{tmp._counter}", tmp._counter + 1
         return name
+
+def is_literal(node: ast_internal_classes.FNode) -> bool:
+    return isinstance(node, (ast_internal_classes.Int_Literal_Node, ast_internal_classes.Double_Literal_Node, ast_internal_classes.Real_Literal_Node, ast_internal_classes.Bool_Literal_Node))
+

--- a/dace/frontend/fortran/intrinsics.py
+++ b/dace/frontend/fortran/intrinsics.py
@@ -5,12 +5,10 @@ from abc import abstractmethod
 from collections import namedtuple
 from typing import Any, List, Optional, Tuple, Union
 
-from numpy import array_repr
-
 from dace.frontend.fortran import ast_internal_classes
 from dace.frontend.fortran.ast_transforms import NodeVisitor, NodeTransformer, ParentScopeAssigner, \
     ScopeVarsDeclarations, TypeInference, par_Decl_Range_Finder, NeedsTypeInferenceException
-from dace.frontend.fortran.ast_utils import fortrantypes2dacetypes, mywalk
+from dace.frontend.fortran.ast_utils import fortrantypes2dacetypes, mywalk, is_literal
 from dace.libraries.blas.nodes.dot import dot_libnode
 from dace.libraries.blas.nodes.gemm import gemm_libnode
 from dace.libraries.standard.nodes import Transpose
@@ -19,9 +17,6 @@ from dace.sdfg.graph import OrderedDiGraph
 from dace.transformation import transformation as xf
 
 FASTNode = Any
-
-def is_literal(node: ast_internal_classes.FNode) -> bool:
-    return isinstance(node, (ast_internal_classes.Int_Literal_Node, ast_internal_classes.Double_Literal_Node, ast_internal_classes.Real_Literal_Node, ast_internal_classes.Bool_Literal_Node))
 
 class IntrinsicTransformation:
 
@@ -540,6 +535,9 @@ class LoopBasedReplacementTransformation(IntrinsicNodeTransformer):
                 return None
 
             _, _, cur_val = self.ast.structures.find_definition(self.scope_vars, arg)
+            #_, cur_val, _= self.ast.structures.find_definition(self.scope_vars, arg)
+
+            assert not isinstance(cur_val.part_ref, ast_internal_classes.Data_Ref_Node)
 
             if isinstance(cur_val.part_ref, ast_internal_classes.Name_Node):
                 cur_val.part_ref = ast_internal_classes.Array_Subscript_Node(
@@ -1333,10 +1331,31 @@ class Merge(LoopBasedReplacement):
                 len_pardecls_first_array = 0
                 len_pardecls_second_array = 0
 
-                for ind in self.first_array.indices:
+                indices = None
+                if isinstance(self.first_array, ast_internal_classes.Data_Ref_Node):
+                    # it would be nice to return it directly from `parse_array`
+                    # but this requires refactoring across the entire module
+                    _, _, cur_val = self.ast.structures.find_definition(self.scope_vars, self.first_array)
+                    indices = cur_val.part_ref.indices
+                else:
+                    indices = self.first_array.indices
+
+                for ind in indices:
                     pardecls = [i for i in mywalk(ind) if isinstance(i, ast_internal_classes.ParDecl_Node)]
                     len_pardecls_first_array += len(pardecls)
-                for ind in self.second_array.indices:
+
+                first_array_indices_count = len(indices)
+
+                indices = None
+                if isinstance(self.second_array, ast_internal_classes.Data_Ref_Node):
+                    # it would be nice to return it directly from `parse_array`
+                    # but this requires refactoring across the entire module
+                    _, _, cur_val = self.ast.structures.find_definition(self.scope_vars, self.second_array)
+                    indices = cur_val.part_ref.indices
+                else:
+                    indices = self.second_array.indices
+
+                for ind in indices:
                     pardecls = [i for i in mywalk(ind) if isinstance(i, ast_internal_classes.ParDecl_Node)]
                     len_pardecls_second_array += len(pardecls)    
                 assert len_pardecls_first_array == len_pardecls_second_array
@@ -1352,7 +1371,7 @@ class Merge(LoopBasedReplacement):
                 self.mask_cond = arg
             else:
 
-                array_node = self._parse_array(node, node.args[2], dims_count=len(self.first_array.indices))
+                array_node = self._parse_array(node, node.args[2], dims_count=first_array_indices_count)
                 if array_node is not None:
 
                     self.mask_first_array = array_node
@@ -1386,7 +1405,12 @@ class Merge(LoopBasedReplacement):
             loop_ranges = []
             par_Decl_Range_Finder(self.second_array, loop_ranges, [], self.count, new_func_body,
                                   self.scope_vars, self.ast.structures, True, allow_scalars=True)
-            self._adjust_array_ranges(node, self.second_array, self.loop_ranges, loop_ranges)
+
+            if isinstance(self.second_array, ast_internal_classes.Data_Ref_Node):
+                _, _, cur_val = self.ast.structures.find_definition(self.scope_vars, self.second_array)
+                self._adjust_array_ranges(node, cur_val.part_ref, self.loop_ranges, loop_ranges)
+            else:
+                self._adjust_array_ranges(node, self.second_array, self.loop_ranges, loop_ranges)
 
             # parse destination
 

--- a/tests/fortran/intrinsic_merge_test.py
+++ b/tests/fortran/intrinsic_merge_test.py
@@ -4,8 +4,9 @@ import numpy as np
 
 from dace.frontend.fortran import ast_transforms, fortran_parser
 
-from tests.fortran.fortran_test_helper import  SourceCodeBuilder
+from tests.fortran.fortran_test_helper import SourceCodeBuilder
 from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_string
+
 
 def test_fortran_frontend_merge_1d():
     """
@@ -260,7 +261,7 @@ def test_fortran_frontend_merge_array_shift():
 
     # Now test to verify it executes correctly with no offset normalization
     sdfg = fortran_parser.create_sdfg_from_string(test_string, "merge_test", True)
-    #sdfg.simplify(verbose=True)
+    # sdfg.simplify(verbose=True)
     sdfg.compile()
     size = 7
 
@@ -277,6 +278,7 @@ def test_fortran_frontend_merge_array_shift():
     sdfg(input1=first, input2=second, mask1=mask1, mask2=mask2, res=res)
     for val in res:
         assert val == 100
+
 
 def test_fortran_frontend_merge_nonarray():
     """
@@ -318,6 +320,7 @@ def test_fortran_frontend_merge_nonarray():
     val[0] = 0
     sdfg(val=val, res=res)
     assert res[0] == 5
+
 
 def test_fortran_frontend_merge_recursive():
     """
@@ -362,7 +365,7 @@ def test_fortran_frontend_merge_recursive():
     mask2 = np.full([size], 1, order="F", dtype=np.int32)
     res = np.full([size], 40, order="F", dtype=np.float64)
 
-    for i in range(int(size/2)):
+    for i in range(int(size / 2)):
         mask1[i] = 1
 
     mask2[-1] = 0
@@ -370,6 +373,7 @@ def test_fortran_frontend_merge_recursive():
     sdfg(input1=first, input2=second, input3=third, mask1=mask1, mask2=mask2, res=res)
 
     assert np.allclose(res, [13, 13, 13, 42, 42, 42, 43])
+
 
 def test_fortran_frontend_merge_scalar():
     """
@@ -398,7 +402,7 @@ def test_fortran_frontend_merge_scalar():
 
     # Now test to verify it executes correctly with no offset normalization
     sdfg = fortran_parser.create_sdfg_from_string(test_string, "merge_test", True)
-    #sdfg.simplify(verbose=True)
+    # sdfg.simplify(verbose=True)
     sdfg.compile()
     size = 7
 
@@ -448,7 +452,7 @@ def test_fortran_frontend_merge_scalar2():
 
     # Now test to verify it executes correctly with no offset normalization
     sdfg = fortran_parser.create_sdfg_from_string(test_string, "merge_test", True)
-    #sdfg.simplify(verbose=True)
+    # sdfg.simplify(verbose=True)
     sdfg.compile()
     size = 7
 
@@ -464,6 +468,7 @@ def test_fortran_frontend_merge_scalar2():
     mask[:] = 1
     sdfg(input1=first, input2=second, mask=mask, res=res)
     assert res[0] == 13
+
 
 def test_fortran_frontend_merge_scalar3():
     """
@@ -494,7 +499,7 @@ def test_fortran_frontend_merge_scalar3():
 
     # Now test to verify it executes correctly with no offset normalization
     sdfg = fortran_parser.create_sdfg_from_string(test_string, "merge_test", True)
-    #sdfg.simplify(verbose=True)
+    # sdfg.simplify(verbose=True)
     sdfg.compile()
     size = 7
 
@@ -553,9 +558,12 @@ def test_fortran_frontend_merge_literal():
     sdfg(input1=13, input2=2, res=res)
     assert res[0] == 1
 
-def test_fortran_frontend_merge_dataref():
 
-    sources, main = SourceCodeBuilder().add_file("""
+def test_fortran_frontend_merge_dataref():
+    sources, main = (
+        SourceCodeBuilder()
+        .add_file(
+            """
                     module lib
                       implicit none
                       type test_type
@@ -594,23 +602,30 @@ def test_fortran_frontend_merge_dataref():
                         double precision, dimension(3) :: res
                         type(test_type2) :: data
 
-                        !res = MERGE(data%var%input_data, data%var%input_data_second, data%var%input_data .lt. 3)
-                        res = MERGE(data%var%input_data, data%var%input_data_second, 1 .lt. 3)
+                        res = MERGE(data%var%input_data, data%var%input_data_second, data%var%input_data .lt. 3)
+                        !res = MERGE(data%var%input_data, data%var%input_data_second, 1 .lt. 3)
 
                         END SUBROUTINE merge_test_function
 
                     END MODULE
-    """, 'main').check_with_gfortran().get()
+    """,
+            "main",
+        )
+        .check_with_gfortran()
+        .get()
+    )
 
     sdfg = create_singular_sdfg_from_string(sources, "test_merge.merge_test", True)
     sdfg.simplify(verbose=True)
     sdfg.compile()
 
     # Minimum is in the beginning
-    data1 = np.full([1], 40, order="F", dtype=np.float64)
-    res = np.full([1], 40, order="F", dtype=np.float64)
+    data1 = np.full([3], 42, order="F", dtype=np.float64)
+    data2 = np.full([3], 40, order="F", dtype=np.float64)
+    res = np.full([3], 0, order="F", dtype=np.float64)
 
-    sdfg(input1=13, input2=42, res=res)
+    sdfg(input1=data1, input2=data2, res=res)
+    print(res)
     assert res[0] == 42
 
     sdfg(input1=13, input2=10, res=res)
@@ -619,17 +634,17 @@ def test_fortran_frontend_merge_dataref():
     sdfg(input1=13, input2=2, res=res)
     assert res[0] == 1
 
-if __name__ == "__main__":
 
-    #test_fortran_frontend_merge_1d()
-    #test_fortran_frontend_merge_comparison_scalar()
-    #test_fortran_frontend_merge_comparison_arrays()
-    #test_fortran_frontend_merge_comparison_arrays_offset()
-    #test_fortran_frontend_merge_array_shift()
-    #test_fortran_frontend_merge_nonarray()
-    #test_fortran_frontend_merge_recursive()
-    #test_fortran_frontend_merge_scalar()
-    #test_fortran_frontend_merge_scalar2()
-    #test_fortran_frontend_merge_scalar3()
-    #test_fortran_frontend_merge_literal()
+if __name__ == "__main__":
+    test_fortran_frontend_merge_1d()
+    test_fortran_frontend_merge_comparison_scalar()
+    test_fortran_frontend_merge_comparison_arrays()
+    test_fortran_frontend_merge_comparison_arrays_offset()
+    test_fortran_frontend_merge_array_shift()
+    test_fortran_frontend_merge_nonarray()
+    test_fortran_frontend_merge_recursive()
+    test_fortran_frontend_merge_scalar()
+    test_fortran_frontend_merge_scalar2()
+    test_fortran_frontend_merge_scalar3()
+    test_fortran_frontend_merge_literal()
     test_fortran_frontend_merge_dataref()


### PR DESCRIPTION
This PR allows fortran's `MERGE` to accept struct references as argument

Beware: the test does not work currently; it segfaults due to incorrect allocation of nested structures by dace.

```cpp
struct test_type {
    double* input_data = {};
    double* input_data_second = {};
};

struct test_type2 {
    test_type* var = {};
};

struct merge_test_state_t {

};

void __program_merge_test_internal(merge_test_state_t*__state, double * __restrict__ input1, double * __restrict__ input2, double * __restrict__ res)
{
    test_type2* data_var_0 = new test_type2;
    data_var_0->var->input_data = new double DACE_ALIGN(64)[3];
    data_var_0->var->input_data_second = new double DACE_ALIGN(64)[3];

```