### PR TITLE
Added Fine Grain Control to `MapFusionVertical`.

### DIFF
--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -69,6 +69,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         "shared" , see `partition_first_outputs()` for more.
     :param require_exclusive_intermediates: If `True` then the transformation will only apply
         if all intermediates are "eclusive", i.e can be removed, see `partition_first_outputs()`.
+    :param allow_only_intermediate_nodes: If `True` then the transformation will only apply if
+        the if all outputs of the first Map are intermediate, i.e. go directly to the second Map.
     :param consolidate_edges_only_if_not_extending: If `True` the transformation will only
         consolidate edges if this does not lead to an extension of the subset.
     :param never_consolidate_edges: If `False`, the default, the function will never
@@ -117,6 +119,11 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         default=False,
         desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
     )
+    allow_only_intermediate_nodes = properties.Property(
+        dtype=bool,
+        default=False,
+        desc="If `True` all outputs of the first Map must be intermediate, i.e. going into the second Map.",
+    )
 
     never_consolidate_edges = properties.Property(
         dtype=bool,
@@ -136,6 +143,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         strict_dataflow: Optional[bool] = None,
         assume_always_shared: Optional[bool] = None,
         require_exclusive_intermediates: Optional[bool] = None,
+        allow_only_intermediate_nodes: Optional[bool] = None,
         consolidate_edges_only_if_not_extending: Optional[bool] = None,
         never_consolidate_edges: Optional[bool] = None,
         **kwargs: Any,
@@ -159,6 +167,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             self.assume_always_shared = assume_always_shared
         if require_exclusive_intermediates is not None:
             self.require_exclusive_intermediates = require_exclusive_intermediates
+        if allow_only_intermediate_nodes is not None:
+            self.allow_only_intermediate_nodes = allow_only_intermediate_nodes
         if never_consolidate_edges is not None:
             self.never_consolidate_edges = never_consolidate_edges
         if consolidate_edges_only_if_not_extending is not None:
@@ -424,8 +434,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         :param param_repl: Use this Map to rename the parameter of the second Map, such
             that they match the one of the first Map.
 
-        :note: The output of this function is affected by the value of `self.assume_always_shared`
-            as well as by `self.require_exclusive_intermediates`.
+        :note: The output of this function is affected by the value of `self.assume_always_shared`,
+            `allow_only_intermediate_nodes` and by `self.require_exclusive_intermediates`.
         """
         # The three outputs set.
         pure_outputs: Set[graph.MultiConnectorEdge[dace.Memlet]] = set()
@@ -453,6 +463,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
                     begin=intermediate_node,
                     end=second_map_entry,
             ):
+                if self.allow_only_intermediate_nodes:  # We do not allow pure output nodes.
+                    return None
                 pure_outputs.add(out_edge)
                 continue
 

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -1345,10 +1345,10 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         # If we are here, then we were unable to locate a previous result of `FindSingelUseData`.
         #  However, before we perform a scan, we check if the shortcuts, i.e. `assume_always_*`
         #  was specified and use them.
-        if self.assume_always_single_use_data:
-            return False
-        elif self.assume_always_shared:
+        if self.assume_always_shared:
             return True
+        elif self.assume_always_single_use_data:
+            return False
 
         # Perform the real scan.
         return self._scan_sdfg_if_data_is_shared(data=data, state=state, sdfg=sdfg)

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -12,7 +12,7 @@ from dace.transformation.dataflow import map_fusion_helper as mfhelper
 class MapFusionVertical(transformation.SingleStateTransformation):
     """Implements the vertical Map fusion transformation.
 
-    The transformation will match the pattern `MapExit -> (A) -> MapEntry`, i.e. two Maps that have
+    The transformation will match the pattern `MapExit -> (A) -> MapEntry`, i.e., two Maps that have
     a linear dependency with one another.
     From a high level perspective it will remove the MapExit node of the first and the MapEntry node
     of the second Map. It will then rewire and modify the Memlets such that the data flow bypasses the
@@ -41,14 +41,14 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     * If the two Maps cover the same iteration space, essentially have the same start, stop and
         iteration , see `find_parameter_remapping()`.
     * Furthermore, they verify if the new fused Map did not introduce read write conflict,
-        essentially it tests if the data is pointwise, i.e. what is read is also written,
+        essentially it tests if the data is pointwise, i.e., what is read is also written,
         see `has_read_write_dependency()`.
     * Then it will examine the intermediate data. This will essentially test if the data that
         is needed by a single iteration of the second Map is produced by a single iteration of
         the first Map, see `partition_first_outputs()`.
 
     By default `strict_dataflow` is enabled. In this mode the transformation is more conservative.
-    The main difference is, that it will not adjust the subsets of the intermediate, i.e. turning
+    The main difference is, that it will not adjust the subsets of the intermediate, i.e., turning
     an array with shape `(1, 1, 1, 1)` into a scalar. Furthermore, shared intermediates, see
     `partition_first_outputs()` will only be created if the data is not referred downstream in
     the dataflow.
@@ -59,18 +59,18 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     the `FindSingleUseData` analysis pass, see note below. If the result of the pass is present
     then the transformation will use it  to determine if a intermediate can be removed.
     The second way is to specify `assume_always_shared`, which instruct the transformation to
-    assume that the intermediate is shared, i.e. will become an output of the fused Map.
-    The downside of this is, that dead dataflow, i.e. writes that are not needed are generated.
+    assume that the intermediate is shared, i.e., will become an output of the fused Map.
+    The downside of this is, that dead dataflow, i.e., writes that are not needed, are generated.
 
-    :param only_inner_maps: Only match Maps that are internal, i.e. inside another Map.
+    :param only_inner_maps: Only match Maps that are internal, i.e., inside another Map.
     :param only_toplevel_maps: Only consider Maps that are at the top.
     :param strict_dataflow: Which dataflow mode should be used, see above.
     :param assume_always_shared: Handle all intermediate nodes as if they were classified as
-        "shared" , see `partition_first_outputs()` for more.
+        "shared", see `partition_first_outputs()` for more.
     :param require_exclusive_intermediates: If `True` then the transformation will only apply
-        if all intermediates are "eclusive", i.e can be removed, see `partition_first_outputs()`.
+        if all intermediates are "eclusive", i.e., can be removed, see `partition_first_outputs()`.
     :param require_all_intermediates: If `True` then the transformation will only apply if
-        the if all outputs of the first Map are intermediate, i.e. are consumed by the second Map.
+        all outputs of the first Map are intermediate, i.e., are consumed by the second Map.
     :param consolidate_edges_only_if_not_extending: If `True` the transformation will only
         consolidate edges if this does not lead to an extension of the subset.
     :param never_consolidate_edges: If `False`, the default, the function will never
@@ -81,7 +81,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     :note: Because of [issue#1911](https://github.com/spcl/dace/issues/1911) the `can_be_applied()`
         can not use the pipeline result and will thus scan the whole SDFG. The `FullMapFusion`
         pass is not affected by this.
-    :note: `require_exclusive_intermediates` means that all intermediates, i.e. AccessNodes
+    :note: `require_exclusive_intermediates` means that all intermediates, i.e., AccessNodes
         connecting the first and second Maps, can be removed, outputs of the first Map that
         are not consumed by the first Map are not considered. However, it means that also
         non-transients are also affected. See `partition_first_outputs()`.
@@ -100,7 +100,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     only_inner_maps = properties.Property(
         dtype=bool,
         default=False,
-        desc="Only perform fusing if the Maps are inner Maps, i.e. does not have top level scope.",
+        desc="Only perform fusing if the Maps are inner Maps, i.e., does not have top level scope.",
     )
 
     strict_dataflow = properties.Property(
@@ -117,12 +117,12 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     require_exclusive_intermediates = properties.Property(
         dtype=bool,
         default=False,
-        desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
+        desc="If `True` then all intermediates need to be 'exclusive', i.e., they will be removed by the fusion.",
     )
     require_all_intermediates = properties.Property(
         dtype=bool,
         default=False,
-        desc="If `True` all outputs of the first Map must be intermediate, i.e. going into the second Map.",
+        desc="If `True` all outputs of the first Map must be intermediate, i.e., going into the second Map.",
     )
 
     never_consolidate_edges = properties.Property(
@@ -380,9 +380,9 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         # Now turn the second output node into the output node of the first Map.
         second_map_exit.map = first_map_entry.map
 
-        # If we have "consolidated" edges, i.e. reused existing edges, then the set
+        # If we have "consolidated" edges, i.e., reused existing edges, then the set
         #  of that might have expanded, thus we have to propagate them. However,
-        #  in case we never consolidated, i.e. all edges were preserved, then we
+        #  in case we never consolidated, i.e., all edges were preserved, then we
         #  can skip that step.
         if not self.never_consolidate_edges:
             propagation.propagate_memlets_map_scope(sdfg, graph, first_map_entry)
@@ -425,7 +425,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
 
         :return: If such a decomposition exists the function will return the three sets
             mentioned above in the same order. In case the decomposition does not exist,
-            i.e. the maps can not be fused the function returns `None`.
+            i.e., the maps can not be fused the function returns `None`.
 
         :param state: The in which the two maps are located.
         :param sdfg: The full SDFG in which we operate.
@@ -520,7 +520,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             #   - The edge shall also not be a reduction edge.
             #   - Defined location to where they write.
             #   - No dynamic Melets.
-            #  Furthermore, we will also extract the subsets, i.e. the location they
+            #  Furthermore, we will also extract the subsets, i.e., the location they
             #  modify inside the intermediate array.
             #  Since we do not allow for WCR, we do not check if the producer subsets intersects.
             producer_subsets: List[subsets.Subset] = []
@@ -578,7 +578,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
                 if not intermediate_node_out_edge.dst_conn.startswith("IN_"):
                     return None
 
-                # Now we look at all edges that leave the second MapEntry, i.e. the
+                # Now we look at all edges that leave the second MapEntry, i.e., the
                 #  edges that feeds the consumer and define what is read inside the Map.
                 #  We do not check them, but collect them and inspect them.
                 # NOTE1: The subset still uses the old iteration variables.
@@ -738,7 +738,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
 
             # Memlets have a lot of additional informations, to ensure that we get
             #  all of them, we have to do it this way. The main reason for this is
-            #  to handle the case were the "Memlet reverse direction", i.e. `data`
+            #  to handle the case were the "Memlet reverse direction", i.e., `data`
             #  refers to the other end of the connection than before.
             assert pre_exit_edge.data.dst_subset is not None
             new_pre_exit_memlet_src_subset = copy.deepcopy(pre_exit_edge.data.src_subset)
@@ -797,10 +797,10 @@ class MapFusionVertical(transformation.SingleStateTransformation):
                 else:
                     # If we found another target than the second MapEntry from the
                     #  intermediate node it means that the node _must_ survive,
-                    #  i.e. we are not in exclusive mode.
+                    #  i.e., we are not in exclusive mode.
                     assert not is_exclusive_set
 
-            # Now we will reroute the connections inside the second Map, i.e.
+            # Now we will reroute the connections inside the second Map, i.e.,
             #  instead of consuming the old intermediate node, they will now
             #  consume the new intermediate node.
             for in_conn_name in conn_names:
@@ -821,7 +821,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
                     #  of the Memlet we make a deep copy of it. There is a tricky part here, we have to
                     #  access `src_subset` however, this is only correctly set once it is put inside the
                     #  SDFG. Furthermore, we have to make sure that the Memlet does not change its direction.
-                    #  i.e. that the association of `subset` and `other_subset` does not change. For this
+                    #  i.e., that the association of `subset` and `other_subset` does not change. For this
                     #  reason we only modify `.data` attribute of the Memlet if its name refers to the old
                     #  intermediate. Furthermore, to play it safe, we only access the subset, `src_subset`
                     #  after we have inserted it to the SDFG.
@@ -979,10 +979,10 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         This is the value that must be substracted from the memlets to adjust, i.e
         (`memlet_to_adjust(correction, negative=True)`). If `producer_offset` is
         `None` then the function computes the correction that should be applied to
-        the producer memlets, i.e. the memlets of the tree converging at
+        the producer memlets, i.e., the memlets of the tree converging at
         `intermediate_node`. If `producer_offset` is given, it should be the output
         of the previous call to this function, with `producer_offset=None`. In this
-        case the function computes the correction for the consumer side, i.e. the
+        case the function computes the correction for the consumer side, i.e., the
         memlet tree that originates at `intermediate_desc`.
 
         :param original_subset: The original subset that was used to write into the
@@ -1198,7 +1198,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         # While it is forbidden that a data container, used as intermediate, is also
         #  used as output of the second Map. It is allowed that the data container
         #  is used as intermediate and as input of the first Map. The partition only
-        #  checks that the data dependencies are mean, i.e. what is read by the second
+        #  checks that the data dependencies are mean, i.e., what is read by the second
         #  Map is also computed (written to the intermediate) it does not take into
         #  account the first Map's read to the data container.
         #  To make an example: The partition function will make sure that if the
@@ -1242,7 +1242,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
 
         # Now we inspect if there is a read write dependency, between data that is
         #  used as input and output of the fused Map. There is no problem is they
-        #  are pointwise, i.e. in each iteration the same locations are accessed.
+        #  are pointwise, i.e., in each iteration the same locations are accessed.
         #  Essentially they all boil down to `a += 1`.
         for inout_data_name in fused_inout_data_names:
             all_subsets = []
@@ -1298,7 +1298,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             else:
                 # The original code used `Range.offset` here, but that one had trouble
                 #  for `r1 = 'j, 0:10'` and `r2 = 'j, 0`. The solution would be to test
-                #  symmetrically, i.e. `r1 - r2` and `r2 - r1`. However, if we would
+                #  symmetrically, i.e., `r1 - r2` and `r2 - r1`. However, if we would
                 #  have `r2_1 = 'j, 0:10'` it consider it as failing, which is not
                 #  what we want. Thus we will use symmetric cover.
                 if not master_subset.covers(subset):
@@ -1317,7 +1317,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         state: dace.SDFGState,
         sdfg: dace.SDFG,
     ) -> bool:
-        """Tests if `data` is shared data, i.e. it can not be removed from the SDFG.
+        """Tests if `data` is shared data, i.e., it can not be removed from the SDFG.
 
         The function returns `True` is `data` refers to shared data and `False` otherwise.
         The process to determine this is as follows:
@@ -1325,7 +1325,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         2) If the AccessNode `data` has more than one outgoing edge or more than one incoming edge
             it is classified as shared.
         3) If `data` refers to non transient memory it is classified as shared.
-        4) If `FindSingleUseData` is in the pipeline it will be used. I.e. it will check if `data`
+        4) If `FindSingleUseData` is in the pipeline it will be used. I.e., it will check if `data`
             is in the set and return `True` or `False` otherwise.
         5) The function will perform a scan of the SDFG.
 

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -120,7 +120,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     )
     assume_always_single_use_data = properties.Property(
         dtype=bool,
-        default=True,
+        default=False,
         desc="If `True` then all intermediates are classified as single use data.",
     )
 

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -78,16 +78,15 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         goes to the same AccessNode.
 
     :note: This transformation modifies more nodes than it matches.
+    :note: While it is always "safe" to specify the `assume_always_shared`, this is not true
+        for `assume_always_single_use_data`. Specifying it when the data is used somewhere
+        else will lead to invalid behaviour. Thus only specify it if you know what you are doing.
     :note: The flags `assume_always_shared` and `assume_always_single_use_data` are intended
-        to speed up the operation in cases where it is clear that the intermediate is single
-        use or if it is shared. These flags instruct the transformation to skip the scan of
-        SDFG. Instead they instruct the transformation to assume that the intermediate is
-        shared, i.e. must be recreated or that it is single use data, i.e. does not need to
-        be preserved. Such situations mostly happens if `can_be_applied_to()` or `apply_to()`
-        is used.
+        when it is clear from the usage context what should happen to the intermediate. This is
+        most often, but not always the case if `can_be_applied_to()` or `apply_to()` are used.
     :note: Because of [issue#1911](https://github.com/spcl/dace/issues/1911) the `can_be_applied()`
-            can not use the pipeline result and will thus scan the whole SDFG. The `FullMapFusion`
-            pass is not affected by this.
+        can not use the pipeline result and will thus scan the whole SDFG. The `FullMapFusion`
+        pass is not affected by this.
     """
 
     first_map_exit = transformation.transformation.PatternNode(nodes.MapExit)

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -1313,6 +1313,9 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         # This means the data is consumed by multiple Maps, through the same AccessNode, in this state
         #  Note currently multiple incoming edges are not handled, but in the spirit of this function
         #  we consider such AccessNodes as shared, because we can not remove the intermediate.
+        # TODO(phimuell): If one of the two Maps has multiple connections to the intermediate,
+        #   then this detection will fail here. This is not a problem because this is currently
+        #   not supported. But still.
         if state.out_degree(data) > 1:
             return True
         if state.in_degree(data) > 1:

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -69,8 +69,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         "shared" , see `partition_first_outputs()` for more.
     :param require_exclusive_intermediates: If `True` then the transformation will only apply
         if all intermediates are "eclusive", i.e can be removed, see `partition_first_outputs()`.
-    :param allow_only_intermediate_nodes: If `True` then the transformation will only apply if
-        the if all outputs of the first Map are intermediate, i.e. go directly to the second Map.
+    :param require_only_intermediates: If `True` then the transformation will only apply if
+        the if all outputs of the first Map are intermediate, i.e. are consumed by the second Map.
     :param consolidate_edges_only_if_not_extending: If `True` the transformation will only
         consolidate edges if this does not lead to an extension of the subset.
     :param never_consolidate_edges: If `False`, the default, the function will never
@@ -119,7 +119,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         default=False,
         desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
     )
-    allow_only_intermediate_nodes = properties.Property(
+    require_only_intermediates = properties.Property(
         dtype=bool,
         default=False,
         desc="If `True` all outputs of the first Map must be intermediate, i.e. going into the second Map.",
@@ -143,7 +143,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         strict_dataflow: Optional[bool] = None,
         assume_always_shared: Optional[bool] = None,
         require_exclusive_intermediates: Optional[bool] = None,
-        allow_only_intermediate_nodes: Optional[bool] = None,
+        require_only_intermediates: Optional[bool] = None,
         consolidate_edges_only_if_not_extending: Optional[bool] = None,
         never_consolidate_edges: Optional[bool] = None,
         **kwargs: Any,
@@ -167,8 +167,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             self.assume_always_shared = assume_always_shared
         if require_exclusive_intermediates is not None:
             self.require_exclusive_intermediates = require_exclusive_intermediates
-        if allow_only_intermediate_nodes is not None:
-            self.allow_only_intermediate_nodes = allow_only_intermediate_nodes
+        if require_only_intermediates is not None:
+            self.require_only_intermediates = require_only_intermediates
         if never_consolidate_edges is not None:
             self.never_consolidate_edges = never_consolidate_edges
         if consolidate_edges_only_if_not_extending is not None:
@@ -435,7 +435,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             that they match the one of the first Map.
 
         :note: The output of this function is affected by the value of `self.assume_always_shared`,
-            `allow_only_intermediate_nodes` and by `self.require_exclusive_intermediates`.
+            `require_only_intermediates` and by `self.require_exclusive_intermediates`.
         """
         # The three outputs set.
         pure_outputs: Set[graph.MultiConnectorEdge[dace.Memlet]] = set()
@@ -463,7 +463,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
                     begin=intermediate_node,
                     end=second_map_entry,
             ):
-                if self.allow_only_intermediate_nodes:  # We do not allow pure output nodes.
+                if self.require_only_intermediates:  # We do not allow pure output nodes.
                     return None
                 pure_outputs.add(out_edge)
                 continue

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -69,7 +69,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         "shared" , see `partition_first_outputs()` for more.
     :param require_exclusive_intermediates: If `True` then the transformation will only apply
         if all intermediates are "eclusive", i.e can be removed, see `partition_first_outputs()`.
-    :param require_only_intermediates: If `True` then the transformation will only apply if
+    :param require_all_intermediates: If `True` then the transformation will only apply if
         the if all outputs of the first Map are intermediate, i.e. are consumed by the second Map.
     :param consolidate_edges_only_if_not_extending: If `True` the transformation will only
         consolidate edges if this does not lead to an extension of the subset.
@@ -119,7 +119,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         default=False,
         desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
     )
-    require_only_intermediates = properties.Property(
+    require_all_intermediates = properties.Property(
         dtype=bool,
         default=False,
         desc="If `True` all outputs of the first Map must be intermediate, i.e. going into the second Map.",
@@ -143,7 +143,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         strict_dataflow: Optional[bool] = None,
         assume_always_shared: Optional[bool] = None,
         require_exclusive_intermediates: Optional[bool] = None,
-        require_only_intermediates: Optional[bool] = None,
+        require_all_intermediates: Optional[bool] = None,
         consolidate_edges_only_if_not_extending: Optional[bool] = None,
         never_consolidate_edges: Optional[bool] = None,
         **kwargs: Any,
@@ -167,8 +167,8 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             self.assume_always_shared = assume_always_shared
         if require_exclusive_intermediates is not None:
             self.require_exclusive_intermediates = require_exclusive_intermediates
-        if require_only_intermediates is not None:
-            self.require_only_intermediates = require_only_intermediates
+        if require_all_intermediates is not None:
+            self.require_all_intermediates = require_all_intermediates
         if never_consolidate_edges is not None:
             self.never_consolidate_edges = never_consolidate_edges
         if consolidate_edges_only_if_not_extending is not None:
@@ -435,7 +435,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             that they match the one of the first Map.
 
         :note: The output of this function is affected by the value of `self.assume_always_shared`,
-            `require_only_intermediates` and by `self.require_exclusive_intermediates`.
+            `require_all_intermediates` and by `self.require_exclusive_intermediates`.
         """
         # The three outputs set.
         pure_outputs: Set[graph.MultiConnectorEdge[dace.Memlet]] = set()
@@ -463,7 +463,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
                     begin=intermediate_node,
                     end=second_map_entry,
             ):
-                if self.require_only_intermediates:  # We do not allow pure output nodes.
+                if self.require_all_intermediates:  # We do not allow pure output nodes.
                     return None
                 pure_outputs.add(out_edge)
                 continue

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -1336,7 +1336,6 @@ class MapFusionVertical(transformation.SingleStateTransformation):
             single_use_data = self._pipeline_results["FindSingelUseData"]
         elif self._single_use_data is not None:
             single_use_data = self._single_use_data
-
         # The single use data was present so scan it.
         if single_use_data is not None:
             assert sdfg in single_use_data

--- a/dace/transformation/passes/full_map_fusion.py
+++ b/dace/transformation/passes/full_map_fusion.py
@@ -45,10 +45,10 @@ class FullMapFusion(ppl.Pass):
         default=False,
         desc="If `True` then all intermediates will be classified as shared.",
     )
-    assume_always_single_use_data = properties.Property(
+    require_exclusive_intermediates = properties.Property(
         dtype=bool,
-        default=True,
-        desc="If `True` then all intermediates are classified as single use data.",
+        default=False,
+        desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
     )
 
     perform_vertical_map_fusion = properties.Property(
@@ -94,7 +94,7 @@ class FullMapFusion(ppl.Pass):
         only_toplevel_maps: Optional[bool] = None,
         strict_dataflow: Optional[bool] = None,
         assume_always_shared: Optional[bool] = None,
-        assume_always_single_use_data: Optional[bool] = None,
+        require_exclusive_intermediates: Optional[bool] = None,
         perform_vertical_map_fusion: Optional[bool] = None,
         perform_horizontal_map_fusion: Optional[bool] = None,
         only_if_common_ancestor: Optional[bool] = None,
@@ -113,8 +113,8 @@ class FullMapFusion(ppl.Pass):
             self.strict_dataflow = strict_dataflow
         if assume_always_shared is not None:
             self.assume_always_shared = assume_always_shared
-        if assume_always_single_use_data is not None:
-            self.assume_always_single_use_data = assume_always_single_use_data
+        if require_exclusive_intermediates is not None:
+            self.require_exclusive_intermediates = require_exclusive_intermediates
         if perform_vertical_map_fusion is not None:
             self.perform_vertical_map_fusion = perform_vertical_map_fusion
         if perform_horizontal_map_fusion is not None:
@@ -135,8 +135,6 @@ class FullMapFusion(ppl.Pass):
 
         if not (self.perform_vertical_map_fusion or self.perform_horizontal_map_fusion):
             raise ValueError('Neither perform `MapFusionVertical` nor `MapFusionHorizontal`')
-        if self.assume_always_shared and self.assume_always_single_use_data:
-            raise ValueError('Specified both `assume_always_single_use_data` and `assume_always_shared`.')
 
     def modifies(self) -> ppl.Modifies:
         return ppl.Modifies.Scopes | ppl.Modifies.AccessNodes | ppl.Modifies.Memlets
@@ -173,7 +171,7 @@ class FullMapFusion(ppl.Pass):
                     only_toplevel_maps=self.only_toplevel_maps,
                     strict_dataflow=self.strict_dataflow,
                     assume_always_shared=self.assume_always_shared,
-                    assume_always_single_use_data=self.assume_always_single_use_data,
+                    require_exclusive_intermediates=self.require_exclusive_intermediates,
                     consolidate_edges_only_if_not_extending=self.consolidate_edges_only_if_not_extending,
                     never_consolidate_edges=self.never_consolidate_edges,
                 ))

--- a/dace/transformation/passes/full_map_fusion.py
+++ b/dace/transformation/passes/full_map_fusion.py
@@ -50,6 +50,11 @@ class FullMapFusion(ppl.Pass):
         default=False,
         desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
     )
+    require_all_intermediates = properties.Property(
+        dtype=bool,
+        default=False,
+        desc="If `True` all outputs of the first Map must be intermediate, i.e. going into the second Map.",
+    )
 
     perform_vertical_map_fusion = properties.Property(
         dtype=bool,
@@ -95,6 +100,7 @@ class FullMapFusion(ppl.Pass):
         strict_dataflow: Optional[bool] = None,
         assume_always_shared: Optional[bool] = None,
         require_exclusive_intermediates: Optional[bool] = None,
+        require_all_intermediates: Optional[bool] = None,
         perform_vertical_map_fusion: Optional[bool] = None,
         perform_horizontal_map_fusion: Optional[bool] = None,
         only_if_common_ancestor: Optional[bool] = None,
@@ -115,6 +121,8 @@ class FullMapFusion(ppl.Pass):
             self.assume_always_shared = assume_always_shared
         if require_exclusive_intermediates is not None:
             self.require_exclusive_intermediates = require_exclusive_intermediates
+        if require_all_intermediates is not None:
+            self.require_all_intermediates = require_all_intermediates
         if perform_vertical_map_fusion is not None:
             self.perform_vertical_map_fusion = perform_vertical_map_fusion
         if perform_horizontal_map_fusion is not None:
@@ -172,6 +180,7 @@ class FullMapFusion(ppl.Pass):
                     strict_dataflow=self.strict_dataflow,
                     assume_always_shared=self.assume_always_shared,
                     require_exclusive_intermediates=self.require_exclusive_intermediates,
+                    require_all_intermediates=self.require_all_intermediates,
                     consolidate_edges_only_if_not_extending=self.consolidate_edges_only_if_not_extending,
                     never_consolidate_edges=self.never_consolidate_edges,
                     # TODO: Remove once issue#1911 has been solved.

--- a/dace/transformation/passes/full_map_fusion.py
+++ b/dace/transformation/passes/full_map_fusion.py
@@ -31,7 +31,7 @@ class FullMapFusion(ppl.Pass):
     only_inner_maps = properties.Property(
         dtype=bool,
         default=False,
-        desc="Only perform fusing if the Maps are inner Maps, i.e. does not have top level scope.",
+        desc="Only perform fusing if the Maps are inner Maps, i.e., does not have top level scope.",
     )
 
     strict_dataflow = properties.Property(
@@ -48,12 +48,12 @@ class FullMapFusion(ppl.Pass):
     require_exclusive_intermediates = properties.Property(
         dtype=bool,
         default=False,
-        desc="If `True` then all intermediates need to be 'exclusive', i.e. they will be removed by the fusion.",
+        desc="If `True` then all intermediates need to be 'exclusive', i.e., they will be removed by the fusion.",
     )
     require_all_intermediates = properties.Property(
         dtype=bool,
         default=False,
-        desc="If `True` all outputs of the first Map must be intermediate, i.e. going into the second Map.",
+        desc="If `True` all outputs of the first Map must be intermediate, i.e., going into the second Map.",
     )
 
     perform_vertical_map_fusion = properties.Property(
@@ -171,7 +171,7 @@ class FullMapFusion(ppl.Pass):
         fusion_transforms = []
         if self.perform_vertical_map_fusion:
             # We have to pass the single use data at construction. This is because that
-            #  `fusion._pipeline_results` is only defined, i.e. not `None` during `apply()`
+            #  `fusion._pipeline_results` is only defined, i.e., not `None` during `apply()`
             #  but during `can_be_applied()` it is not available. Thus we have to set it here.
             fusion_transforms.append(
                 dftrans.MapFusionVertical(

--- a/dace/transformation/passes/full_map_fusion.py
+++ b/dace/transformation/passes/full_map_fusion.py
@@ -202,4 +202,4 @@ class FullMapFusion(ppl.Pass):
         if self.validate and (not self.validate_all):
             sdfg.validate()
 
-        return result if result > 0 else None
+        return result

--- a/dace/transformation/passes/full_map_fusion.py
+++ b/dace/transformation/passes/full_map_fusion.py
@@ -140,7 +140,7 @@ class FullMapFusion(ppl.Pass):
 
         if not (self.perform_vertical_map_fusion or self.perform_horizontal_map_fusion):
             raise ValueError('Neither perform `MapFusionVertical` nor `MapFusionHorizontal`')
-        if not perform_vertical_map_fusion:
+        if not self.perform_vertical_map_fusion:
             unique_vertical_arguments = {
                 "strict_dataflow": strict_dataflow,
                 "assume_always_shared": assume_always_shared,
@@ -152,7 +152,7 @@ class FullMapFusion(ppl.Pass):
                 raise ValueError(
                     f'Used `FullMapFusion` without vertical Map fusion, but speciefied: {", ".join(specified_vertical_arguments)}'
                 )
-        if not perform_horizontal_map_fusion:
+        if not self.perform_horizontal_map_fusion:
             if only_if_common_ancestor is not None:
                 raise ValueError(
                     f'Used `FullMapFusion` without horizontal Map fusion, but speciefied: only_if_common_ancestor')


### PR DESCRIPTION
The transformation already offers the `assume_always_shared` flag, which tells the transformation to assume that the intermediate is shared, which allows to skip the scan of the SDFG.
Intermediate are classified into two categories:
- Shared: Which need to be retained, because they are used somewhere else.
- Exclusive: Only needed to exchange information between the two Maps.

This PR introduces the `require_exclusive_intermediates` flag, which instructs the transformation to only apply if the intermediates are exclusive, i.e. will be removed after the fusion.

It is important that `require_exclusive_intermediates` does not influence the "pure outputs" of the first Map, i.e. the outputs that are not used by the second Map.
To address this the `require_only_intermediates` flag was introduced.
The flag instructs the transformation to only apply if all outputs of the first Map are intermediates, i.e. are consumed by the second Map.

The main use case for these flags is if the transformation is used through the `apply_to()` and `can_be_applied_to()` functions.
Where one wants to make sure that some intermediate is removed.

This PR also introduced the undocumented `_single_use_data` argument to the initializer of the transformation.
The `_single_use_data` member of the transformation is a work around to handle [issue#1911](https://github.com/spcl/dace/issues/1911).
However, when used with `apply_to()` and `can_be_applied_to()` then it is not possible to specify the information, although it is present.
This is not nice and instead the underlying issue should be addressed.