### PR TITLE
GPU Codegen Expansion of Empty Memlets

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -157,7 +157,7 @@ class CUDACodeGen(TargetCodeGenerator):
         # Find GPU<->GPU strided copies that cannot be represented by a single copy command
         from dace.transformation.dataflow import CopyToMap
         for e, state in list(sdfg.all_edges_recursive()):
-            if (not e.data.is_empty()) and isinstance(e.src, nodes.AccessNode) and isinstance(e.dst, nodes.AccessNode):
+            if isinstance(e.src, nodes.AccessNode) and isinstance(e.dst, nodes.AccessNode) and (not e.data.is_empty()):
                 nsdfg = state.parent
                 if (e.src.desc(nsdfg).storage == dtypes.StorageType.GPU_Global
                         and e.dst.desc(nsdfg).storage == dtypes.StorageType.GPU_Global):

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -157,7 +157,7 @@ class CUDACodeGen(TargetCodeGenerator):
         # Find GPU<->GPU strided copies that cannot be represented by a single copy command
         from dace.transformation.dataflow import CopyToMap
         for e, state in list(sdfg.all_edges_recursive()):
-            if isinstance(e.src, nodes.AccessNode) and isinstance(e.dst, nodes.AccessNode):
+            if (not e.data.is_empty()) and isinstance(e.src, nodes.AccessNode) and isinstance(e.dst, nodes.AccessNode):
                 nsdfg = state.parent
                 if (e.src.desc(nsdfg).storage == dtypes.StorageType.GPU_Global
                         and e.dst.desc(nsdfg).storage == dtypes.StorageType.GPU_Global):


### PR DESCRIPTION
Memlets that the GPU code generator can not be expressed as a `cudaMemcpy*()` call are turned into Maps.
However, there was an issue because codegen did not make sure that an Memlet it wants to promote is empty.
So it accessed the subsets of an empty Memlets, which are `None` and hits an error.