### PR TITLE
Fixed Temorary Config Conext Manager

### DIFF
--- a/dace/config.py
+++ b/dace/config.py
@@ -24,8 +24,10 @@ def set_temporary(*path, value):
     """
     old_value = Config.get(*path)
     Config.set(*path, value=value)
-    yield
-    Config.set(*path, value=old_value)
+    try:
+        yield Config
+    finally:
+        Config.set(*path, value=old_value)
 
 
 @contextlib.contextmanager
@@ -42,9 +44,11 @@ def temporary_config():
     """
     with tempfile.NamedTemporaryFile(mode='w+t') as fp:
         Config.save(file=fp)
-        yield
-        fp.seek(0)  # rewind to the beginning of the file.
-        Config.load(file=fp)
+        try:
+            yield Config
+        finally:
+            fp.seek(0)  # rewind to the beginning of the file.
+            Config.load(file=fp)
 
 
 def _env2bool(envval):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -19,6 +19,51 @@ def test_temporary_config():
     assert Config.get(*path) == current_value
 
 
+def test_temporary_config_exception():
+    path = ["compiler", "build_type"]
+    initial_value = Config.get(*path)
+    new_value = initial_value + "_non_existing"
+    assert initial_value != new_value
+
+    try:
+        with temporary_config():
+            Config.set(*path, value=new_value)
+            assert Config.get(*path) == new_value
+            raise ValueError()
+    except ValueError:
+        assert Config.get(*path) == initial_value
+
+    except:
+        # Unknown exception type was raised.
+        raise
+
+    else:
+        raise RuntimeError("No exception was raised.")
+
+
+def test_set_temporary_exception():
+    path = ["compiler", "build_type"]
+    initial_value = Config.get(*path)
+    new_value = initial_value + "_non_existing"
+    assert initial_value != new_value
+
+    try:
+        with set_temporary(*path, value=new_value):
+            assert Config.get(*path) == new_value
+            raise ValueError()
+    except ValueError:
+        assert Config.get(*path) == initial_value
+
+    except:
+        # Unknown exception type was raised.
+        raise
+
+    else:
+        raise RuntimeError("No exception was raised.")
+
+
 if __name__ == '__main__':
     test_set_temporary()
     test_temporary_config()
+    test_temporary_config_exception()
+    test_set_temporary_exception()


### PR DESCRIPTION
The two context managers for temporary configuration contexts, i.e. `set_temporary()` and `temporary_config()`, contained a bug.
If the context, i.e. the `with`-clause, was left through an exception then the old configuration state was not restored.
This could lead to the leaking of configuration options.