### PR TITLE
Loop overwrite elimination

### DIFF
--- a/dace/transformation/interstate/__init__.py
+++ b/dace/transformation/interstate/__init__.py
@@ -12,6 +12,7 @@ from .fpga_transform_sdfg import FPGATransformSDFG
 from .gpu_transform_sdfg import GPUTransformSDFG
 from .sdfg_nesting import NestSDFG, InlineSDFG, InlineTransients, RefineNestedAccess
 from .loop_unroll import LoopUnroll
+from .loop_overwrite_elimination import LoopOverwriteElimination
 from .loop_peeling import LoopPeeling
 from .loop_to_map import LoopToMap
 from .move_loop_into_map import MoveLoopIntoMap

--- a/dace/transformation/interstate/loop_overwrite_elimination.py
+++ b/dace/transformation/interstate/loop_overwrite_elimination.py
@@ -92,9 +92,7 @@ class LoopOverwriteElimination(transformation.MultiStateTransformation):
                     if e.data.dynamic or e.data.wcr is not None:
                         return False
                     write_subsets.add(e.data.get_dst_subset(e, state))
-                if any(
-                    not intersects(rs, ws) for rs in read_subsets for ws in write_subsets
-                ):
+                if any(not intersects(rs, ws) for rs in read_subsets for ws in write_subsets):
                     return False
 
         # Every write needs to be independent of the loop index.
@@ -110,9 +108,7 @@ class LoopOverwriteElimination(transformation.MultiStateTransformation):
 
                     dst_subset = e.data.get_dst_subset(e, state)
                     for rb, re, _ in dst_subset.ndrange():
-                        str_set = set(
-                            [str(s) for s in rb.free_symbols.union(re.free_symbols)]
-                        )
+                        str_set = set([str(s) for s in rb.free_symbols.union(re.free_symbols)])
                         if itervar_dep_syms.intersection(str_set):
                             return False
 
@@ -133,10 +129,7 @@ class LoopOverwriteElimination(transformation.MultiStateTransformation):
                     src_subset = copy.deepcopy(e.data.get_src_subset(e, state))
                     src_subset.replace({self.loop.loop_variable: end})
                     # None of write_subsets should lie within the new subset
-                    if any(
-                        intersects(ws_ss, src_subset)
-                        for ws_ss in write_subsets[dn.data]
-                    ):
+                    if any(intersects(ws_ss, src_subset) for ws_ss in write_subsets[dn.data]):
                         return False
 
         # No conditional edge may depend on the loop variable.

--- a/dace/transformation/interstate/loop_overwrite_elimination.py
+++ b/dace/transformation/interstate/loop_overwrite_elimination.py
@@ -1,0 +1,118 @@
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+"""Eliminates loop overwriting data containers"""
+
+from dace import sdfg as sd
+from dace.sdfg import utils as sdutil
+from dace.sdfg.state import ControlFlowRegion, LoopRegion, ConditionalBlock
+from dace.transformation import transformation, helpers
+from dace.transformation.passes.analysis import loop_analysis
+from dace.sdfg.sdfg import InterstateEdge
+from dace import symbolic
+
+
+@transformation.explicit_cf_compatible
+class LoopOverwriteElimination(transformation.MultiStateTransformation):
+    """
+    Eliminates loops which write to the same location in each iteration by replacing the loop with the last iteration.
+    """
+
+    loop = transformation.PatternNode(LoopRegion)
+
+    @classmethod
+    def expressions(cls):
+        return [sdutil.node_path_graph(cls.loop)]
+
+    def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
+        # Check if this is a for-loop with known range.
+        start = loop_analysis.get_init_assignment(self.loop)
+        end = loop_analysis.get_loop_end(self.loop)
+        stride = loop_analysis.get_loop_stride(self.loop)
+        if start is None or end is None or stride is None:
+            return False
+
+        # Check if any continue, break, or return statements are present in the loop.
+        if self.loop.has_break or self.loop.has_continue or self.loop.has_return:
+            return False
+
+        # Find symbols depending on the loop variable
+        sym_deps = {}
+        for edge in self.loop.all_interstate_edges():
+            for k, v in edge.data.assignments.items():
+                sym_expr = symbolic.pystr_to_symbolic(v)
+                if k not in sym_deps:
+                    sym_deps[k] = set()
+                str_set = set([str(s) for s in sym_expr.free_symbols])
+                sym_deps[k].update(str_set)
+
+        itervar_dep_syms = set()
+        changed = True
+        while changed:
+            changed = False
+            for k, v in sym_deps.items():
+                if k in itervar_dep_syms:
+                    continue
+                if self.loop.loop_variable in v or itervar_dep_syms.intersection(v):
+                    itervar_dep_syms.add(k)
+                    changed = True
+        itervar_dep_syms.add(self.loop.loop_variable)
+
+        # Every write needs to be independent of the loop index.
+        for state in self.loop.all_states():
+            for dn in state.data_nodes():
+                for e in state.in_edges(dn):
+                    # If pointers are involved or it's not an overwrite, give up
+                    if e.data.dynamic or e.data.wcr is not None:
+                        return False
+
+                    dst_subset = e.data.get_dst_subset(e, state)
+                    for rb, re, _ in dst_subset.ndrange():
+                        str_set = set(
+                            [str(s) for s in rb.free_symbols.union(re.free_symbols)]
+                        )
+                        if itervar_dep_syms.intersection(str_set):
+                            return False
+
+        # If an data container is written and read, the read cannot have the same index as the write.
+
+        # No conditional edge may depend on the loop variable.
+        for edge in self.loop.all_interstate_edges():
+            if itervar_dep_syms.intersection(edge.data.condition.get_free_symbols()):
+                return False
+
+        # No conditional block may depend on the loop variable.
+        for node in self.loop.nodes():
+            if not isinstance(node, ConditionalBlock):
+                continue
+            for cond, _ in node.branches:
+                if itervar_dep_syms.intersection(cond.get_free_symbols()):
+                    return False
+
+        return True
+
+    def apply(self, graph: ControlFlowRegion, sdfg: sd.SDFG):
+        start = loop_analysis.get_init_assignment(self.loop)
+        end = loop_analysis.get_loop_end(self.loop)
+        stride = loop_analysis.get_loop_stride(self.loop)
+
+        last_iteration = start + (end - start) // stride * stride
+        itervar = self.loop.loop_variable
+
+        # Rewrite each occurence of the loop variable in the loop body
+        self.loop.replace(itervar, last_iteration)
+
+        # Add the loop contents to the parent graph.
+        graph.add_node(self.loop.start_block)
+        for e in graph.in_edges(self.loop):
+            graph.add_edge(e.src, self.loop.start_block, e.data)
+        sink = graph.add_state(self.loop.label + "_sink")
+        for n in self.loop.sink_nodes():
+            graph.add_edge(n, sink, InterstateEdge())
+        for e in graph.out_edges(self.loop):
+            graph.add_edge(sink, e.dst, e.data)
+        for e in self.loop.edges():
+            graph.add_edge(e.src, e.dst, e.data)
+
+        # Remove loop and if necessary also the loop variable.
+        graph.remove_node(self.loop)
+        if itervar in sdfg.symbols and helpers.is_symbol_unused(sdfg, itervar):
+            sdfg.remove_symbol(itervar)

--- a/tests/transformations/interstate/loop_overwrite_elimination_test.py
+++ b/tests/transformations/interstate/loop_overwrite_elimination_test.py
@@ -330,6 +330,28 @@ def test_overwrite_elimination_tmp2():
     _test_for_unchanged_behavior(tester, 1, 0)
 
 
+def test_overwrite_elimination_loop_dep():
+
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            for j in range(i, 9, 1):
+                A[j] = B[j]
+
+    _test_for_unchanged_behavior(tester, 2, 0)
+
+
+def test_overwrite_elimination_loop_dep2():
+
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            for j in range(i, 9, 1):
+                A[0] = B[j]
+
+    _test_for_unchanged_behavior(tester, 2, 2)
+
+
 if __name__ == "__main__":
     test_overwrite_elimination_basic()
     test_overwrite_elimination_basic2()
@@ -356,3 +378,5 @@ if __name__ == "__main__":
     test_overwrite_elimination_reverse_strided()
     test_overwrite_elimination_tmp()
     test_overwrite_elimination_tmp2()
+    test_overwrite_elimination_loop_dep()
+    test_overwrite_elimination_loop_dep2()

--- a/tests/transformations/interstate/loop_overwrite_elimination_test.py
+++ b/tests/transformations/interstate/loop_overwrite_elimination_test.py
@@ -1,0 +1,287 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests loop overwrite elimination transformations."""
+
+import numpy as np
+import pytest
+import dace
+from dace.transformation.interstate import LoopOverwriteElimination
+from dace.sdfg.state import LoopRegion
+from copy import deepcopy
+
+
+def _test_for_unchanged_behavior(prog, num_loops, num_eliminations):
+    sdfg = prog.to_sdfg(simplify=True)
+    sdfg.validate()
+    sdfg.save("bruh.sdfg")
+
+    # Should have exactly one loop
+    loop_nodes = [n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, LoopRegion)]
+    assert len(loop_nodes) == num_loops
+
+    # Get ground truth values if we expect eliminations
+    if num_eliminations > 0:
+        input_data = {}
+        for argName, argType in sdfg.arglist().items():
+            arr = dace.ndarray(shape=argType.shape, dtype=argType.dtype)
+            arr[:] = np.random.rand(*argType.shape).astype(argType.dtype.type)
+            input_data[argName] = arr
+        ground_truth = deepcopy(input_data)
+        sdfg(**ground_truth)
+
+    # Apply the transformation
+    sdfg.apply_transformations_repeated(LoopOverwriteElimination)
+    sdfg.validate()
+    sdfg.save("bruh2.sdfg")
+
+    # Check that the loop has been eliminated
+    loop_nodes = [n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, LoopRegion)]
+    assert len(loop_nodes) == num_loops - num_eliminations
+
+    # Test if the behavior is unchanged if we expect eliminations
+    if num_eliminations > 0:
+        output_data = deepcopy(input_data)
+        sdfg(**output_data)
+        np.testing.assert_equal(output_data, ground_truth)
+
+
+def test_overwrite_elimination_basic():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+def test_overwrite_elimination_basic2():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            A[i] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+def test_overwrite_elimination_nonzero():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            A[5] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+def test_overwrite_elimination_reverse():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(9, -1, -1):
+            A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+def test_overwrite_elimination_stride():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(0, 10, 2):
+            A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+def test_overwrite_elimination_read():
+    @dace.program
+    def tester(A: dace.float32[10]):
+        for i in range(10):
+            A[0] = A[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+def test_overwrite_elimination_nested_loops():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10, 10]):
+        for i in range(10):
+            for j in range(10):
+                A[0] = B[i, j]
+
+    _test_for_unchanged_behavior(tester, 2, 2)
+
+
+def test_overwrite_elimination_nested_loops2():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            A[0] = B[i]
+            for j in range(5):
+                A[j] = B[j] + 1.0
+
+    _test_for_unchanged_behavior(tester, 2, 1)
+
+
+def test_overwrite_elimination_reverse_nested():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[5, 5]):
+        for i in range(4, -1, -1):
+            for j in range(4, -1, -1):
+                A[0] = B[i, j]
+
+    _test_for_unchanged_behavior(tester, 2, 2)
+
+
+def test_overwrite_elimination_strided_nested():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(0, 10, 2):
+            for j in range(0, 10, 3):
+                A[0] = B[j]
+
+    _test_for_unchanged_behavior(tester, 2, 2)
+
+
+def test_overwrite_elimination_nonlinear_access():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            idx = (i * 3) % 10
+            A[0] = B[idx]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+def test_overwrite_elimination_with_break():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            if B[i] > 0.5:
+                break
+            A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+
+def test_overwrite_elimination_with_continue():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            if B[i] < 0.3:
+                continue
+            else:
+              A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+def test_overwrite_elimination_with_return():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            if B[i] < 0.3:
+                return
+            A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+def test_overwrite_elimination_step_changing():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        i = 0
+        while i < 10:
+            A[0] = B[i]
+            if B[i] > 0.5:
+                i += 2
+            else:
+                i += 1
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+
+def test_overwrite_elimination_conditional_write():
+    @dace.program
+    def tester(A: dace.float32[20], B: dace.float32[20]):
+        for i in range(10):
+            if i % 3 == 0:
+                A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+
+def test_overwrite_elimination_multiple_writes():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10], C: dace.float32[10]):
+        for i in range(10):
+            A[0] = B[i]
+            A[0] = C[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+def test_overwrite_elimination_conditional_write2():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(10):
+            if B[i] > 0.5:
+                A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+
+def test_overwrite_elimination_read2():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(1, 10):
+            A[0] = A[0] + B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 0)
+
+
+def test_overwrite_elimination_triple_nested():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[5, 5, 5]):
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    A[0] = B[i, j, k]
+
+    _test_for_unchanged_behavior(tester, 3, 3)
+
+
+def test_overwrite_elimination_triple_nested_dependency():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[5, 5, 5]):
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    A[j] = B[i, j, k]
+
+    _test_for_unchanged_behavior(tester, 3, 2)
+
+
+def test_overwrite_elimination_reverse_strided():
+    @dace.program
+    def tester(A: dace.float32[10], B: dace.float32[10]):
+        for i in range(9, -1, -2):
+            A[0] = B[i]
+
+    _test_for_unchanged_behavior(tester, 1, 1)
+
+
+if __name__ == "__main__":
+    # test_overwrite_elimination_basic()
+    # test_overwrite_elimination_basic2()
+    # test_overwrite_elimination_nonzero()
+    # test_overwrite_elimination_reverse()
+    # test_overwrite_elimination_read()
+    # test_overwrite_elimination_nested_loops()
+    # test_overwrite_elimination_nested_loops2()
+    # test_overwrite_elimination_reverse_nested()
+    # test_overwrite_elimination_strided_nested()
+    # test_overwrite_elimination_nonlinear_access()
+    # test_overwrite_elimination_with_break()
+    # test_overwrite_elimination_with_continue()
+    # test_overwrite_elimination_with_return()
+    # test_overwrite_elimination_step_changing()
+    # test_overwrite_elimination_conditional_write()
+    # test_overwrite_elimination_multiple_writes()
+    # test_overwrite_elimination_conditional_write2()
+    test_overwrite_elimination_read2() ##
+    # test_overwrite_elimination_triple_nested()
+    # test_overwrite_elimination_triple_nested_dependency()
+    # test_overwrite_elimination_reverse_strided()

--- a/tests/transformations/interstate/loop_overwrite_elimination_test.py
+++ b/tests/transformations/interstate/loop_overwrite_elimination_test.py
@@ -43,6 +43,7 @@ def _test_for_unchanged_behavior(prog, num_loops, num_eliminations):
 
 
 def test_overwrite_elimination_basic():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -50,7 +51,9 @@ def test_overwrite_elimination_basic():
 
     _test_for_unchanged_behavior(tester, 1, 1)
 
+
 def test_overwrite_elimination_basic2():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -58,7 +61,9 @@ def test_overwrite_elimination_basic2():
 
     _test_for_unchanged_behavior(tester, 1, 0)
 
+
 def test_overwrite_elimination_nonzero():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -68,6 +73,7 @@ def test_overwrite_elimination_nonzero():
 
 
 def test_overwrite_elimination_reverse():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(9, -1, -1):
@@ -77,6 +83,7 @@ def test_overwrite_elimination_reverse():
 
 
 def test_overwrite_elimination_stride():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(0, 10, 2):
@@ -86,6 +93,7 @@ def test_overwrite_elimination_stride():
 
 
 def test_overwrite_elimination_read():
+
     @dace.program
     def tester(A: dace.float32[10]):
         for i in range(10):
@@ -95,6 +103,7 @@ def test_overwrite_elimination_read():
 
 
 def test_overwrite_elimination_nested_loops():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10, 10]):
         for i in range(10):
@@ -105,6 +114,7 @@ def test_overwrite_elimination_nested_loops():
 
 
 def test_overwrite_elimination_nested_loops2():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -116,6 +126,7 @@ def test_overwrite_elimination_nested_loops2():
 
 
 def test_overwrite_elimination_reverse_nested():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[5, 5]):
         for i in range(4, -1, -1):
@@ -126,6 +137,7 @@ def test_overwrite_elimination_reverse_nested():
 
 
 def test_overwrite_elimination_strided_nested():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(0, 10, 2):
@@ -136,6 +148,7 @@ def test_overwrite_elimination_strided_nested():
 
 
 def test_overwrite_elimination_nonlinear_access():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -146,6 +159,7 @@ def test_overwrite_elimination_nonlinear_access():
 
 
 def test_overwrite_elimination_with_break():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -157,17 +171,20 @@ def test_overwrite_elimination_with_break():
 
 
 def test_overwrite_elimination_with_continue():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
             if B[i] < 0.3:
                 continue
             else:
-              A[0] = B[i]
+                A[0] = B[i]
 
     _test_for_unchanged_behavior(tester, 1, 0)
 
+
 def test_overwrite_elimination_with_return():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -177,7 +194,9 @@ def test_overwrite_elimination_with_return():
 
     _test_for_unchanged_behavior(tester, 1, 0)
 
+
 def test_overwrite_elimination_step_changing():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         i = 0
@@ -192,6 +211,7 @@ def test_overwrite_elimination_step_changing():
 
 
 def test_overwrite_elimination_conditional_write():
+
     @dace.program
     def tester(A: dace.float32[20], B: dace.float32[20]):
         for i in range(10):
@@ -202,6 +222,7 @@ def test_overwrite_elimination_conditional_write():
 
 
 def test_overwrite_elimination_multiple_writes():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10], C: dace.float32[10]):
         for i in range(10):
@@ -212,6 +233,7 @@ def test_overwrite_elimination_multiple_writes():
 
 
 def test_overwrite_elimination_conditional_write2():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -222,6 +244,7 @@ def test_overwrite_elimination_conditional_write2():
 
 
 def test_overwrite_elimination_read2():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(1, 10):
@@ -229,7 +252,9 @@ def test_overwrite_elimination_read2():
 
     _test_for_unchanged_behavior(tester, 1, 0)
 
+
 def test_overwrite_elimination_read_reverse():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(9, -1, -1):
@@ -237,7 +262,9 @@ def test_overwrite_elimination_read_reverse():
 
     _test_for_unchanged_behavior(tester, 1, 0)
 
+
 def test_overwrite_elimination_read_crossing():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(1, 10):
@@ -245,7 +272,9 @@ def test_overwrite_elimination_read_crossing():
 
     _test_for_unchanged_behavior(tester, 1, 1)
 
+
 def test_overwrite_elimination_triple_nested():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[5, 5, 5]):
         for i in range(5):
@@ -257,6 +286,7 @@ def test_overwrite_elimination_triple_nested():
 
 
 def test_overwrite_elimination_triple_nested_dependency():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[5, 5, 5]):
         for i in range(5):
@@ -268,6 +298,7 @@ def test_overwrite_elimination_triple_nested_dependency():
 
 
 def test_overwrite_elimination_reverse_strided():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(9, -1, -2):
@@ -277,6 +308,7 @@ def test_overwrite_elimination_reverse_strided():
 
 
 def test_overwrite_elimination_tmp():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
         for i in range(10):
@@ -285,10 +317,12 @@ def test_overwrite_elimination_tmp():
 
     _test_for_unchanged_behavior(tester, 1, 1)
 
+
 def test_overwrite_elimination_tmp2():
+
     @dace.program
     def tester(A: dace.float32[10], B: dace.float32[10]):
-        tmp = dace.ndarray(shape=(2,), dtype=dace.float32)
+        tmp = dace.ndarray(shape=(2, ), dtype=dace.float32)
         for i in range(10):
             tmp[1] = B[i]
             A[0] = tmp[0]
@@ -315,7 +349,7 @@ if __name__ == "__main__":
     test_overwrite_elimination_multiple_writes()
     test_overwrite_elimination_conditional_write2()
     test_overwrite_elimination_read2()
-    test_overwrite_elimination_read_reverse() 
+    test_overwrite_elimination_read_reverse()
     test_overwrite_elimination_read_crossing()
     test_overwrite_elimination_triple_nested()
     test_overwrite_elimination_triple_nested_dependency()


### PR DESCRIPTION
This PR adds a new transformation, which eliminates loops writing to the same memory location in each iteration by replacing them with the last iteration.
Example:
```py
for i in range(10):
  A[0] = B[i]
```

is replaced by:
```py
A[0] = B[9]
```