### PR TITLE
Fix compilation issues of reduce_atomic with Apple Clang

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -976,7 +976,9 @@ class CPUCodeGen(TargetCodeGenerator):
 
         # General reduction
         custom_reduction = cpp.unparse_cr(sdfg, memlet.wcr, dtype)
-        return (f'dace::wcr_custom<{dtype.ctype}>:: template {func}({custom_reduction}, {ptr}, {inname})')
+        return (
+            f'const auto __dace__reduction_lambda = {custom_reduction};\ndace::wcr_custom<{dtype.ctype}>::{func}<decltype(__dace__reduction_lambda)>(__dace__reduction_lambda, {ptr}, {inname})'
+        )
 
     def process_out_memlets(self,
                             sdfg: SDFG,

--- a/dace/codegen/targets/snitch.py
+++ b/dace/codegen/targets/snitch.py
@@ -1085,8 +1085,9 @@ class SnitchCodeGen(TargetCodeGenerator):
 
         # General reduction
         custom_reduction = cpp.unparse_cr(sdfg, memlet.wcr, dtype)
-        return (f'dace::wcr_custom<{dtype.ctype}>:: template reduce{atomic}('
-                f'{custom_reduction}, {ptr}, {inname})')
+        return (
+            f'const auto __dace__reduction_lambda = {custom_reduction};\ndace::wcr_custom<{dtype.ctype}>::reduce{atomic}<decltype(__dace__reduction_lambda)>('
+            f'__dace__reduction_lambda, {ptr}, {inname})')
 
     @staticmethod
     def gen_code_snitch(sdfg):


### PR DESCRIPTION
Fixes the following issue with `Apple Clang 17.0.0`
```
E               dace.codegen.exceptions.CompilationError: Compiler failure:
E               [ 25%] Building CXX object CMakeFiles/tests_argmax_test_argmax.dir/Users/ioannmag/cscs_repos/cycle30/dace/.dacecache/tests_argmax_test_argmax/src/cpu/tests_argmax_test_argmax.cpp.o
E               /Users/ioannmag/cscs_repos/cycle30/dace/.dacecache/tests_argmax_test_argmax/src/cpu/tests_argmax_test_argmax.cpp:45:55: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
E                  45 |                     dace::wcr_custom<pair>:: template reduce_atomic([] (const pair& x, const pair& y) { return pair { .idx = ((x.val > y.val) ? x.idx : y.idx), .val = max(x.val, y.val) }; }, __return, out);
E                     |                                                       ^
E               1 error generated.
E               make[2]: *** [CMakeFiles/tests_argmax_test_argmax.dir/Users/ioannmag/cscs_repos/cycle30/dace/.dacecache/tests_argmax_test_argmax/src/cpu/tests_argmax_test_argmax.cpp.o] Error 1
E               make[1]: *** [CMakeFiles/tests_argmax_test_argmax.dir/all] Error 2
E               make: *** [all] Error 2
```
Similar to #1984