### PR TITLE
Safer connectivity test for Jupyter

### DIFF
--- a/dace/jupyter.py
+++ b/dace/jupyter.py
@@ -10,7 +10,7 @@ def _connected():
     try:
         urllib.request.urlopen('https://spcl.github.io/dace-webclient/dist/sdfv.js', timeout=1)
         return True
-    except urllib.error.URLError:
+    except (urllib.error.URLError, TimeoutError):
         return False
 
 


### PR DESCRIPTION
Fixes a sporadic issue in CI where Jupyter would not connect due to a timeout error, which would be misreported as a test failure.