### PR TITLE
Improve Validation 

### DIFF
--- a/tests/codegen/tasklet_generation_test.py
+++ b/tests/codegen/tasklet_generation_test.py
@@ -1,0 +1,62 @@
+import dace
+import pytest
+
+def _gen_sdfg_with_a_print_tasklet_between_map_exits() -> dace.SDFG:
+    sdfg = dace.SDFG('test_sdfg')
+    sdfg.add_array('A', [100], dace.float32)
+    sdfg.add_array('B', [100], dace.float32)
+    state = sdfg.add_state('main')
+
+    outer_map_entry, outer_map_exit = state.add_map(
+        'map1', {'i0': '0:100:10'}, schedule=dace.ScheduleType.Default
+    )
+    inner_map_entry, inner_map_exit = state.add_map(
+        'map1', {'i1': 'i0:i0+10:1'}, schedule=dace.ScheduleType.Default
+    )
+    in_A = state.add_read('A')
+    in_B = state.add_read('B')
+    out_B = state.add_write('B')
+
+    t1 = state.add_tasklet('add', {'_in_a', '_in_b'}, {'_out_b'}, '_out_b = _in_a + _in_b')
+
+    state.add_edge(in_A, None, outer_map_entry, "IN_A", dace.memlet.Memlet.from_array('A', sdfg.arrays['A']))
+    state.add_edge(in_B, None, outer_map_entry, "IN_B", dace.memlet.Memlet.from_array('B', sdfg.arrays['B']))
+    state.add_edge(outer_map_entry, "OUT_A", inner_map_entry, "IN_A", dace.Memlet("A[i0:i0+10]"))
+    state.add_edge(outer_map_entry, "OUT_B", inner_map_entry, "IN_B", dace.Memlet("B[i0:i0+10]"))
+    state.add_edge(inner_map_entry, "OUT_A", t1, "_in_a", dace.Memlet("A[i1]"))
+    state.add_edge(inner_map_entry, "OUT_B", t1, "_in_b", dace.Memlet("B[i1]"))
+    state.add_edge(t1, "_out_b", inner_map_exit, "IN_B", dace.Memlet("B[i1]"))
+    state.add_edge(inner_map_exit, "OUT_B", outer_map_exit, "IN_B", dace.Memlet("B[i0:i0+10]"))
+    state.add_edge(outer_map_exit, "OUT_B", out_B, None, dace.Memlet("B[0:100]"))
+
+    t2 = state.add_tasklet(name='printf',
+                           inputs={},
+                           outputs={},
+                           code_global='#include <stdio.h>',
+                           code='printf("At iteration %d\\n", i0);',
+                           language=dace.Language.CPP)
+    state.add_edge(inner_map_exit, None, t2, None, dace.Memlet())
+    state.add_edge(t2, None, outer_map_exit, None, dace.Memlet())
+
+    outer_map_entry.add_in_connector("IN_A")
+    outer_map_entry.add_in_connector("IN_B")
+    outer_map_entry.add_out_connector("OUT_A")
+    outer_map_entry.add_out_connector("OUT_B")
+    inner_map_entry.add_in_connector("IN_A")
+    inner_map_entry.add_in_connector("IN_B")
+    inner_map_entry.add_out_connector("OUT_A")
+    inner_map_entry.add_out_connector("OUT_B")
+    inner_map_exit.add_in_connector("IN_B")
+    inner_map_exit.add_out_connector("OUT_B")
+    outer_map_exit.add_in_connector("IN_B")
+    outer_map_exit.add_out_connector("OUT_B")
+
+    return sdfg
+
+def test_print_tasklet_between_map_exits():
+    sdfg = _gen_sdfg_with_a_print_tasklet_between_map_exits()
+    sdfg.validate()
+    sdfg.compile()
+
+if __name__ == "__main__":
+    test_print_tasklet_between_map_exits()

--- a/tests/codegen/tasklet_generation_test.py
+++ b/tests/codegen/tasklet_generation_test.py
@@ -1,18 +1,15 @@
 import dace
 import pytest
 
+
 def _gen_sdfg_with_a_print_tasklet_between_map_exits() -> dace.SDFG:
     sdfg = dace.SDFG('test_sdfg')
     sdfg.add_array('A', [100], dace.float32)
     sdfg.add_array('B', [100], dace.float32)
     state = sdfg.add_state('main')
 
-    outer_map_entry, outer_map_exit = state.add_map(
-        'map1', {'i0': '0:100:10'}, schedule=dace.ScheduleType.Default
-    )
-    inner_map_entry, inner_map_exit = state.add_map(
-        'map1', {'i1': 'i0:i0+10:1'}, schedule=dace.ScheduleType.Default
-    )
+    outer_map_entry, outer_map_exit = state.add_map('map1', {'i0': '0:100:10'}, schedule=dace.ScheduleType.Default)
+    inner_map_entry, inner_map_exit = state.add_map('map1', {'i1': 'i0:i0+10:1'}, schedule=dace.ScheduleType.Default)
     in_A = state.add_read('A')
     in_B = state.add_read('B')
     out_B = state.add_write('B')
@@ -53,10 +50,12 @@ def _gen_sdfg_with_a_print_tasklet_between_map_exits() -> dace.SDFG:
 
     return sdfg
 
+
 def test_print_tasklet_between_map_exits():
     sdfg = _gen_sdfg_with_a_print_tasklet_between_map_exits()
     sdfg.validate()
     sdfg.compile()
+
 
 if __name__ == "__main__":
     test_print_tasklet_between_map_exits()

--- a/tests/interstate_edge_utils_test.py
+++ b/tests/interstate_edge_utils_test.py
@@ -1,5 +1,6 @@
 import dace
 import typing
+import pytest
 
 
 def _get_sdfg() -> typing.Tuple[dace.SDFG, dace.InterstateEdge]:
@@ -31,7 +32,6 @@ def _get_sdfg() -> typing.Tuple[dace.SDFG, dace.InterstateEdge]:
         sym3_name: f"{array1_name}[1]",
     }
     e = sdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=interstate_assignments))
-    sdfg.validate()
     return sdfg, e
 
 
@@ -78,6 +78,15 @@ def test_all_used_arrays():
     assert e.data.used_arrays(arrays=sdfg.arrays, union_lhs_symbols=True) == {"scalar2", "scalar1", "array1"}
 
 
+def test_writing_to_scalar_on_iedge_is_invalid():
+    # SDFG can't write to scalars on interstate edges catch for validity
+    with pytest.raises(dace.sdfg.validation.InvalidSDFGInterstateEdgeError,
+                       match="Assignment to a scalar or an array detected in an interstate edge"):
+        sdfg_and_edge: typing.Tuple[dace.SDFG, dace.InterstateEdge] = _get_sdfg()
+        sdfg: dace.SDFG = sdfg_and_edge[0]
+        sdfg.validate()
+
+
 if __name__ == "__main__":
     test_read_symbols()
     test_used_symbols()
@@ -85,4 +94,4 @@ if __name__ == "__main__":
     test_all_read_sdfg_symbols()
     test_all_read_arrays()
     test_all_used_arrays()
-    print("All tests passed!")
+    test_writing_to_scalar_on_iedge_is_invalid()


### PR DESCRIPTION
Improve validation to:
- Detect writes to scalars on interstate edges. For this I added `_no_writes_to_scalars_or_arrays_on_interstate_edges` and a test to `interstate_edge_utils_test` to check that an SDFG where we write to a scalar on iedge is invalid.
- Do not mark tasklets with no incoming and outgoing memlets as sink nodes. Accroding to discussion with Tal earlier the image from the SDFG should be valid as it is not a sink node due to no incoming our outgoing memlets, I improve validation to not mark this tasklet as sink node + add a test case :
<img width="921" height="560" alt="image" src="https://github.com/user-attachments/assets/9656de59-62bc-4f07-8116-050d6e06b749" />
