### PR TITLE
The `temporary_config` Contextmanager Uses an Anyonymous File

### DIFF
--- a/dace/config.py
+++ b/dace/config.py
@@ -40,7 +40,7 @@ def temporary_config():
             Config.set("optimizer", "autooptimize", value=True)
             foo()
     """
-    with tempfile.NamedTemporaryFile(mode='w+t') as fp:
+    with tempfile.TemporaryFile(mode='w+t') as fp:
         Config.save(file=fp)
         yield
         fp.seek(0)  # rewind to the beginning of the file.


### PR DESCRIPTION
The context manager stores its current configuration inside a file.
However, because it has a name it might be influenced from the outside.
Switching to an unnamed file reduces this possibility.
