### PR TITLE
used_symbols() call does not match argument list

### DIFF
--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -912,10 +912,10 @@ class MapEntry(EntryNode):
                     )
                     free_symbols |= code_symbols
                     continue
-            elif isinstance(n, dace.nodes.NestedSDFG):
+            elif isinstance(n, NestedSDFG):
                 free_symbols |= n.used_symbols(all_symbols)
-            else:
-                free_symbols |= n.free_symbols
+
+            free_symbols |= n.free_symbols
 
         # Free symbols from memlets
         for e in parent_state.all_edges(*parent_state.all_nodes_between(self, parent_state.exit_node(self))):


### PR DESCRIPTION
**Description**

The `used_symbols(...)` method is called incorrectly in the `used_symbols_within_scope(...)` function.  
From the `nodes.py` file, we can see that only the `NestedSDFG` class implements this method. However, it is currently invoked with two arguments instead of the single argument it expects. So we need to call it for `NestedSDFG` instances only with
one argument.

In addition, the `hasattr(n, "used_symbols")` check can be removed and replaced with a direct `isinstance` check for `NestedSDFG`, extending the preceding type-based logic for updating the `free_symbols` set.