### PR TITLE
F2dace/case global var fix

### DIFF
--- a/dace/frontend/fortran/ast_components.py
+++ b/dace/frontend/fortran/ast_components.py
@@ -781,14 +781,15 @@ class InternalFortranAst:
         args = get_child(children, ast_internal_classes.Arg_List_Node)
         prefix = get_child(children, ast_internal_classes.Prefix_Node)
 
-        type, elemental = (prefix.type, prefix.elemental) if prefix else ('VOID', False)
+        ftype, elemental = (prefix.type.upper(), prefix.elemental) if prefix else ('VOID', False)
         if prefix is not None and prefix.recursive:
             print("recursive found " + name.name)
 
         ret = get_child(children, ast_internal_classes.Suffix_Node)
         ret_args = args.args if args else []
         return ast_internal_classes.Function_Stmt_Node(
-            name=name, args=ret_args, line_number=get_line(node), ret=ret, elemental=elemental, type=ret)
+            name=name, args=ret_args, line_number=get_line(node), ret=ret, elemental=elemental,
+            type=ret if ret else ftype)
 
     def subroutine_stmt(self, node: FASTNode):
         # print(self.name_list)

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3138,10 +3138,7 @@ def const_eval_nodes(ast: Program) -> Program:
         assert not np.isnan(val)
         val = numpy_type_to_literal(val)
         if val.tostr().startswith('-'):
-            par = object.__new__(Parenthesis)
-            par.string = f'({val})'
-            par.init('(', val, ')')
-            val = par
+            val = Parenthesis(f'({val})')
         replace_node(n, val)
         return True
 

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -522,14 +522,43 @@ BINARY_OPS = {
     '/': _cdiv,
     '.OR.': np.logical_or,
     '.AND.': np.logical_and,
+    '.XOR.': np.logical_xor,
     '**': operator.pow,
 }
 
-TRIG_FNS = {
-    'ATAN': np.arctan,
-    'ASIN': np.arcsin,
+# TODO: Bessel, Complex constructors, DiM, ErF, ErFC
+INTR_FNS = {
+    'ABS': np.fabs,
     'ACOS': np.arccos,
+    'AIMAG': np.imag,
+    'AINT': np.trunc,
+    'AND': np.logical_and,
+    'ANINT': np.round,
+    'ASIN': np.arcsin,
+    'ATAN': np.arctan,
     'ATAN2': np.arctan2,
+    'CONJ': np.conj,
+    'COS': np.cos,
+    'COSH': np.cosh,
+    'EXP': np.exp,
+    'IMAG': np.imag,
+    'IMAGPART': np.imag,
+    'LOG': np.log,
+    'LOG10': np.log10,
+    'MAX': np.max,
+    'MIN': np.min,
+    'MOD': np.fmod,
+    'NOT': np.logical_not,
+    'OR': np.logical_or,
+    'REAL': np.real,
+    'REALPART': np.real,
+    'SIGN': np.copysign,
+    'SIN': np.sin,
+    'SINH': np.sinh,
+    'SQRT': np.sqrt,
+    'TAN': np.tan,
+    'TANH': np.tanh,
+    'XOR': np.logical_xor,
 }
 
 NUMPY_INTS_TYPES = Union[np.int8, np.int16, np.int32, np.int64]
@@ -657,7 +686,7 @@ def _const_eval_basic_type(expr: Base, alias_map: SPEC_TABLE) -> Optional[NUMPY_
             a = _const_eval_basic_type(a, alias_map)
             if isinstance(a, (np.float32, np.float64)):
                 return type(a)(sys.float_info.epsilon)
-        elif intr.string in TRIG_FNS:
+        elif intr.string in INTR_FNS:
             avals = tuple(_const_eval_basic_type(a, alias_map) for a in args)
             if all(isinstance(a, (np.float32, np.float64)) for a in avals):
                 return np.arctan(*avals)

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3138,7 +3138,10 @@ def const_eval_nodes(ast: Program) -> Program:
         assert not np.isnan(val)
         val = numpy_type_to_literal(val)
         if val.tostr().startswith('-'):
-            val = Parenthesis(f"({val})")
+            par = object.__new__(Parenthesis)
+            par.string = f'({val})'
+            par.init('(', val, ')')
+            val = par
         replace_node(n, val)
         return True
 

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -29,7 +29,7 @@ from fparser.two.Fortran2003 import Program_Stmt, Module_Stmt, Function_Stmt, Su
     Deallocate_Stmt, Close_Stmt, Goto_Stmt, Continue_Stmt, Format_Stmt, Stmt_Function_Stmt, Internal_Subprogram_Part, \
     Private_Components_Stmt, Generic_Spec, Language_Binding_Spec, Type_Attr_Spec, Suffix, Proc_Component_Def_Stmt, \
     Proc_Decl, End_Type_Stmt, End_Interface_Stmt, Procedure_Declaration_Stmt, Pointer_Assignment_Stmt, Cycle_Stmt, \
-    Equiv_Operand
+    Equiv_Operand, Case_Value_Range_List
 from fparser.two.Fortran2008 import Procedure_Stmt, Type_Declaration_Stmt, Error_Stop_Stmt
 from fparser.two.utils import Base, walk, BinaryOpBase, UnaryOpBase, NumberBase, BlockBase
 
@@ -3175,6 +3175,16 @@ def const_eval_nodes(ast: Program) -> Program:
         lv, op, rv = asgn.children
         assert op == '='
         _const_eval_node(rv)
+    for rngl in reversed(walk(ast, Case_Value_Range_List)):
+        rng = len(rngl.children)
+        assert rng <= 2
+        # We currently do not yet support two children in Case_Value_Range,
+        # but this implementation should be future-proof.
+        for v in rngl.children:
+            if _const_eval_node(v):
+                continue
+            for nm in reversed(walk(rngl, Name)):
+                _const_eval_node(nm)
     for expr in reversed(walk(ast, EXPRESSION_CLASSES)):
         # Try to const-eval the expression.
         if _const_eval_node(expr):

--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -3137,6 +3137,8 @@ def const_eval_nodes(ast: Program) -> Program:
             return False
         assert not np.isnan(val)
         val = numpy_type_to_literal(val)
+        if val.tostr().startswith('-'):
+            val = Parenthesis(f"({val})")
         replace_node(n, val)
         return True
 

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -914,13 +914,14 @@ class FunctionToSubroutineDefiner(NodeTransformer):
                         if k.name == ret.name:
                             j.vardecl[j.vardecl.index(k)].name = ret_name
                             found = True
+                            break
                     if k.name == node.name.name:
                         j.vardecl[j.vardecl.index(k)].name = ret_name
                         found = True
                         break
 
         if not found:
-            var = ast_internal_classes.Var_Decl_Node(name=ret_name, type='VOID')
+            var = ast_internal_classes.Var_Decl_Node(name=ret_name, type=node.type if node.type else 'VOID')
             stmt_node = ast_internal_classes.Decl_Stmt_Node(vardecl=[var], line_number=node.line_number)
 
             if node.specification_part is not None:
@@ -944,6 +945,7 @@ class FunctionToSubroutineDefiner(NodeTransformer):
         return ast_internal_classes.Subroutine_Subprogram_Node(
             name=ast_internal_classes.Name_Node(name=subr_name, type=node.type),
             args=args,
+            type=node.type,
             specification_part=node.specification_part,
             execution_part=execution_part,
             internal_subprogram_part=node.internal_subprogram_part,
@@ -1006,6 +1008,11 @@ class CallExtractor(NodeTransformer):
     def __init__(self, ast, count=0):
         self.count = count
 
+        self.functions_by_name: Dict[str, ast_internal_classes.Subroutine_Subprogram_Node] = {
+            f.name.name: f for f in mywalk(
+                ast, (ast_internal_classes.Subroutine_Subprogram_Node,
+                      ast_internal_classes.Function_Subprogram_Node))}
+
         ParentScopeAssigner().visit(ast)
 
     def visit_Call_Expr_Node(self, node: ast_internal_classes.Call_Expr_Node):
@@ -1027,7 +1034,11 @@ class CallExtractor(NodeTransformer):
         #    # Ensure we allow to extract function calls from arguments
         #    node.args[i] = self.visit(arg)
 
-        return ast_internal_classes.Name_Node(name="tmp_call_" + str(tmp - 1))
+        ftype = 'VOID'
+        if node.name.name in self.functions_by_name:
+            fn = self.functions_by_name[node.name.name]
+            ftype = fn.type
+        return ast_internal_classes.Name_Node(name="tmp_call_" + str(tmp - 1), type=ftype)
 
     def visit_Execution_Part_Node(self, node: ast_internal_classes.Execution_Part_Node):
 
@@ -1049,6 +1060,9 @@ class CallExtractor(NodeTransformer):
                     # We go in reverse order, counting from end-1 to 0.
                     temp = self.count + len(res) - 1
                     for i in reversed(range(0, len(res))):
+                        if res[i].type == 'VOID' and res[i].name.name in self.functions_by_name:
+                            fn = self.functions_by_name[res[i].name.name]
+                            res[i].type = fn.type
                         node.parent.specification_part.specifications.append(
                             ast_internal_classes.Decl_Stmt_Node(vardecl=[
                                 ast_internal_classes.Var_Decl_Node(
@@ -2320,6 +2334,8 @@ class TypeInference(NodeTransformer):
         self.assert_voids = assert_voids
 
         self.ast = ast
+        self.functions_by_name: Dict[str, ast_internal_classes.Subroutine_Subprogram_Node] = {
+            f.name.name: f for f in mywalk(ast, ast_internal_classes.Subroutine_Subprogram_Node)}
         if assign_scopes:
             ParentScopeAssigner().visit(ast)
         # if scope_vars is None:
@@ -2606,6 +2622,11 @@ class TypeInference(NodeTransformer):
 
         if return_type != 'VOID':
             node.type = return_type
+        # Not sure if this is even needed as we need type inference for
+        # __POW_ and other intrinsics
+        elif node.name.name in self.functions_by_name:
+            fn = self.functions_by_name[node.name.name]
+            node.type = fn.type
 
         return node
 

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -921,7 +921,7 @@ class FunctionToSubroutineDefiner(NodeTransformer):
                         break
 
         if not found:
-            var = ast_internal_classes.Var_Decl_Node(name=ret_name, type=node.type if node.type else 'VOID')
+            var = ast_internal_classes.Var_Decl_Node(name=ret_name, type='VOID')
             stmt_node = ast_internal_classes.Decl_Stmt_Node(vardecl=[var], line_number=node.line_number)
 
             if node.specification_part is not None:
@@ -945,7 +945,6 @@ class FunctionToSubroutineDefiner(NodeTransformer):
         return ast_internal_classes.Subroutine_Subprogram_Node(
             name=ast_internal_classes.Name_Node(name=subr_name, type=node.type),
             args=args,
-            type=node.type,
             specification_part=node.specification_part,
             execution_part=execution_part,
             internal_subprogram_part=node.internal_subprogram_part,
@@ -1034,11 +1033,7 @@ class CallExtractor(NodeTransformer):
         #    # Ensure we allow to extract function calls from arguments
         #    node.args[i] = self.visit(arg)
 
-        ftype = 'VOID'
-        if node.name.name in self.functions_by_name:
-            fn = self.functions_by_name[node.name.name]
-            ftype = fn.type
-        return ast_internal_classes.Name_Node(name="tmp_call_" + str(tmp - 1), type=ftype)
+        return ast_internal_classes.Name_Node(name="tmp_call_" + str(tmp - 1))
 
     def visit_Execution_Part_Node(self, node: ast_internal_classes.Execution_Part_Node):
 
@@ -2334,8 +2329,6 @@ class TypeInference(NodeTransformer):
         self.assert_voids = assert_voids
 
         self.ast = ast
-        self.functions_by_name: Dict[str, ast_internal_classes.Subroutine_Subprogram_Node] = {
-            f.name.name: f for f in mywalk(ast, ast_internal_classes.Subroutine_Subprogram_Node)}
         if assign_scopes:
             ParentScopeAssigner().visit(ast)
         # if scope_vars is None:
@@ -2622,11 +2615,6 @@ class TypeInference(NodeTransformer):
 
         if return_type != 'VOID':
             node.type = return_type
-        # Not sure if this is even needed as we need type inference for
-        # __POW_ and other intrinsics
-        elif node.name.name in self.functions_by_name:
-            fn = self.functions_by_name[node.name.name]
-            node.type = fn.type
 
         return node
 

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1747,8 +1747,8 @@ MODULE main
     IMPLICIT NONE
     REAL :: res1, res2, res3, unk
     REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
-    res1 = unk ** (-7.0)
-    res2 = unk ** (-4.0)
+    res1 = unk ** (- 7.0)
+    res2 = unk ** (- 4.0)
     res3 = unk ** 3.0
   END SUBROUTINE foo
 END MODULE main

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1712,6 +1712,50 @@ END SUBROUTINE main
     assert got == want
     SourceCodeBuilder().add_file(got).check_with_gfortran()
 
+def test_constant_expression_replacement():
+    sources, main = SourceCodeBuilder().add_file("""
+module main
+  implicit none
+  private
+  real, parameter :: &
+    three = 3.0
+contains
+  subroutine foo
+    implicit none
+    real :: res1, res2, res3, unk
+    real, parameter :: &
+        x = -(three + 4.0), &
+        y = -4.0, &
+        z = 3.0
+    res1 = unk ** x
+    res2 = unk ** y
+    res3 = unk ** z
+  end subroutine foo
+end module main
+""").check_with_gfortran().get()
+    ast = parse_and_improve(sources)
+    ast = const_eval_nodes(ast)
+
+    got = ast.tofortran()
+    want = """
+MODULE main
+  IMPLICIT NONE
+  PRIVATE
+  REAL, PARAMETER :: three = 3.0
+  CONTAINS
+  SUBROUTINE foo
+    IMPLICIT NONE
+    REAL :: res1, res2, res3, unk
+    REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
+    res1 = unk ** (- 7.0)
+    res2 = unk ** (- 4.0)
+    res3 = unk ** 3.0
+  END SUBROUTINE foo
+END MODULE main
+""".strip()
+    assert got == want
+    SourceCodeBuilder().add_file(got).check_with_gfortran()
+
 
 def test_constant_resolving_non_expressions():
     sources, main = SourceCodeBuilder().add_file("""

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1747,8 +1747,8 @@ MODULE main
     IMPLICIT NONE
     REAL :: res1, res2, res3, unk
     REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
-    res1 = unk ** (- 7.0)
-    res2 = unk ** (- 4.0)
+    res1 = unk ** (-7.0)
+    res2 = unk ** (-4.0)
     res3 = unk ** 3.0
   END SUBROUTINE foo
 END MODULE main

--- a/tests/fortran/case_test.py
+++ b/tests/fortran/case_test.py
@@ -1,0 +1,93 @@
+# Copyright 2025 ETH Zurich and the DaCe quthors. All rights reserved.
+
+import numpy as np
+
+from dace.frontend.fortran.fortran_parser import create_singular_sdfg_from_string
+from tests.fortran.fortran_test_helper import SourceCodeBuilder
+import pytest
+
+
+def test_fortran_frontend_case_const():
+    """Tests that the cases statement can use parameters."""
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+  integer, parameter :: a = 1
+
+contains
+  subroutine foo(v)
+    integer, intent(inout) :: v
+
+    ! if (v == a) then
+    !   v = 5
+    ! end if
+
+    select case(v)
+    case(a)
+      v = 5
+    end select
+  end subroutine foo
+end module lib
+
+subroutine main(d)
+  use lib
+  implicit none
+  integer :: d(5, 5)
+  call foo(d(1, 2))
+end subroutine main
+""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main')
+    sdfg.validate()
+    sdfg.simplify(verbose=True)
+    a = np.array([[i + j for i in range(5)] for j in range(5)],
+                 order="F", dtype=np.int32)
+    sdfg(d=a)
+    assert(a[0, 1] == 5)
+
+
+@pytest.mark.skip("Fails because range statements in case selectors are not supported.")
+def test_fortran_frontend_case_const_range():
+    """Tests that the cases statement can use parameters."""
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+  integer, parameter :: a = 1
+  integer, parameter :: b = 2
+  integer, parameter :: c = 3
+
+contains
+  subroutine foo(v)
+    integer, intent(inout) :: v
+
+    ! if (v == a) then
+    !   v = 5
+    ! end if
+
+    select case(v)
+    case(b:c)
+      v = 6
+    end select
+  end subroutine foo
+end module lib
+
+subroutine main(d)
+  use lib
+  implicit none
+  integer :: d(5, 5)
+  call foo(d(1, 3))
+  call foo(d(1, 5))
+end subroutine main
+""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, 'main')
+    sdfg.validate()
+    sdfg.simplify(verbose=True)
+    a = np.array([[i + j for i in range(5)] for j in range(5)],
+                 order="F", dtype=np.int32)
+    sdfg(d=a)
+    assert(a[0, 2] == 6)
+    assert(a[0, 4] == 4)
+
+
+if __name__ == "__main__":
+    test_fortran_frontend_case_const()
+    test_fortran_frontend_case_const_range()

--- a/tests/fortran/type_test.py
+++ b/tests/fortran/type_test.py
@@ -564,6 +564,78 @@ end subroutine main
     assert (a[2, 0] == 42)
 
 
+def test_fortran_frontend_func_type_prefix():
+    """
+    Tests that the Fortran frontend can infer the type of a function in a mathematical expression.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+contains
+  real function custom_sum(d)
+    real :: d(5, 5)
+    integer :: i, j
+    do i = 1, 5
+      do j = 1, 5
+        custom_sum = custom_sum + d(i, j)
+      end do
+    end do
+  end function custom_sum
+end module lib
+
+subroutine main(d)
+  use lib
+  implicit none
+  real :: norm
+  real :: d(5, 5)
+  d(1, 1) = custom_sum(d) ** 2.0
+end subroutine main
+""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, entry_point='main')
+    sdfg.validate()
+    sdfg.simplify(verbose=True)
+    a = np.full([5, 5], 1, order="F", dtype=np.float32)
+    sdfg(d=a)
+    assert (a[0, 0] == 625)
+
+
+def test_fortran_frontend_func_type_body():
+    """
+    Tests that the Fortran frontend can infer the type of a function in a mathematical expression.
+    """
+    sources, main = SourceCodeBuilder().add_file("""
+module lib
+  implicit none
+contains
+  function custom_sum(d)
+    real :: custom_sum
+    real :: d(5, 5)
+    integer :: i, j
+    do i = 1, 5
+      do j = 1, 5
+        custom_sum = custom_sum + d(i, j)
+      end do
+    end do
+  end function custom_sum
+end module lib
+
+subroutine main(d)
+  use lib
+  implicit none
+  real :: norm
+  real :: d(5, 5)
+  d(1, 1) = custom_sum(d) ** 2.0
+end subroutine main
+""").check_with_gfortran().get()
+    sdfg = create_singular_sdfg_from_string(sources, entry_point='main')
+    sdfg.validate()
+    sdfg.simplify(verbose=True)
+    a = np.full([5, 5], 1, order="F", dtype=np.float32)
+    sdfg(d=a)
+    assert (a[0, 0] == 625)
+
+
+
 if __name__ == "__main__":
     test_fortran_frontend_basic_type()
     test_fortran_frontend_basic_type2()
@@ -578,3 +650,4 @@ if __name__ == "__main__":
     test_fortran_frontend_type_arg()
     test_fortran_frontend_type_view()
     test_fortran_frontend_type_arg2()
+    test_fortran_frontend_func_type()


### PR DESCRIPTION
Fix const evaluation for CASE statements.

Using a parameter variable in a `Case_Selector` causes a crash because the variable cannot be found during type inference. This fix adds support for CASE statements in `ast_desugaring.py:_const_eval_nodes` to automatically replace parameter variables with integer literals during internal ast transformation.