### PR TITLE
fix: delete big arrays that are moved to heap

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -488,10 +488,10 @@ class CPUCodeGen(TargetCodeGenerator):
 
                 if symbolic.issymbolic(arrsize, sdfg.constants):
                     warnings.warn('Variable-length array %s with size %s '
-                                  'detected and was allocated on heap instead of '
+                                  'detected and was allocated on the heap instead of '
                                   '%s' % (name, cpp.sym2cpp(arrsize), nodedesc.storage))
                 elif (arrsize_bytes > Config.get("compiler", "max_stack_array_size")) == True:
-                    warnings.warn("Array {} with size {} detected and was allocated on heap instead of "
+                    warnings.warn("Array {} with size {} detected and was allocated on the heap instead of "
                                   "{} since its size is greater than max_stack_array_size ({})".format(
                                       name, cpp.sym2cpp(arrsize_bytes), nodedesc.storage,
                                       Config.get("compiler", "max_stack_array_size")))
@@ -573,6 +573,10 @@ class CPUCodeGen(TargetCodeGenerator):
                          node: nodes.AccessNode, nodedesc: data.Data, function_stream: CodeIOStream,
                          callsite_stream: CodeIOStream) -> None:
         arrsize = nodedesc.total_size
+        arrsize_bytes = None
+        if not isinstance(nodedesc.dtype, dtypes.opaque):
+            arrsize_bytes = arrsize * nodedesc.dtype.bytes
+
         alloc_name = cpp.ptr(node.data, nodedesc, sdfg, self._frame)
         if isinstance(nodedesc, data.Array) and nodedesc.start_offset != 0:
             alloc_name = f'({alloc_name} - {cpp.sym2cpp(nodedesc.start_offset)})'
@@ -585,7 +589,9 @@ class CPUCodeGen(TargetCodeGenerator):
         if isinstance(nodedesc, (data.Scalar, data.View, data.Stream, data.Reference)):
             return
         elif (nodedesc.storage == dtypes.StorageType.CPU_Heap
-              or (nodedesc.storage == dtypes.StorageType.Register and symbolic.issymbolic(arrsize, sdfg.constants))):
+              or (nodedesc.storage == dtypes.StorageType.Register and
+                  (symbolic.issymbolic(arrsize, sdfg.constants) or
+                   (arrsize_bytes and ((arrsize_bytes > Config.get("compiler", "max_stack_array_size")) == True))))):
             if isinstance(nodedesc, data.Array):
                 callsite_stream.write(f"delete[] {alloc_name};\n", cfg, state_id, node)
             else:

--- a/tests/codegen/cpp_test.py
+++ b/tests/codegen/cpp_test.py
@@ -2,31 +2,12 @@
 
 from functools import reduce
 from operator import mul
-from typing import Dict, Collection
+import warnings
 
-import dace
-from dace import SDFG, Memlet
+from dace import SDFG, Memlet, dtypes
+from dace.codegen import codegen
 from dace.codegen.targets import cpp
-from dace.sdfg.state import SDFGState
 from dace.subsets import Range
-from dace.transformation.dataflow import RedundantArray
-
-
-def _add_map_with_connectors(st: SDFGState,
-                             name: str,
-                             ndrange: Dict[str, str],
-                             en_conn_bases: Collection[str] = None,
-                             ex_conn_bases: Collection[str] = None):
-    en, ex = st.add_map(name, ndrange)
-    if en_conn_bases:
-        for c in en_conn_bases:
-            en.add_in_connector(f"IN_{c}")
-            en.add_out_connector(f"OUT_{c}")
-    if ex_conn_bases:
-        for c in ex_conn_bases:
-            ex.add_in_connector(f"IN_{c}")
-            ex.add_out_connector(f"OUT_{c}")
-    return en, ex
 
 
 def test_reshape_strides_multidim_array_all_dims_unit():
@@ -166,32 +147,28 @@ def test_reshape_strides_from_strided_and_offset_range():
     assert strides == [6, 2, 1]
 
 
-def redundant_array_crashes_codegen_test_original_graph():
-    g = SDFG('prog')
-    g.add_array('A', (5, 5), dace.float32)
-    g.add_array('b', (1, ), dace.float32, transient=True)
-    g.add_array('c', (5, 5), dace.float32, transient=True)
+def test_arrays_bigger_than_max_stack_size_get_deallocated():
+    # Setup SDFG with array A that is too big to be allocated on the stack.
+    sdfg = SDFG("test")
+    sdfg.add_array(name="A", shape=(10000, ), dtype=dtypes.float64, storage=dtypes.StorageType.Register, transient=True)
+    state = sdfg.add_state("state", is_start_block=True)
+    read = state.add_access("A")
+    tasklet = state.add_tasklet("dummy", {"a"}, {}, "a = 1")
+    state.add_memlet_path(read, tasklet, dst_conn="a", memlet=Memlet("A[0]"))
 
-    st0 = g.add_state('st0', is_start_block=True)
-    st = st0
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        # Generate code for the program by traversing the SDFG state by state
+        program_objects = codegen.generate_code(sdfg)
 
-    # Make a single map that copies A[i, j] to a transient "scalar" b, then copies that out to a transient array
-    # c[i, j], then finally back to A[i, j] again.
-    A = st.add_access('A')
-    en, ex = _add_map_with_connectors(st, 'm0', {'i': '0:1', 'j': '0:1'}, ['A'], ['A'])
-    st.add_edge(A, None, en, 'IN_A', Memlet(expr='A[0:1, 0:1]'))
-    b = st.add_access('b')
-    st.add_edge(en, 'OUT_A', b, None, Memlet(expr='A[i, j] -> b[0]'))
-    c = st.add_access('c')
-    st.add_nedge(b, c, Memlet(expr='b[0] -> c[i, j]'))
-    st.add_edge(c, None, ex, 'IN_A', Memlet(expr='c[i, j] -> A[i, j]'))
-    A = st.add_access('A')
-    st.add_edge(ex, 'OUT_A', A, None, Memlet(expr='A[0:1, 0:1]'))
-    st0.fill_scope_connectors()
+        # Assert that we get the expected warning message
+        assert w
+        assert any("was allocated on the heap instead of" in str(warn.message) for warn in w)
 
-    g.validate()
-    g.compile()
-    return g
+        # In code, assert that we allocate _and_ deallocate on the heap
+        code = program_objects[0].clean_code
+        assert code.find("A = new double") > 0, "A is allocated on the heap."
+        assert code.find("delete[] A") > 0, "A is deallocated from the heap."
 
 
 if __name__ == '__main__':
@@ -200,3 +177,5 @@ if __name__ == '__main__':
     test_reshape_strides_multidim_array_different_shape()
     test_reshape_strides_from_strided_range()
     test_reshape_strides_from_strided_and_offset_range()
+
+    test_arrays_bigger_than_max_stack_size_get_deallocated()


### PR DESCRIPTION
## Description

When arrays have storage type Register, but are bigger than `max_stack_array_size`, they are moved to the heap. In that situation they are dynamically allocated and need to be deleted again.

In the test, I removed `redundant_array_crashes_codegen_test_original_graph()` which is a setup function of a test that got removed in https://github.com/spcl/dace/pull/2105.

I wasn't sure where to put the test. `codegen/cpp_test.py` seemed logical. The new test is also very close to `tests/vla_test.py` (which tests the same but for variable length arrays). Since that test was explicitly for variable length arrays, I didn't wanna put it there. In any case, I'm happy to move the new test around if you want it somewhere else.

Backport on `v1/maintenace` is in PR https://github.com/spcl/dace/pull/2135.