### PR TITLE
Updated `MapFusion`

### DIFF
--- a/tests/transformations/mapfusion_test.py
+++ b/tests/transformations/mapfusion_test.py
@@ -19,7 +19,7 @@ def count_nodes(
     node_type: Union[Tuple[Type, ...], Type],
     return_nodes: bool = False,
 ) -> Union[int, List[nodes.Node]]:
-    """Counts the number of nodes in of a particular type in `graph`.
+    """Counts the number of nodes of a particular type in `graph`.
 
     If `graph` is an SDFGState then only count the nodes inside this state,
     but if `graph` is an SDFG count in all states.

--- a/tests/transformations/mapfusion_test.py
+++ b/tests/transformations/mapfusion_test.py
@@ -30,7 +30,7 @@ def count_nodes(
     """
 
     states = graph.states() if isinstance(graph, dace.SDFG) else [graph]
-    found_nodes: list[dace_nodes.Node] = []
+    found_nodes: list[nodes.Node] = []
     for state_nodes in states:
         for node in state_nodes.nodes():
             if isinstance(node, node_type):

--- a/tests/transformations/mapfusion_test.py
+++ b/tests/transformations/mapfusion_test.py
@@ -2086,7 +2086,7 @@ def _make_reuse_connector() -> Tuple[SDFG, SDFGState]:
         },
         code="__out = __in1 + __in2",
         outputs={"__out": dace.Memlet("b[__i]")},
-        output_nodes={t},
+        input_nodes={t},
         external_edges=True,
     )
     sdfg.validate()
@@ -2114,7 +2114,7 @@ def test_reuse_connector():
     assert count_nodes(sdfg, nodes.MapEntry) == 1
     ac_nodes = count_nodes(sdfg, nodes.AccessNode, return_nodes=True)
     assert len(ac_nodes) == 3
-    assert len([ac for ac in ac_nodes_before if ac.data == "a"]) == 1
+    assert len([ac for ac in ac_nodes if ac.data == "a"]) == 1
 
     run_sdfg(sdfg, **res)
 
@@ -2122,7 +2122,6 @@ def test_reuse_connector():
 
 
 if __name__ == '__main__':
-    """
     test_fusion_intrinsic_memlet_direction()
     test_fusion_dynamic_producer()
     test_fusion_different_global_accesses()
@@ -2156,6 +2155,5 @@ if __name__ == '__main__':
     test_inner_map_dependency()
     test_inner_map_dependency_resolved()
     test_possible_cycle_if_fuesed_sdfg()
-    """
     test_multi_producer_sdfg()
     test_reuse_connector()


### PR DESCRIPTION
This PR adds two new functionalities to `MapFusion`.
Until now it was only possible to fuse two Maps if the intermediate node has a single producer (the top Map).
But this is not strictly required, it can have as multiple producer, the important thing is that the second Map only consumes data that have been written by the first Map.

The second functionality, is actually a fix.
Consider the following situation:
```python
for i in range(10):
    tmp[i] = a[i] + 10
for i in range(10):
    b[i] = tmp[i] * a[i]
```
Both the first and second Map have an input edge from an AccessNode referring to `a`.
There was a functionality that was supposed to remove the edge going to the second map, i.e. reuse the edge that was going to the first map.
However, this was not properly working and this is fixed.
Note that it is not done for the outputs, i.e. if both Map would write to the same data then the new combined Map would have to outgoing edges to that data.
The reason for this is because it would need a special case, furthermore, this is a rare case.
Furthermore, there was an error regarding the handling of nested Maps.
A test for that will be added in the [parallel Map fusion PR](https://github.com/spcl/dace/pull/1987).
