### PR TITLE
Avoid losing symbols in `traverse_sdfg_with_defined_symbols()`

### DIFF
--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1582,7 +1582,7 @@ def _tswds_cf_region(
             if edge.src not in visited:
                 visited.add(edge.src)
                 if isinstance(edge.src, SDFGState):
-                    yield from _tswds_state(sdfg, edge.src, {}, recursive)
+                    yield from _tswds_state(sdfg, edge.src, symbols, recursive)
                 elif isinstance(edge.src, AbstractControlFlowRegion):
                     yield from _tswds_cf_region(sdfg, edge.src, symbols, recursive)
 

--- a/tests/sdfg/utils_test.py
+++ b/tests/sdfg/utils_test.py
@@ -5,7 +5,6 @@ from dace.sdfg import utils
 
 
 def test_traverse_sdfg_with_defined_symbols():
-    pass
     sdfg = dace.SDFG("tester")
     sdfg.add_symbol("my_symbol", dace.int32)
 


### PR DESCRIPTION
From what I can tell, `traverse_sdfg_with_defined_symbols()` is supposed to traverse the SDFG, accumulating symbols as it runs down the tree. The current implementation resets the dict of "already known symbols" when recursing down into a state that is the source of an edge. That seems odd. In particular, not even the globally available `sdfg.symbols` are marked as defined anymore with that reset.

The proposed fix passes along already known symbols like in all other cases, ensuring that the dict of known symbols only ever grows.

This is a port from PR https://github.com/spcl/dace/pull/2054 to the mainline branch.