### PR TITLE
Fix: Memlets in StripMining transformation

### DIFF
--- a/dace/transformation/dataflow/strip_mining.py
+++ b/dace/transformation/dataflow/strip_mining.py
@@ -397,6 +397,7 @@ class StripMining(transformation.SingleStateTransformation):
                     entry_out_conn['OUT_' + conn] = None
                     new_memlet = dcpy(memlet)
                     new_memlet.subset = new_subset
+                    new_memlet.other_subset = None
                     if memlet.dynamic:
                         new_memlet.num_accesses = memlet.num_accesses
                     else:
@@ -442,6 +443,7 @@ class StripMining(transformation.SingleStateTransformation):
                     exit_out_conn['OUT_' + conn] = None
                     new_memlet = dcpy(memlet)
                     new_memlet.subset = new_subset
+                    new_memlet.other_subset = None
                     if memlet.dynamic:
                         new_memlet.num_accesses = memlet.num_accesses
                     else:

--- a/tests/transformations/strip_mining_test.py
+++ b/tests/transformations/strip_mining_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 from dace.transformation.dataflow.strip_mining import StripMining
 

--- a/tests/transformations/strip_miningy_test.py
+++ b/tests/transformations/strip_miningy_test.py
@@ -3,6 +3,7 @@ from dace.transformation.dataflow.strip_mining import StripMining
 
 import numpy as np
 
+
 def test_strip_mining():
     """
     Test a simple example example where Stripmining works
@@ -12,23 +13,25 @@ def test_strip_mining():
     state = sdfg.add_state("main")
 
     # inputs
-    A = state.add_array("A", (64,), dtype=dace.uint32)
-    B = state.add_array("B", (1,), dtype=dace.uint32)
+    A = state.add_array("A", (64, ), dtype=dace.uint32)
+    B = state.add_array("B", (1, ), dtype=dace.uint32)
 
     # kernel map
     map_entry, map_exit = state.add_map("map", dict(i="0:64"))
 
     # Assign tasklet
-    tasklet = state.add_tasklet("assign", inputs=dict(), outputs={"_out"},
-                                code="_out = 1;", language=dace.dtypes.Language.CPP)
-
+    tasklet = state.add_tasklet("assign",
+                                inputs=dict(),
+                                outputs={"_out"},
+                                code="_out = 1;",
+                                language=dace.dtypes.Language.CPP)
 
     # Write first 1 to B[0] then B[0] to A[i]
     state.add_edge(map_entry, None, tasklet, None, dace.Memlet())
     state.add_edge(tasklet, "_out", B, None, dace.Memlet("B[0]"))
     state.add_edge(B, None, map_exit, "IN_A", dace.Memlet("[0] -> A[i]"))
     state.add_edge(map_exit, "OUT_A", A, None, dace.Memlet("A[0:64]", volume=64))
-    map_exit.add_in_connector("IN_A") 
+    map_exit.add_in_connector("IN_A")
     map_exit.add_out_connector("OUT_A")
 
     # 2. Apply StripMining

--- a/tests/transformations/strip_miningy_test.py
+++ b/tests/transformations/strip_miningy_test.py
@@ -1,0 +1,51 @@
+import dace
+from dace.transformation.dataflow.strip_mining import StripMining
+
+import numpy as np
+
+def test_strip_mining():
+    """
+    Test a simple example example where Stripmining works
+    """
+    # 1. The program
+    sdfg = dace.SDFG("assign")
+    state = sdfg.add_state("main")
+
+    # inputs
+    A = state.add_array("A", (64,), dtype=dace.uint32)
+    B = state.add_array("B", (1,), dtype=dace.uint32)
+
+    # kernel map
+    map_entry, map_exit = state.add_map("map", dict(i="0:64"))
+
+    # Assign tasklet
+    tasklet = state.add_tasklet("assign", inputs=dict(), outputs={"_out"},
+                                code="_out = 1;", language=dace.dtypes.Language.CPP)
+
+
+    # Write first 1 to B[0] then B[0] to A[i]
+    state.add_edge(map_entry, None, tasklet, None, dace.Memlet())
+    state.add_edge(tasklet, "_out", B, None, dace.Memlet("B[0]"))
+    state.add_edge(B, None, map_exit, "IN_A", dace.Memlet("[0] -> A[i]"))
+    state.add_edge(map_exit, "OUT_A", A, None, dace.Memlet("A[0:64]", volume=64))
+    map_exit.add_in_connector("IN_A") 
+    map_exit.add_out_connector("OUT_A")
+
+    # 2. Apply StripMining
+    stripmine = StripMining()
+    stripmine.map_entry = map_entry
+    stripmine.dim_idx = 0
+    stripmine.new_dim_prefix = "block"
+    stripmine.tile_size = 32
+    stripmine.tile_stride = 32
+    stripmine.apply(state, sdfg)
+
+    # 3. Run with example input and check correctness
+    A_np = np.zeros([64], dtype=np.uint32)
+    B_np = np.zeros([1], dtype=np.uint32)
+    sdfg(A=A_np, B=B_np)
+    assert np.all(A_np == 1), f"A should be all ones. but got {A_np}"
+
+
+if __name__ == '__main__':
+    test_strip_mining()


### PR DESCRIPTION
**Bug Description:**

To put it simple, the `StripMining` transformation essentially performs tiling- that is, it adds a  **new outer** map which encloses
an existing one, where the new map runs over chunks (=tiles) of the original iteration space, while the inner map handles 
individual elements inside each chunk. The inner map is the original map, where the range just go adapted.

Now, the new (outer) map needs to be connected to the original one, and the dataflow between them must be captured correctly. 
This essentially involves analyzing which parts of a data descriptor should flow for each chunk. For the sake of simplicity, one 
can think of this process as: copying an existing memlet (flowing to and from the original inner map) and update it to create
the correct memlets between the two maps. The screenshots below help visualize this - you can clearly see the similarity 
between the two highlighted memlets.

However, this copying step is problematic when an `other_subset` is present - in such cases, it should be explicitly set to `None` for
the newly created memlet. Otherwise there can be a dimensionality mismatch between the two subsets leading to an invalid SDFG.

**Fix Description**

Set the `other_subset` to `None` for memlets created between the two maps. Additionally, a test case has been added which now passes and would have failed before this fix.


**Failing Example**

After the fix, ```[0] -> A[block_i : Min(63, block_i + 31) + 1]``` in the right image will become  
```A[block_i : Min(63, block_i + 31) + 1]```.

<p float="left">
  <img width="45%" src="https://github.com/user-attachments/assets/33c14e92-43c6-4d93-a77e-87691fa8f9b8" />
  <img width="45%" src="https://github.com/user-attachments/assets/76b7f030-91c6-424d-a91b-3ba9df710840" />
</p>

