### PR TITLE
Updated MultistateInlining

### DIFF
--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -730,7 +730,7 @@ def isolate_nested_sdfg(
     pre_nodes: Set[nodes.Node] = set()
     to_visit: List[nodes.Node] = []
     for iedge in state.in_edges(nsdfg_node):
-        to_visit.extend(iiedge for iiedge in state.in_edges(iedge.src))
+        to_visit.extend(iiedge.src for iiedge in state.in_edges(iedge.src))
     visited: Set[nodes.Node] = set()
     while len(to_visit) > 0:
         node_to_process = to_visit.pop()
@@ -739,7 +739,7 @@ def isolate_nested_sdfg(
         pre_nodes.add(node_to_process)
         to_visit.extend(iedge.src for iedge in state.in_edges(node_to_process))
     if len(pre_nodes) > 0:
-        pre_nodes.update(iedge.src for edge in state.in_edges(nsdfg_node))
+        pre_nodes.update(iedge.src for iedge in state.in_edges(nsdfg_node))
 
     # These are the nodes of the middle state. Which are all access nodes that serves
     #  as input to the nested SDFG and the nested SDFG itself.

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -701,7 +701,7 @@ def state_fission_after(state: SDFGState, node: nodes.Node, label: Optional[str]
 def isolate_nested_sdfg(
     state: SDFGState,
     nsdfg_node: nodes.NestedSDFG,
-    is_applicable: bool = False,
+    test_if_applicable: bool = False,
 ) -> Union[Tuple[SDFGState, SDFGState, SDFGState], bool]:
     """Isolate the nested SDFG.
 
@@ -719,7 +719,7 @@ def isolate_nested_sdfg(
 
     :param state: The state on which we operate.
     :param nested_sdfg: The nested SDFG node that should be isolated.
-    :param is_applicable: If `True` then do not perform the splitting, only verify
+    :param test_if_applicable: If `True` then do not perform the splitting, only verify
         that it can be performed by returning either `True` or `False`.
     """
 
@@ -748,7 +748,7 @@ def isolate_nested_sdfg(
     middle_nodes: Set[nodes.Node] = {nsdfg_node}
     for iedge in state.in_edges(nsdfg_node):
         if (not isinstance(iedge.src, nodes.AccessNode)) or isinstance(iedge.src.desc(state.sdfg), data.View):
-            if is_applicable:
+            if test_if_applicable:
                 return False
             raise ValueError("Can only split if the inputs to the nested SDFG are AccessNodes to non view data.")
         middle_nodes.add(iedge.src)
@@ -760,7 +760,7 @@ def isolate_nested_sdfg(
         #  same memory would be written to multiple times.
         if ((not all(iedge.src is nsdfg_node for iedge in state.in_edges(oedge.dst)))
                 or (not isinstance(oedge.dst, nodes.AccessNode)) or isinstance(oedge.dst, data.View)):
-            if is_applicable:
+            if test_if_applicable:
                 return False
             raise ValueError(
                 "Can only split if the out to the nested SDFG are AccessNodes to non view data and the AccessNodes are only connected to the nested SDFG."
@@ -789,12 +789,12 @@ def isolate_nested_sdfg(
                 node: nodes.Node = iedge.src
                 if node in pre_nodes:
                     if (not isinstance(node, nodes.AccessNode)) or isinstance(node.desc(state.sdfg), data.View):
-                        if is_applicable:
+                        if test_if_applicable:
                             return False
                         raise ValueError("Can not replicate non non-View AccessNodes into the post state.")
                     post_nodes.add(node)
 
-    if is_applicable:
+    if test_if_applicable:
         return True
 
     # Now we are creating the two new states.

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -741,9 +741,9 @@ def isolate_nested_sdfg(
     #  as input to the nested SDFG and the nested SDFG itself.
     #  Note that the AccessNodes serving as input and output of the nested SDFG
     #  belonging to the pre and post set, respectively, as well.
-    middle_nodes: Set[nodes.Node] = {nested_sdfg}
+    middle_nodes: Set[nodes.Node] = {nsdfg_node}
     for iedge in state.in_edges(nsdfg_node):
-        if (not isinstance(iedge.src, nodes.AccessNode)) or isinstance(iedges.src.desc(state.sdfg), data.View):
+        if (not isinstance(iedge.src, nodes.AccessNode)) or isinstance(iedge.src.desc(state.sdfg), data.View):
             if is_applicable:
                 return False
             raise ValueError("Can only split if the inputs to the nested SDFG are AccessNodes to non view data.")
@@ -754,8 +754,8 @@ def isolate_nested_sdfg(
         #  requires that the whole array is mapped inside. So if there would be
         #  multiple incoming edges the original SDFG would be invalid, because the
         #  same memory would be written to multiple times.
-        if ((not all(iedge.src is nested_sdfg for iedge in state.in_edges(oedge.dst)))
-                or (not isinstance(oedge.dst, nodes.AccessNode)) or isinstance(oedges.dst, data.View)):
+        if ((not all(iedge.src is nsdfg_node for iedge in state.in_edges(oedge.dst)))
+                or (not isinstance(oedge.dst, nodes.AccessNode)) or isinstance(oedge.dst, data.View)):
             if is_applicable:
                 return False
             raise ValueError(
@@ -809,7 +809,7 @@ def isolate_nested_sdfg(
 
     # Now add the edges, we only have to inspect the incoming ones.
     for old_dst in pre_nodes:
-        new_dst = pre_old_to_new_map[old_node]
+        new_dst = pre_old_to_new_map[old_dst]
         for old_iedge in state.in_edges(old_dst):
             old_src = old_iedge.src
             new_src = pre_old_to_new_map[old_src]

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -730,7 +730,10 @@ def isolate_nested_sdfg(
     pre_nodes: Set[nodes.Node] = set()
     to_visit: List[nodes.Node] = []
     for iedge in state.in_edges(nsdfg_node):
-        to_visit.extend(iiedge.src for iiedge in state.in_edges(iedge.src))
+        input_node: nodes.AccessNode = iedge.src
+        assert isinstance(input_node, nodes.AccessNode)
+        if state.in_degree(input_node) != 0:
+            to_visit.append(input_node)
     visited: Set[nodes.Node] = set()
     while len(to_visit) > 0:
         node_to_process = to_visit.pop()
@@ -738,8 +741,6 @@ def isolate_nested_sdfg(
             continue
         pre_nodes.add(node_to_process)
         to_visit.extend(iedge.src for iedge in state.in_edges(node_to_process))
-    if len(pre_nodes) > 0:
-        pre_nodes.update(iedge.src for iedge in state.in_edges(nsdfg_node))
 
     # These are the nodes of the middle state. Which are all access nodes that serves
     #  as input to the nested SDFG and the nested SDFG itself.

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -818,14 +818,15 @@ def isolate_nested_sdfg(
         new_dst = pre_old_to_new_map[old_dst]
         for old_iedge in state.in_edges(old_dst):
             old_src = old_iedge.src
-            new_src = pre_old_to_new_map[old_src]
-            pre_state.add_edge(
-                new_src,
-                old_iedge.src_conn,
-                new_dst,
-                old_iedge.dst_conn,
-                copy.deepcopy(old_iedge.data),
-            )
+            if old_src in pre_nodes:
+                new_src = pre_old_to_new_map[old_src]
+                pre_state.add_edge(
+                    new_src,
+                    old_iedge.src_conn,
+                    new_dst,
+                    old_iedge.dst_conn,
+                    copy.deepcopy(old_iedge.data),
+                )
 
     # Now we will populate the post state.
     post_old_to_new_map: Dict[nodes.Node, nodes.Node] = dict()
@@ -840,14 +841,15 @@ def isolate_nested_sdfg(
         new_src = post_old_to_new_map[old_src]
         for old_oedge in state.out_edges(old_src):
             old_dst = old_oedge.dst
-            new_dst = post_old_to_new_map[old_dst]
-            post_state.add_edge(
-                new_src,
-                old_oedge.src_conn,
-                new_dst,
-                old_oedge.dst_conn,
-                copy.deepcopy(old_oedge.data),
-            )
+            if old_dst in post_nodes:
+                new_dst = post_old_to_new_map[old_dst]
+                post_state.add_edge(
+                    new_src,
+                    old_oedge.src_conn,
+                    new_dst,
+                    old_oedge.dst_conn,
+                    copy.deepcopy(old_oedge.data),
+                )
 
     # Remove all nodes from the middle state that are not classified as middle nodes,
     #  this will also remove all the edges that are no longer needed.

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -775,19 +775,13 @@ def isolate_nested_sdfg(
         for node in state.nodes() if (node not in pre_nodes) and (node not in middle_nodes)
     }
 
-    # The second reason, that there are input dependencies that have to be satisfied.
-    #  However, if there are no nodes in the post state, then there are no dependencies.
+    # The second reason, are read dependencies, for this we have to look at the incoming
+    #  edges and add any node that we need.
     if len(post_nodes) != 0:
-        # The first source of them are the nodes used as output of the nested SDFG.
-        post_nodes.update(oedge.dst for oedge in state.out_edges(nsdfg_node))
-
-        # The second source of a read dependency is if the read is from a node that belongs
-        #  to the pre state. This is a little bit of an obscure case and only happens if
-        #  there are parallel paths along the nested SDFG.
         for pnode in post_nodes.copy():
             for iedge in state.in_edges(pnode):
                 node: nodes.Node = iedge.src
-                if node in pre_nodes:
+                if node not in post_nodes:
                     if (not isinstance(node, nodes.AccessNode)) or isinstance(node.desc(state.sdfg), data.View):
                         if test_if_applicable:
                             return False

--- a/dace/transformation/interstate/multistate_inline.py
+++ b/dace/transformation/interstate/multistate_inline.py
@@ -173,14 +173,20 @@ class InlineMultistateSDFG(transformation.SingleStateTransformation):
 
         # Isolate nsdfg in a separate state
         # 1. Push nsdfg node plus dependencies down into new state
+        sdfg.view()
         nsdfg_state = helpers.state_fission_after(outer_state, nsdfg_node)
+        sdfg.view()
         # 2. Push successors of nsdfg node into a later state
         direct_subgraph = set()
         direct_subgraph.add(nsdfg_node)
-        direct_subgraph.update(nsdfg_state.predecessors(nsdfg_node))
-        direct_subgraph.update(nsdfg_state.successors(nsdfg_node))
+        nsdfg_predecessors = nsdfg_state.predecessors(nsdfg_node)
+        nsdfg_successors = nsdfg_state.successors(nsdfg_node)
+        direct_subgraph.update(nsdfg_predecessors)
+        direct_subgraph.update(nsdfg_successors)
         direct_subgraph = StateSubgraphView(nsdfg_state, direct_subgraph)
         nsdfg_state = helpers.state_fission(direct_subgraph)
+        sdfg.view()
+        breakpoint()
 
         # Find original source/destination edges (there is only one edge per
         # connector, according to match)

--- a/tests/inlining_test.py
+++ b/tests/inlining_test.py
@@ -1,9 +1,11 @@
 # Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
+from dace import nodes as dace_nodes
 from dace.sdfg.state import FunctionCallRegion, NamedRegion
 from dace.transformation.interstate import InlineSDFG, StateFusion
 from dace.libraries import blas
 from dace.library import change_default
+from typing import Tuple
 import numpy as np
 import os
 import pytest
@@ -41,6 +43,155 @@ def myprogram(A, B, cst):
 
 def test():
     myprogram.compile(dace.float32[W, H], dace.float32[H, W], dace.int32)
+
+
+def _make_chain_reduction_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.NestedSDFG, dace_nodes.NestedSDFG]:
+
+    def _make_nested_sdfg(name: str) -> dace.SDFG:
+        sdfg = dace.SDFG(name)
+        state = sdfg.add_state(is_start_block=True)
+
+        for name in "ABC":
+            sdfg.add_array(
+                name=name,
+                shape=(10, ),
+                dtype=dace.float64,
+                transient=False,
+            )
+        state.add_mapped_tasklet(
+            "comp",
+            map_ranges={"__i": "0:10"},
+            inputs={
+                "__in1": dace.Memlet("A[__i]"),
+                "__in2": dace.Memlet("B[__i]"),
+            },
+            code="__out = __in1 + __in2",
+            outputs={"__out": dace.Memlet("C[__i]")},
+            external_edges=True,
+        )
+        sdfg.validate()
+        return sdfg
+
+    outer_sdfg = dace.SDFG("chain_reduction_sdfg")
+    state = outer_sdfg.add_state(is_start_block=True)
+
+    anames_s10 = ["I1", "I2", "I3", "I4", "T1", "T4", "T5"]
+    anames_s20 = ["T2"]
+    anames_s30 = ["T3", "O"]
+    sizes = dict()
+    sizes.update({name: 10 for name in anames_s10})
+    sizes.update({name: 20 for name in anames_s20})
+    sizes.update({name: 30 for name in anames_s30})
+
+    for name in anames_s10 + anames_s20 + anames_s30:
+        outer_sdfg.add_array(
+            name=name,
+            shape=(sizes[name], ),
+            dtype=dace.float64,
+            transient=name.startswith("T"),
+        )
+    T1, T2, T3, T4, T5 = (state.add_access(f"T{i}") for i in range(1, 6))
+
+    state.add_mapped_tasklet(
+        "comp1",
+        map_ranges={"__i": "0:10"},
+        inputs={"__in": dace.Memlet("I3[__i]")},
+        code="__out = __in + 1.0",
+        outputs={"__out": dace.Memlet("T4[__i]")},
+        external_edges=True,
+        output_nodes={T4},
+    )
+
+    inner_sdfg_1 = _make_nested_sdfg("first_adding")
+    nsdfg_node_1 = state.add_nested_sdfg(
+        sdfg=inner_sdfg_1,
+        parent=outer_sdfg,
+        inputs={"A", "B"},
+        outputs={"C"},
+        symbol_mapping={},
+    )
+
+    state.add_edge(state.add_access("I4"), None, nsdfg_node_1, "A", dace.Memlet("I4[0:10]"))
+    state.add_edge(state.add_access("I1"), None, nsdfg_node_1, "B", dace.Memlet("I1[0:10]"))
+    state.add_edge(nsdfg_node_1, "C", T5, None, dace.Memlet("T5[0:10]"))
+
+    state.add_nedge(T4, T2, dace.Memlet("T4[0:10] -> [0:10]"))
+    state.add_nedge(T5, T2, dace.Memlet("T5[0:10] -> [10:20]"))
+
+    inner_sdfg_2 = _make_nested_sdfg("second_adding")
+    nsdfg_node_2 = state.add_nested_sdfg(
+        sdfg=inner_sdfg_2,
+        parent=outer_sdfg,
+        inputs={"A", "B"},
+        outputs={"C"},
+        symbol_mapping={},
+    )
+
+    state.add_edge(state.add_access("I1"), None, nsdfg_node_2, "A", dace.Memlet("I1[0:10]"))
+    state.add_edge(state.add_access("I2"), None, nsdfg_node_2, "B", dace.Memlet("I2[0:10]"))
+
+    state.add_edge(nsdfg_node_2, "C", T1, None, dace.Memlet("T1[0:10]"))
+
+    state.add_nedge(T1, T3, dace.Memlet("T1[0:10] -> [0:10]"))
+    state.add_nedge(T2, T3, dace.Memlet("T2[0:20] -> [10:30]"))
+    state.add_nedge(T3, state.add_access("O"), dace.Memlet("T3[0:30] -> [0:30]"))
+    outer_sdfg.validate()
+
+    return outer_sdfg, state, nsdfg_node_1, nsdfg_node_2
+
+
+def _perform_chain_reduction_inlining(which: int, ) -> None:
+    from dace.transformation.interstate import InlineMultistateSDFG
+
+    def count_writes(sdfg):
+        nb_writes = 0
+        for state in sdfg.states():
+            for dnode in state.data_nodes():
+                nb_writes += state.in_degree(dnode)
+        return nb_writes
+
+    def count_nsdfg(sdfg):
+        nb_nsdfg = 0
+        for state in sdfg.states():
+            nb_nsdfg += sum(isinstance(node, dace_nodes.NestedSDFG) for node in state.nodes())
+        return nb_nsdfg
+
+    ref = {arg: np.array(np.random.rand(10), dtype=np.float64, copy=True) for arg in ["I1", "I2", "I3", "I4"]}
+    ref["O"] = np.array(np.random.rand(30), dtype=np.float64, copy=True)
+    res = {k: v.copy() for k, v in ref.items()}
+
+    sdfg, state, nsdfg_node_1, nsdfg_node_2 = _make_chain_reduction_sdfg()
+    initial_writes = count_writes(sdfg)
+    initial_nsdfg = count_nsdfg(sdfg)
+
+    csdfg_ref = sdfg.compile()
+    csdfg_ref(**ref)
+
+    if which == 0:
+        InlineMultistateSDFG.apply_to(
+            sdfg=sdfg,
+            verify=True,
+            nested_sdfg=nsdfg_node_1,
+        )
+    elif which == 1:
+        InlineMultistateSDFG.apply_to(
+            sdfg=sdfg,
+            verify=True,
+            nested_sdfg=nsdfg_node_2,
+        )
+    elif which == -1:
+        nb_applied = sdfg.apply_transformations_repeated(InlineMultistateSDFG)
+        assert nb_applied == 2
+    else:
+        raise ValueError(f"Unknown selector {which}")
+
+    assert initial_writes == count_writes(sdfg)
+    assert count_nsdfg(sdfg) < initial_nsdfg
+
+    csdfg_res = sdfg.compile()
+    csdfg_res(**res)
+
+    assert all(np.allclose(ref[k], res[k]) for k in ref.keys())
 
 
 @pytest.mark.skip('CI failure that cannot be reproduced outside CI')
@@ -258,6 +409,18 @@ def test_multistate_inline_concurrent_subgraphs():
     assert np.allclose(A, expected_a)
     assert np.allclose(B, expected_b)
     assert np.allclose(C, expected_c)
+
+
+def test_chain_reduction_1():
+    _perform_chain_reduction_inlining(0)
+
+
+def test_chain_reduction_2():
+    _perform_chain_reduction_inlining(1)
+
+
+def test_chain_reduction_all():
+    _perform_chain_reduction_inlining(-1)
 
 
 def test_inline_symexpr():
@@ -479,3 +642,6 @@ if __name__ == "__main__":
     test_inline_symbol_assignment()
     test_regression_inline_subset()
     test_inlining_view_input()
+    test_chain_reduction_1()
+    test_chain_reduction_2()
+    test_chain_reduction_all()

--- a/tests/transformations/isolate_nested_sdfg_test.py
+++ b/tests/transformations/isolate_nested_sdfg_test.py
@@ -8,42 +8,58 @@ from dace import nodes as dace_nodes
 from dace.transformation.helpers import isolate_nested_sdfg
 
 
-def count_node(sdfg: Union[dace.SDFG, dace.SDFGState], node_type):
+def count_node(sdfg: Union[dace.SDFG, dace.SDFGState], node_type, return_nodes: bool = False):
     states = [sdfg] if isinstance(sdfg, dace.SDFGState) else sdfg.states()
-    nb_nodes = 0
+    found_nodes = []
     for state in states:
         for node in state.nodes():
             if isinstance(node, node_type):
-                nb_nodes += 1
-    return nb_nodes
+                found_nodes.append(node)
+
+    return found_nodes if return_nodes else len(found_nodes)
+
+
+def count_writes(sdfg: dace.SDFG):
+    """Count the number of write nodes.
+
+    A write is defined as an incoming edge on an AccessNode. Thus this function
+    essentially sums up the input degree of all AccessNodes.
+    """
+    nb_writes = 0
+    for state in sdfg.states():
+        for dnode in state.data_nodes():
+            nb_writes += state.in_degree(dnode)
+    return nb_writes
+
+
+def _make_nested_sdfg_simple() -> dace.SDFG:
+    """Make a simple nested SDFG.
+    """
+    sdfg = dace.SDFG("nested_sdfg")
+    state = sdfg.add_state(is_start_block=True)
+
+    for name in "AB":
+        sdfg.add_array(
+            name=name,
+            shape=(10, ),
+            dtype=dace.float64,
+            transient=False,
+        )
+    state.add_mapped_tasklet(
+        "comp",
+        map_ranges={"__i": "1:9"},
+        inputs={"__in": dace.Memlet("A[__i]")},
+        code="__out = __in + 1.0",
+        outputs={"__out": dace.Memlet("B[__i]")},
+        external_edges=True,
+    )
+    sdfg.validate()
+    return sdfg
 
 
 def _make_already_isloated_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.NestedSDFG]:
     """Creates a nested SDFG that is already isolated.
     """
-
-    def _make_nested_sdfg() -> dace.SDFG:
-        sdfg = dace.SDFG("nested_sdfg")
-        state = sdfg.add_state(is_start_block=True)
-
-        for name in "AB":
-            sdfg.add_array(
-                name=name,
-                shape=(10, ),
-                dtype=dace.float64,
-                transient=False,
-            )
-        state.add_mapped_tasklet(
-            "comp",
-            map_ranges={"__i": "1:9"},
-            inputs={"__in": dace.Memlet("A[__i]")},
-            code="__out = __in + 1.0",
-            outputs={"__out": dace.Memlet("B[__i]")},
-            external_edges=True,
-        )
-        sdfg.validate()
-        return sdfg
-
     outer_sdfg = dace.SDFG("already_isolate_nested_sdfg")
     state = outer_sdfg.add_state(is_start_block=True)
 
@@ -55,8 +71,7 @@ def _make_already_isloated_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dac
             transient=False,
         )
 
-    inner_sdfg = _make_nested_sdfg()
-
+    inner_sdfg = _make_nested_sdfg_simple()
     nsdfg = state.add_nested_sdfg(
         sdfg=inner_sdfg,
         parent=outer_sdfg,
@@ -66,6 +81,51 @@ def _make_already_isloated_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dac
     )
     state.add_edge(state.add_access("A"), None, nsdfg, "A", dace.Memlet("A[0:10]"))
     state.add_edge(nsdfg, "B", state.add_access("B"), None, dace.Memlet("B[0:10]"))
+    outer_sdfg.validate()
+
+    return outer_sdfg, state, nsdfg
+
+
+def _make_non_empty_pre_set_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.NestedSDFG]:
+    """Generates an SDFG that has a non empty pre set.
+    """
+
+    outer_sdfg = dace.SDFG("non_empty_pre_set_nested_sdfg")
+    state = outer_sdfg.add_state(is_start_block=True)
+
+    for name in "ABT":
+        outer_sdfg.add_array(
+            name=name,
+            shape=(10, ),
+            dtype=dace.float64,
+            transient=False,
+        )
+    outer_sdfg.arrays["T"].transient = True
+
+    A, B, T = (state.add_access(name) for name in "ABT")
+
+    state.add_mapped_tasklet(
+        "outer_comp",
+        map_ranges={"__i": "0:10"},
+        inputs={"__in": dace.Memlet("A[__i]")},
+        code="__out = __in + 2.0",
+        outputs={"__out": dace.Memlet("T[__i]")},
+        external_edges=True,
+        input_nodes={A},
+        output_nodes={T},
+    )
+
+    inner_sdfg = _make_nested_sdfg_simple()
+    nsdfg = state.add_nested_sdfg(
+        sdfg=inner_sdfg,
+        parent=outer_sdfg,
+        inputs={"A"},
+        outputs={"B"},
+        symbol_mapping={},
+    )
+    state.add_edge(T, None, nsdfg, "A", dace.Memlet("T[0:10]"))
+    state.add_edge(nsdfg, "B", B, None, dace.Memlet("B[0:10]"))
+    outer_sdfg.validate()
 
     return outer_sdfg, state, nsdfg
 
@@ -91,3 +151,41 @@ def test_already_isolated_sdfg():
     assert post_state.number_of_nodes() == 0
     assert count_node(middle_state, dace_nodes.NestedSDFG) == 1
     assert count_node(middle_state, dace_nodes.AccessNode) == 2
+
+
+def test_non_empty_pre_set():
+    sdfg, state, nsdfg_node = _make_non_empty_pre_set_sdfg()
+
+    assert sdfg.start_block is state
+    assert sdfg.number_of_nodes() == 1
+    assert count_node(sdfg, dace_nodes.NestedSDFG) == 1
+    assert count_node(sdfg, dace_nodes.AccessNode) == 3
+    assert count_node(sdfg, dace_nodes.MapEntry) == 1
+    assert count_node(nsdfg_node.sdfg, dace_nodes.AccessNode) == 2
+    assert count_node(nsdfg_node.sdfg, dace_nodes.MapEntry) == 1
+
+    # Now perform the split. The post state should be empty, and the pre state should
+    #  contain the map.
+    pre_state, middle_state, post_state = isolate_nested_sdfg(state=state, nsdfg_node=nsdfg_node)
+
+    sdfg.validate()
+    assert sdfg.number_of_nodes() == 3
+    assert sdfg.start_block is pre_state
+    assert post_state.number_of_nodes() == 0
+    assert count_node(sdfg, dace_nodes.NestedSDFG) == 1
+    assert count_node(sdfg, dace_nodes.AccessNode) == 4
+    assert count_node(sdfg, dace_nodes.MapEntry) == 1
+
+    pre_ac_nodes = count_node(pre_state, dace_nodes.AccessNode, return_nodes=True)
+    assert len(pre_ac_nodes) == 2
+    assert {"A", "T"} == {n.data for n in pre_ac_nodes}
+    assert count_node(pre_state, dace_nodes.MapEntry) == 1
+    assert pre_state.number_of_nodes() == 5
+
+    middle_ac_nodes = count_node(middle_state, dace_nodes.AccessNode, return_nodes=True)
+    assert len(middle_ac_nodes) == 2
+    assert {"T", "B"} == {n.data for n in middle_ac_nodes}
+    assert count_node(middle_state, dace_nodes.NestedSDFG) == 1
+    assert middle_state.number_of_nodes() == 3
+
+    assert post_state.number_of_nodes() == 0

--- a/tests/transformations/isolate_nested_sdfg_test.py
+++ b/tests/transformations/isolate_nested_sdfg_test.py
@@ -1,0 +1,93 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import numpy as np
+import pytest
+from typing import Tuple, Union
+
+from dace import nodes as dace_nodes
+from dace.transformation.helpers import isolate_nested_sdfg
+
+
+def count_node(sdfg: Union[dace.SDFG, dace.SDFGState], node_type):
+    states = [sdfg] if isinstance(sdfg, dace.SDFGState) else sdfg.states()
+    nb_nodes = 0
+    for state in states:
+        for node in state.nodes():
+            if isinstance(node, node_type):
+                nb_nodes += 1
+    return nb_nodes
+
+
+def _make_already_isloated_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.NestedSDFG]:
+    """Creates a nested SDFG that is already isolated.
+    """
+
+    def _make_nested_sdfg() -> dace.SDFG:
+        sdfg = dace.SDFG("nested_sdfg")
+        state = sdfg.add_state(is_start_block=True)
+
+        for name in "AB":
+            sdfg.add_array(
+                name=name,
+                shape=(10, ),
+                dtype=dace.float64,
+                transient=False,
+            )
+        state.add_mapped_tasklet(
+            "comp",
+            map_ranges={"__i": "1:9"},
+            inputs={"__in": dace.Memlet("A[__i]")},
+            code="__out = __in + 1.0",
+            outputs={"__out": dace.Memlet("B[__i]")},
+            external_edges=True,
+        )
+        sdfg.validate()
+        return sdfg
+
+    outer_sdfg = dace.SDFG("already_isolate_nested_sdfg")
+    state = outer_sdfg.add_state(is_start_block=True)
+
+    for name in "AB":
+        outer_sdfg.add_array(
+            name=name,
+            shape=(10, ),
+            dtype=dace.float64,
+            transient=False,
+        )
+
+    inner_sdfg = _make_nested_sdfg()
+
+    nsdfg = state.add_nested_sdfg(
+        sdfg=inner_sdfg,
+        parent=outer_sdfg,
+        inputs={"A"},
+        outputs={"B"},
+        symbol_mapping={},
+    )
+    state.add_edge(state.add_access("A"), None, nsdfg, "A", dace.Memlet("A[0:10]"))
+    state.add_edge(nsdfg, "B", state.add_access("B"), None, dace.Memlet("B[0:10]"))
+
+    return outer_sdfg, state, nsdfg
+
+
+def test_already_isolated_sdfg():
+    sdfg, state, nsdfg_node = _make_already_isloated_nested_sdfg()
+
+    assert sdfg.start_block is state
+    assert sdfg.number_of_nodes() == 1
+    assert count_node(sdfg, dace_nodes.NestedSDFG) == 1
+    assert count_node(sdfg, dace_nodes.AccessNode) == 2
+    assert count_node(nsdfg_node.sdfg, dace_nodes.AccessNode) == 2
+    assert count_node(nsdfg_node.sdfg, dace_nodes.MapEntry) == 1
+
+    # Now perform the split, because the nested SDFG is already isolated, the pre
+    #  and post states should be empty.
+    pre_state, middle_state, post_state = isolate_nested_sdfg(state=state, nsdfg_node=nsdfg_node)
+
+    sdfg.validate()
+    assert sdfg.number_of_nodes() == 3
+    assert sdfg.start_block is pre_state
+    assert pre_state.number_of_nodes() == 0
+    assert post_state.number_of_nodes() == 0
+    assert count_node(middle_state, dace_nodes.NestedSDFG) == 1
+    assert count_node(middle_state, dace_nodes.AccessNode) == 2

--- a/tests/transformations/isolate_nested_sdfg_test.py
+++ b/tests/transformations/isolate_nested_sdfg_test.py
@@ -89,7 +89,6 @@ def _make_already_isloated_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dac
 def _make_non_empty_pre_set_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.NestedSDFG]:
     """Generates an SDFG that has a non empty pre set.
     """
-
     outer_sdfg = dace.SDFG("non_empty_pre_set_nested_sdfg")
     state = outer_sdfg.add_state(is_start_block=True)
 
@@ -130,6 +129,48 @@ def _make_non_empty_pre_set_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_node
     return outer_sdfg, state, nsdfg
 
 
+def _make_non_empty_post_state_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.NestedSDFG]:
+    """Generates an SDFG that will have an non empty post state and an empty pre state.
+    """
+    outer_sdfg = dace.SDFG("non_empty_post_set_nested_sdfg")
+    state = outer_sdfg.add_state(is_start_block=True)
+
+    for name in "ABT":
+        outer_sdfg.add_array(
+            name=name,
+            shape=(10, ),
+            dtype=dace.float64,
+            transient=False,
+        )
+    outer_sdfg.arrays["T"].transient = True
+    A, B, T = (state.add_access(name) for name in "ABT")
+
+    inner_sdfg = _make_nested_sdfg_simple()
+    nsdfg = state.add_nested_sdfg(
+        sdfg=inner_sdfg,
+        parent=outer_sdfg,
+        inputs={"A"},
+        outputs={"B"},
+        symbol_mapping={},
+    )
+    state.add_edge(A, None, nsdfg, "A", dace.Memlet("A[0:10]"))
+    state.add_edge(nsdfg, "B", T, None, dace.Memlet("T[0:10]"))
+
+    state.add_mapped_tasklet(
+        "outer_comp",
+        map_ranges={"__i": "0:10"},
+        inputs={"__in": dace.Memlet("T[__i]")},
+        code="__out = __in + 2.0",
+        outputs={"__out": dace.Memlet("B[__i]")},
+        external_edges=True,
+        input_nodes={T},
+        output_nodes={B},
+    )
+    outer_sdfg.validate()
+
+    return outer_sdfg, state, nsdfg
+
+
 def test_already_isolated_sdfg():
     sdfg, state, nsdfg_node = _make_already_isloated_nested_sdfg()
 
@@ -163,6 +204,7 @@ def test_non_empty_pre_set():
     assert count_node(sdfg, dace_nodes.MapEntry) == 1
     assert count_node(nsdfg_node.sdfg, dace_nodes.AccessNode) == 2
     assert count_node(nsdfg_node.sdfg, dace_nodes.MapEntry) == 1
+    initial_writes = count_writes(sdfg)
 
     # Now perform the split. The post state should be empty, and the pre state should
     #  contain the map.
@@ -171,10 +213,10 @@ def test_non_empty_pre_set():
     sdfg.validate()
     assert sdfg.number_of_nodes() == 3
     assert sdfg.start_block is pre_state
-    assert post_state.number_of_nodes() == 0
     assert count_node(sdfg, dace_nodes.NestedSDFG) == 1
     assert count_node(sdfg, dace_nodes.AccessNode) == 4
     assert count_node(sdfg, dace_nodes.MapEntry) == 1
+    assert initial_writes == count_writes(sdfg)
 
     pre_ac_nodes = count_node(pre_state, dace_nodes.AccessNode, return_nodes=True)
     assert len(pre_ac_nodes) == 2
@@ -189,3 +231,40 @@ def test_non_empty_pre_set():
     assert middle_state.number_of_nodes() == 3
 
     assert post_state.number_of_nodes() == 0
+
+
+def test_non_empty_post_set():
+    sdfg, state, nsdfg_node = _make_non_empty_post_state_sdfg()
+
+    assert sdfg.start_block is state
+    assert sdfg.number_of_nodes() == 1
+    assert count_node(sdfg, dace_nodes.NestedSDFG) == 1
+    assert count_node(sdfg, dace_nodes.AccessNode) == 3
+    assert count_node(sdfg, dace_nodes.MapEntry) == 1
+    assert count_node(nsdfg_node.sdfg, dace_nodes.AccessNode) == 2
+    assert count_node(nsdfg_node.sdfg, dace_nodes.MapEntry) == 1
+    initial_writes = count_writes(sdfg)
+
+    # Now perform the split. The pre state will be empty, but the map will be relocated to the post state.
+    pre_state, middle_state, post_state = isolate_nested_sdfg(state=state, nsdfg_node=nsdfg_node)
+
+    assert sdfg.number_of_nodes() == 3
+    assert sdfg.start_block is pre_state
+    assert count_node(sdfg, dace_nodes.NestedSDFG) == 1
+    assert count_node(sdfg, dace_nodes.AccessNode) == 4
+    assert count_node(sdfg, dace_nodes.MapEntry) == 1
+    assert initial_writes == count_writes(sdfg)
+
+    assert pre_state.number_of_nodes() == 0
+
+    middle_ac_nodes = count_node(middle_state, dace_nodes.AccessNode, return_nodes=True)
+    assert len(middle_ac_nodes) == 2
+    assert {"T", "A"} == {n.data for n in middle_ac_nodes}
+    assert count_node(middle_state, dace_nodes.NestedSDFG) == 1
+    assert middle_state.number_of_nodes() == 3
+
+    post_ac_nodes = count_node(post_state, dace_nodes.AccessNode, return_nodes=True)
+    assert len(post_ac_nodes) == 2
+    assert {"T", "B"} == {n.data for n in post_ac_nodes}
+    assert count_node(post_state, dace_nodes.MapEntry) == 1
+    assert post_state.number_of_nodes() == 5

--- a/tests/transformations/mapfusion_test.py
+++ b/tests/transformations/mapfusion_test.py
@@ -16,7 +16,7 @@ from dace.transformation.dataflow import MapFusion, MapExpansion
 def count_node(sdfg: SDFG, node_type):
     nb_nodes = 0
     for rsdfg in sdfg.all_sdfgs_recursive():
-        for state in sdfg.states():
+        for state in rsdfg.states():
             for node in state.nodes():
                 if isinstance(node, node_type):
                     nb_nodes += 1

--- a/tests/transformations/state_fusion_test.py
+++ b/tests/transformations/state_fusion_test.py
@@ -480,7 +480,10 @@ def test_check_paths():
     do_fuse = StateFusion()._check_paths(
         first_state=block_0,
         second_state=block_5,
-        match_nodes={qm_b0_w: qm_b5, m1_b0_w: m1_b5},
+        match_nodes={
+            qm_b0_w: qm_b5,
+            m1_b0_w: m1_b5
+        },
         nodes_first=[q_b0_w],
         nodes_second=[q_b5_w],
         second_input={precip_fall_b5, m1_b5, qm_b5},


### PR DESCRIPTION
This PR addresses [issue#1959](https://github.com/spcl/dace/issues/1959), the issue was about that the inlining transformation destroys the SSA invariant we maintain inside GT4Py.
This invariant states that in every code path there is exactly one AccessNode with that is used to write to a data container.

The PR solves this issue by modifying how the nested SDFG is isolated, before this was done in two steps and is now performed in a single step.
The main idea is that the number of writes is preserved.





