### PR TITLE
Specialize scalar utility function

### DIFF
--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -2387,7 +2387,7 @@ def _specialize_scalar_impl(root: 'dace.SDFG', sdfg: 'dace.SDFG', scalar_name: s
     # -> If access node is used then e.g. [scalar] -> [tasklet]
     # -> then [tasklet(assign const value)] -> [access node] -> [tasklet]
 
-    def repl_code_block_or_str(input: CodeBlock | str, src: str, dst: str):
+    def repl_code_block_or_str(input: Union[CodeBlock, str], src: str, dst: str):
         if isinstance(input, CodeBlock):
             return CodeBlock(input.as_string.replace(src, dst))
         else:

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -22,6 +22,7 @@ from dace.cli.progress import optional_progressbar
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Sequence, Tuple, Type, Union
 from dace.properties import CodeBlock
 
+
 def node_path_graph(*args) -> gr.OrderedDiGraph:
     """
     Generates a path graph passing through the input nodes.
@@ -2373,6 +2374,7 @@ def _get_used_symbols_impl(scope: Union[SDFG, ControlFlowRegion, SDFGState, nd.M
         return offset_symbols | used_symbols
     else:
         raise Exception("Unsupported scope type for get_constant_data: {}".format(type(scope)))
+
 
 def _specialize_scalar_impl(root: 'dace.SDFG', sdfg: 'dace.SDFG', scalar_name: str, scalar_val: Union[float, int, str]):
     # This function replaces a scalar with the name <scalar_name> with a constant

--- a/tests/utils/specialize_scalar_test.py
+++ b/tests/utils/specialize_scalar_test.py
@@ -1,6 +1,10 @@
 import dace
+from dace.codegen.control_flow import LoopRegion
+from dace.properties import CodeBlock
+from dace.sdfg.state import ConditionalBlock
 import pytest
 import dace.sdfg.utils as sdutil
+
 
 def _get_sdfg_for_dynamic_map_input():
     sdfg = dace.SDFG("dynamic_input")
@@ -11,21 +15,64 @@ def _get_sdfg_for_dynamic_map_input():
     s1 = sdfg.add_state("s1")
     sdfg.add_edge(s0, s1, dace.InterstateEdge(assignments={"nlev_sym": "nlev"}))
     an = s1.add_access("A")
-    _, _, _ = s1.add_mapped_tasklet(
-        name="assign_map",
-        map_ranges={"i": dace.subsets.Range(ranges=[("0","nlev-1","1"),])},
-        inputs={},
-        outputs={"_out": dace.memlet.Memlet("A[i]")},
-        code="_out = 0",
-        input_nodes=None,
-        external_edges=True,
-        output_nodes={"A": an}
-    )
+    _, _, _ = s1.add_mapped_tasklet(name="assign_map",
+                                    map_ranges={"i": dace.subsets.Range(ranges=[
+                                        ("0", "nlev-1", "1"),
+                                    ])},
+                                    inputs={},
+                                    outputs={"_out": dace.memlet.Memlet("A[i]")},
+                                    code="_out = 0",
+                                    input_nodes=None,
+                                    external_edges=True,
+                                    output_nodes={"A": an})
     return sdfg
 
 
 def _get_sdfg_with_symbol_use_in_if():
-    pass
+    sdfg = dace.SDFG("basic1")
+    _, A = sdfg.add_array(name="A", shape=[
+        5,
+    ], dtype=dace.float64, transient=False)
+    _, B = sdfg.add_array(name="B", shape=[
+        5,
+    ], dtype=dace.float64, transient=False)
+    cb = ConditionalBlock(label="cfb1", sdfg=sdfg, parent=sdfg)
+    sdfg.add_node(cb, is_start_block=True)
+    cfg = dace.ControlFlowRegion(label="cfg1", sdfg=cb.sdfg, parent=cb)
+    cb.add_branch(condition=CodeBlock("nlev < 100"), branch=cfg)
+    s1 = cfg.add_state(label="s1")
+    aA = s1.add_access("A")
+    aB = s1.add_access("B")
+    s1.add_edge(aA, None, aB, None, dace.memlet.Memlet.from_array("A", A))
+
+    return sdfg
+
+
+def _get_sdfg_with_symbol_use_in_for_cfg():
+    sdfg = dace.SDFG("basic1")
+    _, A = sdfg.add_array(name="A", shape=[
+        5,
+    ], dtype=dace.float64, transient=False)
+    _, B = sdfg.add_array(name="B", shape=[
+        5,
+    ], dtype=dace.float64, transient=False)
+    sdfg.add_scalar(name="nlev", dtype=dace.int64)
+    loop = LoopRegion(
+        label="cfb1",
+        condition_expr="i < nlev",
+        loop_var="i",
+        initialize_expr="i = 0",
+        update_expr="i = (i + 1)",
+        sdfg=sdfg,
+    )
+    sdfg.add_node(loop, is_start_block=True)
+    s1 = loop.add_state(label="s1")
+    aA = s1.add_access("A")
+    aB = s1.add_access("B")
+    s1.add_edge(aA, None, aB, None, dace.memlet.Memlet.from_array("A", A))
+
+    return sdfg
+
 
 def test_specialize_with_dynamic_input():
     sdfg = _get_sdfg_for_dynamic_map_input()
@@ -43,6 +90,70 @@ def test_specialize_with_dynamic_input():
     range: dace.subsets.Range = map_entry.map.range
     assert range == dace.subsets.Range(ranges=[("0", "89", "1")])
 
+
+def test_use_in_if_block():
+    sdfg = _get_sdfg_with_symbol_use_in_if()
+    sdfg.validate()
+    sdutil.specialize_scalar(sdfg=sdfg, scalar_name="nlev", scalar_val="90")
+    sdfg.validate()
+    sdfg.compile()
+    cbs = set()
+    for n in sdfg.all_control_flow_regions():
+        print(n, type(n))
+        if isinstance(n, ConditionalBlock):
+            cbs.add(n)
+    assert len(cbs) == 1
+    cb: ConditionalBlock = next(iter(cbs))
+    assert len(cb.branches) == 1
+    assert "nlev" not in cb.branches[0][0].as_string
+
+
+def test_use_in_for_cfg():
+    sdfg = _get_sdfg_with_symbol_use_in_for_cfg()
+    sdfg.validate()
+    sdfg.compile()
+    sdutil.specialize_scalar(sdfg=sdfg, scalar_name="nlev", scalar_val="90")
+    sdfg.validate()
+    sdfg.compile()
+
+
+def test_interstate_assignment():
+    sdfg = dace.SDFG("dynamic_input")
+    sdfg.add_scalar("nlev", dtype=dace.int32, transient=False)
+    sdfg.add_symbol("nlev_sym", stype=dace.int32)
+    s0 = sdfg.add_state("s0")
+    sdfg.add_array("A", ["nlev_sym"], dtype=dace.float64, transient=False)
+    s1 = sdfg.add_state("s1")
+    sdfg.add_edge(s0, s1, dace.InterstateEdge(assignments={"nlev_sym": "nlev"}))
+    sdutil.specialize_scalar(sdfg=sdfg, scalar_name="nlev", scalar_val="90")
+    for e in sdfg.all_interstate_edges():
+        assert e.data.assignments == {"nlev_sym": "90"}
+    return sdfg
+
+
+def test_interstate_read():
+    sdfg = dace.SDFG("interstate_read")
+    _, nlev = sdfg.add_scalar("nlev", dtype=dace.int32, transient=True)
+    sdfg.add_symbol("nlev_sym", stype=dace.int32)
+    s1 = sdfg.add_state("s1")
+    nlev_an = s1.add_access("nlev")
+    tasklet = s1.add_tasklet(name="assign", inputs={}, outputs={"_out"}, code="_out = nlev_sym")
+    tasklet.add_out_connector("_out")
+    s1.add_edge(tasklet, "_out", nlev_an, None, dace.memlet.Memlet.from_array("nlev", nlev))
+
+    sdfg.validate()
+
+    sdutil.specialize_scalar(sdfg=sdfg, scalar_name="nlev", scalar_val="90")
+
+    sdfg.validate()
+
+    # Should be no nodes in the state anymore
+    assert len(s1.nodes()) == 0
+
+
 if __name__ == "__main__":
     test_specialize_with_dynamic_input()
-
+    test_use_in_if_block()
+    test_interstate_assignment()
+    test_interstate_read()
+    test_use_in_for_cfg()

--- a/tests/utils/specialize_scalar_test.py
+++ b/tests/utils/specialize_scalar_test.py
@@ -1,0 +1,48 @@
+import dace
+import pytest
+import dace.sdfg.utils as sdutil
+
+def _get_sdfg_for_dynamic_map_input():
+    sdfg = dace.SDFG("dynamic_input")
+    sdfg.add_scalar("nlev", dtype=dace.int32, transient=False)
+    sdfg.add_symbol("nlev_sym", stype=dace.int32)
+    s0 = sdfg.add_state("s0")
+    sdfg.add_array("A", ["nlev_sym"], dtype=dace.float64, transient=False)
+    s1 = sdfg.add_state("s1")
+    sdfg.add_edge(s0, s1, dace.InterstateEdge(assignments={"nlev_sym": "nlev"}))
+    an = s1.add_access("A")
+    _, _, _ = s1.add_mapped_tasklet(
+        name="assign_map",
+        map_ranges={"i": dace.subsets.Range(ranges=[("0","nlev-1","1"),])},
+        inputs={},
+        outputs={"_out": dace.memlet.Memlet("A[i]")},
+        code="_out = 0",
+        input_nodes=None,
+        external_edges=True,
+        output_nodes={"A": an}
+    )
+    return sdfg
+
+
+def _get_sdfg_with_symbol_use_in_if():
+    pass
+
+def test_specialize_with_dynamic_input():
+    sdfg = _get_sdfg_for_dynamic_map_input()
+    sdfg.validate()
+    sdutil.specialize_scalar(sdfg=sdfg, scalar_name="nlev", scalar_val="90")
+    sdfg.validate()
+    sdfg.compile()
+    map_entries = set()
+    for s in sdfg.all_states():
+        for n in s.nodes():
+            if isinstance(n, dace.nodes.MapEntry):
+                map_entries.add(n)
+    assert len(map_entries) == 1
+    map_entry: dace.nodes.MapEntry = next(iter(map_entries))
+    range: dace.subsets.Range = map_entry.map.range
+    assert range == dace.subsets.Range(ranges=[("0", "89", "1")])
+
+if __name__ == "__main__":
+    test_specialize_with_dynamic_input()
+

--- a/tests/utils/specialize_scalar_test.py
+++ b/tests/utils/specialize_scalar_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 from dace.codegen.control_flow import LoopRegion
 from dace.properties import CodeBlock
@@ -99,7 +100,6 @@ def test_use_in_if_block():
     sdfg.compile()
     cbs = set()
     for n in sdfg.all_control_flow_regions():
-        print(n, type(n))
         if isinstance(n, ConditionalBlock):
             cbs.add(n)
     assert len(cbs) == 1
@@ -115,6 +115,7 @@ def test_use_in_for_cfg():
     sdutil.specialize_scalar(sdfg=sdfg, scalar_name="nlev", scalar_val="90")
     sdfg.validate()
     sdfg.compile()
+
 
 
 def test_interstate_assignment():

--- a/tests/utils/specialize_scalar_test.py
+++ b/tests/utils/specialize_scalar_test.py
@@ -117,7 +117,6 @@ def test_use_in_for_cfg():
     sdfg.compile()
 
 
-
 def test_interstate_assignment():
     sdfg = dace.SDFG("dynamic_input")
     sdfg.add_scalar("nlev", dtype=dace.int32, transient=False)


### PR DESCRIPTION
ScalarToSymbol + SDFG.specialize breaks too often, and on f2dace, I wrote this utility function to directly specialize a scalar to a constant.

It does not fail when the scalar is used as a dynamic map connector and used on interstate edges.

(I am not sure if I need to cover the case where the scalar name is the subset of another array name)
(Btw. maybe we should add warnings, if a data descriptor name is subset of another data descriptor because our string replacement functions can create problems there)