### PR TITLE
CI: Add a timeout for each individual test

### DIFF
--- a/.github/workflows/fpga-ci.yml
+++ b/.github/workflows/fpga-ci.yml
@@ -61,7 +61,7 @@ jobs:
         # and overflowed in the year 2022, run the FPGA tests pretending like it's January 1st 2021.
         # faketime -f "@2021-01-01 00:00:00" pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
         # Try running without faketime
-        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "fpga"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short --timeout=300 -m "fpga"
 
         coverage report
         coverage xml

--- a/.github/workflows/general-ci.yml
+++ b/.github/workflows/general-ci.yml
@@ -59,7 +59,7 @@ jobs:
         else
             export DACE_optimizer_automatic_simplification=${{ matrix.simplify }}
         fi
-        pytest -n auto --cov-report=xml --cov=dace --tb=short -m "not gpu and not verilator and not tensorflow and not mkl and not sve and not papi and not mlir and not lapack and not fpga and not mpi and not rtl_hardware and not scalapack and not datainstrument and not long"
+        pytest -n auto --cov-report=xml --cov=dace --tb=short --timeout=300 -m "not gpu and not verilator and not tensorflow and not mkl and not sve and not papi and not mlir and not lapack and not fpga and not mpi and not rtl_hardware and not scalapack and not datainstrument and not long"
         ./codecov
 
     - name: Test OpenBLAS LAPACK
@@ -75,7 +75,7 @@ jobs:
         else
             export DACE_optimizer_automatic_simplification=${{ matrix.simplify }}
         fi
-        pytest -n 1 --cov-report=xml --cov=dace --tb=short -m "lapack"
+        pytest -n 1 --cov-report=xml --cov=dace --tb=short --timeout=300 -m "lapack"
         ./codecov
 
     - name: Run other tests

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -51,7 +51,7 @@ jobs:
         export DACE_cache=single
         export PATH=$PATH:/usr/local/cuda/bin  # some test is calling cuobjdump, so it needs to be in path
         echo "CUDACXX: $CUDACXX"
-        pytest --cov-report=xml --cov=dace --tb=short -m "gpu"
+        pytest --cov-report=xml --cov=dace --tb=short --timeout=300 -m "gpu"
 
     - name: Run extra GPU tests
       run: |

--- a/.github/workflows/heterogeneous-ci.yml
+++ b/.github/workflows/heterogeneous-ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         source ~/.venv/bin/activate # activate venv
         export DACE_cache=unique
-        pytest --cov-report=xml --cov=dace --tb=short -m "verilator or mkl or papi or datainstrument"
+        pytest --cov-report=xml --cov=dace --tb=short --timeout=300 -m "verilator or mkl or papi or datainstrument"
 
     - name: Run MPI tests
       run: |
@@ -67,7 +67,7 @@ jobs:
         export DACE_testing_deserialize_exception=1
         export DACE_cache=unique
         source ~/.venv/bin/activate # activate venv
-        mpirun -n 2 coverage run --source=dace --parallel-mode -m pytest -x --with-mpi --tb=short -m "mpi"
+        mpirun -n 2 coverage run --source=dace --parallel-mode -m pytest -x --with-mpi --tb=short --timeout=300 -m "mpi"
 
     - name: Test ScaLAPACK PBLAS with pytest
       run: |
@@ -79,7 +79,7 @@ jobs:
         source ~/.venv/bin/activate # activate venv
         for i in {1..4}
         do
-          mpirun -n "$i" --oversubscribe coverage run --source=dace --parallel-mode -m pytest -x --with-mpi --tb=short -m "scalapack"
+          mpirun -n "$i" --oversubscribe coverage run --source=dace --parallel-mode -m pytest -x --with-mpi --tb=short --timeout=300 -m "scalapack"
         done
 
     - name: Report overall coverage

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,10 @@ setup(name='dace',
           'typing-compat; python_version < "3.8"', 'packaging'
       ] + cmake_requires,
       extras_require={
-          'testing':
-          ['coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'ipykernel', 'nbconvert'],
+          'testing': [
+              'coverage', 'pytest-cov', 'scipy', 'absl-py', 'opt_einsum', 'pymlir', 'click', 'ipykernel', 'nbconvert',
+              'pytest-timeout'
+          ],
           'docs': ['jinja2<3.2.0', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme>=0.5.1'],
           'linting': ['pre-commit==4.1.0', 'yapf==0.43.0'],
       },


### PR DESCRIPTION
Limits each test to 5 minutes. Mitigates hangs in CI and prints potentially-hanging test.