### PR TITLE
Offset loops

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -261,7 +261,7 @@ required:
                         type: str
                         title: Arguments
                         description: Compiler argument flags
-                        default: '-std=c++14 -fPIC -Wall -Wextra -O3 -march=native -ffast-math -Wno-unused-parameter -Wno-unused-label'
+                        default: '-fopenmp -std=c++14 -fPIC -Wall -Wextra -O3 -march=native -ffast-math -Wno-unused-parameter -Wno-unused-label'
                         default_Windows: '/O2 /fp:fast /arch:AVX2 /D_USRDLL /D_WINDLL /D__restrict__=__restrict'
 
                     libs:

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -261,7 +261,7 @@ required:
                         type: str
                         title: Arguments
                         description: Compiler argument flags
-                        default: '-fopenmp -std=c++14 -fPIC -Wall -Wextra -O3 -march=native -ffast-math -Wno-unused-parameter -Wno-unused-label'
+                        default: '-std=c++14 -fPIC -Wall -Wextra -O3 -march=native -ffast-math -Wno-unused-parameter -Wno-unused-label'
                         default_Windows: '/O2 /fp:fast /arch:AVX2 /D_USRDLL /D_WINDLL /D__restrict__=__restrict'
 
                     libs:

--- a/dace/transformation/passes/offset_loop_and_maps.py
+++ b/dace/transformation/passes/offset_loop_and_maps.py
@@ -1,0 +1,245 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+import copy
+import dace
+from typing import Dict, Optional, Set
+from sympy.printing.pycode import pycode
+
+from dace import SDFG
+from dace import properties
+from dace import Union
+from dace import ControlFlowRegion
+from dace.properties import Property
+from dace.sdfg.state import ConditionalBlock, LoopRegion
+from dace.transformation import pass_pipeline as ppl, transformation
+
+from dace.sdfg.nodes import CodeBlock
+import ast
+import re
+
+@properties.make_properties
+@transformation.explicit_cf_compatible
+class OffsetLoopsAndMaps(ppl.Pass):
+    CATEGORY: str = 'Optimization Preparation'
+
+    offset_expr = Property(
+        dtype=dace.symbolic.SymExpr,
+        default=dace.symbolic.SymExpr(0)
+    )
+    begin_expr = Property(
+        dtype=dace.symbolic.SymExpr,
+        default=dace.symbolic.SymExpr(0)
+    )
+    # To avoid Invalid type "int" for property offset_expr: expected SymExpr
+    int_offset_expr = Property(
+        dtype=int,
+        default=0
+    )
+    int_begin_expr = Property(
+        dtype=int,
+        default=0
+    )
+    check_begin = Property(
+        dtype=bool,
+        default=False
+    )
+
+    def __init__(self,
+                 offset_expr: Union[dace.symbolic.SymExpr, dace.symbolic.symbol, int],
+                 begin_expr: Union[dace.symbolic.SymExpr, dace.symbolic.symbol, int]):
+        def _cast(expr):
+            if isinstance(expr, int):
+                return dace.symbolic.SymExpr(expr)
+            elif isinstance(expr, dace.symbolic.symbol):
+                return dace.symbolic.SymExpr(str(expr))
+            else:
+                if not isinstance(expr, dace.symbolic.SymExpr):
+                    raise ValueError(f"Input {expr} to OffsetLoopsAndMaps is not a SymExpr | Symbol | Integer")
+                else:
+                    return expr
+
+        if begin_expr is not None:
+            begin_expr = _cast(begin_expr)
+            self.check_begin = True
+            if isinstance(begin_expr, int):
+                self.int_begin_expr = begin_expr
+            else:
+                self.begin_expr = begin_expr
+        else:
+            self.check_begin = False
+
+        offset_expr = _cast(offset_expr)
+
+        # To avoid Invalid type "int" for property offset_expr: expected SymExpr
+        if isinstance(offset_expr, int):
+            self.int_offset_expr = offset_expr
+        else:
+            self.offset_expr = offset_expr
+
+
+    def _get_offset_expr(self):
+        if self.int_offset_expr != 0:
+            return self.int_offset_expr
+        else:
+            return pycode(self.offset_expr)
+    
+    def _get_begin_expr(self):
+        if self.check_begin is False:
+            return None
+        else:
+            if self.int_begin_expr != 0:
+                return self.int_begin_expr
+            else:
+                return pycode(self.begin_expr)
+
+    def modifies(self) -> ppl.Modifies:
+        return ppl.Modifies.Tasklets | ppl.Modifies.CFG | ppl.Modifies.Edges
+
+    def should_reapply(self, modified: ppl.Modifies) -> bool:
+        return False
+
+    def depends_on(self):
+        return {}
+
+    def _create_new_memlet(self, edge_data, repldict: Dict[str, str]) -> dace.memlet.Memlet:
+        """Create a new memlet with substituted subset ranges."""
+        if edge_data is None:
+            return None
+        
+        new_range_list = [
+            (b.subs(repldict), e.subs(repldict), s.subs(repldict))
+            for b, e, s in edge_data.subset
+        ]
+        new_range = dace.subsets.Range(new_range_list)
+        return dace.memlet.Memlet(data=edge_data.data, subset=new_range)
+
+    def _update_edge_if_changed(self, state, edge, new_memlet):
+        """Update edge if the new memlet is different from the current one."""
+        if new_memlet and new_memlet != edge.data:
+            state.remove_edge(edge)
+            state.add_edge(
+                edge.src, edge.src_conn,
+                edge.dst, edge.dst_conn,
+                new_memlet
+            )
+
+    def _process_memlets_in_edges(self, state, edges, repldict: Dict[str, str]):
+        """Process memlets in a collection of edges."""
+        for edge in edges:
+            new_memlet = self._create_new_memlet(edge.data, repldict)
+            self._update_edge_if_changed(state, edge, new_memlet)
+
+    def _process_nested_sdfgs(self, state, repldict: Dict[str, str]):
+        """Recursively process nested SDFGs in state nodes."""
+        for node in state.nodes():
+            if isinstance(node, dace.nodes.NestedSDFG):
+                self._repl_memlets_recursive(node.sdfg, repldict)
+
+    def _repl_memlets_recursive(self, cfg: ControlFlowRegion, repldict: Dict[str, str]):
+        """Recursively replace memlets in all states of a control flow region."""
+        for state in cfg.all_states():
+            self._process_memlets_in_edges(state, state.edges(), repldict)
+            self._process_nested_sdfgs(state, repldict)
+
+    def _repl_memlets_recursive_on_edge_list(self, state, edges, repldict: Dict[str, str]):
+        """Replace memlets on a specific list of edges."""
+        self._process_memlets_in_edges(state, edges, repldict)
+        self._process_nested_sdfgs(state, repldict)
+
+    def _repl_interstate_edges_recursive(self, cfg: ControlFlowRegion, repldict: Dict[str, str]):
+        """Recursively replace interstate edges in control flow region."""
+        # Replace interstate edges
+        for edge in cfg.all_interstate_edges():
+            edge.data.replace_dict(repldict)
+        
+        # Process nested SDFGs
+        for state in cfg.all_states():
+            for node in state.nodes():
+                if isinstance(node, dace.nodes.NestedSDFG):
+                    self._repl_interstate_edges_recursive(node.sdfg, repldict)
+
+    def _repl_recursive(self, cfg: ControlFlowRegion, repldict: Dict[str, str]):
+        """Replace both interstate edges and memlets recursively."""
+        self._repl_interstate_edges_recursive(cfg, repldict)
+        self._repl_memlets_recursive(cfg, repldict)
+        # TODO:
+        # Implement for tasklets in case the loop variable is used as a symbol inside tasklet code
+
+    def _add_to_rhs(self, expr: str, add_expr) -> str:
+        """Add an expression to the right-hand side of a comparison."""
+        try:
+            tree = ast.parse(expr, mode="eval")
+            comparison = tree.body
+            
+            if not isinstance(comparison, ast.Compare) or not comparison.comparators:
+                raise ValueError("Expression must be a comparison with at least one comparator")
+            
+            # Modify the first comparator by adding the expression
+            original_rhs = comparison.comparators[0]
+            add_expr_ast = ast.parse(str(add_expr), mode="eval").body
+            
+            comparison.comparators[0] = ast.BinOp(
+                left=original_rhs,
+                op=ast.Add(),
+                right=add_expr_ast
+            )
+            
+            # Convert back to string and simplify
+            str_expr = ast.unparse(tree)
+            sym_expr = dace.symbolic.SymExpr(str_expr).simplify()
+            return pycode(sym_expr)
+            
+        except Exception as e:
+            raise ValueError(f"Failed to process expression '{expr}': {e}")
+
+    def _apply(self, cfg: dace.ControlFlowRegion):
+        for node in cfg.nodes():
+            if isinstance(node, LoopRegion):
+                node.init_statement
+                node.loop_condition
+                # The begin expression matches apply offset
+                init_lhs, init_rhs = node.init_statement.as_string.split("=")
+                if self._get_begin_expr() is None or dace.symbolic.SymExpr(init_rhs) == self._get_begin_expr():
+                    new_init_statement = pycode(dace.symbolic.SymExpr(f"(({init_rhs}) + {self._get_offset_expr()})").simplify())
+                    node.init_statement = CodeBlock(f"{init_lhs} = {new_init_statement}")
+                    new_loop_condition = self._add_to_rhs(node.loop_condition.as_string, self._get_offset_expr())
+                    node.loop_condition = CodeBlock(new_loop_condition)
+
+                    # Try normalize after update
+                    node.normalize()
+
+                    repldict = {node.loop_variable: f"({node.loop_variable} - {self._get_offset_expr()})"}
+                    self._repl_recursive(node, repldict)
+            elif isinstance(node, dace.SDFGState):
+                state = node
+                for state_node in state.nodes():
+                    if isinstance(state_node, dace.nodes.MapEntry):
+                        has_matches = False
+                        new_range_list = []
+                        repldict  = dict()
+                        for (b, e, s), param in zip(state_node.map.range, state_node.map.params):
+                            if self._get_begin_expr() is None or b == self._get_begin_expr():
+                                has_matches = True
+                                new_range_list.append((b + self._get_offset_expr(), e + self._get_offset_expr(), s))
+                                repldict[param] = f"({param} - {self._get_offset_expr()})"
+                            else:
+                                new_range_list.append((b, e, s))
+
+                        if has_matches:
+                            new_range = dace.subsets.Range(new_range_list)
+                            state_node.map.range = new_range
+                            nodes_between = state.all_nodes_between(state_node, state.exit_node(state_node))
+                            edges_between = state.all_edges(*nodes_between)
+                            self._repl_memlets_recursive_on_edge_list(state, edges_between, repldict)
+                            # TODO:
+                            # Implement for tasklets in case the loop variable is used as a symbol inside tasklet code
+
+        for node in cfg.nodes():
+            if isinstance(node, ControlFlowRegion):
+                self._apply(node)
+            if isinstance(node, ConditionalBlock):
+                for _, body in node.branches:
+                    self._apply(body)
+
+    def apply_pass(self, sdfg: SDFG, pipeline_results) -> Optional[Dict[str, Set[str]]]:
+        # Do it for LoopRegions and Maps
+        self._apply(sdfg)

--- a/dace/transformation/passes/offset_loop_and_maps.py
+++ b/dace/transformation/passes/offset_loop_and_maps.py
@@ -12,11 +12,65 @@ from dace.sdfg.state import ConditionalBlock, LoopRegion
 from dace.transformation import pass_pipeline as ppl, transformation
 from dace.sdfg.nodes import CodeBlock
 import ast
+import dace.sdfg.utils as sdutil
+from sympy import re, symbols, simplify
+from sympy.core.relational import Relational
+import re
+
+
+def _safe_simplify(expr: dace.symbolic.SymExpr) -> dace.symbolic.SymExpr:
+    # If it’s a relational (<, >, <=, >=, ==, !=)
+    if isinstance(expr, Relational):
+        lhs = simplify(expr.lhs)
+        rhs = simplify(expr.rhs)
+        # Recreate the relation with the same operator
+        return expr.func(lhs, rhs)
+    else:
+        return simplify(expr)
 
 
 def _get_expr_from_str(expr: str) -> dace.symbolic.SymExpr:
-    parsed_expr = sympy.sympify(expr, evaluate=False)
+    try:
+        parsed_expr = dace.symbolic.SymExpr(expr)
+    except Exception as e:
+        raise Exception(f"Parsing expression ({expr}) failed with error: {e}")
     return parsed_expr
+
+
+def _split_and_repl(rhs: str, old_var: str, new_expr: str):
+    tokens = re.split(r'([() ])', rhs)
+    tokens = [t for t in tokens if t.strip() != '']
+    ntokens = [t if t != old_var else new_expr for t in tokens]
+    new_code = " ".join(ntokens)
+    return new_code
+
+
+def _token_based_repl_in_tasklet(tasklet: dace.nodes.Tasklet, old_var: str, new_expr: str) -> None:
+    assert len(tasklet.code.as_string.split(
+        "=")) == 2, f"Multiple assignments in a tasklet is not supported by loop-offsetting transformation currently"
+    lhs, rhs = tasklet.code.as_string.split("=")
+    if tasklet.language == dace.dtypes.Language.Python:
+        # Try so simplify
+        stripped_rhs = rhs.strip()
+        # If tasklet has something liek dace.float64(5) this will fail
+        try:
+            sym_expr = dace.symbolic.SymExpr(stripped_rhs).subs({old_var: new_expr})
+            simplified_expr = _safe_simplify(sym_expr)
+            py_code = pycode(simplified_expr)
+            tasklet.code = CodeBlock(lhs.strip() + " = " + py_code, tasklet.language)
+        except Exception as e:
+            new_code = _split_and_repl(rhs, old_var, new_expr)
+            tasklet.code = CodeBlock(lhs.strip() + " = " + new_code, tasklet.language)
+    else:
+        new_code = _split_and_repl(rhs, old_var, new_expr)
+        tasklet.code = CodeBlock(lhs.strip() + " = " + new_code, tasklet.language)
+
+
+def safe_subs(expr, repldict):
+    if hasattr(expr, "subs"):
+        return expr.subs(repldict)
+    else:
+        return expr
 
 
 @properties.make_properties
@@ -24,16 +78,12 @@ def _get_expr_from_str(expr: str) -> dace.symbolic.SymExpr:
 class OffsetLoopsAndMaps(ppl.Pass):
     CATEGORY: str = 'Optimization Preparation'
 
-    offset_expr = Property(dtype=str, default="0")
-    begin_expr = Property(dtype=str, default="0")
-    do_not_check_begin = Property(dtype=bool, default=False)
+    offset_expr = Property(dtype=str, default="0", allow_none=False)
+    begin_expr = Property(dtype=str, default=None, allow_none=True)
 
     def __init__(self, offset_expr: str, begin_expr: Union[str, None]):
         self.offset_expr = offset_expr
-        if begin_expr is None:
-            self.do_not_check_begin = True
-        else:
-            self.begin_expr = begin_expr
+        self.begin_expr = begin_expr
 
     def modifies(self) -> ppl.Modifies:
         return ppl.Modifies.Tasklets | ppl.Modifies.CFG | ppl.Modifies.Edges
@@ -49,9 +99,16 @@ class OffsetLoopsAndMaps(ppl.Pass):
         if edge_data is None:
             return None
         # Using symbols might create problems due to having different symbol objects with same symbols
-        new_range_list = [(b.subs(repldict), e.subs(repldict), s.subs(repldict)) for b, e, s in edge_data.subset]
+        new_range_list = [(safe_subs(b, repldict), safe_subs(e, repldict), safe_subs(s, repldict))
+                          for b, e, s in edge_data.subset]
         new_range_str = ", ".join(f"{b}:{e+1}:{s}" for b, e, s in new_range_list)
-        return dace.memlet.Memlet(expr=f"{edge_data.data}[{new_range_str}]")
+        if edge_data.other_subset is not None:
+            new_other_range_list = [(safe_subs(b, repldict), safe_subs(e, repldict), safe_subs(s, repldict))
+                                    for b, e, s in edge_data.other_subset]
+            new_other_range_str = ", ".join(f"{b}:{e+1}:{s}" for b, e, s in new_other_range_list)
+            return dace.memlet.Memlet(expr=f"{edge_data.data}[{new_range_str}] -> [{new_other_range_str}]")
+        else:
+            return dace.memlet.Memlet(expr=f"{edge_data.data}[{new_range_str}]")
 
     def _update_edge_if_changed(self, state, edge, new_memlet):
         """Update edge if the new memlet is different from the current one."""
@@ -94,12 +151,20 @@ class OffsetLoopsAndMaps(ppl.Pass):
                 if isinstance(node, dace.nodes.NestedSDFG):
                     self._repl_interstate_edges_recursive(node.sdfg, repldict)
 
+    def _repl_use_in_tasklets_recursive(self, cfg: ControlFlowRegion, repldict: Dict[str, str]):
+        for state in cfg.all_states():
+            for node in state.nodes():
+                if isinstance(node, dace.nodes.Tasklet):
+                    for p, repl_expr_str in repldict.items():
+                        _token_based_repl_in_tasklet(node, p, repl_expr_str)
+                if isinstance(node, dace.nodes.NestedSDFG):
+                    self._repl_use_in_tasklets_recursive(node.sdfg, repldict)
+
     def _repl_recursive(self, cfg: ControlFlowRegion, repldict: Dict[str, str]):
         """Replace both interstate edges and memlets recursively."""
         self._repl_interstate_edges_recursive(cfg, repldict)
         self._repl_memlets_recursive(cfg, repldict)
-        # TODO:
-        # Implement for tasklets in case the loop variable is used as a symbol inside tasklet code
+        self._repl_use_in_tasklets_recursive(cfg, repldict)
 
     def _add_to_rhs(self, expr: str, add_expr: dace.symbolic.SymExpr, sdfg: dace.SDFG) -> str:
         """Add an expression to the right-hand side of a comparison."""
@@ -118,7 +183,9 @@ class OffsetLoopsAndMaps(ppl.Pass):
 
         # Convert back to string and simplify
         str_expr = ast.unparse(tree)
-        sym_expr = _get_expr_from_str(str_expr).simplify()
+        # Fix some sign and binary op clashes
+        str_expr = str_expr.replace("+ -", "- ").replace("- -", "+ ")
+        sym_expr = _safe_simplify(_get_expr_from_str(str_expr))
         return pycode(sym_expr)
 
         #except Exception as e:
@@ -131,17 +198,14 @@ class OffsetLoopsAndMaps(ppl.Pass):
                 node.loop_condition
                 # The begin expression matches apply offset
                 init_lhs, init_rhs = node.init_statement.as_string.split("=")
-                if self.do_not_check_begin or _get_expr_from_str(init_rhs) == _get_expr_from_str(self.offset_expr):
+                if self.begin_expr is None or _get_expr_from_str(init_rhs) == _get_expr_from_str(self.begin_expr):
                     init_expr_str = f"(({init_rhs}) + {self.offset_expr})"
-                    init_expr = _get_expr_from_str(init_expr_str)
+                    init_expr = _get_expr_from_str(init_expr_str).simplify()
                     new_init_statement = pycode(init_expr)
                     node.init_statement = CodeBlock(f"{init_lhs} = {new_init_statement}")
                     new_loop_condition = self._add_to_rhs(node.loop_condition.as_string,
                                                           _get_expr_from_str(self.offset_expr), cfg.sdfg)
                     node.loop_condition = CodeBlock(new_loop_condition)
-
-                    # Try normalize after update
-                    node.normalize()
 
                     repldict = {node.loop_variable: f"({node.loop_variable} - {_get_expr_from_str(self.offset_expr)})"}
                     self._repl_recursive(node, repldict)
@@ -153,11 +217,13 @@ class OffsetLoopsAndMaps(ppl.Pass):
                         new_range_list = []
                         repldict = dict()
                         for (b, e, s), param in zip(state_node.map.range, state_node.map.params):
-                            if self.do_not_check_begin is None or b == _get_expr_from_str(self.begin_expr):
+                            if self.begin_expr is None or str(b) == self.begin_expr:
+                                if str(b) == self.begin_expr:
+                                    assert b == _get_expr_from_str(self.begin_expr)
                                 has_matches = True
-                                new_range_list.append((b + self._get_expr_from_str(self.offset_expr),
-                                                       e + self._get_expr_from_str(self.offset_expr), s))
-                                repldict[param] = f"({param} - {pycode(self._get_expr_from_str(self.offset_expr))})"
+                                new_range_list.append((b + _get_expr_from_str(self.offset_expr),
+                                                       e + _get_expr_from_str(self.offset_expr), s))
+                                repldict[param] = f"({param} - {pycode(_get_expr_from_str(self.offset_expr))})"
                             else:
                                 new_range_list.append((b, e, s))
 
@@ -167,22 +233,95 @@ class OffsetLoopsAndMaps(ppl.Pass):
                             nodes_between = state.all_nodes_between(state_node, state.exit_node(state_node))
                             edges_between = state.all_edges(*nodes_between)
                             self._repl_memlets_recursive_on_edge_list(state, edges_between, repldict)
-                            # TODO:
-                            # Implement for tasklets in case the loop variable is used as a symbol inside tasklet code
+                            # For tasklets in case the loop variable is used as a symbol inside tasklet code
+                            for node in nodes_between:
+                                if isinstance(node, dace.nodes.Tasklet):
+                                    for p, repl_expr_str in repldict.items():
+                                        _token_based_repl_in_tasklet(node, p, repl_expr_str)
+                                if isinstance(node, dace.nodes.NestedSDFG):
+                                    self._repl_use_in_tasklets_recursive(node.sdfg, repldict)
 
         for node in cfg.nodes():
             if isinstance(node, ControlFlowRegion):
                 self._apply(node)
-            if isinstance(node, ConditionalBlock):
+            elif isinstance(node, ConditionalBlock):
                 for _, body in node.branches:
                     self._apply(body)
+            else:
+                assert isinstance(node, dace.SDFGState)
+
+    def _find_scalar_write_expr_sets(self, sdfg: dace.SDFG) -> Dict[str, Set[str]]:
+        write_expr_dict = dict()
+        for state in sdfg.all_states():
+            for node in state.nodes():
+                if isinstance(node, dace.nodes.AccessNode) and isinstance(sdfg.sdfg.arrays[node.data],
+                                                                          dace.data.Scalar):
+                    scalar_name = node.data
+                    if scalar_name not in write_expr_dict:
+                        write_expr_dict[scalar_name] = set()
+                    for ie in state.in_edges(node):
+                        if not isinstance(ie.src, dace.nodes.Tasklet):
+                            write_expr_dict[scalar_name].add("?")
+                        else:
+                            code_as_string = ie.src.code.as_string
+                            if ie.src.language == dace.dtypes.Language.Python:
+                                if len(code_as_string.split("=")) != 2:
+                                    write_expr_dict[scalar_name].add("?")
+                                rhs = code_as_string.split("=")[1]
+                                try:
+                                    sym_expr = dace.symbolic.SymExpr(rhs.strip())
+                                    expr_set = {str(s) for s in sym_expr.free_symbols}
+                                    if any(s in ie.src.in_connectors for s in expr_set):
+                                        write_expr_dict[scalar_name].add("?")
+                                    else:
+                                        if len(expr_set) == 1 and pycode(sym_expr) == next(iter(expr_set)).strip():
+                                            write_expr_dict[scalar_name] = write_expr_dict[scalar_name].union(expr_set)
+                                        else:
+                                            write_expr_dict[scalar_name] = write_expr_dict[scalar_name].union("?")
+                                except Exception as e:
+                                    write_expr_dict[scalar_name] = write_expr_dict[scalar_name].union("?")
+                            else:
+                                write_expr_dict[scalar_name].add("?")
+        return write_expr_dict
 
     def apply_pass(self, sdfg: SDFG, pipeline_results) -> Optional[Dict[str, Set[str]]]:
-        # Do it for LoopRegions and Maps
         self._apply(sdfg)
-        # TODO:
-        # Current SDFG results in missing symbols in generated function expressions,
-        # Only saving and loading it seems to fix the issue
-        # create a temporary file
         sdfg.validate()
+
+        # If used for its intention we might get scalars that are the form:
+        # tmp = i (instead of i + some_expr)
+        # This means, if this scalar is always written this value we can specialize it
+        scalar_write_exprs = self._find_scalar_write_expr_sets(sdfg)
+        for scalar_name, expr_set in scalar_write_exprs.items():
+            if len(expr_set) == 1:
+                expr = expr_set.pop()
+                if expr != "?":
+                    #print(f"Specialize {scalar_name} to {expr} as the write expression set is detected to: {expr}")
+                    for state in sdfg.all_states():
+                        for node in state.nodes():
+                            if isinstance(node, dace.nodes.AccessNode) and node.data == scalar_name and isinstance(
+                                    state.sdfg.arrays[node.data], dace.data.Scalar):
+                                for ie in state.in_edges(node):
+                                    if isinstance(ie.src, dace.nodes.Tasklet):
+                                        # Access set not being "?" means it is a symbolic expression and not from in connectors
+                                        assert state.in_degree(ie.src) == 0
+                                        state.remove_node(ie.src)
+                                for oe in state.out_edges(node):
+                                    assert isinstance(oe.dst, dace.nodes.Tasklet)
+                                    oe.dst.remove_in_connector(oe.dst_conn)
+                                    oe.dst.code = CodeBlock(oe.dst.code.as_string.replace(oe.dst_conn, expr),
+                                                            oe.dst.language)
+                                    state.remove_edge(oe)
+                                state.remove_node(node)
+                    sdutil.specialize_scalar(sdfg, scalar_name, expr)
+                else:
+                    #print(f"Do not specialize {scalar_name} as the write expression set is detected as unknown: {expr}")
+                    pass
+            else:
+                #print(f"Do not specialize {scalar_name} as the write expression set cardinality is not 1: {expr_set}")
+                pass
+
+        sdfg.validate()
+
+        dace.sdfg.propagation.propagate_memlets_sdfg(sdfg)
         return None

--- a/dace/transformation/passes/offset_loop_and_maps.py
+++ b/dace/transformation/passes/offset_loop_and_maps.py
@@ -244,6 +244,13 @@ class OffsetLoopsAndMaps(ppl.Pass):
                     self._apply(body)
             else:
                 assert isinstance(node, dace.SDFGState)
+                # Descend into NestedSDFGs so their maps/loops get
+                # offset too -- not just the ones at the enclosing
+                # SDFG's top level (e.g. loop bodies that ``LoopToMap``
+                # promoted into a ``loop_body`` nested SDFG).
+                for state_node in node.nodes():
+                    if isinstance(state_node, dace.nodes.NestedSDFG):
+                        self._apply(state_node.sdfg)
 
     def _find_scalar_write_expr_sets(self, sdfg: dace.SDFG) -> Dict[str, Set[str]]:
         write_expr_dict = dict()

--- a/dace/transformation/passes/offset_loop_and_maps.py
+++ b/dace/transformation/passes/offset_loop_and_maps.py
@@ -95,7 +95,7 @@ class OffsetLoopsAndMaps(ppl.Pass):
 
     def _create_new_memlet(self, edge_data, repldict: Dict[str, str]) -> dace.memlet.Memlet:
         """Create a new memlet with substituted subset ranges."""
-        if edge_data is None:
+        if edge_data is None or edge_data.subset is None:
             return None
         # Using symbols might create problems due to having different symbol objects with same symbols
         new_range_list = [(safe_subs(b, repldict), safe_subs(e, repldict), safe_subs(s, repldict))

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -1,11 +1,12 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
-import os
-import tempfile
-import pytest
 import copy
 import dace
+import numpy
+from dace.properties import CodeBlock
+from dace.sdfg.state import LoopRegion
 from dace.transformation.passes.offset_loop_and_maps import OffsetLoopsAndMaps
 from dace.transformation.passes.symbol_propagation import SymbolPropagation
+import gc
 
 # klev, kidia, kfdia : Symbols
 # z1, z2. rmin: scalar
@@ -15,62 +16,292 @@ from dace.transformation.passes.symbol_propagation import SymbolPropagation
 klev = dace.symbol("klev")
 kidia = dace.symbol("kidia")
 kfdia = dace.symbol("kfdia")
+N = dace.symbol("N")
+
+
+@dace.program
+def _simple_element_wise(za: dace.float64[klev, klev]):
+    for i in range(1, klev + 1):
+        for j in range(1, klev + 1):
+            za[i - 1, j - 1] = 2.0
 
 
 @dace.program
 def _cloudsc_snippet_one(za: dace.float64[klev, kfdia], zliqfrac: dace.float64[klev, kfdia],
-                         zicefrac: dace.float64[klev, kfdia], zqx: dace.float64[klev, kfdia, 5],
-                         zli: dace.float64[klev, kfdia], zy: dace.float64[klev, kfdia, 5],
-                         zx: dace.float64[klev, kfdia, 4], rlmin: dace.float64, z1: dace.int64, z2: dace.int64):
+                         zicefrac: dace.float64[klev, kfdia], zqx: dace.float64[klev, kfdia,
+                                                                                5], zli: dace.float64[klev, kfdia],
+                         zy: dace.float64[klev, kfdia, 5], zx: dace.float64[klev, kfdia, 4], rlmin: dace.float64,
+                         z1: dace.int64, z2: dace.int64, cond_int: dace.int64):
     for i in range(1, klev + 1):
         for j in range(kidia + 1, kfdia + 1):
-            za[i - 1, j - 1] = 2.0 * za[i - 1, j - 1] - 5
+            za[i - 1, j - 1] = 2.0 * za[i - 1, j - 1] - 4.37
             cond1 = rlmin > (0.5 * (zqx[i - 1, j - 1, z1] + zqx[i, j, z2]))
             if cond1:
                 zliqfrac[i - 1, j - 1] = zqx[i - 1, j - 1, z1] * zli[i - 1, j - 1]
-                zicefrac[i - 1, j - 1] = 1 - zliqfrac[i - 1, j - 1]
+                zicefrac[i - 1, j - 1] = 1.0 - zliqfrac[i - 1, j - 1]
             else:
-                zliqfrac[i - 1, j - 1] = 0
-                zicefrac[i - 1, j - 1] = 0
-            for m in dace.map[1:5:1]:
+                zliqfrac[i - 1, j - 1] = 0.0
+                zicefrac[i - 1, j - 1] = 0.0
+            for m in dace.map[1:5:1] @ dace.dtypes.ScheduleType.Sequential:
                 zx[i - 1, j - 1, m - 1] = zy[i - 1, z1, z2]
+
+
+@dace.program
+def _cloudsc_snippet_one_within_if(za: dace.float64[klev, kfdia], zliqfrac: dace.float64[klev, kfdia],
+                                   zicefrac: dace.float64[klev, kfdia], zqx: dace.float64[klev, kfdia, 5],
+                                   zli: dace.float64[klev, kfdia], zy: dace.float64[klev, kfdia,
+                                                                                    5], zx: dace.float64[klev, kfdia,
+                                                                                                         4],
+                                   rlmin: dace.float64, z1: dace.int64, z2: dace.int64, cond_int: dace.int64):
+    if cond_int > 2:
+        for i in range(1, klev + 1):
+            for j in range(kidia + 1, kfdia + 1):
+                za[i - 1, j - 1] = 2.0 * za[i - 1, j - 1] - 4.37
+                cond1 = rlmin > (0.5 * (zqx[i - 1, j - 1, z1] + zqx[i, j, z2]))
+                if cond1:
+                    zliqfrac[i - 1, j - 1] = zqx[i - 1, j - 1, z1] * zli[i - 1, j - 1]
+                    zicefrac[i - 1, j - 1] = 1.0 - zliqfrac[i - 1, j - 1]
+                else:
+                    zliqfrac[i - 1, j - 1] = 0.0
+                    zicefrac[i - 1, j - 1] = 0.0
+                for m in dace.map[1:5:1] @ dace.dtypes.ScheduleType.Sequential:
+                    zx[i - 1, j - 1, m - 1] = zy[i - 1, z1, z2]
+
+
+def _get_symbol_use_in_tasklet_sdfg():
+
+    @dace.program
+    def _symbol_use_in_tasklet(A: dace.float64[N]):
+        for i in range(1, N):
+            scl = i + 1
+            A[scl] = A[i]
+
+    sdfg = _symbol_use_in_tasklet.to_sdfg()
+    states = list(sdfg.all_states())
+    assert len(states) == 1
+    state: dace.SDFGState = states[0]
+
+    # Remove dummy nodes I used to get an SDFG with a Loop region fast
+    for node in state.nodes():
+        state.remove_node(node)
+
+    t_offset = state.add_tasklet(name="create_scl", inputs={}, outputs={"_out"}, code="_out = i - 1")
+    t_assign = state.add_tasklet(name="assign", inputs={"_in"}, outputs={"_out"}, code="_out = _in")
+    state.sdfg.add_scalar(name="tmp", dtype=dace.int64, storage=dace.dtypes.StorageType.Register, transient=True)
+    tmp_read_write = state.add_access("tmp")
+    a_write = state.add_access("A")
+
+    state.add_edge(t_offset, "_out", tmp_read_write, None, dace.memlet.Memlet("tmp[0]"))
+    state.add_edge(tmp_read_write, None, t_assign, "_in", dace.memlet.Memlet("tmp[0]"))
+    state.add_edge(t_assign, "_out", a_write, None, dace.memlet.Memlet("A[i]"))
+    sdfg.validate()
+    return sdfg
+
+
+def _for_regions_and_beings(sdfg: dace.SDFG):
+    d = dict()
+    for cfg in sdfg.all_control_flow_regions():
+        if isinstance(cfg, LoopRegion):
+            d[cfg.loop_variable] = cfg.init_statement.as_string.split("=")[-1].strip() if isinstance(
+                cfg.init_statement, CodeBlock) else str(cfg.init_statement)
+    return d
+
+
+def _make_args():
+    # small sizes that exercise indexing safely
+    klev_v = 5
+    kidia_v = 4
+    kfdia_v = 3
+
+    numpy.random.seed(42)
+    za = numpy.random.randn(klev_v, kfdia_v).astype(numpy.float64)
+    zliqfrac = numpy.zeros((klev_v, kfdia_v)).astype(numpy.float64)
+    zicefrac = numpy.zeros((klev_v, kfdia_v)).astype(numpy.float64)
+    zqx = numpy.random.randn(klev_v, kfdia_v, 5).astype(numpy.float64)
+    zli = numpy.random.randn(klev_v, kfdia_v).astype(numpy.float64)
+    zy = numpy.random.randn(klev_v, kfdia_v, 5).astype(numpy.float64)
+    zx = numpy.zeros((klev_v, kfdia_v, 4), dtype=numpy.float64)
+    rlmin = numpy.float64(0.1 + numpy.abs(numpy.random.randn()))
+    z1 = numpy.int64(0)  # valid index into third dimension (0..4)
+    z2 = numpy.int64(1)
+    cond_int = numpy.int64(3)
+
+    return dict(za=za,
+                zliqfrac=zliqfrac,
+                zicefrac=zicefrac,
+                zqx=zqx,
+                zli=zli,
+                zy=zy,
+                zx=zx,
+                rlmin=rlmin,
+                z1=z1,
+                z2=z2,
+                klev=klev_v,
+                kidia=kidia_v,
+                kfdia=kfdia_v,
+                cond_int=cond_int)
+
+
+def _run_and_compare(original_sdfg, transformed_sdfg, arg_names_to_compare):
+    """
+    Run original_sdfg and transformed_sdfg on the same inputs and compare all mutable
+    arrays in arg_names (list of names) using numpy.allclose.
+    """
+    # Produce fresh inputs
+    args = _make_args()
+    # Make deep copies for running both SDFGs
+    orig_args = {k: (numpy.copy(v) if isinstance(v, numpy.ndarray) else v) for k, v in args.items()}
+    trans_args = {k: (numpy.copy(v) if isinstance(v, numpy.ndarray) else v) for k, v in args.items()}
+
+    # Run: SDFG call expects keyword args matching parameter names
+    original_sdfg(**orig_args)
+    transformed_sdfg(**trans_args)
+
+    # Compare all arrays named in arg_names (these are outputs mutated in-place)
+    af = False
+    for name in arg_names_to_compare:
+        a = orig_args[name]
+        b = trans_args[name]
+        if not numpy.allclose(a, b, atol=1e-8, rtol=1e-6):
+            print(f"Mismatch for '{name}', the diff is: {b - a}")
+            af = True
+    if af is True:
+        assert False
+
+    for k, v in orig_args.items():
+        del k
+        del v
+    for k, v in trans_args.items():
+        del k
+        del v
+    gc.collect()
 
 
 def test_loop_offsetting():
     sdfg = _cloudsc_snippet_one.to_sdfg()
     sdfg.validate()
-    sdfg.compile()
-    sdfg.simplify()
+    copy_sdfg = copy.deepcopy(sdfg)
+    copy_sdfg.name = copy_sdfg.name + "_offset"
+    OffsetLoopsAndMaps(begin_expr=None, offset_expr="-1").apply_pass(copy_sdfg, {})
+    # Begin expressions should be:
+    # 0 and kidia + 1
+    regions = _for_regions_and_beings(copy_sdfg)
+    assert regions["i"] == "0", f"Expected 0 but got {regions['i']}"
+    assert regions["j"] == "kidia", f"Expected kidia but got {regions['j']}"
+    copy_sdfg.validate()
+    sdfg.save("before.sdfg")
+    copy_sdfg.save("after.sdfg")
+    _run_and_compare(sdfg, copy_sdfg, ["za", "zliqfrac", "zicefrac", "zx"])
+
+
+def test_loop_offsetting_w_begin_expr():
+    sdfg = _cloudsc_snippet_one.to_sdfg()
     sdfg.validate()
     copy_sdfg = copy.deepcopy(sdfg)
+    copy_sdfg.name = copy_sdfg.name + "_offset"
+    _pass = OffsetLoopsAndMaps(begin_expr="1", offset_expr="-1")
+    assert _pass.begin_expr == "1"
+    assert _pass.offset_expr == "-1"
+    _pass.apply_pass(copy_sdfg, {})
+    # Begin expressions should be:
+    # 0 and kidia + 1
+    regions = _for_regions_and_beings(copy_sdfg)
+    assert regions["i"] == "0", f"Expected 0 but got {regions['i']}"
+    assert regions["j"] == "(kidia + 1)", f"Expected kidia but got {regions['j']}"
     copy_sdfg.validate()
-    copy_sdfg.compile()
-    OffsetLoopsAndMaps(begin_expr=None, offset_expr="-1").apply_pass(copy_sdfg, {})
-    copy_sdfg.validate()
-    copy_sdfg.compile()
     copy_sdfg.simplify()
-    copy_sdfg.compile()
+    _run_and_compare(sdfg, copy_sdfg, ["za", "zliqfrac", "zicefrac", "zx"])
+
+
+def test_symbol_use_in_tasklet():
+    sdfg = _get_symbol_use_in_tasklet_sdfg()
+    sdfg.validate()
+    copy_sdfg = copy.deepcopy(sdfg)
+    copy_sdfg.name = copy_sdfg.name + "_offset"
+    OffsetLoopsAndMaps(begin_expr=None, offset_expr="-1").apply_pass(copy_sdfg, {})
+    # 1 taskelt should be left
+    num_tasklets = 0
+    for state in copy_sdfg.all_states():
+        for node in state.nodes():
+            if isinstance(node, dace.nodes.Tasklet):
+                num_tasklets += 1
+    assert num_tasklets == 1
+    copy_sdfg.validate()
+    copy_sdfg.simplify()
+
+    orig_args = {"N": 5, "A": numpy.zeros((5, ))}
+    trans_args = {"N": 5, "A": numpy.zeros((5, ))}
+    original_sdfg = sdfg
+    transformed_sdfg = copy_sdfg
+
+    original_sdfg(**orig_args)
+    transformed_sdfg(**trans_args)
+
+    a = orig_args["A"]
+    b = trans_args["A"]
+    assert numpy.allclose(a, b, atol=1e-8, rtol=1e-6), f"Mismatch for 'A', the diff is: {b - a}"
+
+
+def test_simple_element_wise():
+    sdfg = _simple_element_wise.to_sdfg()
+    sdfg.validate()
+    copy_sdfg = copy.deepcopy(sdfg)
+    copy_sdfg.name = copy_sdfg.name + "_offset"
+    OffsetLoopsAndMaps(begin_expr="1", offset_expr="-1").apply_pass(copy_sdfg, {})
+    # 1 taskelt should be left
+    num_tasklets = 0
+    for state in copy_sdfg.all_states():
+        for node in state.nodes():
+            if isinstance(node, dace.nodes.Tasklet):
+                num_tasklets += 1
+    assert num_tasklets == 1
+    copy_sdfg.validate()
+    copy_sdfg.simplify()
+
+    orig_args = {"klev": 5, "za": numpy.zeros((5, 5))}
+    trans_args = {"klev": 5, "za": numpy.zeros((5, 5))}
+    original_sdfg = sdfg
+    transformed_sdfg = copy_sdfg
+
+    original_sdfg(**orig_args)
+    transformed_sdfg(**trans_args)
+
+    a = orig_args["za"]
+    b = trans_args["za"]
+    assert numpy.allclose(a, b, atol=1e-18, rtol=1e-18), f"Mismatch for 'za', the diff is: {b - a}"
 
 
 def test_begin_expr_condition():
-    pass
+    sdfg = _cloudsc_snippet_one.to_sdfg()
+    sdfg.validate()
+    copy_sdfg = copy.deepcopy(sdfg)
+    copy_sdfg.name = copy_sdfg.name + "_offset"
+    OffsetLoopsAndMaps(begin_expr="1", offset_expr="-1").apply_pass(copy_sdfg, {})
+    # Begin expressions should be:
+    # 0 and kidia + 1
+    regions = _for_regions_and_beings(copy_sdfg)
+    assert regions["i"] == "0", f"Expected 0 but got {regions['i']}"
+    assert regions["j"] == "(kidia + 1)", f"Expected kidia + 1 but got {regions['j']}"
+    copy_sdfg.validate()
+    copy_sdfg.simplify()
+    _run_and_compare(sdfg, copy_sdfg, ["za", "zliqfrac", "zicefrac", "zx"])
 
 
 def test_with_conditional():
-    pass
-
-
-def test_with_symbolic_offset_expr():
-    pass
-
-
-def test_with_symbolic_begin_expr():
-    pass
+    sdfg = _cloudsc_snippet_one_within_if.to_sdfg()
+    copy_sdfg = copy.deepcopy(sdfg)
+    copy_sdfg.name = copy_sdfg.name + "_offset"
+    OffsetLoopsAndMaps(begin_expr="1", offset_expr="-1").apply_pass(copy_sdfg, {})
+    regions = _for_regions_and_beings(copy_sdfg)
+    assert regions["i"] == "0", f"Expected 0 but got {regions['i']}"
+    assert regions["j"] == "(kidia + 1)", f"Expected kidia + 1 but got {regions['j']}"
+    _run_and_compare(sdfg, copy_sdfg, ["za", "zliqfrac", "zicefrac", "zx"])
 
 
 if __name__ == "__main__":
+    test_simple_element_wise()
+    test_symbol_use_in_tasklet()
     test_loop_offsetting()
+    test_loop_offsetting_w_begin_expr()
     test_begin_expr_condition()
     test_with_conditional()
-    test_with_symbolic_begin_expr()
-    test_with_symbolic_offset_expr()

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -1,0 +1,73 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+import pytest
+import copy
+import dace
+from dace.transformation.passes.offset_loop_and_maps import OffsetLoopsAndMaps
+
+
+# klev, kidia, kfdia : Symbols
+# z1, z2. rmin: scalar
+# za, zli, zliqfrac, zlicefrac : Array[nlev, kfdia]
+# zqx: Array[klev, kfidia, 5]
+
+klev = dace.symbol("klev")
+kidia = dace.symbol("kidia")
+kfdia = dace.symbol("kfdia")
+
+@dace.program
+def _cloudsc_snippet_one(
+    za : dace.float64[klev, kfdia],
+    zliqfrac : dace.float64[klev, kfdia],
+    zicefrac : dace.float64[klev, kfdia],
+    zqx : dace.float64[klev, kfdia, 5],
+    zli : dace.float64[klev, kfdia],
+    zy: dace.float64[klev, kfdia, 5],
+    zx: dace.float64[klev, kfdia, 4],
+    rlmin: dace.float64,
+    z1: dace.int64,
+    z2: dace.int64
+):
+    for i in range(1, klev + 1):
+        for j in range(kidia + 1, kfdia + 1):
+            za[i-1, j-1] = 2.0 * za[i-1, j-1] - 5
+            cond1 = rlmin > (0.5 * (zqx[i-1, j-1, z1] + zqx[i, j, z2]))
+            if cond1:
+                zliqfrac[i-1, j-1] = zqx[i-1, j-1, z1] * zli[i-1, j-1]
+                zicefrac[i-1, j-1] = 1 - zliqfrac[i-1, j-1]
+            else:
+                zliqfrac[i-1, j-1] = 0
+                zicefrac[i-1, j-1] = 0
+            for m in dace.map[1:5:1]:
+                zx[i - 1, j - 1, m - 1] = zy[i - 1, z1, z2]
+
+
+def test_loop_offsetting():
+    sdfg = _cloudsc_snippet_one.to_sdfg()
+    sdfg.validate()
+    sdfg.compile()
+    sdfg.simplify()
+    sdfg.validate()
+
+    copy_sdfg = copy.deepcopy(sdfg)
+    OffsetLoopsAndMaps(begin_expr=None, offset_expr=-1).apply_pass(copy_sdfg, {})
+    copy_sdfg.validate()
+    copy_sdfg.compile()
+
+def test_begin_expr_condition():
+    pass
+
+def test_with_conditional():
+    pass
+
+def test_with_symbolic_offset_expr():
+    pass
+
+def test_with_symbolic_begin_expr():
+    pass
+
+if __name__ == "__main__":
+    test_loop_offsetting()
+    test_begin_expr_condition()
+    test_with_conditional()
+    test_with_symbolic_begin_expr()
+    test_with_symbolic_offset_expr()

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -1,4 +1,6 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+import os
+import tempfile
 import pytest
 import copy
 import dace
@@ -40,16 +42,32 @@ def test_loop_offsetting():
     sdfg.compile()
     sdfg.simplify()
     sdfg.validate()
+    sdfg.save("s1.sdfg")
 
     copy_sdfg = copy.deepcopy(sdfg)
-    OffsetLoopsAndMaps(begin_expr=None, offset_expr=-1).apply_pass(copy_sdfg, {})
     copy_sdfg.validate()
-    copy_sdfg.save("s3.sdfg")
+    copy_sdfg.compile()
+    copy_sdfg.save("s2.sdfg")
+    OffsetLoopsAndMaps(begin_expr=None, offset_expr="-1").apply_pass(copy_sdfg, {})
+    copy_sdfg.validate()
+    copy_sdfg.compile()
+    #copy_sdfg.save("s3.sdfg")
+    #copy_sdfg.compile() # Triggers compile error
+    #_cloudsc_snippet_one.cpp: In function ‘void _cloudsc_snippet_one_33_12_2_3_2(_cloudsc_snippet_one_state_t*,
+    # double*, const int64_t&, const int64_t&, double&, int)’:
+    #_cloudsc_snippet_one.cpp:21:33: error: ‘i’ was not declared in this scope
+    #   21 |         __tmp_34_42_r + ((((5 * i) * kfdia) + (5 * __sym___tmp_34_52_r))
+    #  + __sym___tmp_34_56_r), __tmp_34_42_r_slice, 1);
+    #copy_sdfg = dace.SDFG.from_file("s3.sdfg")
+    #copy_sdfg.save("s4.sdfg")
+    #copy_sdfg.compile() # Is OK
+
+    copy_sdfg.simplify()
     copy_sdfg.compile()
 
-    SymbolPropagation().apply_pass(copy_sdfg)
-    copy_sdfg.validate()
-    copy_sdfg.save("s4.sdfg")
+    #SymbolPropagation().apply_pass(copy_sdfg)
+    #copy_sdfg.validate()
+    #copy_sdfg.save("s4.sdfg")
 
 
 def test_begin_expr_condition():

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -42,32 +42,14 @@ def test_loop_offsetting():
     sdfg.compile()
     sdfg.simplify()
     sdfg.validate()
-    sdfg.save("s1.sdfg")
-
     copy_sdfg = copy.deepcopy(sdfg)
     copy_sdfg.validate()
     copy_sdfg.compile()
-    copy_sdfg.save("s2.sdfg")
     OffsetLoopsAndMaps(begin_expr=None, offset_expr="-1").apply_pass(copy_sdfg, {})
     copy_sdfg.validate()
     copy_sdfg.compile()
-    #copy_sdfg.save("s3.sdfg")
-    #copy_sdfg.compile() # Triggers compile error
-    #_cloudsc_snippet_one.cpp: In function ‘void _cloudsc_snippet_one_33_12_2_3_2(_cloudsc_snippet_one_state_t*,
-    # double*, const int64_t&, const int64_t&, double&, int)’:
-    #_cloudsc_snippet_one.cpp:21:33: error: ‘i’ was not declared in this scope
-    #   21 |         __tmp_34_42_r + ((((5 * i) * kfdia) + (5 * __sym___tmp_34_52_r))
-    #  + __sym___tmp_34_56_r), __tmp_34_42_r_slice, 1);
-    #copy_sdfg = dace.SDFG.from_file("s3.sdfg")
-    #copy_sdfg.save("s4.sdfg")
-    #copy_sdfg.compile() # Is OK
-
     copy_sdfg.simplify()
     copy_sdfg.compile()
-
-    #SymbolPropagation().apply_pass(copy_sdfg)
-    #copy_sdfg.validate()
-    #copy_sdfg.save("s4.sdfg")
 
 
 def test_begin_expr_condition():

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -3,7 +3,7 @@ import pytest
 import copy
 import dace
 from dace.transformation.passes.offset_loop_and_maps import OffsetLoopsAndMaps
-
+from dace.transformation.passes.symbol_propagation import SymbolPropagation
 
 # klev, kidia, kfdia : Symbols
 # z1, z2. rmin: scalar
@@ -14,29 +14,22 @@ klev = dace.symbol("klev")
 kidia = dace.symbol("kidia")
 kfdia = dace.symbol("kfdia")
 
+
 @dace.program
-def _cloudsc_snippet_one(
-    za : dace.float64[klev, kfdia],
-    zliqfrac : dace.float64[klev, kfdia],
-    zicefrac : dace.float64[klev, kfdia],
-    zqx : dace.float64[klev, kfdia, 5],
-    zli : dace.float64[klev, kfdia],
-    zy: dace.float64[klev, kfdia, 5],
-    zx: dace.float64[klev, kfdia, 4],
-    rlmin: dace.float64,
-    z1: dace.int64,
-    z2: dace.int64
-):
+def _cloudsc_snippet_one(za: dace.float64[klev, kfdia], zliqfrac: dace.float64[klev, kfdia],
+                         zicefrac: dace.float64[klev, kfdia], zqx: dace.float64[klev, kfdia, 5],
+                         zli: dace.float64[klev, kfdia], zy: dace.float64[klev, kfdia, 5],
+                         zx: dace.float64[klev, kfdia, 4], rlmin: dace.float64, z1: dace.int64, z2: dace.int64):
     for i in range(1, klev + 1):
         for j in range(kidia + 1, kfdia + 1):
-            za[i-1, j-1] = 2.0 * za[i-1, j-1] - 5
-            cond1 = rlmin > (0.5 * (zqx[i-1, j-1, z1] + zqx[i, j, z2]))
+            za[i - 1, j - 1] = 2.0 * za[i - 1, j - 1] - 5
+            cond1 = rlmin > (0.5 * (zqx[i - 1, j - 1, z1] + zqx[i, j, z2]))
             if cond1:
-                zliqfrac[i-1, j-1] = zqx[i-1, j-1, z1] * zli[i-1, j-1]
-                zicefrac[i-1, j-1] = 1 - zliqfrac[i-1, j-1]
+                zliqfrac[i - 1, j - 1] = zqx[i - 1, j - 1, z1] * zli[i - 1, j - 1]
+                zicefrac[i - 1, j - 1] = 1 - zliqfrac[i - 1, j - 1]
             else:
-                zliqfrac[i-1, j-1] = 0
-                zicefrac[i-1, j-1] = 0
+                zliqfrac[i - 1, j - 1] = 0
+                zicefrac[i - 1, j - 1] = 0
             for m in dace.map[1:5:1]:
                 zx[i - 1, j - 1, m - 1] = zy[i - 1, z1, z2]
 
@@ -51,19 +44,29 @@ def test_loop_offsetting():
     copy_sdfg = copy.deepcopy(sdfg)
     OffsetLoopsAndMaps(begin_expr=None, offset_expr=-1).apply_pass(copy_sdfg, {})
     copy_sdfg.validate()
+    copy_sdfg.save("s3.sdfg")
     copy_sdfg.compile()
+
+    SymbolPropagation().apply_pass(copy_sdfg)
+    copy_sdfg.validate()
+    copy_sdfg.save("s4.sdfg")
+
 
 def test_begin_expr_condition():
     pass
 
+
 def test_with_conditional():
     pass
+
 
 def test_with_symbolic_offset_expr():
     pass
 
+
 def test_with_symbolic_begin_expr():
     pass
+
 
 if __name__ == "__main__":
     test_loop_offsetting()

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -325,6 +325,62 @@ def test_empty_memlet_does_not_crash_offset_loops_and_maps():
     sdfg.validate()
 
 
+def test_maps_inside_nested_sdfg_are_offset():
+    """Regression: the pass previously only walked the enclosing SDFG's
+    direct ``ControlFlowRegion`` / ``ConditionalBlock`` children,
+    leaving maps that live inside ``NestedSDFG`` bodies unchanged (the
+    typical shape after ``LoopToMap`` promotes a loop body into a
+    ``loop_body`` NSDFG). The fix descends into each NestedSDFG so every
+    reachable map range is offset.
+    """
+    from dace import memlet as mm
+    from dace.transformation.passes.offset_loop_and_maps import OffsetLoopsAndMaps
+
+    # Inner SDFG with a 2D map -- tasklet produces the value, MapExit
+    # writes it back out (so only an ``A`` out-connector on the Map is
+    # needed).
+    inner = dace.SDFG("inner_with_map")
+    inner.add_array("A", [16, 16], dace.float64)
+    inner_state = inner.add_state("body", is_start_block=True)
+    w_inner = inner_state.add_write("A")
+    me, mx = inner_state.add_map("inner_map", {"i": "0:8", "j": "1:5"})
+    mx.add_in_connector("IN_A")
+    mx.add_out_connector("OUT_A")
+    t = inner_state.add_tasklet("set", set(), {"y"}, "y = 1.0")
+    inner_state.add_nedge(me, t, mm.Memlet())
+    inner_state.add_edge(t, "y", mx, "IN_A", mm.Memlet("A[i, j]"))
+    inner_state.add_edge(mx, "OUT_A", w_inner, None, mm.Memlet("A[0:8, 1:5]"))
+
+    # Outer SDFG wraps ``inner`` in a NestedSDFG.
+    outer = dace.SDFG("outer_with_nsdfg")
+    outer.add_array("A", [16, 16], dace.float64)
+    ostate = outer.add_state("ostate", is_start_block=True)
+    aw = ostate.add_write("A")
+    ns = ostate.add_nested_sdfg(inner, set(), {"A"})
+    ostate.add_edge(ns, "A", aw, None, mm.Memlet("A[0:16, 0:16]"))
+    outer.validate()
+
+    OffsetLoopsAndMaps(offset_expr="1", begin_expr=None).apply_pass(outer, {})
+    outer.validate()
+
+    # Walk the post-transform SDFG tree and find the inner 2D map; both
+    # axes must have been shifted by +1.
+    from dace.sdfg import nodes as _nodes
+    inner_map = None
+    for n, _ in outer.all_nodes_recursive():
+        if isinstance(n, _nodes.MapEntry) and n.map.params == ["i", "j"]:
+            inner_map = n
+            break
+    assert inner_map is not None, "inner 2D map vanished after the transformation"
+    (ib, ie, _), (jb, je, _) = inner_map.map.range.ranges
+    # ``0:8`` -> ``(0, 7, 1)`` -> after +1 -> ``(1, 8, 1)``.
+    assert str(ib) == "1", ib
+    assert str(ie) == "8", ie
+    # ``1:5`` -> ``(1, 4, 1)`` -> after +1 -> ``(2, 5, 1)``.
+    assert str(jb) == "2", jb
+    assert str(je) == "5", je
+
+
 if __name__ == "__main__":
     test_simple_element_wise()
     test_symbol_use_in_tasklet()
@@ -332,4 +388,5 @@ if __name__ == "__main__":
     test_loop_offsetting_w_begin_expr()
     test_begin_expr_condition()
     test_with_conditional()
+    test_maps_inside_nested_sdfg_are_offset()
     test_empty_memlet_does_not_crash_offset_loops_and_maps()

--- a/tests/passes/offset_loop_and_maps_test.py
+++ b/tests/passes/offset_loop_and_maps_test.py
@@ -294,6 +294,37 @@ def test_with_conditional():
     _run_and_compare(sdfg, copy_sdfg, ["za", "zliqfrac", "zicefrac", "zx"])
 
 
+def test_empty_memlet_does_not_crash_offset_loops_and_maps():
+    """Regression: ``_create_new_memlet`` iterated ``edge_data.subset``
+    unconditionally. Empty/pass-through memlets (e.g. tasklet→AccessNode
+    with no dataflow) carry ``subset=None`` and crashed the pass with
+    ``TypeError: 'NoneType' object is not iterable``. Trigger the
+    memlet-rewrite path via a LoopRegion whose body contains such an
+    empty-memlet edge.
+    """
+    from dace import memlet as mm
+    from dace.transformation.passes.offset_loop_and_maps import OffsetLoopsAndMaps
+
+    sdfg = dace.SDFG("empty_memlet_tester")
+    sdfg.add_array("A", [8], dace.float64)
+    sdfg.add_array("B", [8], dace.float64)
+    loop = LoopRegion(
+        "loop",
+        condition_expr="i <= 3",
+        loop_var="i",
+        initialize_expr="i = 0",
+        update_expr="i = i + 1",
+    )
+    sdfg.add_node(loop, is_start_block=True)
+    body = loop.add_state("body", is_start_block=True)
+    # AccessNode -> AccessNode edge with an empty memlet (no subset).
+    body.add_nedge(body.add_read("A"), body.add_write("B"), mm.Memlet())
+    sdfg.validate()
+
+    OffsetLoopsAndMaps(offset_expr="1", begin_expr=None).apply_pass(sdfg, {})
+    sdfg.validate()
+
+
 if __name__ == "__main__":
     test_simple_element_wise()
     test_symbol_use_in_tasklet()
@@ -301,3 +332,4 @@ if __name__ == "__main__":
     test_loop_offsetting_w_begin_expr()
     test_begin_expr_condition()
     test_with_conditional()
+    test_empty_memlet_does_not_crash_offset_loops_and_maps()


### PR DESCRIPTION
Mainly designed to replace `(int i = 1; i < something; i ++)` loops with `(int i = 0; i < something; i++)` loops and thus get rid of having many memlets that look like `i - 1, j - 1` by offseting to map and then adding the negative of the offset to the memlets, getting clearer offsets that are easier to read.

The pass supports both Loop regions and maps. And this:
<img width="1136" height="418" alt="image" src="https://github.com/user-attachments/assets/91684702-5cba-471d-882f-fd2592d7cc99" />

Becomes this:
<img width="764" height="387" alt="image" src="https://github.com/user-attachments/assets/5a6a2ee3-4db4-411a-b1a4-a9a919f7ed8f" />
<img width="284" height="178" alt="image" src="https://github.com/user-attachments/assets/410c61f5-123f-4ba4-aa60-d5d0e330b333" />

(The j is offset is correct, I also normalize the loop using the API of loop regions)
