### PR TITLE
F2dace/static parse fix

### DIFF
--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3138,10 +3138,7 @@ def const_eval_nodes(ast: Program) -> Program:
         assert not np.isnan(val)
         val = numpy_type_to_literal(val)
         if val.tostr().startswith('-'):
-            par = object.__new__(Parenthesis)
-            par.string = f'({val})'
-            par.init('(', val, ')')
-            val = par
+            val = Parenthesis(f'({val})')
         replace_node(n, val)
         return True
 

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3138,7 +3138,10 @@ def const_eval_nodes(ast: Program) -> Program:
         assert not np.isnan(val)
         val = numpy_type_to_literal(val)
         if val.tostr().startswith('-'):
-            val = Parenthesis(f"({val})")
+            par = object.__new__(Parenthesis)
+            par.string = f'({val})'
+            par.init('(', val, ')')
+            val = par
         replace_node(n, val)
         return True
 

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3137,6 +3137,8 @@ def const_eval_nodes(ast: Program) -> Program:
             return False
         assert not np.isnan(val)
         val = numpy_type_to_literal(val)
+        if val.tostr().startswith('-'):
+            val = Parenthesis(f"({val})")
         replace_node(n, val)
         return True
 

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1747,8 +1747,8 @@ MODULE main
     IMPLICIT NONE
     REAL :: res1, res2, res3, unk
     REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
-    res1 = unk ** (-7.0)
-    res2 = unk ** (-4.0)
+    res1 = unk ** (- 7.0)
+    res2 = unk ** (- 4.0)
     res3 = unk ** 3.0
   END SUBROUTINE foo
 END MODULE main

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1712,6 +1712,50 @@ END SUBROUTINE main
     assert got == want
     SourceCodeBuilder().add_file(got).check_with_gfortran()
 
+def test_constant_expression_replacement():
+    sources, main = SourceCodeBuilder().add_file("""
+module main
+  implicit none
+  private
+  real, parameter :: &
+    three = 3.0
+contains
+  subroutine foo
+    implicit none
+    real :: res1, res2, res3, unk
+    real, parameter :: &
+        x = -(three + 4.0), &
+        y = -4.0, &
+        z = 3.0
+    res1 = unk ** x
+    res2 = unk ** y
+    res3 = unk ** z
+  end subroutine foo
+end module main
+""").check_with_gfortran().get()
+    ast = parse_and_improve(sources)
+    ast = const_eval_nodes(ast)
+
+    got = ast.tofortran()
+    want = """
+MODULE main
+  IMPLICIT NONE
+  PRIVATE
+  REAL, PARAMETER :: three = 3.0
+  CONTAINS
+  SUBROUTINE foo
+    IMPLICIT NONE
+    REAL :: res1, res2, res3, unk
+    REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
+    res1 = unk ** (- 7.0)
+    res2 = unk ** (- 4.0)
+    res3 = unk ** 3.0
+  END SUBROUTINE foo
+END MODULE main
+""".strip()
+    assert got == want
+    SourceCodeBuilder().add_file(got).check_with_gfortran()
+
 
 def test_constant_resolving_non_expressions():
     sources, main = SourceCodeBuilder().add_file("""

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1747,8 +1747,8 @@ MODULE main
     IMPLICIT NONE
     REAL :: res1, res2, res3, unk
     REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
-    res1 = unk ** (- 7.0)
-    res2 = unk ** (- 4.0)
+    res1 = unk ** (-7.0)
+    res2 = unk ** (-4.0)
     res3 = unk ** 3.0
   END SUBROUTINE foo
 END MODULE main


### PR DESCRIPTION
Fix 'Could not parse...' error caused by substitution of constant variables with expressions preceded by a unary negation operator `-` in `ast_desugaring.py`. This is done by inserting an `fparser.two.Fortran2003.Parenthesis` object in the AST to wrap the offending constant expression in parentheses.