### PR TITLE
Add dace::float32sr type to DaCe

### DIFF
--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -911,6 +911,43 @@ class pyobject(opaque):
         return ctypes.cast(obj_id, ctypes.py_object).value
 
 
+class Float32sr(typeclass):
+
+    def __init__(self):
+        self.type = numpy.float32
+        self.bytes = 4
+        self.dtype = self
+        self.typename = "float"
+        self.stochastically_rounded = True
+
+    def to_json(self):
+        return 'float32sr'
+
+    @staticmethod
+    def from_json(json_obj, context=None):
+        from dace.symbolic import pystr_to_symbolic # must be included!
+        return float32sr()
+
+    @property
+    def ctype(self):
+        return "dace::float32sr"
+
+    @property
+    def ctype_unaligned(self):
+        return self.ctype
+
+    def as_ctypes(self):
+        """ Returns the ctypes version of the typeclass. """
+        return _FFI_CTYPES[self.type]
+
+    def as_numpy_dtype(self):
+        return numpy.dtype(self.type)
+
+    @property
+    def base_type(self):
+        return self
+
+
 class compiletime:
     """
     Data descriptor type hint signalling that argument evaluation is
@@ -1257,6 +1294,7 @@ complex64 = typeclass(numpy.complex64)
 complex128 = typeclass(numpy.complex128)
 string = stringtype()
 MPI_Request = opaque('MPI_Request')
+float32sr = Float32sr()
 
 
 @undefined_safe_enum

--- a/dace/libraries/blas/nodes/dot.py
+++ b/dace/libraries/blas/nodes/dot.py
@@ -70,6 +70,7 @@ class ExpandDotOpenBLAS(ExpandTransformation):
         (desc_x, stride_x), (desc_y, stride_y), desc_res, sz = node.validate(parent_sdfg, parent_state)
         dtype = desc_x.dtype.base_type
         veclen = desc_x.dtype.veclen
+        cast = "(float *)" if dtype == dace.float32sr else ""
 
         try:
             func, _, _ = blas_helpers.cublas_type_metadata(dtype)
@@ -82,7 +83,9 @@ class ExpandDotOpenBLAS(ExpandTransformation):
         n = n or node.n or sz
         if veclen != 1:
             n /= veclen
-        code = f"_result = cblas_{func}({n}, _x, {stride_x}, _y, {stride_y});"
+
+
+        code = f"_result = cblas_{func}({n}, {cast} _x, {stride_x}, {cast} _y, {stride_y});"
         # The return type is scalar in cblas_?dot signature
         tasklet = dace.sdfg.nodes.Tasklet(node.name,
                                           node.in_connectors, {'_result': dtype},
@@ -545,7 +548,11 @@ class Dot(dace.sdfg.nodes.LibraryNode):
         if desc_x.dtype != desc_y.dtype:
             raise TypeError(f"Data types of input operands must be equal: {desc_x.dtype}, {desc_y.dtype}")
         if desc_x.dtype.base_type != desc_res.dtype.base_type:
-            raise TypeError(f"Data types of input and output must be equal: {desc_x.dtype}, {desc_res.dtype}")
+            input_types = (desc_x.dtype.base_type, desc_res.dtype.base_type)
+            if dace.float32sr in input_types and dace.float32sr in input_types:
+                pass  # ignore mismatch if it is stochastically rounded
+            else:
+                raise TypeError(f"Data types of input and output must be equal: {desc_x.dtype}, {desc_res.dtype}")
 
         # Squeeze input memlets
         squeezed1 = copy.deepcopy(in_memlets[0].subset)

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -163,6 +163,8 @@ class ExpandGemmOpenBLAS(ExpandTransformation):
         node.validate(sdfg, state)
         (_, adesc, _, _, _, _), (_, bdesc, _, _, _, _), _ = _get_matmul_operands(node, state, sdfg)
         dtype = adesc.dtype.base_type
+        cast = "(float *)" if dtype == dace.float32sr else ""
+
         func = to_blastype(dtype.type).lower() + 'gemm'
         alpha = f'{dtype.ctype}({node.alpha})'
         beta = f'{dtype.ctype}({node.beta})'
@@ -193,7 +195,7 @@ class ExpandGemmOpenBLAS(ExpandTransformation):
             opt['beta'] = '&__beta'
 
         code += ("cblas_{func}(CblasColMajor, {ta}, {tb}, "
-                 "{M}, {N}, {K}, {alpha}, {x}, {lda}, {y}, {ldb}, {beta}, "
+                 "{M}, {N}, {K}, {alpha},{cast} {x}, {lda}, {cast} {y}, {ldb}, {beta}, "
                  "_c, {ldc});").format_map(opt)
 
         tasklet = dace.sdfg.nodes.Tasklet(

--- a/dace/libraries/blas/nodes/gemv.py
+++ b/dace/libraries/blas/nodes/gemv.py
@@ -735,6 +735,8 @@ class ExpandGemvOpenBLAS(ExpandTransformation):
                                                                                    name_out="_y")
         dtype_a = outer_array_a.dtype.type
         dtype = outer_array_x.dtype.base_type
+        cast = "(float *)" if dtype == dace.float32sr else ""
+
         veclen = outer_array_x.dtype.veclen
         alpha = f'{dtype.ctype}({node.alpha})'
         beta = f'{dtype.ctype}({node.beta})'
@@ -783,7 +785,7 @@ class ExpandGemvOpenBLAS(ExpandTransformation):
             alpha = '&__alpha'
             beta = '&__beta'
 
-        code += f"""cblas_{func}({layout}, {trans}, {m}, {n}, {alpha}, _A, {lda},
+        code += f"""cblas_{func}({layout}, {trans}, {m}, {n}, {alpha}, {cast} _A, {lda},
                                 _x, {strides_x[0]}, {beta}, _y, {strides_y[0]});"""
 
         tasklet = dace.sdfg.nodes.Tasklet(node.name,

--- a/dace/libraries/lapack/nodes/potrf.py
+++ b/dace/libraries/lapack/nodes/potrf.py
@@ -32,13 +32,14 @@ class ExpandPotrfOpenBLAS(ExpandTransformation):
     def expansion(node, parent_state, parent_sdfg, n=None, **kwargs):
         (desc_x, stride_x, rows_x, cols_x), desc_result = node.validate(parent_sdfg, parent_state)
         dtype = desc_x.dtype.base_type
+        cast = "(float *)" if dtype == dace.float32sr else ""
         lapack_dtype = blas_helpers.to_blastype(dtype.type).lower()
         if desc_x.dtype.veclen > 1:
             raise (NotImplementedError)
 
         n = n or node.n
         uplo = "'L'" if node.lower else "'U'"
-        code = f"_res = LAPACKE_{lapack_dtype}potrf(LAPACK_ROW_MAJOR, {uplo}, {rows_x}, _xin, {stride_x});"
+        code = f"_res = LAPACKE_{lapack_dtype}potrf(LAPACK_ROW_MAJOR, {uplo}, {rows_x}, {cast} _xin, {stride_x});"
         tasklet = dace.sdfg.nodes.Tasklet(node.name,
                                           node.in_connectors,
                                           node.out_connectors,

--- a/dace/libraries/linalg/nodes/cholesky.py
+++ b/dace/libraries/linalg/nodes/cholesky.py
@@ -16,6 +16,7 @@ def _make_sdfg(node, parent_state, parent_sdfg, implementation):
 
     inp_desc, inp_shape, out_desc, out_shape = node.validate(parent_sdfg, parent_state)
     dtype = inp_desc.dtype
+    cast = "(float *)" if dtype == dace.float32sr else ""
 
     sdfg = dace.SDFG("{l}_sdfg".format(l=node.label))
 
@@ -35,7 +36,7 @@ def _make_sdfg(node, parent_state, parent_sdfg, implementation):
     _, me, mx = state.add_mapped_tasklet('_uzero_',
                                          dict(__i="0:%s" % out_shape[0], __j="0:%s" % out_shape[1]),
                                          dict(_inp=Memlet.simple('_b', '__i, __j')),
-                                         '_out = (__i < __j) ? 0 : _inp;',
+                                         f'_out = (__i < __j) ? {cast}(0) : _inp;',
                                          dict(_out=Memlet.simple('_b', '__i, __j')),
                                          language=dace.dtypes.Language.CPP,
                                          external_edges=True)

--- a/dace/runtime/include/dace/dace.h
+++ b/dace/runtime/include/dace/dace.h
@@ -24,6 +24,7 @@
 #include "perf/reporting.h"
 #include "comm.h"
 #include "serialization.h"
+#include "stocastic_rounding.h"
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #include "cuda/cudacommon.cuh"

--- a/dace/runtime/include/dace/reduction.h
+++ b/dace/runtime/include/dace/reduction.h
@@ -3,6 +3,7 @@
 #define __DACE_REDUCTION_H
 
 #include <cstdint>
+#include <dace/stocastic_rounding.h>
 
 #include "types.h"
 #include "vector.h"
@@ -114,6 +115,40 @@ namespace dace {
         template <typename WCR>
         static DACE_HDFI float reduce(WCR wcr, float *ptr, const float& value) {
             float old = *ptr;
+            *ptr = wcr(old, value);
+            return old;
+        }
+    };
+
+    template <>
+    struct wcr_custom<dace::float32sr> {
+        template <typename WCR>
+        static DACE_HDFI dace::float32sr reduce_atomic(WCR wcr, dace::float32sr *ptr, const dace::float32sr& value) {
+            #ifdef DACE_USE_GPU_ATOMICS
+                // Stochastic rounding version of atomic float reduction
+                int *iptr = reinterpret_cast<int *>(ptr);
+                int old = *iptr, assumed;
+                do {
+                    assumed = old;
+                    float old_val = __int_as_float(assumed);
+                    float new_val = static_cast<float>(wcr(static_cast<dace::float32sr>(old_val), value));
+                    old = atomicCAS(iptr, assumed, __float_as_int(new_val));
+                } while (assumed != old);
+                return static_cast<dace::float32sr>(__int_as_float(old));
+            #else
+                dace::float32sr old;
+                #pragma omp critical
+                {
+                    old = *ptr;
+                    *ptr = wcr(old, value);
+                }
+                return old;
+            #endif
+        }
+
+        template <typename WCR>
+        static DACE_HDFI dace::float32sr reduce(WCR wcr, dace::float32sr *ptr, const dace::float32sr& value) {
+            dace::float32sr old = *ptr;
             *ptr = wcr(old, value);
             return old;
         }
@@ -310,6 +345,31 @@ namespace dace {
 
         DACE_HDFI float operator()(const float &a, const float &b) const { return ::max(a, b); }
     };
+
+
+    template <>
+    struct _wcr_fixed<ReductionType::Min, dace::float32sr> {
+
+        static DACE_HDFI dace::float32sr reduce_atomic(dace::float32sr *ptr, const dace::float32sr& value) {
+            return wcr_custom<dace::float32sr>::reduce_atomic(
+                _wcr_fixed<ReductionType::Min, dace::float32sr>(), ptr, value);
+        }
+
+
+        DACE_HDFI dace::float32sr operator()(const dace::float32sr &a, const dace::float32sr &b) const { return ::min(a, b); }
+    };
+
+    template <>
+    struct _wcr_fixed<ReductionType::Max, dace::float32sr> {
+
+        static DACE_HDFI dace::float32sr reduce_atomic(dace::float32sr *ptr, const dace::float32sr& value) {
+            return wcr_custom<dace::float32sr>::reduce_atomic(
+                _wcr_fixed<ReductionType::Max, dace::float32sr>(), ptr, value);
+        }
+
+        DACE_HDFI dace::float32sr operator()(const dace::float32sr &a, const dace::float32sr &b) const { return ::max(a, b); }
+    };
+
 
     template <>
     struct _wcr_fixed<ReductionType::Min, double> {

--- a/dace/runtime/include/dace/stocastic_rounding.h
+++ b/dace/runtime/include/dace/stocastic_rounding.h
@@ -1,0 +1,389 @@
+#ifndef __DACE_SROUND_H
+#define __DACE_SROUND_H
+
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <thread>
+
+#ifdef __CUDACC__
+#define DACE_HOST_DEVICE __host__ __device__
+#include <curand_kernel.h>
+#else
+#define DACE_HOST_DEVICE
+#endif
+
+namespace dace {
+class float32sr {
+private:
+    float value;
+
+    static constexpr double FLOATMIN_F32 = 1.1754943508222875e-38; 
+    static thread_local uint64_t rng_state_64;
+    
+    #if !defined(__CUDA_ARCH__)
+
+    DACE_HOST_DEVICE static inline uint64_t lcg64() {
+        rng_state_64 = rng_state_64 * 6364136223846793005ULL + 1442695040888963407ULL; // 64-bit LCG constants
+        return rng_state_64;
+    }
+    
+    DACE_HOST_DEVICE static inline uint64_t xorshift64() {
+        rng_state_64 ^= rng_state_64 << 13;
+        rng_state_64 ^= rng_state_64 >> 7;
+        rng_state_64 ^= rng_state_64 << 17;
+        return rng_state_64;
+    }
+    #endif
+
+    DACE_HOST_DEVICE static float stochastic_round(double x) {
+        // uint64_t rbits = lcg64();
+        uint64_t rbits = get_random_u64(); // it's quicker to use u64 over u32, perhaps due casting?
+        // uint64_t rbits = get_preloaded_random_u64(); // "circular buffer"
+        // uint64_t rbits = 0; // "constant" rounding
+        // uint64_t rbits = xorshift64();
+
+        // if x is subnormal, round randomly; N.B fast-math forces subnormal values to 0
+        if (abs(x) < FLOATMIN_F32) {
+            return static_cast<float>(x + rand_subnormal(rbits));
+        }
+        
+        uint64_t bits = double_to_bits(x);
+        const uint64_t mask = 0x000000001FFFFFFF;  // mask last 29 surplus bits of the double prec mantissa
+
+        bits += (rbits & mask);  // add stochastic perturbation
+        bits &= ~mask;           // truncate lower bits
+        double rounded = bits_to_double(bits);
+        return static_cast<float>(rounded);
+    }
+
+    DACE_HOST_DEVICE static double rand_subnormal(uint64_t rbits) {
+        // Impl of https://github.com/milankl/StochasticRounding.jl/blob/ff86c801ddd15b4182cb551b84811eb24295a48f/src/types.jl#L99C1-L106C4
+        int lz = __builtin_clzll(rbits); // Count leading zeros
+        
+        uint64_t exponent = static_cast<uint64_t>(872 - lz); // Compute biased exponent 
+        exponent <<= 52;
+
+        uint64_t sign = (rbits >> 63) << 63; // Take highest bit as sign
+
+        uint64_t mantissa = rbits & ((1ULL << 52) - 1); // Mask to get mantissa (only lower 52 bits)
+
+        uint64_t bits = sign | exponent | mantissa;
+        double result;
+        std::memcpy(&result, &bits, sizeof(result));
+        return result;
+    }
+
+
+    DACE_HOST_DEVICE static uint64_t double_to_bits(double x) {
+    #if defined(__CUDA_ARCH__)
+        return __double_as_longlong(x);
+    #else
+        uint64_t bits;
+        std::memcpy(&bits, &x, sizeof(bits));
+        return bits;
+    #endif
+    }
+
+
+    DACE_HOST_DEVICE static double bits_to_double(uint64_t bits) {
+    #if defined(__CUDA_ARCH__)
+        return __longlong_as_double(bits);
+    #else
+        double x;
+        std::memcpy(&x, &bits, sizeof(x));
+        return x;
+    #endif
+    }
+
+
+    DACE_HOST_DEVICE static uint64_t get_random_u64() {
+    #if defined(__CUDA_ARCH__)
+        int tid = threadIdx.x + blockIdx.x * blockDim.x;
+        uint64_t seed = clock64() + tid;
+
+        curandStatePhilox4_32_10_t state;
+        curand_init(seed, /* subsequence */ tid, /* offset */ 0, &state);
+
+        uint64_t low = curand(&state); // first 32 bits all 0, last 32 bits are populated by curand
+        return low;
+    #else
+        return lcg64();
+    #endif
+    }
+
+    #if !defined(__CUDA_ARCH__)
+    static std::mt19937_64& get_rng_mt() {
+        static std::mt19937_64 rng(std::random_device{}());
+        return rng;
+    }
+    #endif
+
+    #if !defined(__CUDA_ARCH__)
+    static std::mt19937& get_rng_single() {
+        static std::mt19937 rng(std::random_device{}());
+    return rng;
+}
+#endif
+    
+
+public:
+    DACE_HOST_DEVICE float32sr() : value(0.0f) {}
+    DACE_HOST_DEVICE float32sr(int v) : value(static_cast<double>(v)) {}
+    DACE_HOST_DEVICE float32sr(float v) : value(v) {}
+    DACE_HOST_DEVICE float32sr(double v) : value(stochastic_round(v)) {}
+
+    DACE_HOST_DEVICE operator float() const { return value; }
+    DACE_HOST_DEVICE operator float*() { return &value; }
+    DACE_HOST_DEVICE operator const float*() const { return &value; }
+
+    friend std::istream& operator>>(std::istream& is, float32sr& obj);
+    friend std::ostream& operator<<(std::ostream& os, const float32sr& obj);
+
+
+    DACE_HOST_DEVICE static uint64_t get_preloaded_random_u64() {
+    #if defined(__CUDA_ARCH__)
+        __shared__ uint64_t shared_randoms[1000];
+        __shared__ bool initialized;
+        __shared__ int index;
+
+        if (threadIdx.x == 0 && !initialized) {
+            for (int i = 0; i < 1000; ++i) {
+                shared_randoms[i] = get_random_u64();
+            }
+            index = 0;
+            initialized = true;
+        }
+
+        __syncthreads();
+
+        int my_index = atomicAdd(&index, 1) % 1000;
+        return shared_randoms[my_index];
+    #else
+      struct SharedRandomQueue {
+          std::array<uint64_t, 10000> data;
+          std::atomic<bool> initialized{false};
+          
+          SharedRandomQueue() {
+              initialize();
+          }
+          
+          void initialize() {
+              std::cout << "Initializing shared random queue" << std::endl;
+              for (auto& x : data) {
+                  x = float32sr::get_random_u64();
+              }
+              initialized.store(true, std::memory_order_release);
+          }
+          
+          uint64_t get(size_t idx) const {
+              return data[idx % data.size()];
+          }
+      };
+    
+      static SharedRandomQueue shared_queue;
+      thread_local static size_t thread_index = 0;
+      
+      size_t current_index = thread_index;
+      thread_index = (thread_index + 1) % shared_queue.data.size();
+      
+      return shared_queue.get(current_index);
+    #endif
+    }
+
+
+    #define DEFINE_COMPARISON(op) \
+        DACE_HOST_DEVICE bool operator op (const float32sr& other) const { \
+            return value op other.value; \
+        }
+
+    DEFINE_COMPARISON(==)
+    DEFINE_COMPARISON(!=)
+    DEFINE_COMPARISON(<)
+    DEFINE_COMPARISON(<=)
+    DEFINE_COMPARISON(>)
+    DEFINE_COMPARISON(>=)
+
+    #undef DEFINE_COMPARISON
+    #define DEFINE_COMPARISON(op) \
+        DACE_HOST_DEVICE bool operator op (const float& other) const { \
+            return value op other; \
+        }
+
+    DEFINE_COMPARISON(==)
+    DEFINE_COMPARISON(!=)
+    DEFINE_COMPARISON(<)
+    DEFINE_COMPARISON(<=)
+    DEFINE_COMPARISON(>)
+    DEFINE_COMPARISON(>=)
+
+    #undef DEFINE_COMPARISON
+
+
+    //==================
+    // Assignments
+    //==================
+    DACE_HOST_DEVICE float32sr operator=(const float& v) {
+        value = v;
+        return *this;
+    }
+
+    DACE_HOST_DEVICE float32sr operator=(const double& v) {
+        value = stochastic_round(v);
+        return *this;
+    }
+    
+    DACE_HOST_DEVICE float32sr operator=(const int& v) {
+        value = stochastic_round(static_cast<double>(v));
+        return *this;
+    }
+
+    DACE_HOST_DEVICE float32sr operator=(const int64_t& v) {
+        value = stochastic_round(static_cast<double>(v));
+        return *this;
+    }
+
+
+    //==================
+    // Primary operators
+    //==================
+    DACE_HOST_DEVICE float32sr operator+(const float32sr& other) const {
+        return float32sr(stochastic_round(static_cast<double>(value) + static_cast<double>(other.value)));
+    }
+
+    DACE_HOST_DEVICE float32sr operator*(const float32sr& other) const {
+        return float32sr(stochastic_round(static_cast<double>(value) * static_cast<double>(other.value)));
+    }
+
+    DACE_HOST_DEVICE float32sr operator-(const float32sr& other) const {
+        return float32sr(stochastic_round(static_cast<double>(value) - static_cast<double>(other.value)));
+    }
+
+    DACE_HOST_DEVICE float32sr operator/(const float32sr& other) const {
+        return float32sr(stochastic_round(static_cast<double>(value) / static_cast<double>(other.value)));
+    }
+
+    //==================
+    // Mixing stochatic types with primative types
+    //==================
+    // Mixing RTN + SR should yield SR
+    DACE_HOST_DEVICE float operator+(const float& other) const {
+        return value + other;
+    }
+
+    DACE_HOST_DEVICE float operator*(const float& other) const {
+        return value * other;
+    }
+
+    DACE_HOST_DEVICE float operator-(const float& other) const {
+        return value - other;
+    }
+
+    DACE_HOST_DEVICE float operator/(const float& other) const {
+        return value / other;
+    }
+
+    DACE_HOST_DEVICE float operator+(const int& other) const {
+        return value + other;
+    }
+
+    DACE_HOST_DEVICE float operator*(const int& other) const {
+        return value * other;
+    }
+
+    DACE_HOST_DEVICE float operator-(const int& other) const {
+        return value - other;
+    }
+
+    DACE_HOST_DEVICE float operator/(const int& other) const {
+        return value / other;
+    }
+
+
+
+
+
+    //==================
+    // Compound assignment operators
+    //==================
+
+
+    DACE_HOST_DEVICE float32sr& operator+=(const float32sr& other) {
+        value = stochastic_round(static_cast<double>(value) + static_cast<double>(other.value));
+        return *this;
+    }
+
+    DACE_HOST_DEVICE float32sr& operator-=(const float32sr& other) {
+        value = stochastic_round(static_cast<double>(value) - static_cast<double>(other.value));
+        return *this;
+    }
+
+    DACE_HOST_DEVICE float32sr& operator*=(const float32sr& other) {
+        value = stochastic_round(static_cast<double>(value) * static_cast<double>(other.value));
+        return *this;
+    }
+
+    DACE_HOST_DEVICE float32sr& operator/=(const float32sr& other) {
+        value = stochastic_round(static_cast<double>(value) / static_cast<double>(other.value));
+        return *this;
+    }
+
+};
+
+#if !defined(__CUDA_ARCH__) && !defined(__CUDACC__)
+thread_local uint64_t float32sr::rng_state_64 = 1;
+#endif
+
+inline std::istream& operator>>(std::istream& is, float32sr& obj) {
+    is >> obj.value;
+    return is;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const float32sr& obj) {
+    os << obj.value;
+    return os;
+}
+
+}  // namespace dace
+
+#ifdef __CUDACC__
+#include <cub/util_type.cuh>
+#include <limits>
+
+// This functionality is required by the ICON Velocity Tendecies procedure
+namespace cub { 
+
+template <>
+struct Traits<dace::float32sr> {
+    using PRIMITIVE = float;
+
+    __host__ __device__ static dace::float32sr Lowest() {
+        return dace::float32sr(-std::numeric_limits<float>::infinity());
+    }
+
+    __host__ __device__ static dace::float32sr Max() {
+        return dace::float32sr(std::numeric_limits<float>::infinity());
+    }
+
+    __host__ __device__ static dace::float32sr Zero() {
+        return dace::float32sr(0.0f);
+    }
+
+    __host__ __device__ static dace::float32sr One() {
+        return dace::float32sr(1.0f);
+    }
+
+    static constexpr bool IsFloatingPoint = true;
+};
+
+}
+#endif
+
+
+#endif  // __DACE_SROUND_H

--- a/tests/codegen/float32sr.py
+++ b/tests/codegen/float32sr.py
@@ -1,0 +1,369 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests the properties of the stochastically rounded float type"""
+
+import ctypes
+import dace
+import numpy as np
+import pytest
+from collections import Counter
+
+N = 1000
+M = 5
+EPS = 0.05
+USE_GPU = False
+TYPE = dace.float32sr
+NP_TYPE = np.float32
+
+
+@dace.program
+def dace_test_add(A: TYPE[N], B:TYPE[N], OUT: TYPE[N]):
+    for i in range(N):
+        OUT[i] = A[i] + B[i]
+
+
+def test_add():
+    a = 0.54019
+    b = 1.9e-04
+    fn = dace_test_add
+    theoretical_prob = 0.66799
+    
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    
+    print(count)
+    print(f"empirical_prob: {emp_prob}")
+    print(f"theoretical_prob: {theoretical_prob}")
+
+    assert abs(emp_prob - theoretical_prob) < EPS
+
+
+@dace.program
+def dace_test_sub(A: TYPE[N], B:TYPE[N], OUT: TYPE[N]):
+    for i in range(N):
+        OUT[i] = A[i] - B[i]
+
+
+def test_sub():
+    a = 0.54019
+    b = 1.9e-04
+    fn = dace_test_sub
+    theoretical_prob = 0.32891
+    
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    
+    print(count)
+    print(f"empirical_prob: {emp_prob}")
+    print(f"theoretical_prob: {theoretical_prob}")
+
+    assert abs(emp_prob - theoretical_prob) < EPS
+
+
+def test_sub_exact_rep():
+    a = 0.5
+    b = 0.25
+    fn = dace_test_sub
+    theoretical_prob = 1
+    
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    
+    print(count)
+    print(f"empirical_prob: {emp_prob}")
+    print(f"theoretical_prob: {theoretical_prob}")
+
+    assert abs(emp_prob - theoretical_prob) < EPS
+
+
+@dace.program
+def dace_test_mult(A: TYPE[N], B:TYPE[N], OUT: TYPE[N]):
+    for i in range(N):
+        OUT[i] = A[i] * B[i]
+
+
+def test_mult():
+    a = 0.54019
+    b = 1.9e-04
+    fn = dace_test_mult
+    theoretical_prob = 0.14345 
+    
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    
+    print(count)
+    print(f"empirical_prob: {emp_prob}")
+    print(f"theoretical_prob: {theoretical_prob}")
+
+    assert abs(emp_prob - theoretical_prob) < EPS
+
+
+@dace.program
+def dace_test_div(A: TYPE[N], B:TYPE[N], OUT: TYPE[N]):
+    for i in range(N):
+        OUT[i] = A[i] / B[i]
+
+
+def test_div():
+    a = 0.54019
+    b = 1.9e-04
+    fn = dace_test_div
+    theoretical_prob = 0.38520 
+    
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    
+    print(count)
+    print(f"empirical_prob: {emp_prob}")
+    print(f"theoretical_prob: {theoretical_prob}")
+
+    assert abs(emp_prob - theoretical_prob) < EPS
+
+@dace.program
+def dace_test_dot_runs(A: TYPE[M], B:TYPE[M], OUT: TYPE[1]):
+    OUT[0] = np.dot(A, B)
+
+
+def test_dot_runs():
+    a = 2
+    b = 1.01
+    fn = dace_test_dot_runs
+
+    A = np.array([a] * M, dtype=NP_TYPE)
+    B = np.array([b] * M, dtype=NP_TYPE)
+    OUT = np.zeros(1, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    expected = np.dot(A, B)
+    print(expected)
+    print(OUT[0])
+    assert abs(expected - OUT[0] < EPS) 
+
+@dace.program
+def dace_test_matrix_mult_runs(A: TYPE[M, M], B:TYPE[M, M], OUT: TYPE[M, M]):
+  OUT[:] = A @ B
+
+
+def test_matrix_mult_runs():
+    a = 3.14
+    b = 2.71
+    fn = dace_test_matrix_mult_runs
+
+    A = np.array([a] * M * M, dtype=NP_TYPE)
+    B = np.array([b] * M * M, dtype=NP_TYPE)
+    OUT = np.zeros((M,M), dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = fn.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        fn(A, B, OUT)
+
+    A = A.reshape((M,M))
+    B = B.reshape((M,M))
+    expected = A @ B
+    assert np.array_equal(expected, OUT)
+
+@dace.program
+def dace_test_assignment_properties(OUT: TYPE[N], c: dace.float64):
+    for i in range(N):
+        OUT[i] = c
+
+
+@dace.program
+def dace_test_init_properties(C: TYPE[N], OUT: TYPE[N]):
+    for i in range(N):
+        OUT[i] = C[i]
+
+
+@dace.program
+def dace_test_mixed_addition_properties(A: TYPE[N], B: dace.float64[N], OUT):
+    for i in range(N):
+        OUT[i] = A[i] + B[i]
+
+@dace.program
+def dace_test_single_mixed_addition_properties(A: TYPE[N], B: dace.float32[N], OUT):
+    for i in range(N):
+        OUT[i] = A[i] + B[i]
+
+    
+def test_init_properties():
+    """ Init of a SR with same prec value should be deterministic """
+    c = 1.5401030001
+    C = np.array([c] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = dace_test_init_properties.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(C=C, OUT=OUT)
+    else:
+        dace_test_init_properties(C, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+
+    assert emp_prob == 1
+
+
+def test_assignment_properties():
+    """ Check that doubles are rounded when assigned """
+    c = 1.5401030001
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = dace_test_assignment_properties.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(OUT=OUT, c=c)
+    else:
+        dace_test_assignment_properties(OUT, c)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    _, _, theoretical_prob = calc_bounds(c, NP_TYPE)
+
+    print(count)
+    assert abs(emp_prob - theoretical_prob) < 0.05
+
+
+def test_mixed_addition_properties():
+    """ Check that SR single prec is upcast to double for mixed calculations"""
+    a = 1.5401030001
+    b = 1.9e-07
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=np.float64)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = dace_test_mixed_addition_properties.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        dace_test_mixed_addition_properties(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    theoretical_prob = 1
+
+    print(f"Empircal count: {count}")
+    print(f"Theoretical prob: {theoretical_prob}")
+    assert abs(emp_prob - theoretical_prob) < 0.05
+
+
+def test_single_mixed_addition_properties():
+    """ Check that SR single prec is re-cast to RTN for mixed calculations"""
+    a = 1.5401030001
+    b = 1.9e-07
+    A = np.array([a] * N, dtype=NP_TYPE)
+    B = np.array([b] * N, dtype=NP_TYPE)
+    OUT = np.zeros(N, dtype=NP_TYPE)
+
+    if USE_GPU:
+        sdfg = dace_test_single_mixed_addition_properties.to_sdfg()
+        sdfg.apply_gpu_transformations()
+        sdfg(A=A, B=B, OUT=OUT)
+    else:
+        dace_test_single_mixed_addition_properties(A, B, OUT)
+
+    count = Counter(OUT)
+    emp_prob = count[max(count.keys())] / N
+    theoretical_prob = 1
+
+    print(f"Empircal count: {count}")
+    print(f"Theoretical prob: {theoretical_prob}")
+    assert abs(emp_prob - theoretical_prob) < 0.05
+
+
+def calc_bounds(higher_prec_val, np_type):
+    rounded_val = np_type(higher_prec_val)
+
+    if rounded_val == higher_prec_val:
+        print("Exactly represented")
+        return 0, 0, 1
+
+    lower = np.nextafter(rounded_val, -np.inf, dtype=np_type)
+    upper = np.nextafter(rounded_val, np.inf, dtype=np_type)
+
+    if rounded_val < higher_prec_val:
+        lower = rounded_val
+    else:
+        upper = rounded_val
+    
+
+    print(f"lower: {lower}, upper: {upper}")
+
+    print(f" C: {higher_prec_val}")
+    lower_diff = abs(higher_prec_val - lower)
+    print(f"LF: {lower_diff}")
+    upper_diff = abs(upper - higher_prec_val)
+    print(f"UF: {upper_diff}")
+    theoretical_prob = lower_diff / (lower_diff + upper_diff)
+    
+    return lower_diff, upper_diff, theoretical_prob
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__])
+


### PR DESCRIPTION
This new type enables DaCe users to perform calculations with stochastic rounding in single precision.

This change is validated with unit tests.