### PR TITLE
Remove deprecated `parent` argument for `add_nested_sdfg`

### DIFF
--- a/dace/frontend/common/einsum.py
+++ b/dace/frontend/common/einsum.py
@@ -402,7 +402,7 @@ def _create_einsum_internal(sdfg: SDFG,
         # Create nested SDFG for GEMM
         nsdfg = create_batch_gemm_sdfg(dtype, strides, alpha, beta)
 
-        nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'X', 'Y'}, {'Z'}, strides)
+        nsdfg_node = state.add_nested_sdfg(nsdfg, {'X', 'Y'}, {'Z'}, strides)
         state.add_edge(a, None, nsdfg_node, 'X', Memlet.from_array(a.data, a.desc(sdfg)))
         state.add_edge(b, None, nsdfg_node, 'Y', Memlet.from_array(b.data, b.desc(sdfg)))
         state.add_edge(nsdfg_node, 'Z', c, None, Memlet.from_array(c.data, c.desc(sdfg)))

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -701,11 +701,7 @@ class AST_translator:
                                            strides=array_in_global.strides,
                                            offset=array_in_global.offset)
 
-        internal_sdfg = substate.add_nested_sdfg(new_sdfg,
-                                                 sdfg,
-                                                 ins_in_new_sdfg,
-                                                 outs_in_new_sdfg,
-                                                 symbol_mapping=sym_dict)
+        internal_sdfg = substate.add_nested_sdfg(new_sdfg, ins_in_new_sdfg, outs_in_new_sdfg, symbol_mapping=sym_dict)
 
         # Now adding memlets
         for i in self.libstates:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1580,7 +1580,6 @@ class ProgramVisitor(ExtNodeVisitor):
                                                                   extra_map_symbols=map_symbols)
 
             internal_node = state.add_nested_sdfg(sdfg,
-                                                  self.sdfg,
                                                   set(inputs.keys()),
                                                   set(outputs.keys()),
                                                   debuginfo=self.current_lineinfo)
@@ -2290,11 +2289,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 node,
                 extra_symbols=self._symbols_from_params(params, map_inputs),
                 extra_map_symbols=self._symbols_from_params(params, map_inputs))
-            tasklet = state.add_nested_sdfg(body,
-                                            self.sdfg,
-                                            inputs.keys(),
-                                            outputs.keys(),
-                                            debuginfo=self.current_lineinfo)
+            tasklet = state.add_nested_sdfg(body, inputs.keys(), outputs.keys(), debuginfo=self.current_lineinfo)
             self._add_nested_symbols(tasklet)
             self._add_dependencies(state, tasklet, me, mx, inputs, outputs, map_inputs, symbols)
         elif iterator == 'range':
@@ -4233,12 +4228,7 @@ class ProgramVisitor(ExtNodeVisitor):
                 if strides and (strides[-1] != 1 or sdfg.arrays[a].strides[-1] != 1):
                     warnings.warn(f'Incompatible strides: inner {sdfg.arrays[a].strides} - outer {strides}')
 
-        nsdfg = state.add_nested_sdfg(sdfg,
-                                      self.sdfg,
-                                      inputs.keys(),
-                                      outputs.keys(),
-                                      mapping,
-                                      debuginfo=self.current_lineinfo)
+        nsdfg = state.add_nested_sdfg(sdfg, inputs.keys(), outputs.keys(), mapping, debuginfo=self.current_lineinfo)
         self._add_nested_symbols(nsdfg)
         inputs = {k: (state, v, set()) for k, v in inputs.items()}
         outputs = {k: (state, v, set()) for k, v in outputs.items()}

--- a/dace/frontend/python/replacements/ufunc.py
+++ b/dace/frontend/python/replacements/ufunc.py
@@ -1192,7 +1192,7 @@ def _create_subgraph(visitor: ProgramVisitor,
                 nested_sdfg.add_edge(cond_state, false_state, InterstateEdge(cond_else))
                 nested_sdfg.add_edge(true_state, false_state, InterstateEdge())
 
-                codenode = state.add_nested_sdfg(nested_sdfg, sdfg, set([n for n, _ in nested_sdfg_inputs.values()]),
+                codenode = state.add_nested_sdfg(nested_sdfg, set([n for n, _ in nested_sdfg_inputs.values()]),
                                                  set([n for n, _ in nested_sdfg_outputs.values()]))
                 me, mx = state.add_map(state.label + '_map', map_indices)
                 for arg in inputs + [where]:
@@ -1687,7 +1687,7 @@ def implement_ufunc_accumulate(visitor: ProgramVisitor, ast_node: ast.Call, sdfg
 
     r = state.add_read(inputs[0])
     w = state.add_write(outputs[0])
-    codenode = state.add_nested_sdfg(nested_sdfg, sdfg, {inpconn}, {outconn})
+    codenode = state.add_nested_sdfg(nested_sdfg, {inpconn}, {outconn})
     me, mx = state.add_map(state.label + '_map', map_range)
     state.add_memlet_path(r, me, codenode, memlet=Memlet("{a}[{i}]".format(a=inputs[0], i=input_idx)), dst_conn=inpconn)
     state.add_memlet_path(codenode,

--- a/dace/libraries/standard/nodes/gearbox.py
+++ b/dace/libraries/standard/nodes/gearbox.py
@@ -139,8 +139,7 @@ class ExpandGearbox(dace.transformation.ExpandTransformation):
                                             memlet=dace.Memlet(f"{pack_name}[{elem_it}]"))
                 write_state.add_memlet_path(pack_access, write_nested, memlet=dace.Memlet(f"{write_nested.data}[0]"))
 
-            nested_sdfg_node = state.add_nested_sdfg(nested_sdfg, sdfg,
-                                                     {f"_{in_edge.dst_conn}", f"{buffer_name}_inner"},
+            nested_sdfg_node = state.add_nested_sdfg(nested_sdfg, {f"_{in_edge.dst_conn}", f"{buffer_name}_inner"},
                                                      {f"_{out_edge.src_conn}", f"{buffer_name}_inner"})
             buffer_read = state.add_read(buffer_name)
             buffer_write = state.add_write(buffer_name)

--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -1470,7 +1470,7 @@ class ExpandReduceGPUAuto(pm.ExpandTransformation):
             r = nstate.add_read('_in')
             w = nstate.add_write('_out')
 
-            actual_nested_sdfg = nstate.add_nested_sdfg(nested_sdfg, nsdfg, {'s_mem', '_in'}, {'s_mem'})
+            actual_nested_sdfg = nstate.add_nested_sdfg(nested_sdfg, {'s_mem', '_in'}, {'s_mem'})
 
             inner_in = real_state.add_access('_in')
             inner_smem = real_state.add_access('s_mem')

--- a/dace/libraries/stencil/intel_fpga.py
+++ b/dace/libraries/stencil/intel_fpga.py
@@ -105,7 +105,6 @@ class ExpandStencilIntelFPGA(dace.library.ExpandTransformation):
         nested_sdfg = dace.SDFG(node.label + "_inner", parent=state)
         nested_sdfg_tasklet = state.add_nested_sdfg(
             nested_sdfg,
-            sdfg,
             # Input connectors
             [k + "_in"
              for k in inputs if any(iterator_mapping[k])] + [name + "_buffer_in" for name, _ in buffer_sizes.items()],

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1708,23 +1708,47 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
     def add_nested_sdfg(
         self,
         sdfg: Optional['SDFG'],
-        parent,
         inputs: Union[Set[str], Dict[str, dtypes.typeclass]],
         outputs: Union[Set[str], Dict[str, dtypes.typeclass]],
         symbol_mapping: Dict[str, Any] = None,
         name=None,
         schedule=dtypes.ScheduleType.Default,
-        location=None,
-        debuginfo=None,
+        location: Optional[Dict[str, symbolic.SymbolicType]] = None,
+        debuginfo: Optional[dtypes.DebugInfo] = None,
         external_path: Optional[str] = None,
     ):
-        """ Adds a nested SDFG to the SDFG state. """
+        """
+        Adds a nested SDFG to the SDFG state.
+
+        :param sdfg: The SDFG to nest. Can be None if ``external_path`` is provided.
+        :param inputs: Input connectors of the nested SDFG. Can be a set of connector names
+                       (types will be auto-detected) or a dict mapping connector names to data types.
+        :param outputs: Output connectors of the nested SDFG. Can be a set of connector names
+                        (types will be auto-detected) or a dict mapping connector names to data types.
+        :param symbol_mapping: A dictionary mapping nested SDFG symbol names to expressions in the
+                               parent SDFG's scope. If None, symbols are mapped to themselves.
+        :param name: Name of the nested SDFG node. If None, uses the nested SDFG's label.
+        :param schedule: Schedule type for the nested SDFG node. Defaults to ``ScheduleType.Default``. This argument
+                         is deprecated and will be removed in the future.
+        :param location: Execution location descriptor for the nested SDFG.
+        :param debuginfo: Debug information for the nested SDFG node.
+        :param external_path: Path to an external SDFG file. Used when ``sdfg`` parameter is None.
+        :return: The created NestedSDFG node.
+        :raises ValueError: If neither sdfg nor external_path is provided, or if required symbols
+                           are missing from the symbol mapping.
+        """
         if name is None:
             name = sdfg.label
         debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
 
         if sdfg is None and external_path is None:
             raise ValueError('Neither an SDFG nor an external SDFG path has been provided')
+
+        if schedule != dtypes.ScheduleType.Default:
+            warnings.warn(
+                "The 'schedule' argument is deprecated and will be removed in the future.",
+                DeprecationWarning,
+            )
 
         if sdfg is not None:
             sdfg.parent = self
@@ -1762,9 +1786,9 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
 
             # Validate missing symbols
             missing_symbols = [s for s in symbols if s not in symbol_mapping]
-            if missing_symbols and parent:
+            if missing_symbols and self.sdfg is not None:
                 # If symbols are missing, try to get them from the parent SDFG
-                parent_mapping = {s: s for s in missing_symbols if s in parent.symbols}
+                parent_mapping = {s: s for s in missing_symbols if s in self.sdfg.symbols}
                 symbol_mapping.update(parent_mapping)
                 s.symbol_mapping = symbol_mapping
                 missing_symbols = [s for s in symbols if s not in symbol_mapping]

--- a/dace/transformation/change_strides.py
+++ b/dace/transformation/change_strides.py
@@ -76,7 +76,7 @@ def change_strides(sdfg: dace.SDFG, stride_one_values: List[str], schedule: Sche
     # Only keep inputs and outputs which are persistent
     inputs.intersection_update(persistent_arrays.keys())
     outputs.intersection_update(persistent_arrays.keys())
-    nsdfg = changed_stride_state.add_nested_sdfg(sdfg, new_sdfg, inputs=inputs, outputs=outputs)
+    nsdfg = changed_stride_state.add_nested_sdfg(sdfg, inputs=inputs, outputs=outputs)
     transform_state = new_sdfg.add_state_before(changed_stride_state, label="transform_data", is_start_state=True)
     transform_state_back = new_sdfg.add_state_after(changed_stride_state, "transform_data_back", is_start_state=False)
 

--- a/dace/transformation/dataflow/reduce_expansion.py
+++ b/dace/transformation/dataflow/reduce_expansion.py
@@ -374,7 +374,6 @@ class ReduceExpansion(transformation.SingleStateTransformation):
         node.add_out_connector('_out')
 
         nsdfg = state.add_nested_sdfg(nsdfg,
-                                      sdfg,
                                       node.in_connectors,
                                       node.out_connectors,
                                       schedule=node.schedule,

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -247,7 +247,7 @@ def nest_sdfg_subgraph(sdfg: SDFG, subgraph: SubgraphView, start: Optional[SDFGS
         fsymbols.update(defined_symbols)
         fsymbols = fsymbols - strictly_defined_symbols
         mapping = {s: s for s in fsymbols}
-        cnode = new_state.add_nested_sdfg(nsdfg, None, read_set, write_set, mapping)
+        cnode = new_state.add_nested_sdfg(nsdfg, read_set, write_set, mapping)
         for s in strictly_defined_symbols:
             if s in sdfg.symbols:
                 sdfg.remove_symbol(s)
@@ -495,7 +495,7 @@ def nest_state_subgraph(sdfg: SDFG,
                 edge.data.subset.offset(nsdfg.arrays[edge.data.data].offset, True)
 
     # Add nested SDFG node to the input state
-    nested_sdfg = state.add_nested_sdfg(nsdfg, None,
+    nested_sdfg = state.add_nested_sdfg(nsdfg,
                                         set(input_names.values()) | input_arrays,
                                         set(output_names.values()) | output_arrays.keys())
 

--- a/dace/transformation/interstate/condition_map_interchange.py
+++ b/dace/transformation/interstate/condition_map_interchange.py
@@ -83,7 +83,6 @@ class ConditionMapInterchange(transformation.MultiStateTransformation):
                     sd.SDFG("map_body", parent=state),
                     inputs=inputs,
                     outputs=outputs,
-                    parent=state,
                     symbol_mapping=sym_mapping,
                 )
                 for sym, dt in state.sdfg.symbols.items():

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -436,7 +436,7 @@ class LoopToMap(xf.MultiStateTransformation):
             del sdfg.arrays[name]
 
         # Add NestedSDFG node
-        cnode = body.add_nested_sdfg(nsdfg, body, read_set, write_set)
+        cnode = body.add_nested_sdfg(nsdfg, read_set, write_set)
         if sdfg.parent:
             for s, m in sdfg.parent_nsdfg_node.symbol_mapping.items():
                 if s not in cnode.symbol_mapping:

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -1353,7 +1353,7 @@ class NestSDFG(transformation.MultiStateTransformation):
                 nested_sdfg.symbols[s] = type
 
         # Add the nested SDFG to the parent state and connect it
-        nested_node = outer_state.add_nested_sdfg(nested_sdfg, outer_sdfg, set(inputs.values()), set(outputs.values()))
+        nested_node = outer_state.add_nested_sdfg(nested_sdfg, set(inputs.values()), set(outputs.values()))
 
         for key, val in inputs.items():
             arrnode = outer_state.add_read(key)

--- a/dace/transformation/subgraph/gpu_persistent_fusion.py
+++ b/dace/transformation/subgraph/gpu_persistent_fusion.py
@@ -272,7 +272,6 @@ class GPUPersistentKernel(SubgraphTransformation):
 
         nested_sdfg = launch_state.add_nested_sdfg(
             kernel_sdfg,
-            sdfg,
             kernel_args_read,
             kernel_args_write,
         )

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -707,7 +707,6 @@ class ExpandTransformation(PatternTransformation):
         expansion = type(self).expansion(node, state, sdfg, *args, **kwargs)
         if isinstance(expansion, SDFG):
             expansion = state.add_nested_sdfg(expansion,
-                                              sdfg,
                                               node.in_connectors,
                                               node.out_connectors,
                                               name=node.name,

--- a/samples/fpga/gemm_systolic_vectorized.py
+++ b/samples/fpga/gemm_systolic_vectorized.py
@@ -489,7 +489,7 @@ c_out = c_val + a_in * b_in""")
 
     # We need to enforce sequentiality between these loops
     write_sdfg = dace.SDFG("write_C")
-    write_sdfg_node = state.add_nested_sdfg(write_sdfg, sdfg, {"buffer_in", "forward_in"}, {"forward_out"})
+    write_sdfg_node = state.add_nested_sdfg(write_sdfg, {"buffer_in", "forward_in"}, {"forward_out"})
     state.add_memlet_path(C_buffer_write,
                           write_entry,
                           write_sdfg_node,

--- a/samples/fpga/gemv_fpga.py
+++ b/samples/fpga/gemv_fpga.py
@@ -102,7 +102,7 @@ def make_outer_compute_state(sdfg):
     nested_sdfg.add_edge(load_state, compute_state, dace.sdfg.InterstateEdge())
     nested_sdfg.add_edge(compute_state, store_state, dace.sdfg.InterstateEdge())
 
-    tasklet = state.add_nested_sdfg(nested_sdfg, sdfg, {"A_nested", "x_nested", "y_nested"}, {"y_nested"})
+    tasklet = state.add_nested_sdfg(nested_sdfg, {"A_nested", "x_nested", "y_nested"}, {"y_nested"})
 
     a_device = state.add_array("A_device", (M, N), dtype, transient=True, storage=dace.dtypes.StorageType.FPGA_Global)
     x_device = state.add_array("x_device", (M, ), dtype, transient=True, storage=dace.dtypes.StorageType.FPGA_Global)

--- a/samples/fpga/histogram_fpga.py
+++ b/samples/fpga/histogram_fpga.py
@@ -129,7 +129,7 @@ def make_sdfg(specialize, h, w):
 
     state = sdfg.add_state("compute")
     nested_sdfg = make_nested_sdfg(state)
-    tasklet = state.add_nested_sdfg(nested_sdfg, sdfg, {"A_in"}, {"hist_out"})
+    tasklet = state.add_nested_sdfg(nested_sdfg, {"A_in"}, {"hist_out"})
     a_device = state.add_array("A_device", (H, W), dtype, transient=True, storage=dace.dtypes.StorageType.FPGA_Global)
     hist_device = state.add_array("hist_device", (num_bins, ),
                                   dace.uint32,

--- a/samples/fpga/jacobi_fpga_systolic.py
+++ b/samples/fpga/jacobi_fpga_systolic.py
@@ -160,7 +160,7 @@ def make_outer_compute_state(sdfg):
 
     # Compute
     compute_sdfg = make_compute_sdfg()
-    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg, {"stream_in", "sliding_window", "row_buffers"},
+    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, {"stream_in", "sliding_window", "row_buffers"},
                                               {"stream_out", "sliding_window", "row_buffers"})
     systolic_entry, systolic_exit = state.add_map("unroll_compute", {"p": "0:P"},
                                                   schedule=dace.ScheduleType.FPGA_Device,

--- a/samples/fpga/matrix_multiplication_pipelined.py
+++ b/samples/fpga/matrix_multiplication_pipelined.py
@@ -129,7 +129,7 @@ def make_sdfg(specialized, n, k, m):
     else_state.add_memlet_path(else_C_in, else_tasklet, memlet=else_c_in_memlet, dst_conn="c_in")
     else_state.add_memlet_path(else_tasklet, else_C_out, memlet=else_c_out_memlet, src_conn="c_out")
 
-    tasklet = state.add_nested_sdfg(nested_sdfg, sdfg, {"A_val", "B_val", "C_in"}, {"C_out"})
+    tasklet = state.add_nested_sdfg(nested_sdfg, {"A_val", "B_val", "C_in"}, {"C_out"})
 
     ###########################################################################
     # Compute continued

--- a/samples/fpga/spmv_fpga_stream.py
+++ b/samples/fpga/spmv_fpga_stream.py
@@ -169,9 +169,7 @@ def make_compute_sdfg():
     b_buffer_in = body.add_scalar("b_buffer", dtype, transient=True, storage=StorageType.FPGA_Registers)
     b_buffer_out = body.add_scalar("b_buffer", dtype, transient=True, storage=StorageType.FPGA_Registers)
     nested_sdfg = make_compute_nested_sdfg()
-    tasklet = body.add_nested_sdfg(nested_sdfg,
-                                   sdfg, {"a_in", "x_in", "b_in"}, {"b_out"},
-                                   schedule=ScheduleType.FPGA_Device)
+    tasklet = body.add_nested_sdfg(nested_sdfg, {"a_in", "x_in", "b_in"}, {"b_out"}, schedule=ScheduleType.FPGA_Device)
     body.add_memlet_path(a_pipe, tasklet, dst_conn="a_in", memlet=Memlet.simple(a_pipe, "0"))
     body.add_memlet_path(b_buffer_in, tasklet, dst_conn="b_in", memlet=Memlet.simple(b_buffer_in, "0"))
     body.add_memlet_path(x_pipe, tasklet, dst_conn="x_in", memlet=Memlet.simple(x_pipe, "0"))
@@ -279,8 +277,7 @@ def make_main_state(sdfg: SDFG):
     row_to_x_out = state.add_stream("row_to_x", itype, transient=True, storage=StorageType.FPGA_Local)
     row_to_compute_out = state.add_stream("row_to_compute", itype, transient=True, storage=StorageType.FPGA_Local)
     read_row_sdfg = make_read_row()
-    read_row_tasklet = state.add_nested_sdfg(read_row_sdfg,
-                                             sdfg, {"A_row_mem"},
+    read_row_tasklet = state.add_nested_sdfg(read_row_sdfg, {"A_row_mem"},
                                              {"to_val_pipe", "to_col_pipe", "to_x_pipe", "to_compute_pipe"},
                                              schedule=ScheduleType.FPGA_Device)
     state.add_memlet_path(a_row,
@@ -309,8 +306,7 @@ def make_main_state(sdfg: SDFG):
     row_to_col_in = state.add_stream("row_to_col", itype, transient=True, storage=StorageType.FPGA_Local)
     col_to_x_out = state.add_stream("col_to_x", itype, transient=True, storage=StorageType.FPGA_Local)
     read_col_sdfg = make_read_col()
-    read_col_tasklet = state.add_nested_sdfg(read_col_sdfg,
-                                             sdfg, {"A_col_mem", "row_pipe"}, {"col_pipe"},
+    read_col_tasklet = state.add_nested_sdfg(read_col_sdfg, {"A_col_mem", "row_pipe"}, {"col_pipe"},
                                              schedule=ScheduleType.FPGA_Device)
     state.add_memlet_path(a_col,
                           read_col_tasklet,
@@ -330,8 +326,7 @@ def make_main_state(sdfg: SDFG):
     row_to_val_in = state.add_stream("row_to_val", itype, transient=True, storage=StorageType.FPGA_Local)
     val_to_compute_out = state.add_stream("val_to_compute", dtype, transient=True, storage=StorageType.FPGA_Local)
     read_val_sdfg = make_read_val()
-    read_val_tasklet = state.add_nested_sdfg(read_val_sdfg,
-                                             sdfg, {"A_val_mem", "row_pipe"}, {"compute_pipe"},
+    read_val_tasklet = state.add_nested_sdfg(read_val_sdfg, {"A_val_mem", "row_pipe"}, {"compute_pipe"},
                                              schedule=ScheduleType.FPGA_Device)
     state.add_memlet_path(a_val,
                           read_val_tasklet,
@@ -352,8 +347,7 @@ def make_main_state(sdfg: SDFG):
     col_to_x_in = state.add_stream("col_to_x", itype, transient=True, storage=StorageType.FPGA_Local)
     x_to_compute_out = state.add_stream("x_to_compute", dtype, transient=True, storage=StorageType.FPGA_Local)
     read_x_sdfg = make_read_x()
-    read_x_tasklet = state.add_nested_sdfg(read_x_sdfg,
-                                           sdfg, {"x_mem", "col_pipe", "row_pipe"}, {"compute_pipe"},
+    read_x_tasklet = state.add_nested_sdfg(read_x_sdfg, {"x_mem", "col_pipe", "row_pipe"}, {"compute_pipe"},
                                            schedule=ScheduleType.FPGA_Device)
     state.add_memlet_path(x, read_x_tasklet, dst_conn="x_mem", memlet=dace.memlet.Memlet.simple(x, "0:cols"))
     state.add_memlet_path(col_to_x_in,
@@ -375,8 +369,7 @@ def make_main_state(sdfg: SDFG):
     x_to_compute_in = state.add_stream("x_to_compute", dtype, transient=True, storage=StorageType.FPGA_Local)
     result_to_write_out = state.add_stream("result_to_write", dtype, transient=True, storage=StorageType.FPGA_Local)
     compute_sdfg = make_compute_sdfg()
-    compute_tasklet = state.add_nested_sdfg(compute_sdfg,
-                                            sdfg, {"row_pipe", "a_pipe", "x_pipe"}, {"b_pipe"},
+    compute_tasklet = state.add_nested_sdfg(compute_sdfg, {"row_pipe", "a_pipe", "x_pipe"}, {"b_pipe"},
                                             schedule=ScheduleType.FPGA_Device)
     state.add_memlet_path(row_to_compute_in,
                           compute_tasklet,
@@ -399,7 +392,7 @@ def make_main_state(sdfg: SDFG):
     result_to_write_in = state.add_stream("result_to_write", dtype, transient=True, storage=StorageType.FPGA_Local)
     b = state.add_array("b_device", (rows, ), dtype, transient=True, storage=StorageType.FPGA_Global)
     write_sdfg = make_write_sdfg()
-    write_tasklet = state.add_nested_sdfg(write_sdfg, sdfg, {"b_pipe"}, {"b_mem"}, schedule=ScheduleType.FPGA_Device)
+    write_tasklet = state.add_nested_sdfg(write_sdfg, {"b_pipe"}, {"b_mem"}, schedule=ScheduleType.FPGA_Device)
     state.add_memlet_path(result_to_write_in,
                           write_tasklet,
                           dst_conn="b_pipe",

--- a/samples/sdfg_api/nested_states.py
+++ b/samples/sdfg_api/nested_states.py
@@ -46,7 +46,7 @@ state = sdfg.add_state('s0')
 me, mx = state.add_map('mymap', dict(k='0:2'))
 # NOTE: The names of the inputs/outputs of the nested SDFG must match array
 #       names above (lines 30, 32)!
-nsdfg = state.add_nested_sdfg(sub_sdfg, sdfg, {'sA'}, {'sC'})
+nsdfg = state.add_nested_sdfg(sub_sdfg, {'sA'}, {'sC'})
 Ain = state.add_read('A')
 Aout = state.add_write('A')
 

--- a/tests/chained_nested_tasklet_test.py
+++ b/tests/chained_nested_tasklet_test.py
@@ -79,7 +79,7 @@ def test_nested_sdfg():
 
     # Add outer edges
     omap_entry, omap_exit = state.add_map('omap', dict(k='0:2'))
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'a'}, {'b'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'a'}, {'b'})
     state.add_memlet_path(A_, omap_entry, nsdfg_node, dst_conn='a', memlet=Memlet('A[0:N]'))
     state.add_memlet_path(nsdfg_node, omap_exit, B_, src_conn='b', memlet=Memlet('B[0:N]'))
 

--- a/tests/codegen/allocation_lifetime_test.py
+++ b/tests/codegen/allocation_lifetime_test.py
@@ -33,7 +33,7 @@ def _test_determine_alloc(lifetime: dace.AllocationLifetime, unused: bool = Fals
     nstate.add_memlet_path(nstate.add_read('A'), ime, t1, memlet=dace.Memlet('A[i]'))
     nstate.add_memlet_path(t2, imx, nstate.add_write('B'), memlet=dace.Memlet('B[0]', wcr='lambda a,b: a+b'))
     #########################################################################
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'A'}, {'B'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'A'}, {'B'})
     state.add_memlet_path(state.add_read('A'), me, nsdfg_node, dst_conn='A', memlet=dace.Memlet('A[0:N]'))
     state.add_memlet_path(nsdfg_node, mx, state.add_write('B'), src_conn='B', memlet=dace.Memlet('B[0:N]'))
 
@@ -130,7 +130,7 @@ def test_persistent_gpu_copy_regression():
     nstate.add_edge(a_trans, None, nstate.add_write("noutput"), None, nsdfg.make_array_memlet("transient_heap"))
 
     a_gpu = state.add_read("input_gpu")
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {"ninput"}, {"noutput"})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {"ninput"}, {"noutput"})
     wR = state.add_write("__return")
 
     state.add_edge(state.add_read("input"), None, a_gpu, None, sdfg.make_array_memlet("input"))
@@ -434,13 +434,13 @@ def test_double_nested_persistent_write():
     osdfg.add_transient('pers', [20], dace.float64, lifetime=dace.AllocationLifetime.Persistent)
     state = osdfg.add_state()
     me, mx = state.add_map('mapit', dict(i='0:20'))
-    nsdfg = state.add_nested_sdfg(sdfg, None, {}, {'pers'})
+    nsdfg = state.add_nested_sdfg(sdfg, {}, {'pers'})
     state.add_nedge(me, nsdfg, dace.Memlet())
     state.add_memlet_path(nsdfg, mx, state.add_write('pers'), src_conn='pers', memlet=dace.Memlet('pers[0:20]'))
 
     oosdfg = dace.SDFG('npw_outer')
     state = oosdfg.add_state()
-    nsdfg = state.add_nested_sdfg(osdfg, None, {}, {})
+    nsdfg = state.add_nested_sdfg(osdfg, {}, {})
 
     oosdfg.compile()
 

--- a/tests/codegen/nested_kernel_transient_test.py
+++ b/tests/codegen/nested_kernel_transient_test.py
@@ -19,7 +19,7 @@ def _test_kernel_transient(persistent: bool):
     top_sdfg.arg_names = ['A']
     top_sdfg.add_datadesc('A', copy.deepcopy(sdfg.arrays['A']))
     state = top_sdfg.add_state()
-    n = state.add_nested_sdfg(sdfg, None, {}, {'A'})
+    n = state.add_nested_sdfg(sdfg, {}, {'A'})
     w = state.add_write('A')
     state.add_edge(n, 'A', w, None, dace.Memlet('A'))
 

--- a/tests/codegen/symbol_arguments_test.py
+++ b/tests/codegen/symbol_arguments_test.py
@@ -52,7 +52,7 @@ def test_nested_sdfg_redefinition():
     sdfg = dace.SDFG('tester')
     nsdfg = dace.SDFG('nester')
     state = sdfg.add_state()
-    nnode = state.add_nested_sdfg(nsdfg, None, {}, {}, symbol_mapping=dict(sym=0))
+    nnode = state.add_nested_sdfg(nsdfg, {}, {}, symbol_mapping=dict(sym=0))
 
     nstate = nsdfg.add_state()
     nstate.add_tasklet('nothing', {}, {}, 'a = sym')

--- a/tests/codegen/unroller_general_test.py
+++ b/tests/codegen/unroller_general_test.py
@@ -52,7 +52,7 @@ def create_deeply_nested_sdfg():
     )
 
     nsdfg.add_edge(nstate, nstate2, InterstateEdge(None, dict(mpt="k")))
-    nsdfg_node = state.add_nested_sdfg(nsdfg, state, set(["xin"]), set(['xout']))
+    nsdfg_node = state.add_nested_sdfg(nsdfg, set(["xin"]), set(['xout']))
     nsdfg_node.unique_name = "SomeUniqueName"
 
     state.add_memlet_path(

--- a/tests/const_access_test.py
+++ b/tests/const_access_test.py
@@ -14,7 +14,7 @@ t = nstate.add_tasklet('add', {'inp'}, {'out'}, 'out = inp + inp')
 nstate.add_edge(nstate.add_read('a'), None, t, 'inp', dace.Memlet.simple('a', '0'))
 nstate.add_edge(t, 'out', nstate.add_write('a'), None, dace.Memlet.simple('a', '0'))
 
-nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'a'}, {})
+nsdfg_node = state.add_nested_sdfg(nsdfg, {'a'}, {})
 state.add_edge(state.add_read('A'), None, nsdfg_node, 'a', dace.Memlet.simple('A', '0'))
 
 

--- a/tests/fpga/channel_mangling_test.py
+++ b/tests/fpga/channel_mangling_test.py
@@ -120,7 +120,7 @@ def make_nested_sdfg_fpga(dtype=dace.float32):
     tmp = state.add_write("device_tmp")
 
     # add nested sdfg with symbol mapping
-    nested_sdfg = state.add_nested_sdfg(to_nest, sdfg, {"x"}, {"y"})
+    nested_sdfg = state.add_nested_sdfg(to_nest, {"x"}, {"y"})
     state.add_memlet_path(x, nested_sdfg, dst_conn="x", memlet=Memlet("device_X[0:N]"))
     state.add_memlet_path(nested_sdfg, tmp, src_conn="y", memlet=Memlet("device_tmp[0:N]"))
 
@@ -134,7 +134,7 @@ def make_nested_sdfg_fpga(dtype=dace.float32):
     y = state2.add_write("device_Y")
 
     # add nested sdfg with symbol mapping
-    nested_sdfg = state2.add_nested_sdfg(to_nest, sdfg, {"x"}, {"y"})
+    nested_sdfg = state2.add_nested_sdfg(to_nest, {"x"}, {"y"})
     state2.add_memlet_path(tmp_read, nested_sdfg, dst_conn="x", memlet=Memlet("device_tmp[0:N]"))
     state2.add_memlet_path(nested_sdfg, y, src_conn="y", memlet=Memlet("device_Y[0:N]"))
 

--- a/tests/fpga/multibank_deeply_nested_fpga_test.py
+++ b/tests/fpga/multibank_deeply_nested_fpga_test.py
@@ -39,7 +39,7 @@ def create_deeply_nested_sdfg(mem_type):
     output_mem = mem.Memlet("xout[2*k+w, i]")
     nstate.add_memlet_path(x_read, map_entry, imap_entry, nope, memlet=input_mem, dst_conn="_in")
     nstate.add_memlet_path(nope, imap_exit, map_exit, x_write, memlet=output_mem, src_conn="_out")
-    nsdfg_node = state.add_nested_sdfg(nsdfg, state, set(["xin"]), set(['xout']))
+    nsdfg_node = state.add_nested_sdfg(nsdfg, set(["xin"]), set(['xout']))
 
     state.add_memlet_path(xarr,
                           top_map_entry,

--- a/tests/fpga/nested_sdfg_as_kernel_test.py
+++ b/tests/fpga/nested_sdfg_as_kernel_test.py
@@ -190,8 +190,7 @@ def make_fpga_sdfg():
 
     to_nest = make_vec_add_sdfg()
     # add nested sdfg with symbol mapping
-    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, sdfg, {"_device_x", "_device_y"}, {"_device_z"},
-                                                 {"size": "n"})
+    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, {"_device_x", "_device_y"}, {"_device_z"}, {"size": "n"})
 
     non_fpga_state.add_memlet_path(in_device_x,
                                    nested_sdfg,
@@ -210,8 +209,7 @@ def make_fpga_sdfg():
 
     to_nest = make_vec_add_sdfg()
     # add nested sdfg with symbol mapping
-    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, sdfg, {"_device_x", "_device_y"}, {"_device_z"},
-                                                 {"size": "n"})
+    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, {"_device_x", "_device_y"}, {"_device_z"}, {"size": "n"})
 
     non_fpga_state.add_memlet_path(out_device_z,
                                    nested_sdfg,
@@ -341,8 +339,7 @@ def make_fpga_sdfg_independent():
 
     to_nest = make_vec_add_sdfg()
     # add nested sdfg with symbol mapping
-    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, sdfg, {"_device_x", "_device_y"}, {"_device_z"},
-                                                 {"size": "n"})
+    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, {"_device_x", "_device_y"}, {"_device_z"}, {"size": "n"})
 
     non_fpga_state.add_memlet_path(in_device_x,
                                    nested_sdfg,
@@ -361,8 +358,7 @@ def make_fpga_sdfg_independent():
 
     to_nest = make_vec_mul_sdfg()
     # add nested sdfg with symbol mapping
-    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, sdfg, {"_device_x", "_device_y"}, {"_device_z"},
-                                                 {"size": "n"})
+    nested_sdfg = non_fpga_state.add_nested_sdfg(to_nest, {"_device_x", "_device_y"}, {"_device_z"}, {"size": "n"})
 
     non_fpga_state.add_memlet_path(in_device_v,
                                    nested_sdfg,

--- a/tests/fpga/simple_systolic_array_test.py
+++ b/tests/fpga/simple_systolic_array_test.py
@@ -164,13 +164,13 @@ def make_fpga_state(sdfg):
     state = sdfg.add_state("simple_array")
 
     read_A_sdfg = make_read_A_sdfg()
-    read_A_sdfg_node = state.add_nested_sdfg(read_A_sdfg, sdfg, {"mem"}, {"pipe"})
+    read_A_sdfg_node = state.add_nested_sdfg(read_A_sdfg, {"mem"}, {"pipe"})
 
     compute_sdfg = make_compute_sdfg()
-    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, sdfg, {"A_stream_in"}, {"A_stream_out"})
+    compute_sdfg_node = state.add_nested_sdfg(compute_sdfg, {"A_stream_in"}, {"A_stream_out"})
 
     write_A_sdfg = make_write_A_sdfg()
-    write_A_sdfg_node = state.add_nested_sdfg(write_A_sdfg, sdfg, {"pipe"}, {"mem"})
+    write_A_sdfg_node = state.add_nested_sdfg(write_A_sdfg, {"pipe"}, {"mem"})
 
     A_IN = state.add_array("A_device", [N],
                            dtype=dace.int32,

--- a/tests/fpga/unique_nested_sdfg_fpga_test.py
+++ b/tests/fpga/unique_nested_sdfg_fpga_test.py
@@ -141,7 +141,7 @@ def make_nested_sdfg_fpga(unique_names):
     z = state.add_write("z")
 
     # add nested sdfg with symbol mapping
-    nested_sdfg = state.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "n"})
+    nested_sdfg = state.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "n"})
 
     if unique_names:
         nested_sdfg.unique_name = sdfg_name
@@ -163,7 +163,7 @@ def make_nested_sdfg_fpga(unique_names):
     w = state2.add_read("w")
     u = state2.add_write("u")
 
-    nested_sdfg = state2.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "m"})
+    nested_sdfg = state2.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "m"})
 
     if unique_names:
         nested_sdfg.unique_name = sdfg_name

--- a/tests/inline_external_edges_test.py
+++ b/tests/inline_external_edges_test.py
@@ -27,7 +27,7 @@ nstate.add_edge(L_inout, None, t2, 'l', dace.Memlet.simple('local', '0'))
 nstate.add_edge(t2, 'mm', M_localout, None, dace.Memlet.simple('m', '0'))
 ###############
 
-nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'local'}, {'local', 'm'})
+nsdfg_node = state.add_nested_sdfg(nsdfg, {'local'}, {'local', 'm'})
 state.add_memlet_path(L_in, me, nsdfg_node, memlet=dace.Memlet.simple('L', 'i'), dst_conn='local')
 state.add_memlet_path(nsdfg_node, mx, L_out, memlet=dace.Memlet.simple('L', 'i'), src_conn='local')
 state.add_memlet_path(nsdfg_node, mx, M_out, memlet=dace.Memlet.simple('M', 'i'), src_conn='m')

--- a/tests/inline_noncontig_dim_test.py
+++ b/tests/inline_noncontig_dim_test.py
@@ -25,7 +25,7 @@ s.add_mapped_tasklet('dostuff',
 
 # Add nested SDFG to SDFG
 map_entry, map_exit = state.add_map('elements', dict(j='0:3'))
-nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'aA'}, {'bB'})
+nsdfg_node = state.add_nested_sdfg(nsdfg, {'aA'}, {'bB'})
 state.add_memlet_path(A, map_entry, nsdfg_node, dst_conn='aA', memlet=dace.Memlet.simple('A', '0:2, j, 0:4'))
 state.add_memlet_path(nsdfg_node, map_exit, B, src_conn='bB', memlet=dace.Memlet.simple('B', '0:2, j, 0:4'))
 

--- a/tests/inline_nonsink_access_test.py
+++ b/tests/inline_nonsink_access_test.py
@@ -38,7 +38,7 @@ def make_sdfg(outer_shape, inner_shape, outer_index, inner_index):
     nstate.add_edge(t_cube, 'o', D, None, dace.Memlet.simple('D', inner_index))
 
     # Add nested SDFG to SDFG
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'C', 'D'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {'C', 'D'})
     state.add_edge(nsdfg_node, 'C', A, None, dace.Memlet('A'))
     state.add_edge(nsdfg_node, 'D', B, None, dace.Memlet('B'))
 

--- a/tests/inlining_test.py
+++ b/tests/inlining_test.py
@@ -105,7 +105,6 @@ def _make_chain_reduction_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.
     inner_sdfg_1 = _make_nested_sdfg("first_adding")
     nsdfg_node_1 = state.add_nested_sdfg(
         sdfg=inner_sdfg_1,
-        parent=outer_sdfg,
         inputs={"A", "B"},
         outputs={"C"},
         symbol_mapping={},
@@ -121,7 +120,6 @@ def _make_chain_reduction_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_nodes.
     inner_sdfg_2 = _make_nested_sdfg("second_adding")
     nsdfg_node_2 = state.add_nested_sdfg(
         sdfg=inner_sdfg_2,
-        parent=outer_sdfg,
         inputs={"A", "B"},
         outputs={"C"},
         symbol_mapping={},
@@ -251,8 +249,8 @@ def test_empty_memlets():
     nstate2.add_edge(tasklet2, 'a_res', nstate2.add_write('field_a'), None, dace.Memlet.simple('field_a',
                                                                                                subset_str='0'))
 
-    nsdfg1_node = state.add_nested_sdfg(nsdfg1, None, {'field_a'}, {'field_b'})
-    nsdfg2_node = state.add_nested_sdfg(nsdfg2, None, {'field_a'}, {'field_a'})
+    nsdfg1_node = state.add_nested_sdfg(nsdfg1, {'field_a'}, {'field_b'})
+    nsdfg2_node = state.add_nested_sdfg(nsdfg2, {'field_a'}, {'field_a'})
 
     a_read = state.add_read('field_a')
     state.add_edge(a_read, None, nsdfg1_node, 'field_a', dace.Memlet.simple('field_a', subset_str='0'))
@@ -437,7 +435,7 @@ def test_inline_symexpr():
     sdfg.add_symbol('i', dace.int32)
     state = sdfg.add_state()
     w = state.add_write('A')
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'a'}, {'j': 'min(i, 10)'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {'a'}, {'j': 'min(i, 10)'})
     state.add_edge(nsdfg_node, 'a', w, None, dace.Memlet('A'))
 
     # Verify that compilation works before inlining

--- a/tests/memlet_propagation_squeezing_test.py
+++ b/tests/memlet_propagation_squeezing_test.py
@@ -32,8 +32,7 @@ def make_sdfg(squeeze, name):
     nsdfg.add_loop(None, nstate, None, 'i', '0', 'i < N - 2', 'i + 1')
 
     # Connect nested SDFG to toplevel one
-    nsdfg_node = state.add_nested_sdfg(nsdfg,
-                                       None, {}, {'a1', 'a2'} if squeeze else {'a'},
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {'a1', 'a2'} if squeeze else {'a'},
                                        symbol_mapping=dict(j='j', N='N', M='M'))
     state.add_nedge(me, nsdfg_node, dace.Memlet())
     # Add outer memlet that is overapproximated

--- a/tests/memlet_propagation_volume_test.py
+++ b/tests/memlet_propagation_volume_test.py
@@ -79,7 +79,7 @@ def make_sdfg():
     bound_pipe = state.add_stream('bound_in', dace.int32, transient=True, storage=StorageType.FPGA_Local)
     out_stream = state.add_stream('out_stream', dace.int32, transient=True, storage=StorageType.FPGA_Local)
 
-    nest = state.add_nested_sdfg(make_nested_sdfg(), sdfg, {
+    nest = state.add_nested_sdfg(make_nested_sdfg(), {
         'IN_a',
         'IN_bound',
     }, {

--- a/tests/multistream_copy_cudatest.py
+++ b/tests/multistream_copy_cudatest.py
@@ -79,7 +79,7 @@ def test_copy_sync():
     state = sdfg.add_state_after(state)
     ro = state.add_read('gpu_scal_outer')
     wo = state.add_write('output_outer')
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'gpu_scal'}, {'output'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'gpu_scal'}, {'output'})
     state.add_edge(ro, None, nsdfg_node, 'gpu_scal', dace.Memlet('gpu_scal_outer'))
     state.add_edge(nsdfg_node, 'output', wo, None, dace.Memlet('output_outer'))
 

--- a/tests/nested_cr_test.py
+++ b/tests/nested_cr_test.py
@@ -18,7 +18,7 @@ state = sdfg.add_state('a')
 # Nodes
 sdfg.add_array('B', (1, ), dace.int32)
 B = state.add_write('B')
-n = state.add_nested_sdfg(nsdfg, None, set(), {'nout'})
+n = state.add_nested_sdfg(nsdfg, set(), {'nout'})
 state.add_edge(n, 'nout', B, None, Memlet.simple('B', '0', wcr_str='lambda a, b: a*b'))
 
 

--- a/tests/nested_sdfg_scalar_test.py
+++ b/tests/nested_sdfg_scalar_test.py
@@ -20,7 +20,7 @@ def _construct_sdfg():
                               external_edges=True)
 
     r = state.add_read('A')
-    n = state.add_nested_sdfg(nsdfg, None, {'a'}, {'b'})
+    n = state.add_nested_sdfg(nsdfg, {'a'}, {'b'})
     w = state.add_write('A')
     state.add_edge(r, None, n, 'a', dace.Memlet.simple('A', '1'))
     state.add_edge(n, 'b', w, None, dace.Memlet.simple('A', '0'))

--- a/tests/nested_sdfg_test.py
+++ b/tests/nested_sdfg_test.py
@@ -35,7 +35,7 @@ def test():
     B = state.add_array('B', [N, N], dp.float32)
 
     map_entry, map_exit = state.add_map('elements', [('i', '0:N'), ('j', '0:N')])
-    nsdfg = state.add_nested_sdfg(sdfg_internal.to_sdfg(), mysdfg, {'input'}, {'output'})
+    nsdfg = state.add_nested_sdfg(sdfg_internal.to_sdfg(), {'input'}, {'output'})
 
     # Add edges
     state.add_memlet_path(A, map_entry, nsdfg, dst_conn='input', memlet=Memlet.simple(A, 'i,j'))
@@ -84,7 +84,7 @@ def test_external_nsdfg():
     internal = sdfg_internal.to_sdfg()
     fd, filename = tempfile.mkstemp(suffix='.sdfg')
     internal.save(filename)
-    nsdfg = state.add_nested_sdfg(None, mysdfg, {'input'}, {'output'}, name='sdfg_internal', external_path=filename)
+    nsdfg = state.add_nested_sdfg(None, {'input'}, {'output'}, name='sdfg_internal', external_path=filename)
 
     # Add edges
     state.add_memlet_path(A, map_entry, nsdfg, dst_conn='input', memlet=Memlet.simple(A, 'i,j'))

--- a/tests/nested_stream_test.py
+++ b/tests/nested_stream_test.py
@@ -20,7 +20,7 @@ sdfg.add_stream('SB', dace.int32, transient=True)
 sdfg.add_array('B', (2, ), dace.int32)
 SB = state.add_access('SB')
 B = state.add_write('B')
-n = state.add_nested_sdfg(nsdfg, None, set(), {'nout'})
+n = state.add_nested_sdfg(nsdfg, set(), {'nout'})
 state.add_edge(n, 'nout', SB, None, Memlet.simple('SB', '0'))
 state.add_nedge(SB, B, Memlet.simple('B', '0'))
 

--- a/tests/nested_vector_type_test.py
+++ b/tests/nested_vector_type_test.py
@@ -73,7 +73,7 @@ x_in1 = state.add_read('x1')
 y_in1 = state.add_read('y1')
 z_out1 = state.add_write('z1')
 
-nested_sdfg = state.add_nested_sdfg(vecAdd_sdfg, sdfg, {"_x", "_y"}, {"_res"})
+nested_sdfg = state.add_nested_sdfg(vecAdd_sdfg, {"_x", "_y"}, {"_res"})
 
 state.add_memlet_path(x_in1, nested_sdfg, dst_conn='_x', memlet=Memlet.simple(x_in1, "0:n"))
 state.add_memlet_path(y_in1, nested_sdfg, dst_conn='_y', memlet=Memlet.simple(y_in1, "0:n"))

--- a/tests/passes/constant_propagation_test.py
+++ b/tests/passes/constant_propagation_test.py
@@ -240,7 +240,7 @@ def test_recursive_cprop():
     sdfg.add_edge(a, b, dace.InterstateEdge(assignments=dict(i=1)))
 
     nsdfg = dace.SDFG('nested')
-    b.add_nested_sdfg(nsdfg, None, {}, {}, symbol_mapping={'i': 'i + 1'})
+    b.add_nested_sdfg(nsdfg, {}, {}, symbol_mapping={'i': 'i + 1'})
 
     nstate = nsdfg.add_state()
     t = nstate.add_tasklet('doprint', {}, {}, 'printf("%d\\n", i)')
@@ -422,7 +422,7 @@ def test_for_with_external_init_nested():
     nbody.add_edge(nt, '__out', na, None, dace.Memlet('inner_A[i]'))
 
     a = main.add_access('A')
-    t = main.add_nested_sdfg(nsdfg, None, {}, {'inner_A'}, {'N': 'N', 'i': 'i'})
+    t = main.add_nested_sdfg(nsdfg, {}, {'inner_A'}, {'N': 'N', 'i': 'i'})
     main.add_edge(t, 'inner_A', a, None, dace.Memlet.from_array('A', sdfg.arrays['A']))
 
     sdfg.validate()
@@ -465,7 +465,7 @@ def test_for_with_external_init_nested_start_with_guard():
     nbody.add_edge(nt, '__out', na, None, dace.Memlet('inner_A[i-1]'))
 
     a = main.add_access('A')
-    t = main.add_nested_sdfg(nsdfg, None, {}, {'inner_A'}, {'N': 'N', 'i': 'i'})
+    t = main.add_nested_sdfg(nsdfg, {}, {'inner_A'}, {'N': 'N', 'i': 'i'})
     main.add_edge(t, 'inner_A', a, None, dace.Memlet.from_array('A', sdfg.arrays['A']))
 
     sdfg.validate()

--- a/tests/passes/dead_code_elimination_test.py
+++ b/tests/passes/dead_code_elimination_test.py
@@ -246,7 +246,7 @@ def test_dde_inout(libnode):
                 a[i] = b[i + 1] + 1
 
         nsdfg = nested.to_sdfg(simplify=False)
-        node = state.add_nested_sdfg(nsdfg, None, {'b'}, {'a', 'b'})
+        node = state.add_nested_sdfg(nsdfg, {'b'}, {'a', 'b'})
         outconn = 'b'
     else:
         node = dace.nodes.LibraryNode('tester')  # Library node without side effects

--- a/tests/passes/find_single_use_data_test.py
+++ b/tests/passes/find_single_use_data_test.py
@@ -243,7 +243,6 @@ def _make_access_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFG]:
     state = sdfg.add_state(is_start_block=True)
     nsdfg_node = state.add_nested_sdfg(
         nsdfg,
-        parent=sdfg,
         inputs={'a'},
         outputs={'b'},
         symbol_mapping={},

--- a/tests/passes/scalar_to_symbol_test.py
+++ b/tests/passes/scalar_to_symbol_test.py
@@ -457,7 +457,7 @@ def test_nested_promotion_connector(with_subscript):
     nstate2.add_edge(a, None, t, 'inp', dace.Memlet('a[s2, s2 + 1]'))
     nstate2.add_edge(t, 'out', b, None, dace.Memlet('b[0]'))
 
-    nnode = state.add_nested_sdfg(nsdfg, None, {'a', 's'}, {'b'})
+    nnode = state.add_nested_sdfg(nsdfg, {'a', 's'}, {'b'})
     aouter = state.add_read('A')
     souter = state.add_read('scal')
     bouter = state.add_write('B')

--- a/tests/schedule_tree/naming_test.py
+++ b/tests/schedule_tree/naming_test.py
@@ -38,7 +38,7 @@ def _nested_irreducible_loops():
     nsdfg = _irreducible_loop_to_loop()
 
     l1 = sdfg.node(5)
-    l1.add_nested_sdfg(nsdfg, None, {}, {})
+    l1.add_nested_sdfg(nsdfg, {}, {})
     return sdfg
 
 
@@ -96,7 +96,7 @@ def test_clash_symbol_mapping(constprop):
     nstate2.add_edge(t, 'b', w, None, dace.Memlet('out[k]'))
 
     # Connect nested SDFG to parent SDFG with an offset memlet
-    nsdfg_node = state2.add_nested_sdfg(nsdfg, None, {}, {'out'}, {'N': 'M', 'M': 'N', 'k': 'k'})
+    nsdfg_node = state2.add_nested_sdfg(nsdfg, {}, {'out'}, {'N': 'M', 'M': 'N', 'k': 'k'})
     w = state2.add_write('A')
     state2.add_edge(nsdfg_node, 'out', w, None, dace.Memlet('A[100:200]'))
 
@@ -153,7 +153,7 @@ def test_edgecase_symbol_mapping():
     nsdfg.add_edge(nstate, nstate2, dace.InterstateEdge(assignments={'k': 'M + 1'}))
     nsdfg.add_edge(nstate2, nstate3, dace.InterstateEdge(assignments={'l': 'k'}))
 
-    state2.add_nested_sdfg(nsdfg, None, {}, {}, {'N': 'M', 'M': 'N', 'k': 'M + 1'})
+    state2.add_nested_sdfg(nsdfg, {}, {}, {'N': 'M', 'M': 'N', 'k': 'M + 1'})
 
     stree = as_schedule_tree(sdfg)
 

--- a/tests/schedule_tree/nesting_test.py
+++ b/tests/schedule_tree/nesting_test.py
@@ -209,7 +209,7 @@ def test_dealias_interstate_edge():
 
     # Connect to nested SDFG both with renaming and offset memlets
     state = sdfg.add_state()
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'A', 'B'}, {})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'A', 'B'}, {})
     ra = state.add_read('A')
     rb = state.add_read('B')
     state.add_edge(ra, None, nsdfg_node, 'B', dace.Memlet('A[1:20]'))

--- a/tests/sdfg/disallowed_access_test.py
+++ b/tests/sdfg/disallowed_access_test.py
@@ -18,7 +18,7 @@ def test_gpu_access_on_host_interstate_ok():
     state2 = nsdfg.add_state()
     nsdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(s='a[i]')))
 
-    nnode = state.add_nested_sdfg(nsdfg, None, {'a'}, {}, {'i': 'i'})
+    nnode = state.add_nested_sdfg(nsdfg, {'a'}, {}, {'i': 'i'})
     r = state.add_read('A')
     state.add_memlet_path(r, me, nnode, dst_conn='a', memlet=dace.Memlet('A[0:20]'))
     state.add_nedge(nnode, mx, dace.Memlet())
@@ -64,7 +64,7 @@ def test_gpu_access_on_device_interstate_edge_default():
     state2 = nsdfg.add_state()
     nsdfg.add_edge(state1, state2, dace.InterstateEdge(assignments=dict(s='A[4]')))
 
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'A'}, {})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'A'}, {})
     state.add_memlet_path(state.add_read('A'), me, nsdfg_node, dst_conn='A', memlet=dace.Memlet('A[0:20]'))
     state.add_nedge(nsdfg_node, mx, dace.Memlet())
 

--- a/tests/sdfg/free_symbols_test.py
+++ b/tests/sdfg/free_symbols_test.py
@@ -40,7 +40,7 @@ def test_state_subgraph():
     nsdfg = dace.SDFG('nsdfg')
     nstate = nsdfg.add_state()
     me, mx = state.add_map('map', dict(i='0:N'))
-    nsdfg = state.add_nested_sdfg(nsdfg, None, {}, {}, symbol_mapping=dict(l=L / 2, i='i'))
+    nsdfg = state.add_nested_sdfg(nsdfg, {}, {}, symbol_mapping=dict(l=L / 2, i='i'))
     state.add_nedge(me, nsdfg, dace.Memlet())
     state.add_nedge(nsdfg, mx, dace.Memlet())
 
@@ -121,7 +121,7 @@ def test_nested_sdfg_free_symbols():
                         dace.InterstateEdge(condition='k >= 10', assignments={'j': 'j + 1'}))
     inner_sdfg.add_edge(inner_body_state, inner_guard_state, dace.InterstateEdge(assignments={'k': 'k + 1'}))
 
-    outer_body_state_2.add_nested_sdfg(inner_sdfg, None, {}, {}, symbol_mapping={'j': 'j'})
+    outer_body_state_2.add_nested_sdfg(inner_sdfg, {}, {}, symbol_mapping={'j': 'j'})
 
     assert not outer_sdfg.free_symbols
     assert 'i' not in inner_sdfg.free_symbols

--- a/tests/sdfg/nested_sdfg_deepcopy_test.py
+++ b/tests/sdfg/nested_sdfg_deepcopy_test.py
@@ -11,7 +11,7 @@ def test_deepcopy_same_state():
     state = sdfg.add_state('state')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {})
 
     copy_nsdfg = copy.deepcopy(nsdfg_node)
     assert copy_nsdfg.sdfg.parent_nsdfg_node is copy_nsdfg
@@ -29,7 +29,7 @@ def test_deepcopy_same_state_edge():
     state = sdfg.add_state('state')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {})
 
     copy_nsdfg = copy.deepcopy(nsdfg_node)
     assert copy_nsdfg.sdfg.parent_nsdfg_node is copy_nsdfg
@@ -48,7 +48,7 @@ def test_deepcopy_diff_state():
     state_1 = sdfg.add_state('state_1')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state_0.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state_0.add_nested_sdfg(nsdfg, {}, {})
 
     copy_nsdfg = copy.deepcopy(nsdfg_node)
     assert copy_nsdfg.sdfg.parent_nsdfg_node is copy_nsdfg
@@ -68,7 +68,7 @@ def test_deepcopy_diff_state_edge():
     state_1 = sdfg.add_state('state_1')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state_0.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state_0.add_nested_sdfg(nsdfg, {}, {})
 
     copy_nsdfg = copy.deepcopy(nsdfg_node)
     assert copy_nsdfg.sdfg.parent_nsdfg_node is copy_nsdfg
@@ -87,7 +87,7 @@ def test_deepcopy_diff_sdfg():
     state_0 = sdfg_0.add_state('state_0')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state_0.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state_0.add_nested_sdfg(nsdfg, {}, {})
 
     copy_nsdfg = copy.deepcopy(nsdfg_node)
     assert copy_nsdfg.sdfg.parent_nsdfg_node is copy_nsdfg
@@ -108,7 +108,7 @@ def test_deepcopy_diff_sdfg_edge():
     state_0 = sdfg_0.add_state('state_0')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state_0.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state_0.add_nested_sdfg(nsdfg, {}, {})
 
     copy_nsdfg = copy.deepcopy(nsdfg_node)
     assert copy_nsdfg.sdfg.parent_nsdfg_node is copy_nsdfg
@@ -131,7 +131,7 @@ def test_deepcopy_top_level():
     state = sdfg.add_state('state')
 
     nsdfg = dace.SDFG('nested')
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {})
 
     copy_sdfg = copy.deepcopy(sdfg)
     copy_state = copy_sdfg.states()[0]

--- a/tests/sdfg/validation/nested_sdfg_test.py
+++ b/tests/sdfg/validation/nested_sdfg_test.py
@@ -22,7 +22,7 @@ def test_inout_connector_validation_success():
     state = sdfg.add_state()
     read_b = state.add_access("B")
     write_b = state.add_access("B")
-    tasklet = state.add_nested_sdfg(nsdfg, sdfg, {"C"}, {"C"})
+    tasklet = state.add_nested_sdfg(nsdfg, {"C"}, {"C"})
     state.add_edge(read_b, None, tasklet, 'C', dace.Memlet.from_array('B', sdfg.arrays['B']))
     state.add_edge(tasklet, 'C', write_b, None, dace.Memlet.from_array('B', sdfg.arrays['B']))
 
@@ -55,14 +55,14 @@ def test_inout_connector_validation_success_2():
     nstate = nsdfg_0.add_state()
     tasklet_0 = nstate.add_tasklet("tasklet_00", {}, {"__out"}, "__out = 3")
     write_b_0 = nstate.add_access("B")
-    tasklet_1 = nstate.add_nested_sdfg(nsdfg_1, nsdfg_0, {"C"}, {"C"})
+    tasklet_1 = nstate.add_nested_sdfg(nsdfg_1, {"C"}, {"C"})
     write_b_1 = nstate.add_access("B")
     nstate.add_edge(tasklet_0, '__out', write_b_0, None, dace.Memlet.from_array('B', nsdfg_0.arrays['B']))
     nstate.add_edge(write_b_0, None, tasklet_1, 'C', dace.Memlet.from_array('B', nsdfg_0.arrays['B']))
     nstate.add_edge(tasklet_1, 'C', write_b_1, None, dace.Memlet.from_array('B', nsdfg_0.arrays['B']))
 
     state = sdfg.add_state()
-    tasklet = state.add_nested_sdfg(nsdfg_0, sdfg, {}, {"B"})
+    tasklet = state.add_nested_sdfg(nsdfg_0, {}, {"B"})
     write_a = state.add_access("A")
     state.add_edge(tasklet, 'B', write_a, None, dace.Memlet.from_array('A', sdfg.arrays['A']))
 
@@ -95,7 +95,7 @@ def test_inout_connector_validation_fail():
     state = sdfg.add_state()
     read_a = state.add_access("A")
     write_b = state.add_access("B")
-    tasklet = state.add_nested_sdfg(nsdfg, sdfg, {"C"}, {"C"})
+    tasklet = state.add_nested_sdfg(nsdfg, {"C"}, {"C"})
     state.add_edge(read_a, None, tasklet, 'C', dace.Memlet.from_array('A', sdfg.arrays['A']))
     state.add_edge(tasklet, 'C', write_b, None, dace.Memlet.from_array('B', sdfg.arrays['B']))
 
@@ -136,7 +136,7 @@ def test_nested_sdfg_with_transient_connector():
 
     state = sdfg.add_state('s0')
     me, mx = state.add_map('mymap', dict(k='0:2'))
-    nsdfg = state.add_nested_sdfg(sub_sdfg, sdfg, {'sA'}, {'sC'})
+    nsdfg = state.add_nested_sdfg(sub_sdfg, {'sA'}, {'sC'})
     Ain = state.add_read('A')
     Aout = state.add_write('A')
 

--- a/tests/symbol_type_test.py
+++ b/tests/symbol_type_test.py
@@ -22,7 +22,7 @@ def test_nested_symbol_type():
     outer_sdfg.add_array('data', shape=[1], dtype=dace.float32)
 
     data = outer_state.add_write('data')
-    nested = outer_state.add_nested_sdfg(test_sdfg, outer_sdfg, {}, {'output'})
+    nested = outer_state.add_nested_sdfg(test_sdfg, {}, {'output'})
 
     outer_state.add_memlet_path(nested, data, src_conn='output', memlet=Memlet.simple(data.data, "0"))
 

--- a/tests/transformations/isolate_nested_sdfg_test.py
+++ b/tests/transformations/isolate_nested_sdfg_test.py
@@ -102,7 +102,6 @@ def _make_already_isloated_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dac
     inner_sdfg = _make_nested_sdfg_simple()
     nsdfg = state.add_nested_sdfg(
         sdfg=inner_sdfg,
-        parent=outer_sdfg,
         inputs={"A"},
         outputs={"B"},
         symbol_mapping={},
@@ -145,7 +144,6 @@ def _make_non_empty_pre_set_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_node
     inner_sdfg = _make_nested_sdfg_simple()
     nsdfg = state.add_nested_sdfg(
         sdfg=inner_sdfg,
-        parent=outer_sdfg,
         inputs={"A"},
         outputs={"B"},
         symbol_mapping={},
@@ -186,7 +184,6 @@ def _make_non_empty_pre_set_sdfg_2() -> Tuple[dace.SDFG, dace.SDFGState, dace_no
     inner_sdfg = _make_nested_sdfg_adding()
     nsdfg = state.add_nested_sdfg(
         sdfg=inner_sdfg,
-        parent=outer_sdfg,
         inputs={"A", "B"},
         outputs={"C"},
         symbol_mapping={},
@@ -219,7 +216,6 @@ def _make_non_empty_post_state_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_n
     inner_sdfg = _make_nested_sdfg_simple()
     nsdfg = state.add_nested_sdfg(
         sdfg=inner_sdfg,
-        parent=outer_sdfg,
         inputs={"A"},
         outputs={"B"},
         symbol_mapping={},
@@ -258,7 +254,6 @@ def _make_non_empty_post_state_sdfg_2() -> Tuple[dace.SDFG, dace.SDFGState, dace
     inner_sdfg = _make_nested_sdfg_simple()
     nsdfg = state.add_nested_sdfg(
         sdfg=inner_sdfg,
-        parent=outer_sdfg,
         inputs={"A"},
         outputs={"B"},
         symbol_mapping={},
@@ -313,7 +308,6 @@ def _make_multi_path_nested_sdfg() -> Tuple[dace.SDFG, dace.SDFGState, dace_node
     inner_sdfg = _make_nested_sdfg_adding()
     nsdfg_node = state.add_nested_sdfg(
         sdfg=inner_sdfg,
-        parent=outer_sdfg,
         inputs={"A", "B"},
         outputs={"C"},
         symbol_mapping={},

--- a/tests/transformations/map_fusion_vertical_test.py
+++ b/tests/transformations/map_fusion_vertical_test.py
@@ -554,7 +554,6 @@ def test_fusion_with_nested_sdfg_0():
         me1, mx1 = state.add_map("first_map", ndrange={"__i0": "0:10"})
         nsdfg = state.add_nested_sdfg(
             sdfg=_make_nested_sdfg(),
-            parent=sdfg,
             inputs={"a", "b", "c"},
             outputs={"t"},
             symbol_mapping={},

--- a/tests/transformations/map_unroll_test.py
+++ b/tests/transformations/map_unroll_test.py
@@ -16,7 +16,7 @@ def test_map_unroll():
     entry_outer, exit_outer = outer_state.add_map("map_outer", {"i": "0:3", "j": "0:1"})
     entry_inner, exit_inner = outer_state.add_map("map_inner", {"k": "0:2"})
     nsdfg = dace.SDFG("unroll_nested")
-    nsdfg_node = outer_state.add_nested_sdfg(nsdfg, sdfg, {"x"}, {"y"})
+    nsdfg_node = outer_state.add_nested_sdfg(nsdfg, {"x"}, {"y"})
     outer_state.add_memlet_path(read,
                                 entry_outer,
                                 entry_inner,

--- a/tests/transformations/mapfission_test.py
+++ b/tests/transformations/mapfission_test.py
@@ -121,7 +121,7 @@ def test_nested_transient():
     rnode = state.add_read('A')
     wnode = state.add_write('A')
     me, mx = state.add_map('outer', dict(i='0:2'))
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {'a'}, {'b'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'a'}, {'b'})
     state.add_memlet_path(rnode, me, nsdfg_node, dst_conn='a', memlet=dace.Memlet.simple('A', 'i'))
     state.add_memlet_path(nsdfg_node, mx, wnode, src_conn='b', memlet=dace.Memlet.simple('A', 'i'))
 
@@ -183,7 +183,7 @@ def test_multidim():
     t = nstate.add_tasklet('reset', {}, {'out'}, 'out = 0')
     a = nstate.add_write('a')
     nstate.add_edge(t, 'out', a, None, dace.Memlet.simple('a', '0'))
-    nsdfg_node = state.add_nested_sdfg(nsdfg, None, {}, {'a'})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {'a'})
 
     state.add_edge(me, None, nsdfg_node, None, dace.Memlet())
     anode = state.add_write('A')
@@ -288,7 +288,7 @@ def test_mapfission_with_symbols():
 
     a = state.add_access('A')
     b = state.add_access('B')
-    t = state.add_nested_sdfg(nsdfg, None, {}, {'inner_A', 'inner_B'})
+    t = state.add_nested_sdfg(nsdfg, {}, {'inner_A', 'inner_B'})
     state.add_nedge(me, t, dace.Memlet())
     state.add_memlet_path(t, mx, a, memlet=dace.Memlet('A[0, i]'), src_conn='inner_A')
     state.add_memlet_path(t, mx, b, memlet=dace.Memlet('B[0, i]'), src_conn='inner_B')
@@ -336,7 +336,7 @@ def test_two_edges_through_map():
 
     a = state.add_access('A')
     b = state.add_access('B')
-    t = state.add_nested_sdfg(nsdfg, None, {'inner_A'}, {'inner_B'}, {'N': 'N', 'i': 'i'})
+    t = state.add_nested_sdfg(nsdfg, {'inner_A'}, {'inner_B'}, {'N': 'N', 'i': 'i'})
     state.add_memlet_path(a, me, t, memlet=dace.Memlet.from_array('A', sdfg.arrays['A']), dst_conn='inner_A')
     state.add_memlet_path(t, mx, b, memlet=dace.Memlet('B[i]'), src_conn='inner_B')
 
@@ -434,7 +434,7 @@ def test_array_copy_outside_scope():
     inode = state.add_access(iname)
     onode = state.add_access(oname)
     me, mx = state.add_map('map', {'i': '0:10'})
-    snode = state.add_nested_sdfg(nsdfg, None, {'ninp'}, {'nout'})
+    snode = state.add_nested_sdfg(nsdfg, {'ninp'}, {'nout'})
     state.add_memlet_path(inode, me, snode, memlet=dace.Memlet(data=iname, subset='i'), dst_conn='ninp')
     state.add_memlet_path(snode, mx, onode, memlet=dace.Memlet(data=oname, subset='i'), src_conn='nout')
 
@@ -487,7 +487,7 @@ def test_single_data_multiple_connectors():
     b = outer_state.add_access('B')
 
     me, mx = outer_state.add_map('map', {'i': '0:2'})
-    inner_sdfg_node = outer_state.add_nested_sdfg(inner_sdfg, None, {'A0', 'A1'}, {'B0', 'B1'})
+    inner_sdfg_node = outer_state.add_nested_sdfg(inner_sdfg, {'A0', 'A1'}, {'B0', 'B1'})
 
     outer_state.add_memlet_path(a, me, inner_sdfg_node, memlet=dace.Memlet(data='A', subset='0, 0:10'), dst_conn='A0')
     outer_state.add_memlet_path(a, me, inner_sdfg_node, memlet=dace.Memlet(data='A', subset='1, 0:10'), dst_conn='A1')
@@ -562,7 +562,7 @@ def test_dependent_symbol():
                                     code='__b1 = __a0 - __a1',
                                     external_edges=True)
 
-    nsdfg = inner_state.add_nested_sdfg(inner_sdfg2, None, {'A0', 'A1'}, {'B1'})
+    nsdfg = inner_state.add_nested_sdfg(inner_sdfg2, {'A0', 'A1'}, {'B1'})
     a0 = inner_state.add_access('A0')
     a1 = inner_state.add_access('A1')
     b1 = inner_state.add_access('B1')
@@ -577,8 +577,7 @@ def test_dependent_symbol():
     b = outer_state.add_access('B')
 
     me, mx = outer_state.add_map('map', {'i': '0:2'})
-    inner_sdfg_node = outer_state.add_nested_sdfg(inner_sdfg,
-                                                  None, {'A0', 'A1'}, {'B0', 'B1'},
+    inner_sdfg_node = outer_state.add_nested_sdfg(inner_sdfg, {'A0', 'A1'}, {'B0', 'B1'},
                                                   symbol_mapping={
                                                       'first': 'max(0, i - fidx)',
                                                       'last': 'min(10, i + lidx)'

--- a/tests/transformations/prune_connectors_test.py
+++ b/tests/transformations/prune_connectors_test.py
@@ -28,8 +28,7 @@ def make_sdfg():
 
     sdfg_middle = dace.SDFG("middle")
     sdfg_middle.add_symbol("N", dace.int32)
-    nsdfg_middle = state_outer.add_nested_sdfg(sdfg_middle,
-                                               sdfg_outer, {"read_used_middle", "read_unused_middle"},
+    nsdfg_middle = state_outer.add_nested_sdfg(sdfg_middle, {"read_used_middle", "read_unused_middle"},
                                                {"write_used_middle", "write_unused_middle"},
                                                name="middle")
     state_middle = sdfg_middle.add_state("middle")
@@ -38,8 +37,7 @@ def make_sdfg():
 
     sdfg_inner = dace.SDFG("inner")
     sdfg_inner.add_symbol("N", dace.int32)
-    nsdfg_inner = state_middle.add_nested_sdfg(sdfg_inner,
-                                               sdfg_middle, {"read_used_inner", "read_unused_inner"},
+    nsdfg_inner = state_middle.add_nested_sdfg(sdfg_inner, {"read_used_inner", "read_unused_inner"},
                                                {"write_used_inner", "write_unused_inner"},
                                                name="inner")
     state_inner = sdfg_inner.add_state("inner")
@@ -111,8 +109,7 @@ def make_sdfg():
     isolated_read = state_outer.add_read("read_unused_outer")
     isolated_write = state_outer.add_write("write_unused_outer")
     isolated_sdfg = dace.SDFG("isolated_sdfg")
-    isolated_nsdfg = state_outer.add_nested_sdfg(isolated_sdfg,
-                                                 sdfg_outer, {"read_unused_isolated"}, {"write_unused_isolated"},
+    isolated_nsdfg = state_outer.add_nested_sdfg(isolated_sdfg, {"read_unused_isolated"}, {"write_unused_isolated"},
                                                  name="isolated")
     isolated_sdfg.add_array("read_unused_isolated", shape=(n, n), dtype=dace.uint16, transient=False)
     isolated_sdfg.add_array("write_unused_isolated", shape=(n, n), dtype=dace.uint16, transient=False)
@@ -231,7 +228,6 @@ def _make_read_write_sdfg(conforming_memlet: bool, ) -> Tuple[dace.SDFG, dace.no
     # Add the nested SDFG
     nsdfg = ostate.add_nested_sdfg(
         sdfg=isdfg,
-        parent=osdfg,
         inputs={"inner_A"},
         outputs={"inner_A", "inner_B"},
     )
@@ -294,7 +290,7 @@ def test_unused_retval():
     a = nstate.add_access('used')
     nstate.add_edge(nstate.add_tasklet('do', {}, {'out'}, 'out = 1'), 'out', a, None, dace.Memlet('used[0]'))
     nstate.add_nedge(a, nstate.add_write('__return'), dace.Memlet('__return[0]'))
-    nsnode = state.add_nested_sdfg(nsdfg, None, {}, {'used', '__return'})
+    nsnode = state.add_nested_sdfg(nsdfg, {}, {'used', '__return'})
     state.add_edge(nsnode, 'used', state.add_write('output'), None, dace.Memlet('output[0]'))
     state.add_edge(nsnode, '__return', state.add_write('tmp'), None, dace.Memlet('tmp[0]'))
 
@@ -322,7 +318,7 @@ def test_unused_retval_2():
     a = nstate.add_access('used')
     nstate.add_edge(nstate.add_tasklet('do', {}, {'out'}, 'out = 1'), 'out', a, None, dace.Memlet('used[0]'))
     nstate.add_nedge(a, nstate.add_write('__return'), dace.Memlet('__return[0]'))
-    nsnode = state.add_nested_sdfg(nsdfg, None, {}, {'used', '__return'})
+    nsnode = state.add_nested_sdfg(nsdfg, {}, {'used', '__return'})
     me, mx = state.add_map('doit', dict(i='0:2'))
     state.add_nedge(me, nsnode, dace.Memlet())
     state.add_memlet_path(nsnode, mx, state.add_write('output'), memlet=dace.Memlet('output[i]'), src_conn='used')
@@ -459,7 +455,7 @@ def test_prune_connectors_with_conditional_block():
     b_state.add_nedge(b_state.add_access(b), b_state.add_access(out), dace.Memlet(out))
 
     state = sdfg.add_state()
-    nsdfg_node = state.add_nested_sdfg(nsdfg, sdfg, inputs={a, b, cond}, outputs={out})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, inputs={a, b, cond}, outputs={out})
     me, mx = state.add_map('map', dict(i="0:4"))
     state.add_memlet_path(state.add_access(A), me, nsdfg_node, dst_conn=a, memlet=dace.Memlet(f"{A}[i]"))
     state.add_memlet_path(state.add_access(B), me, nsdfg_node, dst_conn=b, memlet=dace.Memlet(f"{B}[i]"))

--- a/tests/transformations/refine_nested_access_test.py
+++ b/tests/transformations/refine_nested_access_test.py
@@ -23,7 +23,7 @@ def test_refine_dataflow():
     A = state.add_access('A')
     B = state.add_access('B')
     me, mx = state.add_map('m', dict(i='0:5', j='0:5'))
-    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), sdfg, {'A'}, {'B'}, {'i': 'i', 'j': 'j'})
+    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), {'A'}, {'B'}, {'i': 'i', 'j': 'j'})
     state.add_memlet_path(A, me, nsdfg, dst_conn='A', memlet=dace.Memlet.from_array('A', sdfg.arrays['A']))
     state.add_memlet_path(nsdfg, mx, B, src_conn='B', memlet=dace.Memlet.from_array('B', sdfg.arrays['B']))
 
@@ -63,10 +63,7 @@ def test_refine_interstate():
     B = state.add_access('B')
     select = state.add_access('select')
     me, mx = state.add_map('m', dict(i='0:5', j='0:5'))
-    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), sdfg, {'A', 'select'}, {'B'}, {
-        'i': 'i',
-        'j': 'j'
-    })
+    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), {'A', 'select'}, {'B'}, {'i': 'i', 'j': 'j'})
     state.add_memlet_path(A, me, nsdfg, dst_conn='A', memlet=dace.Memlet.from_array('A', sdfg.arrays['A']))
     state.add_memlet_path(select,
                           me,
@@ -119,7 +116,7 @@ def test_free_symbols_only_by_indices():
     ia = state.add_access('idx_a')
     ib = state.add_access('idx_b')
     map_entry, map_exit = state.add_map('map', dict(i='0:5'))
-    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), sdfg, {'A', 'idx_a', 'idx_b'}, {'B'}, {'i': 'i'})
+    nsdfg = state.add_nested_sdfg(inner_sdfg.to_sdfg(simplify=False), {'A', 'idx_a', 'idx_b'}, {'B'}, {'i': 'i'})
     state.add_memlet_path(A, map_entry, nsdfg, dst_conn='A', memlet=dace.Memlet.from_array('A', sdfg.arrays['A']))
     state.add_memlet_path(nsdfg, map_exit, B, src_conn='B', memlet=dace.Memlet.from_array('B', sdfg.arrays['B']))
     state.add_memlet_path(ia,
@@ -215,7 +212,6 @@ def _make_rna_read_and_write_set_sdfg(diff_in_out: bool) -> dace.SDFG:
 
     nsdfg = state.add_nested_sdfg(
         nested_sdfg,
-        parent=sdfg,
         inputs={"A"},
         outputs={"T2", "T1"} if diff_in_out else {"T1"},
         symbol_mapping={},

--- a/tests/transformations/state_elimination_test.py
+++ b/tests/transformations/state_elimination_test.py
@@ -26,7 +26,7 @@ def test_eliminate_end_state_noassign():
     sdfg.add_edge(state1, state2, dace.InterstateEdge())
     sdfg.add_edge(state2, state3, dace.InterstateEdge(assignments=dict(k='k + 1')))
 
-    nsdfg = outer_state.add_nested_sdfg(sdfg, outer_sdfg, {}, {}, symbol_mapping={'k': 3})
+    nsdfg = outer_state.add_nested_sdfg(sdfg, {}, {}, symbol_mapping={'k': 3})
 
     nsdfg.sdfg.simplify()
     nsdfg.sdfg.simplify()

--- a/tests/transformations/state_fission_test.py
+++ b/tests/transformations/state_fission_test.py
@@ -85,7 +85,7 @@ def make_nested_sdfg_cpu():
     y = state.add_read("y")
     z = state.add_write("z")
 
-    nested_sdfg = state.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"})
+    nested_sdfg = state.add_nested_sdfg(to_nest, {"x", "y"}, {"z"})
 
     state.add_memlet_path(x, nested_sdfg, dst_conn="x", memlet=Memlet.simple(x, "0:n", num_accesses=n))
     state.add_memlet_path(y, nested_sdfg, dst_conn="y", memlet=Memlet.simple(y, "0:n", num_accesses=n))
@@ -102,7 +102,7 @@ def make_nested_sdfg_cpu():
     w = state.add_read("w")
     u = state.add_write("u")
 
-    nested_sdfg = state.add_nested_sdfg(to_nest, sdfg, {"v", "w"}, {"u"})
+    nested_sdfg = state.add_nested_sdfg(to_nest, {"v", "w"}, {"u"})
 
     state.add_memlet_path(v, nested_sdfg, dst_conn="v", memlet=Memlet.simple(v, "0:m", num_accesses=m))
     state.add_memlet_path(w, nested_sdfg, dst_conn="w", memlet=Memlet.simple(w, "0:m", num_accesses=m))

--- a/tests/transformations/subgraph_fusion/invariant_dimension_test.py
+++ b/tests/transformations/subgraph_fusion/invariant_dimension_test.py
@@ -70,7 +70,7 @@ def fix_sdfg(sdfg, graph):
 
     # next up replace sdfg
     inner_sdfg = helper_sdfg.to_sdfg()
-    nnode = graph.add_nested_sdfg(inner_sdfg, sdfg, {'AA', 'BB', 'CC'}, {'CC'})
+    nnode = graph.add_nested_sdfg(inner_sdfg, {'AA', 'BB', 'CC'}, {'CC'})
     # redirect edges
     connectors = []
     for e in graph.in_edges(nested_original):

--- a/tests/unique_nested_sdfg_test.py
+++ b/tests/unique_nested_sdfg_test.py
@@ -108,7 +108,7 @@ def make_nested_vecAdd_sdfg(sdfg_name: str, dtype=dace.float32):
     to_nest = make_vecAdd_sdfg(nested_sdfg_name, dtype)
 
     # Nest it and connect memlets
-    nested_sdfg = vecAdd_parent_state.add_nested_sdfg(to_nest, vecAdd_parent_sdfg, {"x", "y"}, {"z"})
+    nested_sdfg = vecAdd_parent_state.add_nested_sdfg(to_nest, {"x", "y"}, {"z"})
     vecAdd_parent_state.add_memlet_path(x_in,
                                         nested_sdfg,
                                         dst_conn="x",
@@ -149,7 +149,7 @@ def make_nested_sdfg_cpu_single_state():
     z = state.add_write("z")
 
     # add it as nested SDFG, with proper symbol mapping
-    nested_sdfg = state.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "n"})
+    nested_sdfg = state.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "n"})
 
     state.add_memlet_path(x, nested_sdfg, dst_conn="x", memlet=Memlet.simple(x, "0:n", num_accesses=n))
     state.add_memlet_path(y, nested_sdfg, dst_conn="y", memlet=Memlet.simple(y, "0:n", num_accesses=n))
@@ -165,7 +165,7 @@ def make_nested_sdfg_cpu_single_state():
     w = state.add_read("w")
     u = state.add_write("u")
 
-    nested_sdfg = state.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "m"})
+    nested_sdfg = state.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "m"})
 
     state.add_memlet_path(v, nested_sdfg, dst_conn="x", memlet=Memlet.simple(v, "0:m", num_accesses=m))
     state.add_memlet_path(w, nested_sdfg, dst_conn="y", memlet=Memlet.simple(w, "0:m", num_accesses=m))
@@ -198,7 +198,7 @@ def make_nested_sdfg_cpu_two_states():
     z = state_0.add_write("z")
 
     # add it as nested SDFG, with proper symbol mapping
-    nested_sdfg = state_0.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "n"})
+    nested_sdfg = state_0.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "n"})
 
     state_0.add_memlet_path(x, nested_sdfg, dst_conn="x", memlet=Memlet.simple(x, "0:n", num_accesses=n))
     state_0.add_memlet_path(y, nested_sdfg, dst_conn="y", memlet=Memlet.simple(y, "0:n", num_accesses=n))
@@ -216,7 +216,7 @@ def make_nested_sdfg_cpu_two_states():
     w = state_1.add_read("w")
     u = state_1.add_write("u")
 
-    nested_sdfg = state_1.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "m"})
+    nested_sdfg = state_1.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "m"})
 
     state_1.add_memlet_path(v, nested_sdfg, dst_conn="x", memlet=Memlet.simple(v, "0:m", num_accesses=m))
     state_1.add_memlet_path(w, nested_sdfg, dst_conn="y", memlet=Memlet.simple(w, "0:m", num_accesses=m))
@@ -248,7 +248,7 @@ def make_nested_nested_sdfg_cpu():
     z = state_0.add_write("z")
 
     # add it as nested SDFG, with proper symbol mapping
-    nested_sdfg = state_0.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "n"})
+    nested_sdfg = state_0.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "n"})
 
     state_0.add_memlet_path(x, nested_sdfg, dst_conn="x", memlet=Memlet.simple(x, "0:n", num_accesses=n))
     state_0.add_memlet_path(y, nested_sdfg, dst_conn="y", memlet=Memlet.simple(y, "0:n", num_accesses=n))
@@ -266,7 +266,7 @@ def make_nested_nested_sdfg_cpu():
     w = state_1.add_read("w")
     u = state_1.add_write("u")
 
-    nested_sdfg = state_1.add_nested_sdfg(to_nest, sdfg, {"x", "y"}, {"z"}, {"size": "m"})
+    nested_sdfg = state_1.add_nested_sdfg(to_nest, {"x", "y"}, {"z"}, {"size": "m"})
 
     state_1.add_memlet_path(v, nested_sdfg, dst_conn="x", memlet=Memlet.simple(v, "0:m", num_accesses=m))
     state_1.add_memlet_path(w, nested_sdfg, dst_conn="y", memlet=Memlet.simple(w, "0:m", num_accesses=m))


### PR DESCRIPTION
The argument was deprecated for several released versions.