### PR TITLE
Avoid losing symbols in `traverse_sdfg_with_defined_symbols`

### DIFF
--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1564,7 +1564,7 @@ def _tswds_cf_region(
         if edge.src not in visited:
             visited.add(edge.src)
             if isinstance(edge.src, SDFGState):
-                yield from _tswds_state(sdfg, edge.src, {}, recursive)
+                yield from _tswds_state(sdfg, edge.src, symbols, recursive)
             elif isinstance(edge.src, ControlFlowRegion):
                 yield from _tswds_cf_region(sdfg, edge.src, symbols, recursive)
 

--- a/tests/sdfg/utils_test.py
+++ b/tests/sdfg/utils_test.py
@@ -1,0 +1,21 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+
+from dace.sdfg import utils
+
+
+def test_traverse_sdfg_with_defined_symbols():
+    pass
+    sdfg = dace.SDFG("tester")
+    sdfg.add_symbol("my_symbol", dace.int32)
+
+    start = sdfg.add_state("start", is_start_block=True)
+    start.add_tasklet("noop", set(), set(), "")
+    sdfg.add_state_after(start, "next")
+
+    for _state, _node, defined_symbols in utils.traverse_sdfg_with_defined_symbols(sdfg):
+        assert "my_symbol" in defined_symbols
+
+
+if __name__ == "__main":
+    test_traverse_sdfg_with_defined_symbols()


### PR DESCRIPTION
## Description

From what I can tell, `traverse_sdfg_with_defined_symbols()` is supposed to traverse the SDFG, accumulating symbols as it runs down the tree. The current implementation resets the dict of "already known symbols" when recursing down into a state that is the source of an edge. That seems odd. In particular, not even the globally available `sdfg.symbols` are marked as defined anymore with that reset.

The proposed fix passes along already known symbols like in all other cases, ensuring that the dict of known symbols only ever grows.