### PR TITLE
Fixed unsafe modification of `ScopeTree.children`

### DIFF
--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1301,15 +1301,18 @@ def scope_tree_recursive(state: SDFGState, entry: Optional[nodes.EntryNode] = No
     # Add nested SDFGs as children
     def traverse(state: SDFGState, treenode: ScopeTree):
         snodes = state.scope_children()[treenode.entry]
+        children_to_inspect = treenode.children.copy()  # Avoid modifying a cached structure.
         for node in snodes:
             if isinstance(node, nodes.NestedSDFG):
                 for nstate in node.sdfg.states():
                     ntree = nstate.scope_tree()[None]
                     ntree.state = nstate
-                    treenode.children.append(ntree)
-        for child in treenode.children:
+                    assert ntree not in children_to_inspect
+                    children_to_inspect.append(ntree)
+
+        for child in children_to_inspect:
             if hasattr(child, 'state') and child.state != state:
-                traverse(getattr(child, 'state', state), child)
+                traverse(child.state, child)
 
     traverse(state, stree)
     return stree


### PR DESCRIPTION
The error occurred with structure such as seen below (although they are inside a Map).


![2025-07-02-151241_1104x827_scrot](https://github.com/user-attachments/assets/fd092cb6-1808-40c8-bd2a-5a35149def2c)

The error was that an element that was in the list before was added again, probably because the thing was not properly separated. 
The underlying issue was that the SDFG could not be compiled, if one would long enough we would get an out of memory error. 

I will try to turn the SDFG below into an error.




