### PR TITLE
Only report cycles if we found some

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -624,16 +624,16 @@ class DataflowGraphView(BlockGraphView, abc.ABC):
 
             # Sanity checks
             if validate and len(eq) != 0:
-                cycles = self.find_cycles()
+                cycles = list(self.find_cycles())
                 if cycles:
-                    raise ValueError('Found cycles in state %s: %s' % (self.label, list(cycles)))
+                    raise ValueError('Found cycles in state %s: %s' % (self.label, cycles))
                 raise RuntimeError("Leftover nodes in queue: {}".format(eq))
 
             entry_nodes = set(n for n in self.nodes() if isinstance(n, nd.EntryNode)) | {None}
             if (validate and len(result) != len(entry_nodes)):
-                cycles = self.find_cycles()
+                cycles = list(self.find_cycles())
                 if cycles:
-                    raise ValueError('Found cycles in state %s: %s' % (self.label, list(cycles)))
+                    raise ValueError('Found cycles in state %s: %s' % (self.label, cycles))
                 raise RuntimeError("Some nodes were not processed: {}".format(entry_nodes - result.keys()))
 
             # Cache result


### PR DESCRIPTION
## Description

The issue here is that `find_cycles()` returns a generator, which is truthy even if there are no cycle. The proposed solution is to evaluate the generator. That way, if the generated list is empty, it will be falsy and we won't report cycles if there are none. This allows developers to see the other error message, which is currently unreachable.

Same as PR https://github.com/spcl/dace/pull/2055.