### PR TITLE
Allocate arrays in scope after map variables are defined

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -2354,7 +2354,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                 callsite_stream.write(
                     f'auto {scope_map.params[0]} = {scope_map.range[0][0]} + {dynmap_step} * {dynmap_var};', cfg,
                     state_id, scope_entry)
-                
+
             # Emit internal array allocation (deallocation handled at MapExit)
             self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -2354,6 +2354,9 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                 callsite_stream.write(
                     f'auto {scope_map.params[0]} = {scope_map.range[0][0]} + {dynmap_step} * {dynmap_var};', cfg,
                     state_id, scope_entry)
+                
+            # Emit internal array allocation (deallocation handled at MapExit)
+            self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 
         elif scope_map.schedule == dtypes.ScheduleType.GPU_Device:
             dfg_kernel = self._kernel_state.scope_subgraph(self._kernel_map)
@@ -2504,7 +2507,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                     callsite_stream.write('int %s = %s;' % (varname, expr), cfg, state_id, scope_entry)
                     self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
 
-                # Emit internal array allocation here (deallocation handled at MapExit)
+                # Emit internal array allocation (deallocation handled at MapExit)
                 self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 
                 # Generate conditions for this subgrid's execution using min and max

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -2474,6 +2474,10 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                                                   varname=varname,
                                                   expr=expr,
                                               ), cfg, state_id, node)
+                        
+                # Emit internal array allocation here for GPU_ThreadBlock (deallocation handled at MapExit)
+                self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
+
             else:  # Device map in Device map
                 brange = subsets.Range(scope_map.range[::-1])
                 kdims = brange.size()
@@ -2499,6 +2503,9 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                     expr = _topy(tidx[i]).replace('__DAPT%d' % i, block_expr)
                     callsite_stream.write('int %s = %s;' % (varname, expr), cfg, state_id, scope_entry)
                     self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+
+                # Emit internal array allocation here (deallocation handled at MapExit)
+                self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 
                 # Generate conditions for this subgrid's execution using min and max
                 # element, e.g. skipping out-of-bounds threads
@@ -2538,8 +2545,6 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
             for dim in range(len(scope_map.range)):
                 callsite_stream.write('{', cfg, state_id, scope_entry)
 
-        # Emit internal array allocation (deallocation handled at MapExit)
-        self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 
         # Generate all index arguments for block
         if scope_map.schedule == dtypes.ScheduleType.GPU_ThreadBlock:
@@ -2582,6 +2587,9 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                     expr = _topy(tidx[i]).replace('__DAPT%d' % i, block_expr)
                     callsite_stream.write('int %s = %s;' % (varname, expr), cfg, state_id, scope_entry)
                     self._dispatcher.defined_vars.add(varname, DefinedType.Scalar, 'int')
+
+            # Emit internal array allocation here (deallocation handled at MapExit)
+            self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 
             # Generate conditions for this block's execution using min and max
             # element, e.g. skipping out-of-bounds threads in trailing block

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -2474,7 +2474,7 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
                                                   varname=varname,
                                                   expr=expr,
                                               ), cfg, state_id, node)
-                        
+
                 # Emit internal array allocation here for GPU_ThreadBlock (deallocation handled at MapExit)
                 self._frame.allocate_arrays_in_scope(sdfg, cfg, scope_entry, function_stream, callsite_stream)
 
@@ -2544,7 +2544,6 @@ gpuError_t __err = {backend}LaunchKernel((void*){kname}, dim3({gdims}), dim3({bd
         else:
             for dim in range(len(scope_map.range)):
                 callsite_stream.write('{', cfg, state_id, scope_entry)
-
 
         # Generate all index arguments for block
         if scope_map.schedule == dtypes.ScheduleType.GPU_ThreadBlock:

--- a/tests/codegen/gpu_allocation_order.py
+++ b/tests/codegen/gpu_allocation_order.py
@@ -1,0 +1,62 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+import pytest
+from dace.codegen.exceptions import CompilationError
+
+@pytest.mark.gpu
+def test_allocation_requiring_map_variables():
+    """ 
+    The goal of this test is to ensure map variables are defined
+    before allocating arrays in scopes, since the allocated array's 
+    size may depend on a map variable.
+    """
+
+    # Create SDFG and state
+    sdfg = dace.SDFG("example")
+    state = sdfg.add_state("main")
+
+    # Add input and output array (same array) and corrsponding accessNodes
+    sdfg.add_array("gpu_A", (128,), dace.uint32, storage=dace.dtypes.StorageType.GPU_Global)
+    gpu_a_acc_read = state.add_access("gpu_A")
+    gpu_a_acc_write = state.add_access("gpu_A")
+
+
+    # Add GPU_Device and GPU_ThreadBlock Maps
+    gpu_map_entry, gpu_map_exit = state.add_map("gpu_map", dict(bi="0:128:32"),
+                                                schedule=dace.dtypes.ScheduleType.GPU_Device)
+    tb_map_entry, tb_map_exit = state.add_map("tb", dict(i="bi:bi+32"),
+                                               schedule=dace.dtypes.ScheduleType.GPU_ThreadBlock,)
+    
+    # Add transient helper Array + a corresponding accessNode
+    sdfg.add_transient("gpu_A_helper", ("i+128",), dace.uint32, storage=dace.dtypes.StorageType.Register, 
+                       lifetime=dace.dtypes.AllocationLifetime.Scope)
+    gpu_a_helper_acc = state.add_access("gpu_A_helper")
+
+
+    # Add Edges & connectors
+    state.add_edge(gpu_a_acc_read, None, gpu_map_entry, "IN_gpu_A", dace.Memlet("gpu_A[0:128]"))
+    state.add_edge(gpu_map_entry, "OUT_gpu_A", tb_map_entry, "IN_gpu_A", dace.Memlet("gpu_A[0:bi+32]"))
+    gpu_map_entry.add_in_connector("IN_gpu_A")
+    gpu_map_entry.add_out_connector("OUT_gpu_A")
+    tb_map_entry.add_in_connector("IN_gpu_A")
+    
+    # Weird copy, which triggers error if allocation happens to late during code generation
+    state.add_edge(tb_map_entry, "OUT_gpu_A", gpu_a_helper_acc, None, dace.Memlet("gpu_A[0:i]"))
+    tb_map_entry.add_out_connector("OUT_gpu_A")
+
+    state.add_edge(gpu_a_helper_acc, None, tb_map_exit, "IN_1", dace.Memlet("gpu_A_helper[i]"))
+    state.add_edge(tb_map_exit, "OUT_1", gpu_map_exit, "IN_1", dace.Memlet("gpu_A_helper[bi:bi+32]"))
+    state.add_edge(gpu_map_exit, "OUT_1", gpu_a_acc_write, None, dace.Memlet("gpu_A[0:128]"))
+
+    tb_map_exit.add_in_connector("IN_1")
+    tb_map_exit.add_out_connector("OUT_1")
+    gpu_map_exit.add_in_connector("IN_1")
+    gpu_map_exit.add_out_connector("OUT_1")
+
+    try:
+        sdfg.compile()
+    except CompilationError as e:
+        pytest.fail(f"sdfg.compile() failed with: {e}")
+
+if __name__ == '__main__':
+    test_allocation_requiring_map_variables()

--- a/tests/codegen/gpu_allocation_order.py
+++ b/tests/codegen/gpu_allocation_order.py
@@ -3,11 +3,12 @@ import dace
 import pytest
 from dace.codegen.exceptions import CompilationError
 
+
 @pytest.mark.gpu
 def test_allocation_requiring_map_variables():
-    """ 
+    """
     The goal of this test is to ensure map variables are defined
-    before allocating arrays in scopes, since the allocated array's 
+    before allocating arrays in scopes, since the allocated array's
     size may depend on a map variable.
     """
 
@@ -16,22 +17,26 @@ def test_allocation_requiring_map_variables():
     state = sdfg.add_state("main")
 
     # Add input and output array (same array) and corrsponding accessNodes
-    sdfg.add_array("gpu_A", (128,), dace.uint32, storage=dace.dtypes.StorageType.GPU_Global)
+    sdfg.add_array("gpu_A", (128, ), dace.uint32, storage=dace.dtypes.StorageType.GPU_Global)
     gpu_a_acc_read = state.add_access("gpu_A")
     gpu_a_acc_write = state.add_access("gpu_A")
 
-
     # Add GPU_Device and GPU_ThreadBlock Maps
-    gpu_map_entry, gpu_map_exit = state.add_map("gpu_map", dict(bi="0:128:32"),
+    gpu_map_entry, gpu_map_exit = state.add_map("gpu_map",
+                                                dict(bi="0:128:32"),
                                                 schedule=dace.dtypes.ScheduleType.GPU_Device)
-    tb_map_entry, tb_map_exit = state.add_map("tb", dict(i="bi:bi+32"),
-                                               schedule=dace.dtypes.ScheduleType.GPU_ThreadBlock,)
-    
+    tb_map_entry, tb_map_exit = state.add_map(
+        "tb",
+        dict(i="bi:bi+32"),
+        schedule=dace.dtypes.ScheduleType.GPU_ThreadBlock,
+    )
+
     # Add transient helper Array + a corresponding accessNode
-    sdfg.add_transient("gpu_A_helper", ("i+128",), dace.uint32, storage=dace.dtypes.StorageType.Register, 
+    sdfg.add_transient("gpu_A_helper", ("i+128", ),
+                       dace.uint32,
+                       storage=dace.dtypes.StorageType.Register,
                        lifetime=dace.dtypes.AllocationLifetime.Scope)
     gpu_a_helper_acc = state.add_access("gpu_A_helper")
-
 
     # Add Edges & connectors
     state.add_edge(gpu_a_acc_read, None, gpu_map_entry, "IN_gpu_A", dace.Memlet("gpu_A[0:128]"))
@@ -39,7 +44,7 @@ def test_allocation_requiring_map_variables():
     gpu_map_entry.add_in_connector("IN_gpu_A")
     gpu_map_entry.add_out_connector("OUT_gpu_A")
     tb_map_entry.add_in_connector("IN_gpu_A")
-    
+
     # Weird copy, which triggers error if allocation happens to late during code generation
     state.add_edge(tb_map_entry, "OUT_gpu_A", gpu_a_helper_acc, None, dace.Memlet("gpu_A[0:i]"))
     tb_map_entry.add_out_connector("OUT_gpu_A")
@@ -57,6 +62,7 @@ def test_allocation_requiring_map_variables():
         sdfg.compile()
     except CompilationError as e:
         pytest.fail(f"sdfg.compile() failed with: {e}")
+
 
 if __name__ == '__main__':
     test_allocation_requiring_map_variables()


### PR DESCRIPTION
**Description**

In `CUDACodeGen`, arrays in a scope should be allocated **after** defining the map variables.
Currently, the allocation happens earlier, which can (and does) lead to code referencing undefined variables.

For example, consider the following part of an SDFG:

<img width="899" height="458" alt="Screenshot 2025-08-24 195204" src="https://github.com/user-attachments/assets/e1bef451-808d-4491-9fb9-b37efe32493c" />


Which will generate:

```cpp
B_0 = &gpu_B[((N * (i + 1)) + j)];
```
**before** `j`is defined, resulting in a compiler error.