### PR TITLE
Fix _get_assignments()

### DIFF
--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -2333,8 +2333,8 @@ def _get_used_symbols_impl(scope: Union[SDFG, ControlFlowRegion, SDFGState, nd.M
 
     def _get_assignments(cfg: Union[ControlFlowRegion, SDFG]) -> Set[str]:
         written_symbols = set()
-        for edge in cfg.all_edges(*list(cfg.all_control_flow_blocks())):
-            if edge.data is not None and isinstance(edge.data, dace.InterstateEdge):
+        for edge in cfg.all_interstate_edges():
+            if edge.data is not None:
                 written_symbols = written_symbols.union(edge.data.assignments.keys())
         return written_symbols
 


### PR DESCRIPTION
**Description**

Passing: 

`*list(cfg.all_control_flow_blocks())`

as argument to the function

`cfg.all_edges(..)`

leads to a `KeyError`. The reason is,  that `cfg.all_control_flow_blocks()`  returns `ControlFlowBlock`'s of **nested** `ControlFlowRegion`'s which are not in `cfg._nodes` used by the `all_edges(...)` function.  

If I understand it correctly, the goal of the `_get_assignments(...)` function is to find whether a symbol is written to
via an interstate edge. In this case, using  `cfg.all_interstate_edges()` should fix the issue.

