### PR TITLE
Fix networkx state space explosion for cycle detection in state propagation

### DIFF
--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -595,8 +595,7 @@ def _annotate_loop_ranges(sdfg, unannotated_cycle_states):
             # This backedge closes a loop that was not annotated, and thus is not a proper for-loop. The states in this
             # cycle are thus unannotated.
             cycle_states = set()
-            cycle_states.add(be.dst)
-            for cycle_state in dfs_conditional(sdfg, [be.dst], lambda p, _: p is not be.src):
+            for cycle_state in dfs_conditional(sdfg, [be.src], lambda p, _: p is not be.dst, reverse=True):
                 cycle_states.add(cycle_state)
             unannotated_cycle_states.append(cycle_states)
 

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 """
 Functionality relating to Memlet propagation (deducing external memlets
 from internal memory accesses and scope ranges).
@@ -571,114 +571,34 @@ def _annotate_loop_ranges(sdfg, unannotated_cycle_states):
     """
 
     # We import here to avoid cyclic imports.
-    from dace.sdfg import utils as sdutils
-    from dace.transformation.interstate.loop_detection import find_for_loop
+    from dace.transformation.passes.pattern_matching import match_patterns
+    from dace.transformation.interstate.loop_detection import LoopRangeAnnotator
+    from dace.sdfg.utils import dfs_conditional
+    from dace.sdfg.analysis import cfg as cfg_analysis
 
     condition_edges = {}
+    loop_back_edges = set()
 
-    for cycle in sdfg.find_cycles():
-        # In each cycle, try to identify a valid loop guard state.
-        guard = None
-        begin = None
-        itvar = None
-        for v in cycle:
-            # Try to identify a valid for-loop guard.
-            in_edges = sdfg.in_edges(v)
-            out_edges = sdfg.out_edges(v)
+    for match in match_patterns(sdfg, LoopRangeAnnotator):
+        annotator: LoopRangeAnnotator = match
+        cond_edge = annotator.loop_condition_edge()
+        guard_state = annotator.loop_guard_state()
+        loop_back_edge = annotator.loop_increment_edge()
+        if cond_edge is not None and guard_state is not None:
+            condition_edges[guard_state] = cond_edge
+        if loop_back_edge is not None:
+            loop_back_edges.add(loop_back_edge)
+        annotator.apply(sdfg, sdfg)
 
-            # A for-loop guard has two or more incoming edges (1 increment and
-            # n init, all identical), and exactly two outgoing edges (loop and
-            # exit loop).
-            if len(in_edges) < 2 or len(out_edges) != 2:
-                continue
-
-            # All incoming guard edges must set exactly one variable and it must
-            # be the same for all of them.
-            itvars = set()
-            for iedge in in_edges:
-                if len(iedge.data.assignments) > 0:
-                    if not itvars:
-                        itvars = set(iedge.data.assignments.keys())
-                    else:
-                        itvars &= set(iedge.data.assignments.keys())
-                else:
-                    itvars = None
-                    break
-            if not itvars or len(itvars) > 1:
-                continue
-            itvar = next(iter(itvars))
-            itvarsym = pystr_to_symbolic(itvar)
-
-            # The outgoing edges must be negations of one another.
-            if out_edges[0].data.condition_sympy() != (sympy.Not(out_edges[1].data.condition_sympy())):
-                continue
-
-            # Make sure the last state of the loop (i.e. the state leading back
-            # to the guard via 'increment' edge) is part of this cycle. If not,
-            # we're looking at the guard for a nested cycle, which we ignore for
-            # this cycle.
-            increment_edge = None
-            for iedge in in_edges:
-                if itvarsym in pystr_to_symbolic(iedge.data.assignments[itvar]).free_symbols:
-                    increment_edge = iedge
-                    break
-            if increment_edge is None:
-                continue
-            if increment_edge.src not in cycle:
-                continue
-
-            # One of the child states must be in the loop (loop begin), and the
-            # other one must be outside the cycle (loop exit).
-            loop_state = None
-            exit_state = None
-            if out_edges[0].dst in cycle and out_edges[1].dst not in cycle:
-                loop_state = out_edges[0].dst
-                exit_state = out_edges[1].dst
-            elif out_edges[1].dst in cycle and out_edges[0].dst not in cycle:
-                loop_state = out_edges[1].dst
-                exit_state = out_edges[0].dst
-            if loop_state is None or exit_state is None:
-                continue
-
-            # This is a valid guard state candidate.
-            guard = v
-            begin = loop_state
-            break
-
-        if guard is not None and begin is not None and itvar is not None:
-            # A guard state was identified, see if it has valid for-loop ranges
-            # and annotate the loop as such.
-
-            # Ensure that this guard's loop wasn't annotated yet.
-            if itvar in begin.ranges:
-                continue
-
-            res = find_for_loop(sdfg, guard, begin, itervar=itvar)
-            if res is None:
-                # No range detected, mark as unbounded.
-                unannotated_cycle_states.append(cycle)
-            else:
-                itervar, rng, _ = res
-
-                # Make sure the range is flipped in a direction such that the
-                # stride is positive (in order to match subsets.Range).
-                start, stop, stride = rng
-                # This inequality needs to be checked exactly like this due to
-                # constraints in sympy/symbolic expressions, do not simplify!!!
-                if (stride < 0) == True:
-                    rng = (stop, start, -stride)
-
-                loop_states = sdutils.dfs_conditional(sdfg, sources=[begin], condition=lambda _, child: child != guard)
-                for v in loop_states:
-                    v.ranges[itervar] = subsets.Range([rng])
-                guard.ranges[itervar] = subsets.Range([rng])
-                condition_edges[guard] = sdfg.edges_between(guard, begin)[0]
-                guard.is_loop_guard = True
-                guard.itvar = itervar
-        else:
-            # There's no guard state, so this cycle marks all states in it as
-            # dynamically unbounded.
-            unannotated_cycle_states.append(cycle)
+    for be in cfg_analysis.back_edges(sdfg):
+        if be not in loop_back_edges:
+            # This backedge closes a loop that was not annotated, and thus is not a proper for-loop. The states in this
+            # cycle are thus unannotated.
+            cycle_states = set()
+            cycle_states.add(be.dst)
+            for cycle_state in dfs_conditional(sdfg, [be.dst], lambda p, _: p is not be.src):
+                cycle_states.add(cycle_state)
+            unannotated_cycle_states.append(cycle_states)
 
     return condition_edges
 

--- a/dace/transformation/interstate/loop_detection.py
+++ b/dace/transformation/interstate/loop_detection.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 """ Loop detection transformation """
 
 import sympy as sp
@@ -8,6 +8,7 @@ from typing import AnyStr, Iterable, Optional, Tuple, List, Set
 from dace import sdfg as sd, symbolic
 from dace.sdfg import graph as gr, utils as sdutil, InterstateEdge
 from dace.sdfg.state import ControlFlowRegion, ControlFlowBlock
+from dace.subsets import Range
 from dace.transformation import transformation
 
 
@@ -17,20 +18,23 @@ class DetectLoop(transformation.PatternTransformation):
     """ Detects a for-loop construct from an SDFG. """
 
     # Always available
-    loop_begin = transformation.PatternNode(sd.SDFGState)
-    exit_state = transformation.PatternNode(sd.SDFGState)
+    loop_begin = transformation.PatternNode(ControlFlowBlock)
+    exit_state = transformation.PatternNode(ControlFlowBlock)
 
     # Available for natural loops
-    loop_guard = transformation.PatternNode(sd.SDFGState)
+    loop_guard = transformation.PatternNode(ControlFlowBlock)
 
     # Available for rotated loops
-    loop_latch = transformation.PatternNode(sd.SDFGState)
+    loop_latch = transformation.PatternNode(ControlFlowBlock)
 
     # Available for rotated and self loops
-    entry_state = transformation.PatternNode(sd.SDFGState)
+    entry_state = transformation.PatternNode(ControlFlowBlock)
 
     # Available for explicit-latch rotated loops
-    loop_break = transformation.PatternNode(sd.SDFGState)
+    loop_break = transformation.PatternNode(ControlFlowBlock)
+
+    break_edges: Set[gr.Edge[InterstateEdge]] = set()
+    continue_edges: Set[gr.Edge[InterstateEdge]] = set()
 
     @classmethod
     def expressions(cls):
@@ -129,15 +133,21 @@ class DetectLoop(transformation.PatternTransformation):
         elif expr_index == 4:
             return self.detect_self_loop(graph, accept_missing_itvar=permissive) is not None
         elif expr_index in (5, 7):
-            return self.detect_rotated_loop(graph, multistate_loop=True, accept_missing_itvar=permissive,
+            return self.detect_rotated_loop(graph,
+                                            multistate_loop=True,
+                                            accept_missing_itvar=permissive,
                                             separate_latch=True) is not None
         elif expr_index == 6:
-            return self.detect_rotated_loop(graph, multistate_loop=False, accept_missing_itvar=permissive,
+            return self.detect_rotated_loop(graph,
+                                            multistate_loop=False,
+                                            accept_missing_itvar=permissive,
                                             separate_latch=True) is not None
 
         raise ValueError(f'Invalid expression index {expr_index}')
 
-    def detect_loop(self, graph: ControlFlowRegion, multistate_loop: bool,
+    def detect_loop(self,
+                    graph: ControlFlowRegion,
+                    multistate_loop: bool,
                     accept_missing_itvar: bool = False) -> Optional[str]:
         """
         Detects a loop of the form:
@@ -183,7 +193,17 @@ class DetectLoop(transformation.PatternTransformation):
 
         # All nodes inside loop must be dominated by loop guard
         dominators = nx.dominance.immediate_dominators(graph.nx, graph.start_block)
-        loop_nodes = sdutil.dfs_conditional(graph, sources=[begin], condition=lambda _, child: child != guard)
+        postdominators = sdutil.postdominators(graph, True)
+        loop_nodes = self.loop_body()
+        # If the exit state is in the loop nodes, this is not a valid loop
+        if self.exit_state in loop_nodes:
+            return None
+        elif any(self.exit_state not in postdominators[1][n] for n in loop_nodes):
+            # The loop exit must post-dominate all loop nodes
+            return None
+        elif nx.has_path(graph.nx, self.exit_state, guard):
+            # If there is a path from the exit state to the guard, this is not a valid loop
+            return None
         backedge = None
         for node in loop_nodes:
             for e in graph.out_edges(node):
@@ -219,8 +239,11 @@ class DetectLoop(transformation.PatternTransformation):
 
         return next(iter(itvar))
 
-    def detect_rotated_loop(self, graph: ControlFlowRegion, multistate_loop: bool,
-                            accept_missing_itvar: bool = False, separate_latch: bool = False) -> Optional[str]:
+    def detect_rotated_loop(self,
+                            graph: ControlFlowRegion,
+                            multistate_loop: bool,
+                            accept_missing_itvar: bool = False,
+                            separate_latch: bool = False) -> Optional[str]:
         """
         Detects a loop of the form:
 
@@ -260,15 +283,23 @@ class DetectLoop(transformation.PatternTransformation):
         if latch_outedges[0].data.condition_sympy() != (sp.Not(latch_outedges[1].data.condition_sympy())):
             return None
 
+        # Make sure the backedge (i.e, one of the condition edges) goes from the latch to the beginning state.
+        if latch_outedges[0].dst is not self.loop_begin and latch_outedges[1].dst is not self.loop_begin:
+            return None
+
         # All nodes inside loop must be dominated by loop start
         dominators = nx.dominance.immediate_dominators(graph.nx, graph.start_block)
         if begin is ltest:
             loop_nodes = [begin]
         else:
-            loop_nodes = list(sdutil.dfs_conditional(graph, sources=[begin], condition=lambda _, child: child != ltest))
+            loop_nodes = self.loop_body()
         loop_nodes.append(latch)
         if ltest is not latch and ltest is not begin:
             loop_nodes.append(ltest)
+        postdominators = sdutil.postdominators(graph, True)
+        if any(self.exit_state not in postdominators[1][n] for n in loop_nodes):
+            # The loop exit must post-dominate all loop nodes
+            return None
         backedge = None
         for node in loop_nodes:
             for e in graph.out_edges(node):
@@ -369,37 +400,72 @@ class DetectLoop(transformation.PatternTransformation):
             return find_for_loop(guard.parent_graph, guard, entry, itervar)
         elif self.expr_index in (2, 3, 5, 6, 7):
             latch = self.loop_latch
-            return find_rotated_for_loop(latch.parent_graph, latch, entry, itervar,
+            return find_rotated_for_loop(latch.parent_graph,
+                                         latch,
+                                         entry,
+                                         itervar,
                                          separate_latch=(self.expr_index in (5, 6, 7)))
         elif self.expr_index == 4:
             return find_rotated_for_loop(entry.parent_graph, entry, entry, itervar)
 
         raise ValueError(f'Invalid expression index {self.expr_index}')
 
+    def _loop_body_dfs(self, terminator: ControlFlowBlock) -> Iterable[ControlFlowBlock]:
+        self.break_edges.clear()
+        visited = set()
+        start = self.loop_begin
+        graph = start.parent_graph
+        exit_state = self.exit_state
+        yield start
+        visited.add(start)
+        stack = [(start, iter(graph.successors(start)))]
+        while stack:
+            parent, children = stack[-1]
+            try:
+                child = next(children)
+                if child not in visited:
+                    visited.add(child)
+                    if child == exit_state:
+                        # If the exit state is reachable from the loop body, that counts as a break edge.
+                        for e in graph.edges_between(parent, child):
+                            self.break_edges.add(e)
+                    elif child != terminator:
+                        try:
+                            yield child
+                            stack.append((child, iter(graph.successors(child))))
+                        except sdutil.StopTraversal:
+                            pass
+                    else:
+                        # If we reached the terminator, we do not traverse further. All edges reaching the terminator
+                        # are marked as continue edges. If there is only one continue edge int the end, it can be
+                        # discarded (not actually a continue, simply the edge closing the loop).
+                        for e in graph.edges_between(parent, child):
+                            self.continue_edges.add(e)
+            except StopIteration:
+                stack.pop()
+
     def loop_body(self) -> List[ControlFlowBlock]:
         """
         Returns a list of all control flow blocks (or states) contained in the loop.
         """
-        begin = self.loop_begin
-        graph = begin.parent_graph
         if self.expr_index in (0, 1):
             guard = self.loop_guard
-            return list(sdutil.dfs_conditional(graph, sources=[begin], condition=lambda _, child: child != guard))
+            return list(self._loop_body_dfs(guard))
         elif self.expr_index in (2, 3):
             latch = self.loop_latch
-            loop_nodes = list(sdutil.dfs_conditional(graph, sources=[begin], condition=lambda _, child: child != latch))
+            loop_nodes = list(self._loop_body_dfs(latch))
             loop_nodes += [latch]
             return loop_nodes
         elif self.expr_index == 4:
-            return [begin]
+            return [self.loop_begin]
         elif self.expr_index in (5, 7):
             ltest = self.loop_break
             latch = self.loop_latch
-            loop_nodes = list(sdutil.dfs_conditional(graph, sources=[begin], condition=lambda _, child: child != ltest))
+            loop_nodes = list(self._loop_body_dfs(ltest))
             loop_nodes += [ltest, latch]
             return loop_nodes
         elif self.expr_index == 6:
-            return [begin, self.loop_latch]
+            return [self.loop_begin, self.loop_latch]
 
         return []
 
@@ -496,11 +562,12 @@ class DetectLoop(transformation.PatternTransformation):
         raise ValueError(f'Invalid expression index {self.expr_index}')
 
 
-def rotated_loop_find_itvar(begin_inedges: List[gr.Edge[InterstateEdge]],
-                            latch_inedges: List[gr.Edge[InterstateEdge]],
-                            backedge: gr.Edge[InterstateEdge], latch: ControlFlowBlock,
-                            accept_missing_itvar: bool = False) -> Tuple[Optional[str],
-                                                                         Optional[gr.Edge[InterstateEdge]]]:
+def rotated_loop_find_itvar(
+        begin_inedges: List[gr.Edge[InterstateEdge]],
+        latch_inedges: List[gr.Edge[InterstateEdge]],
+        backedge: gr.Edge[InterstateEdge],
+        latch: ControlFlowBlock,
+        accept_missing_itvar: bool = False) -> Tuple[Optional[str], Optional[gr.Edge[InterstateEdge]]]:
     # The iteration variable must be assigned (initialized) on all edges leading into the beginning block, which
     # are not the backedge. Gather all variabes for which that holds - they are all candidates for the iteration
     # variable (Phase 1). Said iteration variable must then be incremented:
@@ -582,7 +649,7 @@ def find_for_loop(
         List[sd.SDFGState], sd.SDFGState]]]:
     """
     Finds loop range from state machine.
-    
+
     :param guard: State from which the outgoing edges detect whether to exit
                   the loop or not.
     :param entry: First state in the loop body.
@@ -694,7 +761,7 @@ def find_rotated_for_loop(
         List[sd.SDFGState], sd.SDFGState]]]:
     """
     Finds rotated loop range from state machine.
-    
+
     :param latch: State from which the outgoing edges detect whether to reenter the loop or not.
     :param entry: First state in the loop body.
     :param itervar: An optional field that overrides the analyzed iteration variable.
@@ -791,3 +858,39 @@ def find_rotated_for_loop(
         return None
 
     return itervar, (start, end, stride), (start_states, last_loop_state)
+
+
+class LoopRangeAnnotator(DetectLoop):
+
+    def loop_guard_state(self):
+        """
+        Returns the loop guard state of this loop (i.e., latch state or begin state for inverted or self loops).
+        """
+        if self.expr_index in (0, 1):
+            return self.loop_guard
+        elif self.expr_index in (2, 3, 5, 6, 7):
+            return self.loop_latch
+        else:
+            return self.loop_begin
+
+    def apply(self, graph, sdfg):
+        itvar, rng, _ = self.loop_information()
+
+        body = self.loop_body()
+        meta = self.loop_meta_states()
+        full_body = set(body)
+        full_body.update(meta)
+
+        # Make sure the range is flipped such that the stride is positive (in order to match subsets.Range).
+        start, stop, stride = rng
+        # =====
+        # NOTE: This inequality needs to be checked exactly like this due to sympy limitations, do not simplify!
+        if (stride < 0) == True:
+            rng = (stop, start, -stride)
+        # =====
+
+        for v in full_body:
+            v.ranges[itvar] = Range([rng])
+        guard_state = self.loop_guard_state()
+        guard_state.is_loop_guard = True
+        guard_state.itvar = itvar

--- a/dace/transformation/interstate/loop_detection.py
+++ b/dace/transformation/interstate/loop_detection.py
@@ -201,9 +201,6 @@ class DetectLoop(transformation.PatternTransformation):
         elif any(self.exit_state not in postdominators[1][n] for n in loop_nodes):
             # The loop exit must post-dominate all loop nodes
             return None
-        elif nx.has_path(graph.nx, self.exit_state, guard):
-            # If there is a path from the exit state to the guard, this is not a valid loop
-            return None
         backedge = None
         for node in loop_nodes:
             for e in graph.out_edges(node):
@@ -860,7 +857,7 @@ def find_rotated_for_loop(
     return itervar, (start, end, stride), (start_states, last_loop_state)
 
 
-class LoopRangeAnnotator(DetectLoop):
+class LoopRangeAnnotator(DetectLoop, transformation.MultiStateTransformation):
 
     def loop_guard_state(self):
         """

--- a/dace/transformation/interstate/loop_detection.py
+++ b/dace/transformation/interstate/loop_detection.py
@@ -859,6 +859,14 @@ def find_rotated_for_loop(
 
 class LoopRangeAnnotator(DetectLoop, transformation.MultiStateTransformation):
 
+    def can_be_applied(self, graph, expr_index, sdfg, permissive = False):
+        if super().can_be_applied(graph, expr_index, sdfg, permissive):
+            loop_info = self.loop_information()
+            if loop_info is None:
+                return False
+            return True
+        return False
+
     def loop_guard_state(self):
         """
         Returns the loop guard state of this loop (i.e., latch state or begin state for inverted or self loops).

--- a/tests/sdfg/work_depth_test.py
+++ b/tests/sdfg/work_depth_test.py
@@ -320,8 +320,8 @@ if __name__ == '__main__':
     for test_name in work_depth_test_cases.keys():
         test_work_depth(test_name)
 
-    for test, correct in tests_cases_avg_par:
-        test_avg_par(test, correct)
+    for test in tests_cases_avg_par.keys():
+        test_avg_par(test)
 
     for expr, assums, res in assumptions_tests:
         test_assumption_system(expr, assums, res)


### PR DESCRIPTION
Networkx runs into a state space explosion for large loop graphs with many branches when querying simple cycles in the graph. Since state propagation (used by memlet propagation) makes use of that, this causes the operation to not complete in any reasonable time frame. This PR back-ports the improved loop detection from DaCe 2.0 and changes state propagation's loop range annotation to make use of that, instead of relying on Networkx's cycle querying.