### PR TITLE
Add NVTX range in CUDA GPU kernel call of program

### DIFF
--- a/dace/codegen/CMakeLists.txt
+++ b/dace/codegen/CMakeLists.txt
@@ -141,7 +141,7 @@ if(DACE_ENABLE_CUDA)
 
   set(CMAKE_CUDA_ARCHITECTURES "${LOCAL_CUDA_ARCHITECTURES}")
   enable_language(CUDA)
-  list(APPEND DACE_LIBS CUDA::cudart)
+  list(APPEND DACE_LIBS CUDA::cudart CUDA::nvtx3)
   add_definitions(-DWITH_CUDA)
 
   if (MSVC_IDE)

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -140,6 +140,8 @@ class DaCeCodeGenerator(object):
         if backend == 'frame':
             global_stream.write('#include "../../include/hash.h"\n', sdfg)
 
+        global_stream.write('#ifdef WITH_CUDA\n#include <nvtx3/nvToolsExt.h>\n#endif\n', sdfg)
+
         #########################################################
         # Environment-based includes
         for env in self.environments:
@@ -266,7 +268,13 @@ struct {mangle_dace_state_struct_name(sdfg)} {{
             f'''
 DACE_EXPORTED void __program_{fname}({mangle_dace_state_struct_name(fname)} *__state{params_comma})
 {{
+    #ifdef WITH_CUDA
+    nvtxRangePushA("{fname}");
+    #endif
     __program_{fname}_internal(__state{paramnames_comma});
+    #ifdef WITH_CUDA
+    nvtxRangePop();
+    #endif
 }}''', sdfg)
 
         for target in self._dispatcher.used_targets:


### PR DESCRIPTION
This changes were made by [Ioannis Magkanaris](https://github.com/iomaganaris), I only opened the PR.
It adds NVTX ranges around the kernel call generated by DaCe, this allows to easily distinguish it from other CUDA activity such as CuPy.
