### PR TITLE
F2dace/func type fix

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -781,14 +781,15 @@ class InternalFortranAst:
         args = get_child(children, ast_internal_classes.Arg_List_Node)
         prefix = get_child(children, ast_internal_classes.Prefix_Node)
 
-        type, elemental = (prefix.type, prefix.elemental) if prefix else ('VOID', False)
+        ftype, elemental = (prefix.type.upper(), prefix.elemental) if prefix else ('VOID', False)
         if prefix is not None and prefix.recursive:
             print("recursive found " + name.name)
 
         ret = get_child(children, ast_internal_classes.Suffix_Node)
         ret_args = args.args if args else []
         return ast_internal_classes.Function_Stmt_Node(
-            name=name, args=ret_args, line_number=get_line(node), ret=ret, elemental=elemental, type=ret)
+            name=name, args=ret_args, line_number=get_line(node), ret=ret, elemental=elemental,
+            type=ret if ret else ftype)
 
     def subroutine_stmt(self, node: FASTNode):
         # print(self.name_list)


### PR DESCRIPTION
Fix type inference for functions that are part of an expression where the return type cannot be deduced trivially.

For `foo() + 3`, type inference works even if the type of foo() is unknown or `void` because the hierarchically "maximum" type is automatically deduced.

However, type inference fails for expressions like `foo() ** 3` if the type of `foo()` is unknown because the `**` operation is handled by the intrinsic function `__POW_()`. Thus the type of `foo()` must be known at this point.

The fix consists of two parts: First, the type is attached to the function declaration in `ast_components.py::function_stmt`. Second, the type is retrieved from a list of function declarations in `ast_transforms.py::Call_Extractor`, which transforms each function call into a subroutine call+temporary variable.