### PR TITLE
Backport: Memlet propagation: return set - as promised

### DIFF
--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1497,11 +1497,11 @@ def propagate_subset(memlets: List[Memlet],
     return new_memlet
 
 
-def _freesyms(expr):
-    """ 
+def _freesyms(expr) -> Set:
+    """
     Helper function that either returns free symbols for sympy expressions
     or an empty set if constant.
     """
     if isinstance(expr, sympy.Basic):
         return expr.free_symbols
-    return {}
+    return set()


### PR DESCRIPTION
The function is supposed to return an empty set, but instead returned an empty dict. Now it returns a set as promised. Added a return type such that mypy would complain.

This is a backport of https://github.com/spcl/dace/pull/2007 to `v1/maintenance`.