### PR TITLE
Broadcast Hoisting

### DIFF
--- a/dace/transformation/dataflow/__init__.py
+++ b/dace/transformation/dataflow/__init__.py
@@ -31,6 +31,7 @@ from .local_storage import InLocalStorage, OutLocalStorage
 from .double_buffering import DoubleBuffering
 from .streaming_memory import StreamingMemory, StreamingComposition
 from .reduce_expansion import ReduceExpansion
+from .broadcast_hoisting import BroadcastHoisting
 
 # Complexity reduction
 from .dedup_access import DeduplicateAccess

--- a/dace/transformation/dataflow/broadcast_hoisting.py
+++ b/dace/transformation/dataflow/broadcast_hoisting.py
@@ -97,10 +97,8 @@ class BroadcastHoisting(xf.SingleStateTransformation):
               innermost_map_2 = next_succ
               next_succ = list(graph.successors(innermost_map_2))[0]
           
-          next_prev = innermost_map_2
-          while isinstance(next_prev, nodes.MapEntry) and len(set(next_prev.map.params) - used_indices) == 0:
-              innermost_map_2 = next_prev
-              next_prev = list(graph.predecessors(innermost_map_2))[0]
+          while isinstance(innermost_map_2, nodes.MapEntry) and len(set(innermost_map_2.map.params) - used_indices) == 0:
+              innermost_map_2 = list(graph.predecessors(innermost_map_2))[0]
 
           map_range_2: Range = innermost_map_2.map.range
           ranges_2 = None

--- a/dace/transformation/dataflow/broadcast_hoisting.py
+++ b/dace/transformation/dataflow/broadcast_hoisting.py
@@ -1,0 +1,133 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+
+from dace import properties
+from dace.transformation import transformation as xf
+from dace.sdfg import SDFGState,SDFG, nodes, utils as sdutil
+from dace.memlet import Memlet
+from dace.sdfg.state import ControlFlowRegion
+from dace.subsets import Range, Subset
+
+
+@properties.make_properties
+class BroadcastHoisting(xf.SingleStateTransformation):
+    """
+    Interchanges two consecutive maps, where one map broadcasts data.
+
+    Example:
+    ```
+    for n in range(...):
+      x[n] = y[n] # one to one
+    for n in range(...):
+      for k in range(...):
+        z[n, k] = x[n] # broadcast
+    ```
+    becomes
+    ```
+    for n in range(...):
+      for k in range(...):
+        x[n, k] = y[n] # broadcast
+    for n in range(...):
+      for k in range(...):
+        z[n, k] = x[n, k] # one to one
+    ```
+
+    """
+
+    map_exit_1 = xf.PatternNode(nodes.MapExit)
+    access_node = xf.PatternNode(nodes.AccessNode)
+    map_entry_2 = xf.PatternNode(nodes.MapEntry)
+
+    @classmethod
+    def expressions(cls):
+        return [sdutil.node_path_graph(cls.map_exit_1, cls.access_node, cls.map_entry_2)]
+
+    def can_be_applied(self, graph: SDFGState, expr_index: int, sdfg: SDFG, permissive: bool = False) -> bool:
+        # Access node must be a transient array
+        if not sdfg.arrays[self.access_node.data].transient:
+            return False
+        
+        # Access node must participate in a broadcast in the second map
+        # This the case if the read volume is higher than the write volume and both are not zero
+        read_vol = 0
+        write_vol = 0
+        for edge in graph.in_edges(self.access_node):
+                write_vol += edge.data.volume
+        for edge in graph.out_edges(self.access_node):
+                read_vol += edge.data.volume
+
+        if read_vol == 0 or write_vol == 0:
+            return False
+        if read_vol <= write_vol:
+            return False
+
+
+        return True
+
+
+    def apply(self, graph: SDFGState, sdfg: SDFG):
+        # Get symbols used in the access node
+        used_indices = set()
+        for node in graph.all_nodes_between(self.map_entry_2, graph.exit_node(self.map_entry_2)):
+            for edge in graph.in_edges(node):
+                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
+                    used_indices.update(edge.data.subset.free_symbols)
+            for edge in graph.out_edges(node):
+                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
+                    used_indices.update(edge.data.subset.free_symbols)
+
+        # Get the range and index name of the innermost map of the second map, which has parameters not already used by the access node
+        innermost_map_2  = self.map_entry_2
+        next_succ = list(graph.successors(innermost_map_2))[0]
+        while isinstance(next_succ, nodes.MapEntry) and len(set(next_succ.map.params) - used_indices) > 0:
+            innermost_map_2 = next_succ
+            next_succ = list(graph.successors(innermost_map_2))[0]
+
+        map_range_2: Range = innermost_map_2.map.range
+        ranges_2 = None
+        idx_2 = None
+        for i, idx in enumerate(innermost_map_2.map.params):
+            if idx not in used_indices:
+                ranges_2 = map_range_2.ranges[i]
+                idx_2 = idx
+                break
+
+        # Add a new dimension to the access node
+        access_node = self.access_node
+        old_shape = sdfg.arrays[access_node.data].shape
+        new_shape = old_shape + (ranges_2[1] - ranges_2[0] + 1, )
+        sdfg.arrays[access_node.data].set_shape(new_shape)
+
+        # Add index to the second map
+        handled_edges = set()
+        for node in graph.all_nodes_between(innermost_map_2, graph.exit_node(innermost_map_2)):
+            for edge in graph.in_edges(node):
+                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                    edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
+                    handled_edges.add(edge)
+            for edge in graph.out_edges(node):
+                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                    edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
+                    handled_edges.add(edge)
+
+                    
+        # Add a new range to the first map
+        innermost_map_1 = self.map_exit_1
+        while isinstance(list(graph.predecessors(innermost_map_1))[0], nodes.MapExit):
+            innermost_map_1 = list(graph.predecessors(innermost_map_1))[0]
+        idx_1 = sdfg.find_new_symbol(idx_2)
+        innermost_map_1.map.params.append(idx_1)
+        innermost_map_1.map.range += Range([ranges_2])
+
+        for node in graph.all_nodes_between(graph.entry_node(innermost_map_1), innermost_map_1):
+            for edge in graph.in_edges(node):
+                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                    edge.data.subset = edge.data.subset + Range([(idx_1, idx_1, 1)])
+                    handled_edges.add(edge)
+            for edge in graph.out_edges(node):
+                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                    edge.data.subset = edge.data.subset + Range([(idx_1, idx_1, 1)])
+                    handled_edges.add(edge)
+        
+        # Propagate memlets
+        sdutil.propagation.propagate_memlets_sdfg(sdfg)
+

--- a/dace/transformation/dataflow/broadcast_hoisting.py
+++ b/dace/transformation/dataflow/broadcast_hoisting.py
@@ -46,75 +46,88 @@ class BroadcastHoisting(xf.SingleStateTransformation):
         # Access node must be a transient array
         if not sdfg.arrays[self.access_node.data].transient:
             return False
-        
+
         # Access node must participate in a broadcast in the second map
         # This the case if the read volume is higher than the write volume and both are not zero
-        read_vol = 0
         write_vol = 0
         for edge in graph.in_edges(self.access_node):
                 write_vol += edge.data.volume
+
         for edge in graph.out_edges(self.access_node):
-                read_vol += edge.data.volume
+                read_vol = edge.data.volume
 
-        sym_assignments = {}
-        for sym in read_vol.free_symbols | write_vol.free_symbols:
-            sym_assignments[sym] = 10
-        read_vol_eval = evaluate(read_vol, sym_assignments)
-        write_vol_eval = evaluate(write_vol, sym_assignments)
+                sym_assignments = {}
+                for sym in read_vol.free_symbols | write_vol.free_symbols:
+                    sym_assignments[sym] = 10
+                read_vol_eval = evaluate(read_vol, sym_assignments)
+                write_vol_eval = evaluate(write_vol, sym_assignments)
 
-        if read_vol_eval == 0 or write_vol_eval == 0:
-            return False
-        if read_vol_eval <= write_vol_eval:
-            return False
+                if read_vol_eval == 0 or write_vol_eval == 0:
+                    return False
+                if read_vol_eval <= write_vol_eval:
+                    return False
 
         return True
 
 
     def apply(self, graph: SDFGState, sdfg: SDFG):
-        # Get symbols used in the access node
-        used_indices = set()
-        for node in graph.all_nodes_between(self.map_entry_2, graph.exit_node(self.map_entry_2)):
-            for edge in graph.in_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
-                    used_indices.update(edge.data.subset.free_symbols)
-            for edge in graph.out_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
-                    used_indices.update(edge.data.subset.free_symbols)
+        # Collect all successor maps
+        succ_maps = set()
+        for node in graph.successors(self.access_node):
+            if isinstance(node, nodes.MapEntry):
+                succ_maps.add(node)
 
-        # Get the range and index name of the innermost map of the second map, which has parameters not already used by the access node
-        innermost_map_2  = self.map_entry_2
-        next_succ = list(graph.successors(innermost_map_2))[0]
-        while isinstance(next_succ, nodes.MapEntry) and len(set(next_succ.map.params) - used_indices) > 0:
-            innermost_map_2 = next_succ
-            next_succ = list(graph.successors(innermost_map_2))[0]
+        min_lower_bound = None
+        max_upper_bound = None
+        for succ_map in succ_maps:
+          # Get symbols used in the access node
+          used_indices = set()
+          for node in graph.all_nodes_between(succ_map, graph.exit_node(succ_map)):
+              for edge in graph.in_edges(node):
+                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
+                      used_indices.update(edge.data.subset.free_symbols)
+              for edge in graph.out_edges(node):
+                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
+                      used_indices.update(edge.data.subset.free_symbols)
 
-        map_range_2: Range = innermost_map_2.map.range
-        ranges_2 = None
-        idx_2 = None
-        for i, idx in enumerate(innermost_map_2.map.params):
-            if idx not in used_indices:
-                ranges_2 = map_range_2.ranges[i]
-                idx_2 = idx
-                break
+          # Get the range and index name of the innermost map of the second map, which has parameters not already used by the access node
+          innermost_map_2  = succ_map
+          next_succ = list(graph.successors(innermost_map_2))[0]
+          while isinstance(next_succ, nodes.MapEntry):
+              innermost_map_2 = next_succ
+              next_succ = list(graph.successors(innermost_map_2))[0]
+          
+          next_prev = innermost_map_2
+          while isinstance(next_prev, nodes.MapEntry) and len(set(next_prev.map.params) - used_indices) == 0:
+              innermost_map_2 = next_prev
+              next_prev = list(graph.predecessors(innermost_map_2))[0]
 
-        # Add a new dimension to the access node
-        access_node = self.access_node
-        old_shape = sdfg.arrays[access_node.data].shape
-        new_shape = old_shape + (ranges_2[1] - ranges_2[0] + 1, )
-        sdfg.arrays[access_node.data].set_shape(new_shape)
+          map_range_2: Range = innermost_map_2.map.range
+          ranges_2 = None
+          idx_2 = None
+          for i, idx in enumerate(innermost_map_2.map.params):
+              if idx not in used_indices:
+                  ranges_2 = map_range_2.ranges[i]
+                  idx_2 = idx
+                  break   
 
-        # Add index to the second map
-        handled_edges = set()
-        for node in graph.all_nodes_between(innermost_map_2, graph.exit_node(innermost_map_2)):
-            for edge in graph.in_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data and idx_2 not in edge.data.free_symbols:
-                    edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
-                    handled_edges.add(edge)
-            for edge in graph.out_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data and idx_2 not in edge.data.free_symbols:
-                    edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
-                    handled_edges.add(edge)
+          # Add index to the second map
+          handled_edges = set()
+          for node in graph.all_nodes_between(innermost_map_2, graph.exit_node(innermost_map_2)):
+              for edge in graph.in_edges(node):
+                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data and idx_2 not in edge.data.free_symbols:
+                      edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
+                      handled_edges.add(edge)
+              for edge in graph.out_edges(node):
+                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data and idx_2 not in edge.data.free_symbols:
+                      edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
+                      handled_edges.add(edge)
 
+          # store the bounds of the second map
+          if min_lower_bound is None or ranges_2[0] < min_lower_bound:
+              min_lower_bound = ranges_2[0]
+          if max_upper_bound is None or ranges_2[1] > max_upper_bound:
+              max_upper_bound = ranges_2[1]
                     
         # Add a new range to the first map
         innermost_map_1 = self.map_exit_1
@@ -122,18 +135,23 @@ class BroadcastHoisting(xf.SingleStateTransformation):
             innermost_map_1 = list(graph.predecessors(innermost_map_1))[0]
         idx_1 = sdfg.find_new_symbol(idx_2)
         innermost_map_1.map.params.append(idx_1)
-        innermost_map_1.map.range += Range([ranges_2])
+        innermost_map_1.map.range += Range([(min_lower_bound, max_upper_bound, 1)])
 
         for node in graph.all_nodes_between(graph.entry_node(innermost_map_1), innermost_map_1):
             for edge in graph.in_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
                     edge.data.subset = edge.data.subset + Range([(idx_1, idx_1, 1)])
                     handled_edges.add(edge)
             for edge in graph.out_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
                     edge.data.subset = edge.data.subset + Range([(idx_1, idx_1, 1)])
                     handled_edges.add(edge)
         
+                     # Add a new dimension to the access node
+        old_shape = sdfg.arrays[self.access_node.data].shape
+        new_shape = old_shape + (max_upper_bound - min_lower_bound + 1, )
+        sdfg.arrays[self.access_node.data].set_shape(new_shape)
+
         # Propagate memlets
         sdutil.propagation.propagate_memlets_sdfg(sdfg)
 

--- a/dace/transformation/dataflow/broadcast_hoisting.py
+++ b/dace/transformation/dataflow/broadcast_hoisting.py
@@ -2,7 +2,7 @@
 
 from dace import properties
 from dace.transformation import transformation as xf
-from dace.sdfg import SDFGState,SDFG, nodes, utils as sdutil
+from dace.sdfg import SDFGState, SDFG, nodes, utils as sdutil
 from dace.memlet import Memlet
 from dace.sdfg.state import ControlFlowRegion
 from dace.subsets import Range, Subset
@@ -18,6 +18,7 @@ class BroadcastHoisting(xf.SingleStateTransformation):
     ```
     for n in range(...):
       x[n] = y[n] # one to one
+
     for n in range(...):
       for k in range(...):
         z[n, k] = x[n] # broadcast
@@ -27,6 +28,7 @@ class BroadcastHoisting(xf.SingleStateTransformation):
     for n in range(...):
       for k in range(...):
         x[n, k] = y[n] # broadcast
+
     for n in range(...):
       for k in range(...):
         z[n, k] = x[n, k] # one to one
@@ -51,24 +53,28 @@ class BroadcastHoisting(xf.SingleStateTransformation):
         # This the case if the read volume is higher than the write volume and both are not zero
         write_vol = 0
         for edge in graph.in_edges(self.access_node):
-                write_vol += edge.data.volume
+            write_vol += edge.data.volume
 
         for edge in graph.out_edges(self.access_node):
-                read_vol = edge.data.volume
+            read_vol = edge.data.volume
 
-                sym_assignments = {}
-                for sym in read_vol.free_symbols | write_vol.free_symbols:
-                    sym_assignments[sym] = 10
-                read_vol_eval = evaluate(read_vol, sym_assignments)
-                write_vol_eval = evaluate(write_vol, sym_assignments)
+            sym_assignments = {}
+            for sym in read_vol.free_symbols | write_vol.free_symbols:
+                sym_assignments[sym] = 10
+            read_vol_eval = evaluate(read_vol, sym_assignments)
+            write_vol_eval = evaluate(write_vol, sym_assignments)
 
-                if read_vol_eval == 0 or write_vol_eval == 0:
-                    return False
-                if read_vol_eval <= write_vol_eval:
-                    return False
+            if read_vol_eval == 0 or write_vol_eval == 0:
+                return False
+            if read_vol_eval <= write_vol_eval:
+                return False
+
+        # Indirect accesses would be okay, but DaCe does not perform proper slicing with nested SDFGs, thus we cannot perform this transformation if nested SDFGs are involved
+        for node in graph.all_nodes_between(self.map_entry_2, graph.exit_node(self.map_entry_2)):
+            if isinstance(node, nodes.NestedSDFG):
+                return False
 
         return True
-
 
     def apply(self, graph: SDFGState, sdfg: SDFG):
         # Collect all successor maps
@@ -79,54 +85,57 @@ class BroadcastHoisting(xf.SingleStateTransformation):
 
         min_lower_bound = None
         max_upper_bound = None
+        handled_edges = set()
         for succ_map in succ_maps:
-          # Get symbols used in the access node
-          used_indices = set()
-          for node in graph.all_nodes_between(succ_map, graph.exit_node(succ_map)):
-              for edge in graph.in_edges(node):
-                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
-                      used_indices.update(edge.data.subset.free_symbols)
-              for edge in graph.out_edges(node):
-                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
-                      used_indices.update(edge.data.subset.free_symbols)
+            # Get symbols used in the access node
+            used_indices = set()
+            for node in graph.all_nodes_between(succ_map, graph.exit_node(succ_map)):
+                for edge in graph.in_edges(node):
+                    if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data):
+                        used_indices.update(edge.data.subset.free_symbols)
+                for edge in graph.out_edges(node):
+                    if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data):
+                        used_indices.update(edge.data.subset.free_symbols)
 
-          # Get the range and index name of the innermost map of the second map, which has parameters not already used by the access node
-          innermost_map_2  = succ_map
-          next_succ = list(graph.successors(innermost_map_2))[0]
-          while isinstance(next_succ, nodes.MapEntry):
-              innermost_map_2 = next_succ
-              next_succ = list(graph.successors(innermost_map_2))[0]
-          
-          while isinstance(innermost_map_2, nodes.MapEntry) and len(set(innermost_map_2.map.params) - used_indices) == 0:
-              innermost_map_2 = list(graph.predecessors(innermost_map_2))[0]
+            # Get the range and index name of the innermost map of the second map, which has parameters not already used by the access node
+            innermost_map_2 = succ_map
+            next_succ = list(graph.successors(innermost_map_2))[0]
+            while isinstance(next_succ, nodes.MapEntry):
+                innermost_map_2 = next_succ
+                next_succ = list(graph.successors(innermost_map_2))[0]
 
-          map_range_2: Range = innermost_map_2.map.range
-          ranges_2 = None
-          idx_2 = None
-          for i, idx in enumerate(innermost_map_2.map.params):
-              if idx not in used_indices:
-                  ranges_2 = map_range_2.ranges[i]
-                  idx_2 = idx
-                  break   
+            while (isinstance(innermost_map_2, nodes.MapEntry)
+                   and len(set(innermost_map_2.map.params) - used_indices) == 0):
+                innermost_map_2 = list(graph.predecessors(innermost_map_2))[0]
 
-          # Add index to the second map
-          handled_edges = set()
-          for node in graph.all_nodes_between(innermost_map_2, graph.exit_node(innermost_map_2)):
-              for edge in graph.in_edges(node):
-                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data and idx_2 not in edge.data.free_symbols:
-                      edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
-                      handled_edges.add(edge)
-              for edge in graph.out_edges(node):
-                  if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data and idx_2 not in edge.data.free_symbols:
-                      edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
-                      handled_edges.add(edge)
+            map_range_2: Range = innermost_map_2.map.range
+            ranges_2 = None
+            idx_2 = None
+            for i, idx in enumerate(innermost_map_2.map.params):
+                if idx not in used_indices:
+                    ranges_2 = map_range_2.ranges[i]
+                    idx_2 = idx
+                    break
 
-          # store the bounds of the second map
-          if min_lower_bound is None or ranges_2[0] < min_lower_bound:
-              min_lower_bound = ranges_2[0]
-          if max_upper_bound is None or ranges_2[1] > max_upper_bound:
-              max_upper_bound = ranges_2[1]
-                    
+            # Add index to the second map
+            for node in graph.all_nodes_between(innermost_map_2, graph.exit_node(innermost_map_2)):
+                for edge in graph.in_edges(node):
+                    if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data
+                            and idx_2 not in edge.data.free_symbols):
+                        edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
+                        handled_edges.add(edge)
+                for edge in graph.out_edges(node):
+                    if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data
+                            and idx_2 not in edge.data.free_symbols):
+                        edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
+                        handled_edges.add(edge)
+
+            # store the bounds of the second map
+            if min_lower_bound is None or ranges_2[0] < min_lower_bound:
+                min_lower_bound = ranges_2[0]
+            if max_upper_bound is None or ranges_2[1] > max_upper_bound:
+                max_upper_bound = ranges_2[1]
+
         # Add a new range to the first map
         innermost_map_1 = self.map_exit_1
         while isinstance(list(graph.predecessors(innermost_map_1))[0], nodes.MapExit):
@@ -137,19 +146,25 @@ class BroadcastHoisting(xf.SingleStateTransformation):
 
         for node in graph.all_nodes_between(graph.entry_node(innermost_map_1), innermost_map_1):
             for edge in graph.in_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
+                if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data):
                     edge.data.subset = edge.data.subset + Range([(idx_1, idx_1, 1)])
                     handled_edges.add(edge)
             for edge in graph.out_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data:
+                if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data):
                     edge.data.subset = edge.data.subset + Range([(idx_1, idx_1, 1)])
                     handled_edges.add(edge)
-        
-                     # Add a new dimension to the access node
+
+        # Add a new dimension to the access node
         old_shape = sdfg.arrays[self.access_node.data].shape
         new_shape = old_shape + (max_upper_bound - min_lower_bound + 1, )
         sdfg.arrays[self.access_node.data].set_shape(new_shape)
 
+        # Add dimension to all other memlets that were not handled
+        for edge, p in sdfg.all_edges_recursive():
+            if (isinstance(edge.data, Memlet) and edge.data.data == self.access_node.data and edge not in handled_edges
+                    and p.sdfg is sdfg  # Avoid nested SDFGs
+                ):
+                edge.data.subset = edge.data.subset + Range([(0, 0, 1)])
+
         # Propagate memlets
         sdutil.propagation.propagate_memlets_sdfg(sdfg)
-

--- a/dace/transformation/dataflow/broadcast_hoisting.py
+++ b/dace/transformation/dataflow/broadcast_hoisting.py
@@ -101,11 +101,11 @@ class BroadcastHoisting(xf.SingleStateTransformation):
         handled_edges = set()
         for node in graph.all_nodes_between(innermost_map_2, graph.exit_node(innermost_map_2)):
             for edge in graph.in_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data and idx_2 not in edge.data.free_symbols:
                     edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
                     handled_edges.add(edge)
             for edge in graph.out_edges(node):
-                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data:
+                if isinstance(edge.data, Memlet) and edge.data.data == access_node.data and idx_2 not in edge.data.free_symbols:
                     edge.data.subset = edge.data.subset + Range([(idx_2, idx_2, 1)])
                     handled_edges.add(edge)
 

--- a/tests/transformations/broadcast_hoisting_test.py
+++ b/tests/transformations/broadcast_hoisting_test.py
@@ -316,6 +316,25 @@ def test_broadcast_hoisting_mixed_dimensions():
     _test_for_unchanged_behavior(mixed_dim_test, ["A"], [1])
 
 
+def test_broadcast_hoisting_laplace():
+    """Test broadcasting in a more complex program like Laplace."""
+
+    N = dace.symbol("N")
+
+    @dace.program
+    def laplace(A: dace.float64[N], T: dace.int64):
+        tmp = np.zeros_like(A)
+
+        for _ in range(T):
+            for i in dace.map[1:N - 1]:
+                tmp[i] = A[i - 1] - 2 * A[i] + A[i + 1]
+
+            for i in dace.map[1:N - 1]:
+                A[i] = tmp[i - 1] - 2 * tmp[i] + tmp[i + 1]
+
+    _test_for_unchanged_behavior(laplace, ["tmp"])
+
+
 if __name__ == "__main__":
     test_broadcast_hoisting_basic()
     test_broadcast_hoisting_non_transient()
@@ -331,3 +350,4 @@ if __name__ == "__main__":
     test_broadcast_hoisting_indirect_access()
     test_broadcast_hoisting_dynamic_range()
     test_broadcast_hoisting_mixed_dimensions()
+    test_broadcast_hoisting_laplace()

--- a/tests/transformations/broadcast_hoisting_test.py
+++ b/tests/transformations/broadcast_hoisting_test.py
@@ -1,0 +1,125 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests dimension creation transformations."""
+
+import numpy as np
+import pytest
+import dace
+from dace.transformation.dataflow import BroadcastHoisting
+from copy import deepcopy
+
+
+def _test_for_unchanged_behavior(prog, array_name, dim_increase = 0):
+    sdfg: dace.SDFG = prog.to_sdfg(simplify=True)
+    sdfg.validate()
+
+    # Get the dimension of the array
+    old_array_dim = len(sdfg.arrays[array_name].shape)
+
+    # Get ground truth values if we expect dimension increase
+    if dim_increase > 0:
+        input_data = {}
+        for argName, argType in sdfg.arglist().items():
+            arr = dace.ndarray(shape=argType.shape, dtype=argType.dtype)
+            arr[:] = np.random.rand(*argType.shape).astype(argType.dtype.type)
+            input_data[argName] = arr
+        ground_truth = deepcopy(input_data)
+        sdfg(**ground_truth)
+
+    # Apply the transformation
+    sdfg.apply_transformations_repeated(BroadcastHoisting)
+    sdfg.validate()
+    sdfg.save("test_broadcast_hoisting.sdfg")
+
+    # Check that the array shape has been modified correctly
+    new_array_dim = len(sdfg.arrays[array_name].shape)
+    assert new_array_dim == old_array_dim + dim_increase
+
+    # Test if the behavior is unchanged if we expect dimension increase
+    if dim_increase > 0:
+        output_data = deepcopy(input_data)
+        sdfg(**output_data)
+        np.testing.assert_equal(output_data, ground_truth)
+
+
+def test_broadcast_hoisting_basic():
+
+    @dace.program
+    def tester(B: dace.float32[10], C: dace.float32[10, 10]):
+        A = dace.define_local([10], dace.float32)
+        for i in dace.map[0:10]:
+                A[i] = B[i]
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+              C[i, j] = A[i]
+
+    _test_for_unchanged_behavior(tester, 'A', 1)
+
+
+
+def test_broadcast_hoisting_non_transient():
+    """Tests that the transformation doesn't apply to non-transient arrays."""
+    
+    @dace.program
+    def non_transient_test(A: dace.float32[10], C: dace.float32[10, 10]):
+        # A is an input array, not transient
+        for i in dace.map[0:10]:
+            A[i] = A[i] + 1  # Modify but don't create
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                C[i, j] = A[i]  # Broadcast
+    
+    _test_for_unchanged_behavior(non_transient_test, 'A')
+
+
+def test_broadcast_hoisting_equal_volume():
+    """Tests that the transformation doesn't apply when read volume equals write volume."""
+    
+    @dace.program
+    def equal_volume_test(B: dace.float32[10], C: dace.float32[10]):
+        A = dace.define_local([10], dace.float32)
+        for i in dace.map[0:10]:
+            A[i] = B[i]  # Write to A
+        for i in dace.map[0:10]:
+            C[i] = A[i]  # Read from A with same volume
+    
+    _test_for_unchanged_behavior(equal_volume_test, 'A')
+
+
+def test_broadcast_hoisting_less_read_volume():
+    """Tests that the transformation doesn't apply when read volume is less than write volume."""
+    
+    @dace.program
+    def less_read_test(B: dace.float32[10, 10], C: dace.float32[5]):
+        A = dace.define_local([10, 10], dace.float32)
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                A[i, j] = B[i, j]  # Write to full array
+        for i in dace.map[0:5]:
+            C[i] = A[i, 0]  # Read only part of the array
+    
+    _test_for_unchanged_behavior(less_read_test, 'A')
+
+
+def test_broadcast_hoisting_multiple_dims():
+    """Test broadcasting with multiple additional dimensions."""
+    
+    @dace.program
+    def multi_dim_test(B: dace.float32[10], C: dace.float32[10, 10, 10]):
+        A = dace.define_local([10], dace.float32)
+        for i in dace.map[0:10]:
+            A[i] = B[i]
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                for k in dace.map[0:10]:
+                    C[i, j, k] = A[i]  # Broadcasting to two additional dimensions
+    
+    _test_for_unchanged_behavior(multi_dim_test, 'A', 2)
+
+
+if __name__ == "__main__":
+    test_broadcast_hoisting_basic()
+    test_broadcast_hoisting_non_transient()
+    test_broadcast_hoisting_equal_volume()
+    test_broadcast_hoisting_less_read_volume()
+    test_broadcast_hoisting_multiple_dims()
+

--- a/tests/transformations/broadcast_hoisting_test.py
+++ b/tests/transformations/broadcast_hoisting_test.py
@@ -276,9 +276,11 @@ def test_broadcast_hoisting_indirect_access():
 
 def test_broadcast_hoisting_dynamic_range():
     """Test with dynamically computed range bounds."""
-    
+
+    N = dace.symbol('N')
+
     @dace.program
-    def dynamic_range_test(B: dace.float32[10], N: dace.int32, C: dace.float32[10, 10]):
+    def dynamic_range_test(B: dace.float32[10], C: dace.float32[10, 10]):
         A = dace.define_local([10], dace.float32)
         
         for i in dace.map[0:10]:

--- a/tests/transformations/broadcast_hoisting_test.py
+++ b/tests/transformations/broadcast_hoisting_test.py
@@ -8,6 +8,32 @@ from dace.transformation.dataflow import BroadcastHoisting
 from copy import deepcopy
 
 
+def _get_small_input_data(sdfg: dace.SDFG) -> dict:
+    """
+    Generate small input data for the given SDFG with non-trivial entries.
+    """
+    input_data = {}
+    sym_data = {}
+    for sym in sdfg.symbols:
+        if sym not in sdfg.constants:
+            sym_data[sym] = 3  # Default value for symbolic constants
+            input_data[sym] = 3  # Default value for symbolic arguments
+
+    for argName, argType in sdfg.arglist().items():
+        if isinstance(argType, dace.data.Scalar):
+            input_data[argName] = 3
+            continue
+
+        shape = []
+        for entry in argType.shape:
+            shape.append(dace.symbolic.evaluate(entry, sdfg.constants or sym_data))
+        shape = tuple(shape)
+        arr = dace.ndarray(shape=shape, dtype=argType.dtype)
+        # prime number to avoid nice alignment
+        arr[:] = (np.arange(arr.size).reshape(arr.shape) + 3) % 7 + 3
+        input_data[argName] = arr
+    return input_data
+
 def _test_for_unchanged_behavior(prog, array_name, dim_increase = 0):
     sdfg: dace.SDFG = prog.to_sdfg(simplify=True)
     sdfg.validate()
@@ -17,11 +43,7 @@ def _test_for_unchanged_behavior(prog, array_name, dim_increase = 0):
 
     # Get ground truth values if we expect dimension increase
     if dim_increase > 0:
-        input_data = {}
-        for argName, argType in sdfg.arglist().items():
-            arr = dace.ndarray(shape=argType.shape, dtype=argType.dtype)
-            arr[:] = np.random.rand(*argType.shape).astype(argType.dtype.type)
-            input_data[argName] = arr
+        input_data = _get_small_input_data(sdfg)
         ground_truth = deepcopy(input_data)
         sdfg(**ground_truth)
 
@@ -116,10 +138,189 @@ def test_broadcast_hoisting_multiple_dims():
     _test_for_unchanged_behavior(multi_dim_test, 'A', 2)
 
 
+def test_broadcast_hoisting_symbolic():
+    """Test broadcasting with symbolic dimensions."""
+    
+    N = dace.symbol('N')
+    
+    @dace.program
+    def symbolic_test(B: dace.float32[N], C: dace.float32[N, N]):
+        A = dace.define_local([N], dace.float32)
+        for i in dace.map[0:N]:
+            A[i] = B[i]
+        for i in dace.map[0:N]:
+            for j in dace.map[0:N]:
+                C[i, j] = A[i]
+    
+    _test_for_unchanged_behavior(symbolic_test, 'A', 1)
+
+
+def test_broadcast_hoisting_strided_access():
+    """Test broadcasting with strided access patterns."""
+    
+    @dace.program
+    def strided_test(B: dace.float32[20], C: dace.float32[10, 10]):
+        A = dace.define_local([10], dace.float32)
+        for i in dace.map[0:10]:
+            A[i] = B[i * 2]  # Strided read from B
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                C[i, j] = A[i]  # Broadcast
+    
+    _test_for_unchanged_behavior(strided_test, 'A', 1)
+
+
+def test_broadcast_hoisting_multiple_consumers():
+    """Test broadcasting with multiple consumers of the broadcast data."""
+    
+    @dace.program
+    def multiple_consumers_test(B: dace.float32[10], C: dace.float32[10, 10], D: dace.float32[10, 5]):
+        A = dace.define_local([10], dace.float32)
+        for i in dace.map[0:10]:
+            A[i] = B[i]
+        # Multiple consumers of A
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                C[i, j] = A[i]
+        for i in dace.map[0:10]:
+            for j in dace.map[0:5]:
+                D[i, j] = A[i] * 2
+    
+    _test_for_unchanged_behavior(multiple_consumers_test, 'A', 1)
+
+
+def test_broadcast_hoisting_nested():
+    """Test with nested broadcasting operations."""
+    
+    @dace.program
+    def nested_broadcast_test(B: dace.float32[10], D: dace.float32[10, 10, 10]):
+        A = dace.define_local([10], dace.float32)
+        C = dace.define_local([10, 10], dace.float32)
+        
+        for i in dace.map[0:10]:
+            A[i] = B[i]
+        
+        # First broadcast
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                C[i, j] = A[i]
+        
+        # Second broadcast
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                for k in dace.map[0:10]:
+                    D[i, j, k] = C[i, j]
+    
+    _test_for_unchanged_behavior(nested_broadcast_test, 'A', 1)
+    _test_for_unchanged_behavior(nested_broadcast_test, 'C', 1)
+
+
+def test_broadcast_hoisting_small_ranges():
+    """Test broadcasting with small ranges, including size 1."""
+    
+    @dace.program
+    def small_range_test(B: dace.float32[5], C: dace.float32[5, 1]):
+        A = dace.define_local([5], dace.float32)
+        for i in dace.map[0:5]:
+            A[i] = B[i]
+        for i in dace.map[0:5]:
+            for j in dace.map[0:1]:  # Single iteration map
+                C[i, j] = A[i]
+    
+    _test_for_unchanged_behavior(small_range_test, 'A', 1)
+
+
+def test_broadcast_hoisting_non_consecutive_maps():
+    """Test with operations between the two maps."""
+    
+    @dace.program
+    def non_consecutive_test(B: dace.float32[10], C: dace.float32[10, 10]):
+        A = dace.define_local([10], dace.float32)
+        E = dace.define_local([1], dace.float32)
+        
+        for i in dace.map[0:10]:
+            A[i] = B[i]
+        
+        # Operation between maps
+        E[0] = 1.0
+        
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                C[i, j] = A[i] * E[0]
+    
+    _test_for_unchanged_behavior(non_consecutive_test, 'A', 1)
+
+
+def test_broadcast_hoisting_indirect_access():
+    """Test with indirect array access."""
+    
+    @dace.program
+    def indirect_access_test(B: dace.float32[10], idx: dace.int32[10], C: dace.float32[10, 10]):
+        A = dace.define_local([10], dace.float32)
+        
+        for i in dace.map[0:10]:
+            A[i] = B[i]
+        
+        for i in dace.map[0:10]:
+            for j in dace.map[0:10]:
+                C[i, j] = A[idx[i]]  # Indirect access
+    
+    # Should not transform due to indirect access
+    _test_for_unchanged_behavior(indirect_access_test, 'A')
+
+
+def test_broadcast_hoisting_dynamic_range():
+    """Test with dynamically computed range bounds."""
+    
+    @dace.program
+    def dynamic_range_test(B: dace.float32[10], N: dace.int32, C: dace.float32[10, 10]):
+        A = dace.define_local([10], dace.float32)
+        
+        for i in dace.map[0:10]:
+            A[i] = B[i]
+        
+        # Dynamic upper bound
+        for i in dace.map[0:10]:
+            for j in dace.map[0:N]:  # Dynamic bound
+                if j < 10:  # Safety check
+                    C[i, j] = A[i]
+    
+    _test_for_unchanged_behavior(dynamic_range_test, 'A', 1)
+
+
+def test_broadcast_hoisting_mixed_dimensions():
+    """Test with mixed dimensions in arrays."""
+    
+    @dace.program
+    def mixed_dim_test(B: dace.float32[10, 5], C: dace.float32[10, 5, 8]):
+        # A is already multidimensional
+        A = dace.define_local([10, 5], dace.float32)
+        
+        for i in dace.map[0:10]:
+            for j in dace.map[0:5]:
+                A[i, j] = B[i, j]
+        
+        for i in dace.map[0:10]:
+            for j in dace.map[0:5]:
+                for k in dace.map[0:8]:
+                    C[i, j, k] = A[i, j]  # Broadcast along third dimension
+    
+    _test_for_unchanged_behavior(mixed_dim_test, 'A', 1)
+
+
 if __name__ == "__main__":
     test_broadcast_hoisting_basic()
     test_broadcast_hoisting_non_transient()
     test_broadcast_hoisting_equal_volume()
     test_broadcast_hoisting_less_read_volume()
     test_broadcast_hoisting_multiple_dims()
+    test_broadcast_hoisting_symbolic()
+    test_broadcast_hoisting_strided_access()
+    test_broadcast_hoisting_multiple_consumers()
+    test_broadcast_hoisting_nested()
+    test_broadcast_hoisting_small_ranges()
+    test_broadcast_hoisting_non_consecutive_maps()
+    test_broadcast_hoisting_indirect_access()
+    test_broadcast_hoisting_dynamic_range()
+    test_broadcast_hoisting_mixed_dimensions()
 

--- a/tests/transformations/broadcast_hoisting_test.py
+++ b/tests/transformations/broadcast_hoisting_test.py
@@ -220,8 +220,8 @@ def test_broadcast_hoisting_nested():
     _test_for_unchanged_behavior(nested_broadcast_test, ['A','C'], [2,1])
 
 
-def test_broadcast_hoisting_small_ranges():
-    """Test broadcasting with small ranges, including size 1."""
+def test_broadcast_hoisting_no_broadcast():
+    """Test broadcasting with a fake broadcast (no actual broadcast)."""
     
     @dace.program
     def small_range_test(B: dace.float32[5], C: dace.float32[5, 1]):
@@ -232,7 +232,7 @@ def test_broadcast_hoisting_small_ranges():
             for j in dace.map[0:1]:  # Single iteration map
                 C[i, j] = A[i]
     
-    _test_for_unchanged_behavior(small_range_test, ['A'], [1])
+    _test_for_unchanged_behavior(small_range_test, ['A'])
 
 
 def test_broadcast_hoisting_non_consecutive_maps():
@@ -323,7 +323,7 @@ if __name__ == "__main__":
     test_broadcast_hoisting_strided_access()
     test_broadcast_hoisting_multiple_consumers()
     test_broadcast_hoisting_nested()
-    test_broadcast_hoisting_small_ranges()
+    test_broadcast_hoisting_no_broadcast()
     test_broadcast_hoisting_non_consecutive_maps()
     test_broadcast_hoisting_indirect_access()
     test_broadcast_hoisting_dynamic_range()


### PR DESCRIPTION
This PR adds a new transformation, which pushes a broadcast operation up (i.e. earlier). It does so by extending the dimensions of the array being broadcasted to turn the broadcast into a one-to-one opration. 
Example:
  ```py
  for n in range(...):
    x[n] = y[n] # one to one

  for n in range(...):
    for k in range(...):
      z[n, k] = x[n] # broadcast
  ```

  becomes:
  ```py
  for n in range(...):
    for k in range(...):
      x[n, k] = y[n] # broadcast

  for n in range(...):
    for k in range(...):
      z[n, k] = x[n, k] # one to one
  ```