### PR TITLE
[f2dace/dev, fortran] Collection of smaller fixes: 1) If the config injections have inconsistent values, raise an exception 2) Fix a bug when copying fparser ast node (but avoid deepcopy if possible) 3) Fix the bug with complete unused and unreferenced interface 4) Fix the bug with moving constants into global data structure 5) Fix the type injection test for py3.9 6) Fix the Py->C call

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -406,7 +406,7 @@ class CompiledSDFG(object):
                  for aname, arg in zip(self.argnames, args)})
         argtuple, initargtuple = self._construct_args(kwargs)  # Missing arguments will be detected here.
         # Return values are cached in `self._lastargs`.
-        return self.fast_call(argtuple, initargtuple, do_gpu_check=True)
+        return self.fast_call(argtuple, argtuple, do_gpu_check=True)
 
     def fast_call(
         self,

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -585,6 +585,8 @@ def _eval_int_literal(x: Union[Signed_Int_Literal_Constant, Int_Literal_Constant
 def _eval_real_literal(x: Union[Signed_Real_Literal_Constant, Real_Literal_Constant],
                        alias_map: SPEC_TABLE) -> NUMPY_REALS_TYPES:
     num, kind = x.children
+    if isinstance(kind, Name):
+        kind = kind.string
     if kind is None:
         if 'D' in num:
             num = num.replace('D', 'e')

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -1437,8 +1437,6 @@ def deconstruct_interface_calls(ast: Program) -> Program:
         if fref_spec not in iface_map:
             # We are only interested in calls to interfaces here.
             continue
-        if fref_spec in unused_ifaces:
-            unused_ifaces.remove(fref_spec)
         if not iface_map[fref_spec]:
             # We cannot resolve this one, because there is no candidate.
             print(f"{fref_spec} does not have any candidate to resolve to; moving on", file=sys.stderr)
@@ -1509,7 +1507,8 @@ def deconstruct_interface_calls(ast: Program) -> Program:
         replace_node(name, Name(pname_alias))
 
     for ui in unused_ifaces:
-        assert ui in alias_map and isinstance(alias_map[ui], Interface_Stmt)
+        assert ui in alias_map
+        assert isinstance(alias_map[ui], Interface_Stmt) or isinstance(alias_map[ui].parent.parent, Interface_Block)
         remove_self(alias_map[ui].parent)
 
     ast = consolidate_uses(ast)

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3578,6 +3578,10 @@ def consolidate_global_data_into_arg(ast: Program, always_add_global_data_arg: b
         if not spart:
             continue
         for tdecl in children_of_type(spart, Type_Declaration_Stmt):
+            typ, attr, _ = tdecl.children
+            if 'PARAMETER' in f"{attr}":
+                # This is a constant which should have been propagated away already.
+                continue
             all_global_vars.append(tdecl.tofortran())
     all_derived_types = '\n'.join(all_derived_types)
     all_global_vars = '\n'.join(all_global_vars)

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -120,9 +120,10 @@ class TYPE_SPEC:
             'REAL4': 'REAL(kind=4)',
             'REAL8': 'REAL(kind=8)',
             'REAL': 'REAL(kind=4)',
+            'LOGICAL': 'LOGICAL',
         }
         typ = self.spec[-1]
-        typ = TYPE_MAP.get(typ, typ)
+        typ = TYPE_MAP.get(typ, f"type({typ})")
 
         bits: List[str] = [typ]
         if self.alloc:

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -851,7 +851,8 @@ def find_dataref_component_spec(dref: Union[Name, Data_Ref], scope_spec: SPEC, a
     return comp_spec
 
 
-def find_type_dataref(dref: Union[Name, Part_Ref, Data_Ref, Data_Pointer_Object], scope_spec: SPEC, alias_map: SPEC_TABLE) -> TYPE_SPEC:
+def find_type_dataref(dref: Union[Name, Part_Ref, Data_Ref, Data_Pointer_Object], scope_spec: SPEC,
+                      alias_map: SPEC_TABLE) -> TYPE_SPEC:
     _, root_type, rest = _dataref_root(dref, scope_spec, alias_map)
     cur_type = root_type
 
@@ -3336,10 +3337,9 @@ def _find_items_applicable_to_instance(items: Iterable[ConstInjection],
 
 
 def _type_injection_applies_to_component(item: ConstTypeInjection, defn_spec: SPEC, comp: str) -> bool:
-    if len(item.component_spec) > 1:
-        print(f"Unimplemented: type injection must have just one-level of component for now; got {item.component_spec} "
-              f"to match against {comp}; moving on...", file=sys.stderr)
-        return False
+    assert len(item.component_spec) > 1, \
+        (f"Unimplemented: type injection must have just one-level of component for now; "
+         f"got {item.component_spec} to match against {comp}")
     item_comp = item.component_spec[-1]
 
     if item.type_spec != defn_spec:
@@ -3388,6 +3388,9 @@ def inject_const_evals(ast: Program,
                 print(f"{item}/{item.scope_spec} does not refer to a valid object; moving on...", file=sys.stderr)
                 continue
         if isinstance(item, ConstTypeInjection):
+            if len(item.component_spec) > 1:
+                print(f"{item}/{item.component_spec} must have just one-level for now; moving on...", file=sys.stderr)
+                continue
             if item.type_spec not in alias_map or not isinstance(alias_map[item.type_spec].parent, Derived_Type_Def):
                 print(f"{item}/{item.type_spec} does not refer to a valid type; moving on...", file=sys.stderr)
                 continue

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -2969,6 +2969,14 @@ def _get_module_or_program_parts(mod: Union[Module, Main_Program]) \
 def consolidate_uses(ast: Program, alias_map: Optional[SPEC_TABLE] = None) -> Program:
     alias_map = alias_map or alias_specs(ast)
     for sp in reversed(walk(ast, Specification_Part)):
+        # First, we do a surgery to fix the kind parameter of the literals that refer to a variable, but FParser leaves
+        # them as plain strings instead of making them `Name`s.
+        for lit in walk(sp.parent, LITERAL_CLASSES):
+            val, kind = lit.children
+            if not isinstance(kind, str):
+                continue
+            set_children(lit, (val, Name(kind)))
+
         use_map: Dict[str, Set[str]] = {}
         # Build the table to keep the use statements only if they are actually necessary.
         for nm in walk(sp.parent, Name):

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3337,7 +3337,7 @@ def _find_items_applicable_to_instance(items: Iterable[ConstInjection],
 
 
 def _type_injection_applies_to_component(item: ConstTypeInjection, defn_spec: SPEC, comp: str) -> bool:
-    assert len(item.component_spec) > 1, \
+    assert len(item.component_spec) == 1, \
         (f"Unimplemented: type injection must have just one-level of component for now; "
          f"got {item.component_spec} to match against {comp}")
     item_comp = item.component_spec[-1]
@@ -3388,9 +3388,6 @@ def inject_const_evals(ast: Program,
                 print(f"{item}/{item.scope_spec} does not refer to a valid object; moving on...", file=sys.stderr)
                 continue
         if isinstance(item, ConstTypeInjection):
-            if len(item.component_spec) > 1:
-                print(f"{item}/{item.component_spec} must have just one-level for now; moving on...", file=sys.stderr)
-                continue
             if item.type_spec not in alias_map or not isinstance(alias_map[item.type_spec].parent, Derived_Type_Def):
                 print(f"{item}/{item.type_spec} does not refer to a valid type; moving on...", file=sys.stderr)
                 continue

--- a/dace/frontend/fortran/ast_internal_classes.py
+++ b/dace/frontend/fortran/ast_internal_classes.py
@@ -120,8 +120,15 @@ class Exit_Node(FNode):
 
 
 class Main_Program_Node(FNode):
-    _attributes = ("name",)
-    _fields = ("execution_part", "specification_part")
+    def __init__(self, name: 'Name_Node', specification_part: 'Specification_Part_Node',
+                 execution_part: 'Execution_Part_Node', **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+        self.specification_part = specification_part
+        self.execution_part = execution_part
+
+    _attributes = ('name',)
+    _fields = ('execution_part', 'specification_part')
 
 
 class Module_Node(FNode):

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -20,9 +20,9 @@ from dace.frontend.fortran.ast_utils import mywalk, iter_fields, iter_attributes
 class NeedsTypeInferenceException(BaseException):
 
     def __init__(self, func_name, line_number):
-
         self.line_number = line_number
         self.func_name = func_name
+
 
 class Structure:
 
@@ -295,7 +295,7 @@ class FindNames(NodeVisitor):
 class FindDefinedNames(NodeVisitor):
     def __init__(self):
         self.names: List[str] = []
-        self.specs: {} = {} 
+        self.specs: {} = {}
 
     def visit_Var_Decl_Node(self, node: ast_internal_classes.Var_Decl_Node):
         self.names.append(node.name)
@@ -725,7 +725,7 @@ class ArgumentExtractor(NodeTransformer):
             # These needs to be extracted, so register a temporary variable.
             tmpname = TempName.get_name('tmp_arg')
             decl = ast_internal_classes.Decl_Stmt_Node(
-                    vardecl=[ast_internal_classes.Var_Decl_Node(name=tmpname, type='VOID', sizes=None, init=None)])
+                vardecl=[ast_internal_classes.Var_Decl_Node(name=tmpname, type='VOID', sizes=None, init=None)])
             node.parent.specification_part.specifications.append(decl)
 
             if isinstance(arg, ast_internal_classes.Actual_Arg_Spec_Node):
@@ -754,7 +754,7 @@ class ArgumentExtractor(NodeTransformer):
             newbody.append(ex)
             self.execution_preludes[-1].clear()
         self.execution_preludes.pop()
-        return ast_internal_classes.Execution_Part_Node(execution = newbody)
+        return ast_internal_classes.Execution_Part_Node(execution=newbody)
 
 
 class FunctionCallTransformer(NodeTransformer):
@@ -1049,7 +1049,6 @@ class CallExtractor(NodeTransformer):
                     # We go in reverse order, counting from end-1 to 0.
                     temp = self.count + len(res) - 1
                     for i in reversed(range(0, len(res))):
-
                         node.parent.specification_part.specifications.append(
                             ast_internal_classes.Decl_Stmt_Node(vardecl=[
                                 ast_internal_classes.Var_Decl_Node(
@@ -1674,8 +1673,7 @@ class AllocatableReplacerTransformer(NodeTransformer):
             newbody.append(ex)
             self.execution_preludes[-1].clear()
         self.execution_preludes.pop()
-        return ast_internal_classes.Execution_Part_Node(execution = newbody)
-
+        return ast_internal_classes.Execution_Part_Node(execution=newbody)
 
 
 def par_Decl_Range_Finder(node: ast_internal_classes.Array_Subscript_Node,
@@ -1761,7 +1759,8 @@ def par_Decl_Range_Finder(node: ast_internal_classes.Array_Subscript_Node,
                 lower_boundary = None
                 if offsets[idx] != 1:
                     # support symbols and integer literals
-                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node, ast_internal_classes.BinOp_Node)):
+                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node,
+                                                 ast_internal_classes.BinOp_Node)):
                         lower_boundary = offsets[idx]
                     else:
                         # check if offset is a number
@@ -1797,7 +1796,8 @@ def par_Decl_Range_Finder(node: ast_internal_classes.Array_Subscript_Node,
                 if offsets[idx] != 1:
 
                     # support symbols and integer literals
-                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node, ast_internal_classes.BinOp_Node)):
+                    if isinstance(offsets[idx], (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node,
+                                                 ast_internal_classes.BinOp_Node)):
                         offset = offsets[idx]
                     else:
                         try:
@@ -1973,11 +1973,11 @@ class IfConditionExtractor(NodeTransformer):
             if isinstance(child, ast_internal_classes.If_Stmt_Node):
                 if isinstance(child.cond, ast_internal_classes.BinOp_Node):
                     if child.cond.op == "==" and isinstance(child.cond.rval, ast_internal_classes.Int_Literal_Node):
-                       if isinstance(child.cond.lval, ast_internal_classes.Name_Node):
-                           if child.cond.lval.name=="jb_var_2205":
-                               newbody.append(child)
-                               continue 
-                    
+                        if isinstance(child.cond.lval, ast_internal_classes.Name_Node):
+                            if child.cond.lval.name == "jb_var_2205":
+                                newbody.append(child)
+                                continue
+
                 old_cond = child.cond
                 newbody.append(
                     ast_internal_classes.Decl_Stmt_Node(vardecl=[
@@ -2009,7 +2009,6 @@ class IfConditionExtractor(NodeTransformer):
         return ast_internal_classes.Execution_Part_Node(execution=newbody)
 
 
-
 class WhileConditionExtractor(NodeTransformer):
     """
     Ensures that each loop iterator is unique by extracting the actual iterator and assigning it to a uniquely named local variable
@@ -2023,8 +2022,7 @@ class WhileConditionExtractor(NodeTransformer):
         for child in node.execution:
 
             if isinstance(child, ast_internal_classes.While_Stmt_Node):
-                
-                    
+
                 old_cond = child.cond
                 newbody.append(
                     ast_internal_classes.Decl_Stmt_Node(vardecl=[
@@ -2049,10 +2047,9 @@ class WhileConditionExtractor(NodeTransformer):
                     rval=copy.deepcopy(old_cond),
                     line_number=child.line_number,
                     parent=child.parent))
-                
 
                 newwhile = ast_internal_classes.While_Stmt_Node(cond=newcond, body=newwhilebody,
-                                                          line_number=child.line_number, parent=child.parent)
+                                                                line_number=child.line_number, parent=child.parent)
                 self.count += 1
 
                 newbody.append(newwhile)
@@ -2235,8 +2232,8 @@ class TypeInference(NodeTransformer):
         self.ast = ast
         if assign_scopes:
             ParentScopeAssigner().visit(ast)
-        #if scope_vars is None:
-        #we must always recompute, things might have changed
+        # if scope_vars is None:
+        # we must always recompute, things might have changed
         if (True):
             self.scope_vars = ScopeVarsDeclarations(ast)
             self.scope_vars.visit(ast)
@@ -2288,7 +2285,7 @@ class TypeInference(NodeTransformer):
                             op='+',
                             rval=ast_internal_classes.Int_Literal_Node(value="1"),
                             lval=ast_internal_classes.Parenthesis_Expr_Node(
-                                expr = ast_internal_classes.BinOp_Node(
+                                expr=ast_internal_classes.BinOp_Node(
                                     op='-',
                                     rval=idx.range[0],
                                     lval=idx.range[1]
@@ -2444,7 +2441,6 @@ class TypeInference(NodeTransformer):
                 node.sizes = None
                 node.offsets = None
 
-
         if node.type == 'VOID':
             print("Couldn't infer the type for binop!")
 
@@ -2452,7 +2448,7 @@ class TypeInference(NodeTransformer):
 
     def visit_Data_Ref_Node(self, node: ast_internal_classes.Data_Ref_Node):
 
-        #if node.type != 'VOID':
+        # if node.type != 'VOID':
         #    return node
 
         node.parent_ref = self.visit(node.parent_ref)
@@ -2556,13 +2552,15 @@ class TypeInference(NodeTransformer):
 
     def _get_offsets(self, node):
 
-        if isinstance(node, (ast_internal_classes.Int_Literal_Node, ast_internal_classes.Real_Literal_Node, ast_internal_classes.Bool_Literal_Node)):
+        if isinstance(node, (ast_internal_classes.Int_Literal_Node, ast_internal_classes.Real_Literal_Node,
+                             ast_internal_classes.Bool_Literal_Node)):
             node.offsets = [1]
         return node.offsets
 
     def _get_sizes(self, node):
 
-        if isinstance(node, (ast_internal_classes.Int_Literal_Node, ast_internal_classes.Real_Literal_Node, ast_internal_classes.Bool_Literal_Node)):
+        if isinstance(node, (ast_internal_classes.Int_Literal_Node, ast_internal_classes.Real_Literal_Node,
+                             ast_internal_classes.Bool_Literal_Node)):
             node.sizes = []
         return node.sizes
 
@@ -2617,7 +2615,6 @@ class PointerRemoval(NodeTransformer):
             else:
                 newbody.append(self.visit(child))
         return ast_internal_classes.Execution_Part_Node(execution=newbody)
-
 
     def visit_Specification_Part_Node(self, node: ast_internal_classes.Specification_Part_Node):
 
@@ -3117,11 +3114,11 @@ class ParDeclOffsetNormalizer(NodeTransformer):
 
     def visit_Data_Ref_Node(self, node: ast_internal_classes.Data_Ref_Node):
 
-        #struct, variable, last_var = self.structures.find_definition(
+        # struct, variable, last_var = self.structures.find_definition(
         #    self.scope_vars, node
-        #)
+        # )
 
-        #if not isinstance(last_var.part_ref, ast_internal_classes.Array_Subscript_Node):
+        # if not isinstance(last_var.part_ref, ast_internal_classes.Array_Subscript_Node):
         #    return node
 
         self.data_ref_stack.append(copy.deepcopy(node))
@@ -3188,11 +3185,13 @@ class ParDeclOffsetNormalizer(NodeTransformer):
 
         return node
 
+
 class ArrayLoopLister(NodeVisitor):
 
     def __init__(self, scope_vars, structures):
         self.nodes: List[ast_internal_classes.Array_Subscript_Node] = []
-        self.dataref_nodes: List[Tuple[ast_internal_classes.Data_Ref_Node, ast_internal_classes.Array_Subscript_Node]] = []
+        self.dataref_nodes: List[
+            Tuple[ast_internal_classes.Data_Ref_Node, ast_internal_classes.Array_Subscript_Node]] = []
 
         self.scopes_vars = scope_vars
         self.structures = structures
@@ -3201,7 +3200,6 @@ class ArrayLoopLister(NodeVisitor):
         self.nodes.append(node)
 
     def visit_Data_Ref_Node(self, node: ast_internal_classes.Data_Ref_Node):
-
         _, var_def, last_data_ref_node = self.structures.find_definition(self.scopes_vars, node)
 
         if isinstance(last_data_ref_node.part_ref, ast_internal_classes.Array_Subscript_Node):
@@ -3226,7 +3224,7 @@ class ArrayLoopExpander(NodeTransformer):
     def lister_type() -> Type:
         pass
 
-    def __init__(self, ast, functions = None):
+    def __init__(self, ast, functions=None):
         self.count = 0
 
         self.ast = ast
@@ -3249,7 +3247,7 @@ class ArrayLoopExpander(NodeTransformer):
                 newbody.append(self.visit(child_))
                 continue
 
-            #if res is not None and len(res) > 0:
+            # if res is not None and len(res) > 0:
             for child in res:
 
                 if isinstance(child, ast_internal_classes.BinOp_Node):
@@ -3257,7 +3255,7 @@ class ArrayLoopExpander(NodeTransformer):
                     current = child.lval
                     ranges = []
                     par_Decl_Range_Finder(current, ranges, [], self.count, newbody, self.scope_vars,
-                                        self.ast.structures, True)
+                                          self.ast.structures, True)
 
                     # if res_range is not None and len(res_range) > 0:
 
@@ -3282,7 +3280,7 @@ class ArrayLoopExpander(NodeTransformer):
                         # we don't process it.
                         if not isinstance(arg, ast_internal_classes.Name_Node):
                             par_Decl_Range_Finder(current, ranges, [], self.count, newbody, self.scope_vars,
-                                                self.ast.structures, True)
+                                                  self.ast.structures, True)
                             all_ranges.append(ranges)
                         else:
                             all_ranges.append([])
@@ -3290,7 +3288,8 @@ class ArrayLoopExpander(NodeTransformer):
                     for ranges in all_ranges[1:]:
 
                         if len(ranges) != len(all_ranges[0]):
-                            warnings.warn(f"Mismatch between dimensionality of array expansion, in line: {child.line_number}")
+                            warnings.warn(
+                                f"Mismatch between dimensionality of array expansion, in line: {child.line_number}")
 
                     # For simplicity, the range is dictated by the first array
                     ranges = None
@@ -3313,12 +3312,12 @@ class ArrayLoopExpander(NodeTransformer):
                 else:
                     raise NotImplementedError()
 
-                #rvals = [i for i in mywalk(child.rval) if isinstance(i, ast_internal_classes.Array_Subscript_Node)]
+                # rvals = [i for i in mywalk(child.rval) if isinstance(i, ast_internal_classes.Array_Subscript_Node)]
                 for i in rval_lister.nodes:
                     rangesrval = []
 
                     par_Decl_Range_Finder(i, rangesrval, [], self.count, newbody, self.scope_vars,
-                                        self.ast.structures, False, ranges)
+                                          self.ast.structures, False, ranges)
                     for i, j in zip(ranges, rangesrval):
                         if i != j:
                             if isinstance(i, list) and isinstance(j, list) and len(i) == len(j):
@@ -3341,7 +3340,7 @@ class ArrayLoopExpander(NodeTransformer):
                     i = dataref[0]
 
                     par_Decl_Range_Finder(i, rangesrval, [], self.count, newbody, self.scope_vars,
-                                        self.ast.structures, False, ranges)
+                                          self.ast.structures, False, ranges)
                     for i, j in zip(ranges, rangesrval):
                         if i != j:
                             if isinstance(i, list) and isinstance(j, list) and len(i) == len(j):
@@ -3362,7 +3361,7 @@ class ArrayLoopExpander(NodeTransformer):
 
                 if isinstance(child, ast_internal_classes.BinOp_Node):
                     body = ast_internal_classes.BinOp_Node(lval=current, op="=", rval=child.rval,
-                                                        line_number=child.line_number,parent=child.parent)
+                                                           line_number=child.line_number, parent=child.parent)
                 elif isinstance(child, ast_internal_classes.Call_Expr_Node):
                     body = child
 
@@ -3373,35 +3372,36 @@ class ArrayLoopExpander(NodeTransformer):
                         lval=ast_internal_classes.Name_Node(name="tmp_parfor_" + str(self.count + range_index)),
                         op="=",
                         rval=initrange,
-                        line_number=child.line_number,parent=child.parent)
+                        line_number=child.line_number, parent=child.parent)
                     cond = ast_internal_classes.BinOp_Node(
                         lval=ast_internal_classes.Name_Node(name="tmp_parfor_" + str(self.count + range_index)),
                         op="<=",
                         rval=finalrange,
-                        line_number=child.line_number,parent=child.parent)
+                        line_number=child.line_number, parent=child.parent)
                     iter = ast_internal_classes.BinOp_Node(
                         lval=ast_internal_classes.Name_Node(name="tmp_parfor_" + str(self.count + range_index)),
                         op="=",
                         rval=ast_internal_classes.BinOp_Node(
                             lval=ast_internal_classes.Name_Node(name="tmp_parfor_" + str(self.count + range_index)),
                             op="+",
-                            rval=ast_internal_classes.Int_Literal_Node(value="1"),parent=child.parent),
-                        line_number=child.line_number,parent=child.parent)
+                            rval=ast_internal_classes.Int_Literal_Node(value="1"), parent=child.parent),
+                        line_number=child.line_number, parent=child.parent)
                     current_for = ast_internal_classes.Map_Stmt_Node(
                         init=init,
                         cond=cond,
                         iter=iter,
                         body=ast_internal_classes.Execution_Part_Node(execution=[body]),
-                        line_number=child.line_number,parent=child.parent)
+                        line_number=child.line_number, parent=child.parent)
                     body = current_for
                     range_index += 1
 
                 newbody.append(body)
 
                 self.count = self.count + range_index
-            #else:
+            # else:
             #    newbody.append(self.visit(child))
         return ast_internal_classes.Execution_Part_Node(execution=newbody)
+
 
 class ArrayLoopNodeLister(NodeVisitor):
     """
@@ -3437,7 +3437,9 @@ class ArrayLoopNodeLister(NodeVisitor):
             # Same logic applies to structures
             #
             # BUT: we explicitly exclude patterns like arr = func()
-            if isinstance(node.lval, (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node)) and not isinstance(node.rval, ast_internal_classes.Call_Expr_Node):
+            if isinstance(node.lval,
+                          (ast_internal_classes.Name_Node, ast_internal_classes.Data_Ref_Node)) and not isinstance(
+                    node.rval, ast_internal_classes.Call_Expr_Node):
 
                 if isinstance(node.lval, ast_internal_classes.Name_Node):
 
@@ -3474,6 +3476,7 @@ class ArrayLoopNodeLister(NodeVisitor):
     def visit_Execution_Part_Node(self, node: ast_internal_classes.Execution_Part_Node):
         return
 
+
 class ArrayToLoop(ArrayLoopExpander):
     """
         Transforms the AST by removing expressions arr = <arbitrary-ast-operators>(input-arrays...) a replacing them with loops:
@@ -3491,6 +3494,7 @@ class ArrayToLoop(ArrayLoopExpander):
 
     def __init__(self, ast):
         super().__init__(ast)
+
 
 class ElementalIntrinsicNodeLister(NodeVisitor):
     """
@@ -3516,7 +3520,7 @@ class ElementalIntrinsicNodeLister(NodeVisitor):
         self.structures = structures
 
         self.ELEMENTAL_INTRINSICS = set(
-            ["EXP","MAX","MIN"]
+            ["EXP", "MAX", "MIN"]
         )
 
         self.ELEMENTAL_FUNCTIONS = set()
@@ -3530,7 +3534,8 @@ class ElementalIntrinsicNodeLister(NodeVisitor):
 
     def visit_Call_Expr_Node(self, node: ast_internal_classes.Call_Expr_Node):
 
-        is_elemental_intrinsic = node.name.name.startswith('__dace') and node.name.name.split('__dace_')[1] in self.ELEMENTAL_INTRINSICS
+        is_elemental_intrinsic = node.name.name.startswith('__dace') and node.name.name.split('__dace_')[
+            1] in self.ELEMENTAL_INTRINSICS
 
         # for functions changed into subroutines, their name is adapted as {name}_srt
         is_elemental = node.name.name.split('_srt')[0] in self.ELEMENTAL_FUNCTIONS
@@ -3538,7 +3543,8 @@ class ElementalIntrinsicNodeLister(NodeVisitor):
         if not is_elemental_intrinsic and not is_elemental:
             return
 
-        args_pardecls = [i for arg in node.args for i in mywalk(arg) if isinstance(i, ast_internal_classes.ParDecl_Node)]
+        args_pardecls = [i for arg in node.args for i in mywalk(arg) if
+                         isinstance(i, ast_internal_classes.ParDecl_Node)]
 
         if len(args_pardecls) > 0:
             self.nodes.append(node)
@@ -3625,7 +3631,7 @@ class ElementalIntrinsicNodeLister(NodeVisitor):
 
                 var = self.scope_vars.get_var(node.lval.parent, node.lval.name)
 
-                #if var.type == 'VOID':
+                # if var.type == 'VOID':
                 #    raise NeedsTypeInferenceException(node.rval.name.name, node.line_number)
 
                 if var.sizes is None or len(var.sizes) == 0:
@@ -3653,6 +3659,7 @@ class ElementalIntrinsicNodeLister(NodeVisitor):
                 )
                 self.nodes.append(node)
 
+
 class ElementalIntrinsicExpander(ArrayLoopExpander):
     """
         Transforms the AST by removing expressions arr = func(input) a replacing them with loops:
@@ -3677,7 +3684,6 @@ class ElementalIntrinsicExpander(ArrayLoopExpander):
 
 
 class ParDeclNonContigArrayExpander(NodeTransformer):
-
     """
         Variable processer lets the main function know that the following array needs to be processed:
         - Counter to determine iterator name and the name of temporary array.
@@ -3720,7 +3726,7 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                     var = self.scope_vars.get_var(node.parent, n.lval.name)
                     var.sizes = None
                 elif isinstance(n.lval, ast_internal_classes.Array_Subscript_Node):
-                    var = self.scope_vars.get_var(node.parent, n.lval.name.name )
+                    var = self.scope_vars.get_var(node.parent, n.lval.name.name)
                     var.sizes = None
 
             for tmp_array_name, tmp_array in self.nodes_to_process.items():
@@ -3756,15 +3762,14 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                     dest_indices[idx] = iter_var
 
                 dest = ast_internal_classes.Array_Subscript_Node(
-                    name = ast_internal_classes.Name_Node(name=tmp_array.name),
-                    type = tmp_array.type,
-                    indices = dest_indices,
-                    line_numbe = child.line_number
+                    name=ast_internal_classes.Name_Node(name=tmp_array.name),
+                    type=tmp_array.type,
+                    indices=dest_indices,
+                    line_numbe=child.line_number
                 )
 
                 source_indices = copy.deepcopy(tmp_array.indices)
                 for idx, main_var, var in tmp_array.noncontig_dims:
-
                     iter_var = ast_internal_classes.Name_Node(name=f"tmp_parfor_{tmp_array.counter}_{idx}")
 
                     var.indices = [iter_var]
@@ -3782,7 +3787,6 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                 )
 
                 for idx, _, _ in tmp_array.noncontig_dims:
-
                     initrange = ast_internal_classes.Int_Literal_Node(value="1")
                     finalrange = tmp_array.sizes[idx]
 
@@ -3804,20 +3808,20 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                         lval=iter_var,
                         op="=",
                         rval=initrange,
-                        line_number=child.line_number,parent=child.parent)
+                        line_number=child.line_number, parent=child.parent)
                     cond = ast_internal_classes.BinOp_Node(
                         lval=iter_var,
                         op="<=",
                         rval=finalrange,
-                        line_number=child.line_number,parent=child.parent)
+                        line_number=child.line_number, parent=child.parent)
                     iter = ast_internal_classes.BinOp_Node(
                         lval=iter_var,
                         op="=",
                         rval=ast_internal_classes.BinOp_Node(
                             lval=iter_var,
                             op="+",
-                            rval=ast_internal_classes.Int_Literal_Node(value="1"),parent=child.parent),
-                        line_number=child.line_number,parent=child.parent)
+                            rval=ast_internal_classes.Int_Literal_Node(value="1"), parent=child.parent),
+                        line_number=child.line_number, parent=child.parent)
                     current_for = ast_internal_classes.Map_Stmt_Node(
                         init=init,
                         cond=cond,
@@ -3834,7 +3838,7 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
 
         return ast_internal_classes.Execution_Part_Node(execution=newbody)
 
-    #def visit_Data_Ref_Node(self, node: ast_internal_classes.Data_Ref_Node):
+    # def visit_Data_Ref_Node(self, node: ast_internal_classes.Data_Ref_Node):
 
     def _handle_name_node(self, idx, actual_index, var, new_sizes, noncont_sizes, new_offsets):
 
@@ -3892,7 +3896,6 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
 
         new_indices = []
         for idx, index in enumerate(node.indices):
-
             old_data_ref_stack = self.data_ref_stack
             self.data_ref_stack = []
             new_indices.append(self.visit(index))
@@ -3934,10 +3937,10 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                         We will later assign actual indices when processing the loop code.
                     """
                     idx_arr = ast_internal_classes.Array_Subscript_Node(
-                        name = ast_internal_classes.Name_Node(name=actual_index.name),
-                        type = actual_index.type,
-                        indices = None,
-                        line_number = actual_index.line_number
+                        name=ast_internal_classes.Name_Node(name=actual_index.name),
+                        type=actual_index.type,
+                        indices=None,
+                        line_number=actual_index.line_number
                     )
                     if isinstance(index, ast_internal_classes.Data_Ref_Node):
                         last_var.part_ref = idx_arr
@@ -3993,17 +3996,17 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                     """
                     new_sizes.append(
                         ast_internal_classes.BinOp_Node(
-                            lval = ast_internal_classes.BinOp_Node(
-                                lval = actual_index.range[1],
-                                op = "-",
-                                rval = actual_index.range[0],
-                                line_number = node.line_number,
-                                parent = node.parent
+                            lval=ast_internal_classes.BinOp_Node(
+                                lval=actual_index.range[1],
+                                op="-",
+                                rval=actual_index.range[0],
+                                line_number=node.line_number,
+                                parent=node.parent
                             ),
-                            op = "+",
-                            rval = ast_internal_classes.Int_Literal_Node(value="1"),
-                            line_number = node.line_number,
-                            parent = node.parent
+                            op="+",
+                            rval=ast_internal_classes.Int_Literal_Node(value="1"),
+                            line_number=node.line_number,
+                            parent=node.parent
                         )
                     )
                 else:
@@ -4027,11 +4030,11 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
                 We will later assign actual indices when processing the loop code.
             """
             source = ast_internal_classes.Array_Subscript_Node(
-                name = ast_internal_classes.Name_Node(name=node.name.name),
-                type = node.type,
+                name=ast_internal_classes.Name_Node(name=node.name.name),
+                type=node.type,
                 # will be fixed in further processing
-                indices = None,
-                line_number = node.line_number
+                indices=None,
+                line_number=node.line_number
             )
             main_source = source
             for dataref in self.data_ref_stack[::-1]:
@@ -4045,11 +4048,10 @@ class ParDeclNonContigArrayExpander(NodeTransformer):
             self.counter += 1
 
             return ast_internal_classes.Name_Node(
-                name = name,
-                type = node.type,
-                line_number = node.line_number
+                name=name,
+                type=node.type,
+                line_number=node.line_number
             )
         else:
             node.indices = indices
             return node
-

--- a/dace/frontend/fortran/config_propagation_data.py
+++ b/dace/frontend/fortran/config_propagation_data.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from pathlib import Path
 from typing import List, Any, Dict, Optional, Generator, Iterable, Tuple
 
@@ -42,6 +43,9 @@ def find_all_config_injections(ti_files: Iterable[Path]) -> Generator[ConstInjec
             if not l.strip():
                 continue
             x = deserialize(l.strip())
+            if len(x.component_spec) > 1:
+                print(f"{x}/{x.component_spec} must have just one-level for now; moving on...", file=sys.stderr)
+                continue
             root = '.'.join(x.type_spec if isinstance(x, ConstTypeInjection) else x.root_spec)
             comp = '.'.join(x.component_spec)
             key = (root, comp)

--- a/dace/frontend/fortran/config_propagation_data.py
+++ b/dace/frontend/fortran/config_propagation_data.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List, Any, Dict, Optional, Generator, Iterable
+from typing import List, Any, Dict, Optional, Generator, Iterable, Tuple
 
 from dace.frontend.fortran.ast_desugaring import ConstTypeInjection, ConstInstanceInjection, ConstInjection, SPEC
 
@@ -27,22 +27,6 @@ def deserialize(s: str) -> ConstInjection:
         else ConstInstanceInjection(scope, root, component, value)
 
 
-def deserialize_v2(s: str,
-                   typ: SPEC,
-                   scope: Optional[SPEC] = None) -> List[ConstTypeInjection]:
-    cfg = [tuple(ln.strip().split('=')) for ln in s.split('\n') if ln.strip()]
-    cfg = [(k.strip(), v.strip()) for k, v in cfg]
-    injs = []
-    for k, v in cfg:
-        kparts = tuple(k.split('.')[1:])  # Drop the first part that represents the type, but is not specific.
-        if v == 'T':
-            v = 'true'
-        elif v == 'F':
-            v = 'false'
-        injs.append(ConstTypeInjection(scope, typ, kparts, v))
-    return injs
-
-
 def find_all_config_injection_files(root: Path) -> Generator[Path, None, None]:
     if root.is_file():
         yield root
@@ -51,17 +35,26 @@ def find_all_config_injection_files(root: Path) -> Generator[Path, None, None]:
             yield f
 
 
-def find_all_config_injections(ti_files: Iterable[Path]) -> Generator[ConstTypeInjection, None, None]:
+def find_all_config_injections(ti_files: Iterable[Path]) -> Generator[ConstInjection, None, None]:
+    inj_map: Dict[Tuple[str, str], ConstInjection] = {}
     for f in ti_files:
         for l in f.read_text().strip().splitlines():
             if not l.strip():
                 continue
-            yield deserialize(l.strip())
+            x = deserialize(l.strip())
+            root = '.'.join(x.type_spec if isinstance(x, ConstTypeInjection) else x.root_spec)
+            comp = '.'.join(x.component_spec)
+            key = (root, comp)
+            if key in inj_map:
+                assert inj_map[key].value == x.value, \
+                    f"Inconsistent values in constant injections: {x} vs. {inj_map[key]}"
+            else:
+                inj_map[key] = x
+                yield x
 
 
-def ecrad_config_injection_list(root: str = 'dace/frontend/fortran/conf_files') -> List[ConstTypeInjection]:
-    cfgs = [Path(root).joinpath(f).read_text() for f in [
+def ecrad_config_injection_list(root: str = 'dace/frontend/fortran/conf_files') -> List[ConstInjection]:
+    ti_files = [Path(root).joinpath(f) for f in [
         'config.ti', 'aerosol_optics.ti', 'cloud_optics.ti', 'gas_optics_lw.ti', 'gas_optics_sw.ti', 'pdf_sampler.ti',
         'aerosol.ti', 'cloud.ti', 'flux.ti', 'gas.ti', 'single_level.ti', 'thermodynamics.ti']]
-    injs = [deserialize(l.strip()) for c in cfgs for l in c.splitlines() if l.strip()]
-    return injs
+    return list(find_all_config_injections(ti_files))

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -2770,13 +2770,17 @@ def run_fparser_transformations(ast: Program, cfg: ParseConfig):
 
     if cfg.make_noop:
         print("FParser Op: Making certain functions no-op in the AST...")
+        noop_missed: Set[SPEC] = set(cfg.make_noop)
         for fn in walk(ast, (Function_Stmt, Subroutine_Stmt)):
             fnspec = ident_spec(fn)
             if fnspec not in cfg.make_noop:
                 continue
+            noop_missed.remove(fnspec)
             expart = atmost_one(children_of_type(fn.parent, Execution_Part))
             if expart:
                 remove_self(expart)
+        if noop_missed:
+            print(f"The following functions could not be found for making no-op: {noop_missed}", file=sys.stderr)
 
     print("FParser Op: Removing local indirections from AST...")
     # NOTE: The local indirection removal operations should not need full resolution (e.g., build an alias map).

--- a/dace/frontend/fortran/tools/create_preprocessed_ast.py
+++ b/dace/frontend/fortran/tools/create_preprocessed_ast.py
@@ -56,7 +56,9 @@ contains
   end function cass_cptr
 end module iso_c_binding
 module iso_fortran_env
+  integer, parameter :: real32 = 4
   integer, parameter :: real64 = 8
+  integer, parameter :: int32 = 4
   integer, parameter :: int64 = 8
   character, parameter :: compiler_version = "", compiler_options = ""
 end module iso_fortran_env


### PR DESCRIPTION
1. If the config injections have inconsistent values, raise an exception
2. Fix a bug when copying fparser ast node (but avoid deepcopy if possible)
3. Fix the bug with complete unused and unreferenced interface
4. Fix the bug with moving constants into global data structure
5. Fix the type injection test for py3.9
6. Fix the Py->C call