### PR TITLE
Updated/fixed/finalized the `set_opts()` mechanism of the passes.

### DIFF
--- a/dace/transformation/pass_pipeline.py
+++ b/dace/transformation/pass_pipeline.py
@@ -135,7 +135,15 @@ class Pass:
         return result
 
     def set_opts(self, opts: Dict[str, Any]) -> None:
-        pass
+        pass_pattern = self.__class__.__name__ + "."
+        for opt_name in opts:
+            if not opt_name.startswith(pass_pattern):
+                continue
+            attr_name = opt_name[0:len(pass_pattern)]
+            assert hasattr(
+                self, attr_name
+            ), f"Tried to set attribute '{attr_name}' on a '{self.__class__.__name__}' instance, but that option is unknown."
+            setattr(self, attr_name, opts[opt_name])
 
 
 @properties.make_properties

--- a/dace/transformation/pass_pipeline.py
+++ b/dace/transformation/pass_pipeline.py
@@ -139,7 +139,7 @@ class Pass:
         for opt_name in opts:
             if not opt_name.startswith(pass_pattern):
                 continue
-            attr_name = opt_name[0:len(pass_pattern)]
+            attr_name = opt_name[len(pass_pattern):]
             assert hasattr(
                 self, attr_name
             ), f"Tried to set attribute '{attr_name}' on a '{self.__class__.__name__}' instance, but that option is unknown."

--- a/dace/transformation/passes/fusion_inline.py
+++ b/dace/transformation/passes/fusion_inline.py
@@ -88,16 +88,6 @@ class InlineSDFGs(ppl.Pass):
     def report(self, pass_retval: int) -> str:
         return f'Inlined {pass_retval} SDFGs.'
 
-    def set_opts(self, opts):
-        opt_keys = [
-            'multistate',
-        ]
-
-        for k in opt_keys:
-            attr_k = InlineSDFGs.__name__ + '.' + k
-            if attr_k in opts:
-                setattr(self, k, opts[attr_k])
-
 
 @dataclass(unsafe_hash=True)
 @properties.make_properties
@@ -165,18 +155,6 @@ class InlineControlFlowRegions(ppl.Pass):
 
     def report(self, pass_retval: int) -> str:
         return f'Inlined {pass_retval} regions.'
-
-    def set_opts(self, opts):
-        opt_keys = [
-            'no_inline_loops',
-            'no_inline_conditional',
-            'no_inline_function_call_regions',
-            'no_inline_named_regions',
-        ]
-
-        for k in opt_keys:
-            if k in opts:
-                setattr(self, k, opts[k])
 
 
 @dataclass(unsafe_hash=True)

--- a/dace/transformation/passes/simplify.py
+++ b/dace/transformation/passes/simplify.py
@@ -96,8 +96,8 @@ class SimplifyPass(ppl.FixedPointPipeline):
         self.no_inline_named_regions = no_inline_named_regions
 
         pass_opts = {
-            'no_inline_function_call_regions': self.no_inline_function_call_regions,
-            'no_inline_named_regions': self.no_inline_named_regions,
+            'InlineControlFlowRegions.no_inline_function_call_regions': self.no_inline_function_call_regions,
+            'InlineControlFlowRegions.no_inline_named_regions': self.no_inline_named_regions,
         }
         if pass_options:
             pass_opts.update(pass_options)


### PR DESCRIPTION
This PR properly implements the `Pass.set_opts()` mechanism.
The format is such that the key must be prefixed with the name of the transformation for which the key should be set.
According to Philipp Schaad this was the intended behaviour, but it was not implemented properly.
Now the function is implemented once in the `Pass` and sub classes does not have to provide their own implementation.


