### PR TITLE
Add OpenBLAS support and enable static linking of LAPACKE

### DIFF
--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -282,7 +282,7 @@ def get_environment_flags(environments) -> Tuple[List[str], Set[str]]:
     cmake_variables = collections.OrderedDict()
     cmake_packages = set()
     cmake_includes = set()
-    cmake_libraries = set()
+    cmake_libraries = list()
     cmake_compile_flags = set()
     cmake_link_flags = set()
     cmake_files = set()
@@ -308,7 +308,8 @@ def get_environment_flags(environments) -> Tuple[List[str], Set[str]]:
             cmake_variables[var] = env_variables[var]
         cmake_packages |= set(_get_or_eval(env.cmake_packages))
         cmake_includes |= set(_get_or_eval(env.cmake_includes))
-        cmake_libraries |= set(_get_or_eval(env.cmake_libraries))
+        for lib in _get_or_eval(env.cmake_libraries):
+            cmake_libraries.append(lib)
         cmake_compile_flags |= set(_get_or_eval(env.cmake_compile_flags))
         cmake_link_flags |= set(_get_or_eval(env.cmake_link_flags))
         # Make path absolute
@@ -339,7 +340,7 @@ def get_environment_flags(environments) -> Tuple[List[str], Set[str]]:
         "-DDACE_ENV_VAR_VALUES=\"{}\"".format(";".join(cmake_variables.values())),
         "-DDACE_ENV_PACKAGES=\"{}\"".format(" ".join(sorted(cmake_packages))),
         "-DDACE_ENV_INCLUDES=\"{}\"".format(" ".join(sorted(cmake_includes))),
-        "-DDACE_ENV_LIBRARIES=\"{}\"".format(" ".join(sorted(cmake_libraries))),
+        "-DDACE_ENV_LIBRARIES=\"{}\"".format(" ".join(cmake_libraries)),
         "-DDACE_ENV_COMPILE_FLAGS=\"{}\"".format(" ".join(cmake_compile_flags)),
         # "-DDACE_ENV_LINK_FLAGS=\"{}\"".format(" ".join(cmake_link_flags)),
         "-DDACE_ENV_CMAKE_FILES=\"{}\"".format(";".join(sorted(cmake_files))),

--- a/dace/libraries/blas/environments/openblas.py
+++ b/dace/libraries/blas/environments/openblas.py
@@ -26,11 +26,14 @@ class OpenBLAS:
 
     @staticmethod
     def cmake_libraries():
+        openblas_path = ctypes.util.find_library('openblas')
+        if openblas_path:
+            return [openblas_path]
         lapacke_path = ctypes.util.find_library('lapacke')
         blas_path = ctypes.util.find_library('blas')
         if lapacke_path and blas_path:
             return [lapacke_path, blas_path]
-        return []
+        return ['lapacke', 'lapack', 'blas', 'gfortran']
 
     @staticmethod
     def is_installed():


### PR DESCRIPTION
i made changes to support cholesky2 from npbenchmarks, as it failed with an undefined reference to LAPACKE and I don’t have
BLAS and LAPACKE installed as shared libs.
- added support for OpenBLAS if it is installed on the system
- allowed static linking by including LAPACKE, LAPACK, BLAS, and gfortran in the link list
- updated cmake_libraries to be a list as the order of linking matters
