### PR TITLE
Positional Arguments for `CompiledSDFG` Restored From Cache

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -210,6 +210,10 @@ class CompiledSDFG(object):
         self._free_symbols = self._sdfg.free_symbols
         self.argnames = argnames
 
+        if self.argnames is None and len(sdfg.arg_names) != 0:
+            warnings.warn('You passed `None` as `argnames` to `CompiledSDFG`, but the SDFG you passed has positional'
+                          ' arguments. This is allowed but deprecated.')
+
         self.has_gpu_code = False
         self.external_memory_types = set()
         for _, _, aval in self._sdfg.arrays_recursive():

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -394,7 +394,7 @@ def load_from_file(sdfg, binary_filename):
     lib = csd.ReloadableDLL(binary_filename, sdfg.name)
 
     # Load and return the compiled function
-    return csd.CompiledSDFG(sdfg, lib)
+    return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
 
 
 def get_binary_name(object_folder, object_name, lib_extension=Config.get('compiler', 'library_extension')):


### PR DESCRIPTION
When the `load_from_file()` function, which is used to load an SDFG from the cache, then it did not specify the `argnames` argument of `CompiledSDFG`'s constructor, with the effect that the `CompiledSDFG` would not accept any positional arguments, although they where specified and `sdfg._recompile = True; csdfg = sdfg.compile()` would accept them.

This PR also adds a warning if a `CompiledSDFG` was constructed this way, but it is not an error, for backward compatibility reasons.
