### PR TITLE
Fixed State Renaming in `MultistateInline`

### DIFF
--- a/dace/transformation/interstate/multistate_inline.py
+++ b/dace/transformation/interstate/multistate_inline.py
@@ -288,8 +288,8 @@ class InlineMultistateSDFG(transformation.SingleStateTransformation):
         for nstate in nsdfg.states():
             if nstate.label in statenames:
                 newname = data.find_new_name(nstate.label, statenames)
-                statenames.add(newname)
                 nstate.label = newname
+            statenames.add(nstate.label)
 
         #######################################################
         # Add nested SDFG states into top-level SDFG


### PR DESCRIPTION
The error was that the state name was only added to the list of known names if it was already known. Assume that the top SDFG had the states with name `name1`, but the nested SDFG had the states `name1` and `name1_0` (the `_0` is the pattern added by the `find_new_name()` function). The error happens if `name1_0` is processed before, because it is not known it was not added to `statements`, then `name1` is processed, because it is known, the parent has a state of the same name, it is passed to `find_name_name()`. That function will then see that `name1_0` is free and use that name. This leads to the error because now two states with the name `name1_0` are present in the SDFG, once the original state (from the nested SDFG) and one the state (from the nested SDFG) that was previously named `name1`.