### PR TITLE
Do Not Merge: Changes to DaCe CUDA compilation flags

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -303,7 +303,7 @@ required:
                         type: str
                         title: nvcc Arguments
                         description: Compiler argument flags for CUDA
-                        default: '-Xcompiler -march=native --use_fast_math -Xcompiler -Wno-unused-parameter'
+                        default: '--generate-line-info -Xcompiler -march=native -Xcompiler -Wno-unused-parameter'
                         default_Windows: '-O3 --use_fast_math'
 
                     hip_args:


### PR DESCRIPTION
Added compilation flag for line info and removed fast_math flag from CUDA compilation flags.

Note:
This PR replaces [PR#2](https://github.com/GridTools/dace/pull/2) that had some conflict with main.