### PR TITLE
Refine `try_initialize()` in Map Fusion

### DIFF
--- a/dace/transformation/dataflow/map_fusion_horizontal.py
+++ b/dace/transformation/dataflow/map_fusion_horizontal.py
@@ -175,10 +175,14 @@ class MapFusionHorizontal(transformation.SingleStateTransformation):
         #  See [issue 1708](https://github.com/spcl/dace/issues/1703)
         #  Because we do not need to look at them, we were able to skip them in the
         #  `can_be_applied()` function, but now we have to do it.
-        # TODO(phimuell): Once [PR#2081](https://github.com/spcl/dace/pull/2081) is merged
-        #   restrict it to the subgraph and the edges of the scope nodes.
-        for edge in graph.edges():
-            edge.data.try_initialize(sdfg, graph, edge)
+        for map_entry, map_exit in [(first_map_entry, first_map_exit), (second_map_entry, second_map_exit)]:
+            inner_subgraph = graph.scope_subgraph(map_entry)
+            for edge in inner_subgraph.edges():
+                edge.data.try_initialize(sdfg, graph, edge)
+            for iedge in graph.in_edges(map_entry):
+                iedge.data.try_initialize(sdfg, graph, iedge)
+            for oedge in graph.out_edges(map_exit):
+                oedge.data.try_initialize(sdfg, graph, oedge)
 
         # We have to get the scope_dict before we start mutating the graph.
         scope_dict: Dict = graph.scope_dict().copy()

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -155,7 +155,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
 
     def can_be_applied(
         self,
-        graph: Union[dace.SDFGState, SDFG],
+        graph: dace.SDFGState,
         expr_index: int,
         sdfg: dace.SDFG,
         permissive: bool = False,
@@ -168,9 +168,10 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         * Tests if the decomposition exists.
         """
         # NOTE: The after this point it is not legal to access the matched nodes
-        first_map_entry: nodes.MapEntry = graph.entry_node(self.first_map_exit)
         first_map_exit: nodes.MapExit = self.first_map_exit
+        first_map_entry: nodes.MapEntry = graph.entry_node(first_map_exit)
         second_map_entry: nodes.MapEntry = self.second_map_entry
+        second_map_exit: nodes.MapExit = graph.exit_node(second_map_entry)
 
         assert isinstance(first_map_exit, nodes.MapExit)
         assert isinstance(second_map_entry, nodes.MapEntry)
@@ -197,10 +198,14 @@ class MapFusionVertical(transformation.SingleStateTransformation):
         # NOTE: Technically we would have to rerun this also in the `apply()` method, but
         #   we do not do it, because we assume that it was called directly after
         #   `can_be_applied()` has been called.
-        # TODO(phimuell): Once [PR#2081](https://github.com/spcl/dace/pull/2081) is merged
-        #   restrict it to the subgraph and the edges of the scope nodes.
-        for edge in graph.edges():
-            edge.data.try_initialize(sdfg, graph, edge)
+        for map_entry, map_exit in [(first_map_entry, first_map_exit), (second_map_entry, second_map_exit)]:
+            inner_subgraph = graph.scope_subgraph(map_entry)
+            for edge in inner_subgraph.edges():
+                edge.data.try_initialize(sdfg, graph, edge)
+            for iedge in graph.in_edges(map_entry):
+                iedge.data.try_initialize(sdfg, graph, iedge)
+            for oedge in graph.out_edges(map_exit):
+                oedge.data.try_initialize(sdfg, graph, oedge)
 
         # Tests if there are read write dependencies that are caused by the bodies
         #  of the Maps, such as referring to the same data. Note that this tests are


### PR DESCRIPTION
To ensure that we have consistent subsets inside the Memlets, see [issue#1703](https://github.com/spcl/dace/issues/1703), we have to call `try_initialize()` on the edges.
This PR restrict this to the edges that are actually affected and gives thus a speedup.



