### PR TITLE
Fix compiler error with template keyword without type in reduce_atomic

### DIFF
--- a/dace/runtime/include/dace/reduction.h
+++ b/dace/runtime/include/dace/reduction.h
@@ -532,7 +532,7 @@ namespace dace {
 
         static DACE_HDFI T reduce_atomic(T *ptr, const T& value)
         {
-            return wcr_custom<T>::template reduce_atomic(
+            return wcr_custom<T>::reduce_atomic(
                 _wcr_fixed<REDTYPE, T>(), ptr, value);
         }
     };

--- a/dace/runtime/include/dace/reduction.h
+++ b/dace/runtime/include/dace/reduction.h
@@ -532,7 +532,7 @@ namespace dace {
 
         static DACE_HDFI T reduce_atomic(T *ptr, const T& value)
         {
-            return wcr_custom<T>::reduce_atomic(
+            return wcr_custom<T>::template reduce_atomic<decltype(_wcr_fixed<REDTYPE, T>())>(
                 _wcr_fixed<REDTYPE, T>(), ptr, value);
         }
     };


### PR DESCRIPTION
Here is the log of the issue when trying to compile a `DaCe` `gt4py` program with latest `Apple Clang`:
```
>               raise cgx.CompilationError('Compiler failure:\n' + ex.output)
E               dace.codegen.exceptions.CompilationError: Compiler failure:
E               [ 25%] Building CXX object CMakeFiles/temporary_fields_for_turbulence_diagnostics.dir/var/folders/5x/5gbpjy215c1_x31rmwc75t7m0000gp/T/gt4py_session_j2sksukj/temporary_fields_for_turbulence_diagnostics_b33111c9ad98f7f80e665d9dd613c7639b719e0e6e7b933278775078ee836dd0/src/cpu/temporary_fields_for_turbulence_diagnostics.cpp.o
E               In file included from /var/folders/5x/5gbpjy215c1_x31rmwc75t7m0000gp/T/gt4py_session_j2sksukj/temporary_fields_for_turbulence_diagnostics_b33111c9ad98f7f80e665d9dd613c7639b719e0e6e7b933278775078ee836dd0/src/cpu/temporary_fields_for_turbulence_diagnostics.cpp:2:
E               In file included from /Users/ioannmag/cscs_repos/cycle28/icon4py/.venv/lib/python3.10/site-packages/dace/codegen/../runtime/include/dace/dace.h:20:
E               /Users/ioannmag/cscs_repos/cycle28/icon4py/.venv/lib/python3.10/site-packages/dace/codegen/../runtime/include/dace/reduction.h:535:44: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
E                 535 |             return wcr_custom<T>::template reduce_atomic(
E                     |                                            ^
E               1 error generated.
E               make[2]: *** [CMakeFiles/temporary_fields_for_turbulence_diagnostics.dir/var/folders/5x/5gbpjy215c1_x31rmwc75t7m0000gp/T/gt4py_session_j2sksukj/temporary_fields_for_turbulence_diagnostics_b33111c9ad98f7f80e665d9dd613c7639b719e0e6e7b933278775078ee836dd0/src/cpu/temporary_fields_for_turbulence_diagnostics.cpp.o] Error 1
E               make[1]: *** [CMakeFiles/temporary_fields_for_turbulence_diagnostics.dir/all] Error 2
E               make: *** [all] Error 2
```