### PR TITLE
Constant intrinsic evaluation always assumed arctan.

### DIFF
--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -689,7 +689,7 @@ def _const_eval_basic_type(expr: Base, alias_map: SPEC_TABLE) -> Optional[NUMPY_
         elif intr.string in INTR_FNS:
             avals = tuple(_const_eval_basic_type(a, alias_map) for a in args)
             if all(isinstance(a, (np.float32, np.float64)) for a in avals):
-                return np.arctan(*avals)
+                return INTR_FNS[intr.string](*avals)
         elif intr.string == 'SELECTED_REAL_KIND':
             p, r = args
             p, r = _const_eval_basic_type(p, alias_map), _const_eval_basic_type(r, alias_map)

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -3068,3 +3068,28 @@ END SUBROUTINE main
 """.strip()
     assert got == want
     SourceCodeBuilder().add_file(got).check_with_gfortran()
+
+
+def test_constant_function_evaluation():
+    sources, main = SourceCodeBuilder().add_file("""
+subroutine main
+  implicit none
+  double precision :: a = sqrt(4.)
+  double precision :: b = cos(0.)
+  double precision :: c = abs(-3.)
+end subroutine main
+""").check_with_gfortran().get()
+    ast = parse_and_improve(sources)
+    ast = const_eval_nodes(ast)
+
+    got = ast.tofortran()
+    want = """
+SUBROUTINE main
+  IMPLICIT NONE
+  DOUBLE PRECISION :: a = 2.0
+  DOUBLE PRECISION :: b = 1.0
+  DOUBLE PRECISION :: c = 3.0
+END SUBROUTINE main
+""".strip()
+    assert got == want
+    SourceCodeBuilder().add_file(got).check_with_gfortran()


### PR DESCRIPTION
In `const_eval_basic_type()`, `np.arctan()` was applied by default. Instead, we find the correct function from the `INTR_FNS` dictionary. The corresponding test checks some simple identities.