### PR TITLE
Updated the validation regarding `other_subset`

### DIFF
--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -751,11 +751,7 @@ def validate_state(state: 'dace.sdfg.SDFGState',
                 if e.data.subset.dims() != len(arr.shape):
                     raise InvalidSDFGEdgeError(
                         "Memlet subset does not match node dimension "
-                        "(expected %d, got %d)" % (len(arr.shape), e.data.subset.dims()),
-                        sdfg,
-                        state_id,
-                        eid,
-                    )
+                        "(expected %d, got %d)" % (len(arr.shape), e.data.subset.dims()), sdfg, state_id, eid)
 
                 # Bounds
                 if any(((minel + off) < 0) == True for minel, off in zip(e.data.subset.min_element(), arr.offset)):
@@ -778,24 +774,21 @@ def validate_state(state: 'dace.sdfg.SDFGState',
                 if e.data.other_subset.dims() != len(arr.shape):
                     raise InvalidSDFGEdgeError(
                         "Memlet other_subset does not match node dimension "
-                        "(expected %d, got %d)" % (len(arr.shape), e.data.other_subset.dims()),
-                        sdfg,
-                        state_id,
-                        eid,
-                    )
+                        "(expected %d, got %d)" % (len(arr.shape), e.data.other_subset.dims()), sdfg, state_id, eid)
 
                 # Bounds
                 if any(
                     ((minel + off) < 0) == True for minel, off in zip(e.data.other_subset.min_element(), arr.offset)):
-                    raise InvalidSDFGEdgeError(
-                        "Memlet other_subset negative out-of-bounds",
-                        sdfg,
-                        state_id,
-                        eid,
-                    )
+                    if e.data.dynamic:
+                        warnings.warn(f'Potential negative out-of-bounds memlet other_subset: {e}')
+                    else:
+                        raise InvalidSDFGEdgeError("Memlet other_subset negative out-of-bounds", sdfg, state_id, eid)
                 if any(((maxel + off) >= s) == True
                        for maxel, s, off in zip(e.data.other_subset.max_element(), arr.shape, arr.offset)):
-                    raise InvalidSDFGEdgeError("Memlet other_subset out-of-bounds", sdfg, state_id, eid)
+                    if e.data.dynamic:
+                        warnings.warn(f'Potential out-of-bounds memlet other_subset: {e}')
+                    else:
+                        raise InvalidSDFGEdgeError("Memlet other_subset out-of-bounds", sdfg, state_id, eid)
 
             # Test subset and other_subset for undefined symbols
             if Config.get_bool('experimental', 'validate_undefs'):


### PR DESCRIPTION
If the validation founds an out of bound access for in the subset of a Memlet that is marked as `dynamic` it will only output a warning. If it however, finds this oob behaviour in `other_subset` it will generate an hard error.

This commit changes this behaviour such that also for `other_subset` only a warning is generated, makes them more uniform.