### PR TITLE
Do not trigger emit copy on out memlets of a tasklet if memlet is none

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1039,8 +1039,8 @@ class CPUCodeGen(TargetCodeGenerator):
             if node == dst_node:
                 continue
 
-            # Tasklet -> array
-            if isinstance(node, nodes.CodeNode):
+            # Tasklet -> array with a memlet. Writing to array is emitted only if the memlet is not empty
+            if isinstance(node, nodes.CodeNode) and not edge.data.is_empty():
                 if not uconn:
                     raise SyntaxError("Cannot copy memlet without a local connector: {} to {}".format(
                         str(edge.src), str(edge.dst)))

--- a/tests/codegen/no_emit_copy_on_empty_memlet_test.py
+++ b/tests/codegen/no_emit_copy_on_empty_memlet_test.py
@@ -1,17 +1,22 @@
 import dace
 import pytest
 
+
 def _gen_sdfg() -> dace.SDFG:
     sdfg = dace.SDFG('test_no_emit_copy_on_empty_memlet')
     state = sdfg.add_state()
 
-
     nameA, arrA = sdfg.add_array('A', [2], dace.float32)
     nameB, arrB = sdfg.add_array('B', [2], dace.float32)
 
-
-    tasklet1 = state.add_tasklet('tasklet1', {}, {}, 'printf("Hello World Before Copy\\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
-    tasklet2 = state.add_tasklet('tasklet2', {}, {}, 'printf("Hello World After Copy\\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
+    tasklet1 = state.add_tasklet('tasklet1', {}, {},
+                                 'printf("Hello World Before Copy\\n");',
+                                 language=dace.Language.CPP,
+                                 code_global="#include <stdio.h>")
+    tasklet2 = state.add_tasklet('tasklet2', {}, {},
+                                 'printf("Hello World After Copy\\n");',
+                                 language=dace.Language.CPP,
+                                 code_global="#include <stdio.h>")
 
     anA = state.add_access(nameA)
     anB = state.add_access(nameB)
@@ -20,6 +25,7 @@ def _gen_sdfg() -> dace.SDFG:
     state.add_edge(anB, None, tasklet2, None, dace.Memlet())
 
     return sdfg
+
 
 def test_no_emit_copy_on_empty_memlet():
     sdfg = _gen_sdfg()

--- a/tests/codegen/no_emit_copy_on_empty_memlet_test.py
+++ b/tests/codegen/no_emit_copy_on_empty_memlet_test.py
@@ -1,0 +1,27 @@
+import dace
+import pytest
+
+def _gen_sdfg() -> dace.SDFG:
+    sdfg = dace.SDFG('test_no_emit_copy_on_empty_memlet')
+    state = sdfg.add_state()
+
+
+    nameA, arrA = sdfg.add_array('A', [2], dace.float32)
+    nameB, arrB = sdfg.add_array('B', [2], dace.float32)
+
+
+    tasklet1 = state.add_tasklet('tasklet1', {}, {}, 'prinf("Hello World Before Copy\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
+    tasklet2 = state.add_tasklet('tasklet2', {}, {}, 'prinf("Hello World After Copy\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
+
+    anA = state.add_access(nameA)
+    anB = state.add_access(nameB)
+    state.add_edge(tasklet1, None, anA, None, dace.Memlet())
+    state.add_edge(anA, None, anB, None, dace.Memlet.from_array(name=nameA, datadesc=sdfg.arrays[nameA]))
+    state.add_edge(anB, None, tasklet2, None, dace.Memlet())
+
+    return sdfg
+
+def test_no_emit_copy_on_empty_memlet():
+    sdfg = _gen_sdfg()
+    sdfg.validate()
+    sdfg.compile()

--- a/tests/codegen/no_emit_copy_on_empty_memlet_test.py
+++ b/tests/codegen/no_emit_copy_on_empty_memlet_test.py
@@ -10,13 +10,13 @@ def _gen_sdfg() -> dace.SDFG:
     nameB, arrB = sdfg.add_array('B', [2], dace.float32)
 
 
-    tasklet1 = state.add_tasklet('tasklet1', {}, {}, 'prinf("Hello World Before Copy\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
-    tasklet2 = state.add_tasklet('tasklet2', {}, {}, 'prinf("Hello World After Copy\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
+    tasklet1 = state.add_tasklet('tasklet1', {}, {}, 'printf("Hello World Before Copy\\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
+    tasklet2 = state.add_tasklet('tasklet2', {}, {}, 'printf("Hello World After Copy\\n");', language=dace.Language.CPP, code_global="#include <stdio.h>")
 
     anA = state.add_access(nameA)
     anB = state.add_access(nameB)
     state.add_edge(tasklet1, None, anA, None, dace.Memlet())
-    state.add_edge(anA, None, anB, None, dace.Memlet.from_array(name=nameA, datadesc=sdfg.arrays[nameA]))
+    state.add_edge(anA, None, anB, None, dace.Memlet.from_array(dataname=nameA, datadesc=sdfg.arrays[nameA]))
     state.add_edge(anB, None, tasklet2, None, dace.Memlet())
 
     return sdfg
@@ -25,3 +25,7 @@ def test_no_emit_copy_on_empty_memlet():
     sdfg = _gen_sdfg()
     sdfg.validate()
     sdfg.compile()
+
+
+if __name__ == "__main__":
+    test_no_emit_copy_on_empty_memlet()


### PR DESCRIPTION
Do not trigger emit copy on out memlets of a tasklet if memlet is none - this prevents from validation to fail because it thinkgs an empty memlet triggers a copy to an access node without a dst conenctor.