### PR TITLE
F2dace/fix nested sdfg recursive symbols

### DIFF
--- a/dace/frontend/fortran/ast_utils.py
+++ b/dace/frontend/fortran/ast_utils.py
@@ -1,5 +1,5 @@
 # Copyright 2023 ETH Zurich and the DaCe authors. All rights reserved.
-from collections import Counter
+from collections import Counter, defaultdict
 from itertools import chain
 from typing import List, Set, Iterator, Type, TypeVar, Dict, Tuple, Iterable, Union, Optional
 
@@ -133,6 +133,9 @@ class TaskletWriter:
     :param name_mapping: mapping of names in the code to names in the sdfg
     :return: python code for a tasklet, as a string
     """
+
+    # store all tasklets generated for quick retrieval of assignments
+    TASKLETS_CREATED = defaultdict(lambda: defaultdict(Tuple[str, ast_internal_classes.FNode]))
 
     def __init__(self,
                  outputs: List[str],
@@ -420,6 +423,8 @@ class TaskletWriter:
         if op != "=":
             return "(" + left + op + right + ")"
         else:
+            if isinstance(node.lval, ast_internal_classes.Name_Node):
+                TaskletWriter.TASKLETS_CREATED[self.sdfg][node.lval.name] = (right, node.rval)
             return left + op + right
 
 


### PR DESCRIPTION
One more bug in processing complex struct initialization that is taken to the parent SDFG. If this initialization depends on another variable, e.g., `struct[index].value`, then we need to move `index` as well to the global initialization.

This fixes compilation issues in dycore functions.

Depends on #2063.