### PR TITLE
Avoided costly copy operation

### DIFF
--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -1425,6 +1425,15 @@ class DebugInfo:
         return DebugInfo(json_obj['start_line'], json_obj['start_column'], json_obj['end_line'], json_obj['end_column'],
                          json_obj['filename'])
 
+    def __deepcopy__(self, memo) -> 'DebugInfo':
+        """Performs a `deepcopy` of `self`.
+
+        Because all members of `self` are immutable this function is essentially a shallow copy.
+        """
+        new = object.__new__(DebugInfo)
+        new.__dict__.update(self.__dict__)
+        return new
+
 
 ######################################################
 # Static (utility) functions

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -199,22 +199,28 @@ class Memlet(object):
         return ret
 
     def __deepcopy__(self, memo):
+        """Performs a deep copy of `self`.
+
+        Note for performance reasons the immutable objects of `self` will not be copied.
+        Furthermore, all references to SDFGs, state and edges are set to `None`.
+        """
         node = object.__new__(Memlet)
 
-        # Set properties
-        node._volume = dcpy(self._volume, memo=memo)
+        # Immutable objects are: Python strings, integer, boolean but also SymPy expressions, i.e. symbols.
+        node._volume = self._volume
         node._dynamic = self._dynamic
         node._subset = dcpy(self._subset, memo=memo)
         node._other_subset = dcpy(self._other_subset, memo=memo)
-        node._data = dcpy(self._data, memo=memo)
+        node._data = self._data
         node._wcr = dcpy(self._wcr, memo=memo)
-        node._wcr_nonatomic = dcpy(self._wcr_nonatomic, memo=memo)
+        node._wcr_nonatomic = self._wcr_nonatomic
         node._debuginfo = dcpy(self._debuginfo, memo=memo)
         node._wcr_nonatomic = self._wcr_nonatomic
         node._allow_oob = self._allow_oob
-        node._is_data_src = self._is_data_src
-
         node._guid = generate_element_id(node)
+
+        # TODO: Since we set the `.sdfg` and friends to `None` we should probably also set this to `None`.
+        node._is_data_src = self._is_data_src
 
         # Nullify graph references
         node._sdfg = None

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -297,8 +297,22 @@ class Range(Subset):
         return hash(tuple(r for r in self.ranges))
 
     def __add__(self, other):
-        sum_ranges = self.ranges + other.ranges
+        sum_ranges = [(*ranges, tile)
+                      for ranges, tile in zip(self.ranges + other.ranges, self.tile_sizes + self.tile_sizes)]
         return Range(sum_ranges)
+
+    def __deepcopy__(self, memo) -> 'Range':
+        """Performs a deepcopy of `self`.
+
+        For performance reasons only the mutable parts are copied.
+        """
+        # Because SymPy expression and numbers and tuple in Python are immutable, it is enough
+        #  to shallow copy the list that stores them.
+        node = object.__new__(Range)
+        node.ranges = self.ranges.copy()
+        node.tile_sizes = self.tile_sizes.copy()
+
+        return node
 
     def num_elements(self):
         return reduce(sp.Mul, self.size(), 1)
@@ -889,6 +903,19 @@ class Indices(Subset):
 
     def __hash__(self):
         return hash(tuple(i for i in self.indices))
+
+    def __deepcopy__(self, memo) -> 'Indices':
+        """Performs a deepcopy of `self`.
+
+        For performance reasons only the mutable parts are copied.
+        """
+        # Because SymPy expression and numbers and tuple in Python are immutable, it is enough
+        #  to shallow copy the list that stores them.
+        node = object.__new__(Indices)
+        node.ranges = self.ranges.copy()
+        node.tile_sizes = self.tile_sizes.copy()
+
+        return node
 
     def num_elements(self):
         return 1


### PR DESCRIPTION
During a profiling it was noticed that a huge fraction of the time was spend in `__deepcopy__` of Memlets.
After some investigation it turned out that this was caused by copying SymPy expressions.

In SymPy symbols are [immutable](https://docs.sympy.org/latest/explanation/glossary.html#term-Immutable) the documentation makes this quite clear.
Thus copying such an object should be trivial, however, for some reason it is not (apparently SymPy does not define the `__deepcopy__()` function).

Thus this PR adds a `__deepcopy__()` method to the:
- `Memlet`
- `Range`
- `Indices`
- `DebugInfo`

This method only copies the members that are mutable but does not touch the immutable parts.
The effect is a speedup of about >10%, the side effect, however, is that `deepcopy()`, at least for some object, is no longer deep, however, due to the immutability, there is no behavioral change.

Furthermore, this PR fixes the `__add__()` method of the `Range`.



