### PR TITLE
Fix issues w.r.t. references in the Python frontend

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -26,7 +26,7 @@ from dace.frontend.python.astutils import rname
 from dace.frontend.python import nested_call, replacements, preprocessing
 from dace.frontend.python.memlet_parser import DaceSyntaxError, parse_memlet, ParseMemlet, inner_eval_ast, MemletExpr
 from dace.sdfg import nodes
-from dace.sdfg.propagation import propagate_memlet, propagate_subset, propagate_states
+from dace.sdfg.propagation import propagate_memlet, propagate_subset, propagate_states, align_memlet
 from dace.memlet import Memlet
 from dace.properties import LambdaProperty, CodeBlock
 from dace.sdfg import SDFG, SDFGState
@@ -2937,7 +2937,12 @@ class ProgramVisitor(ExtNodeVisitor):
                     memlet.other_subset = op_subset
                     if op:
                         memlet.wcr = LambdaProperty.from_string('lambda x, y: x {} y'.format(op))
-                    state.add_nedge(op1, op2, memlet)
+                    if isinstance(self.sdfg.arrays[target_name], data.Reference):
+                        e = state.add_edge(op1, None, op2, 'set', memlet)
+                        # Align memlet to referenced array
+                        e.data = align_memlet(state, e, dst=False)
+                    else:
+                        state.add_nedge(op1, op2, memlet)
             else:
                 memlet = Memlet("{a}[{s}]".format(a=target_name,
                                                   s=','.join(['__i%d' % i for i in range(len(target_subset))])))
@@ -3444,9 +3449,10 @@ class ProgramVisitor(ExtNodeVisitor):
             storage = dtypes.StorageType.Default
             type_name = rname(node.annotation)
             warnings.warn('typeclass {} is not supported'.format(type_name))
-        if node.value is None and dtype is not None:  # Annotating type without assignment
+        if dtype is not None:
             self.annotated_types[rname(node.target)] = dtype
-            return
+            if node.value is None:  # Annotating type without assignment
+                return
         results = self._visit_assign(node, node.target, None, dtype=dtype)
         if storage != dtypes.StorageType.Default:
             self.sdfg.arrays[results[0][0]].storage = storage
@@ -3629,6 +3635,12 @@ class ProgramVisitor(ExtNodeVisitor):
                     result_data = self.sdfg.arrays[result]
                     if (name.startswith('__return') and isinstance(result_data, data.Scalar)):
                         true_name, new_data = self.add_temp_transient([1], result_data.dtype)
+                        self.variables[name] = true_name
+                        defined_vars[name] = true_name
+                    elif name in self.annotated_types and isinstance(self.annotated_types[name], data.Reference):
+                        desc = copy.deepcopy(self.annotated_types[name])
+                        desc.transient = True
+                        true_name = self.sdfg.add_datadesc(name, desc, find_new_name=True)
                         self.variables[name] = true_name
                         defined_vars[name] = true_name
                     elif (not name.startswith('__return')

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1819,6 +1819,9 @@ def all_isedges_between(src: ControlFlowBlock, dst: ControlFlowBlock) -> Iterabl
         # Step 2
         src_pivot = src
         for r in involved_src:
+            if isinstance(r, ConditionalBlock):
+                src_pivot = r
+                continue
             for sink in r.sink_nodes():
                 for p in r.all_simple_paths(src_pivot, sink, as_edges=True):
                     for e in p:
@@ -1829,6 +1832,9 @@ def all_isedges_between(src: ControlFlowBlock, dst: ControlFlowBlock) -> Iterabl
         # Step 3
         dst_pivot = dst
         for r in involved_dst:
+            if isinstance(r, ConditionalBlock):
+                dst_pivot = r
+                continue
             for p in r.all_simple_paths(r.start_block, dst_pivot, as_edges=True):
                 for e in p:
                     edges.add(e)

--- a/tests/sdfg/reference_test.py
+++ b/tests/sdfg/reference_test.py
@@ -10,6 +10,72 @@ import pytest
 import networkx as nx
 
 
+def test_frontend_reference():
+    N = dace.symbol('N')
+    M = dace.symbol('M')
+    mystruct = dace.data.Structure(
+        members={
+            "data": dace.data.Array(dace.float32, (N, M), strides=(1, N)),
+            "arrA": dace.data.ArrayReference(dace.float32, (N,)),
+            "arrB": dace.data.ArrayReference(dace.float32, (N,)),
+        },
+        name="MyStruct"
+    )
+
+    @dace.program
+    def init_prog(mydat: mystruct, fill_value: int) -> None:
+        mydat.arrA = mydat.data[:, 2]
+        mydat.arrB = mydat.data[:, 0]
+
+        # loop over all arrays and initialize them with `fill_value`
+        for index in range(M):
+            mydat.data[:, index] = fill_value
+
+        # Initialize the two named ones by name
+        mydat.arrA[:] = fill_value + 1
+        mydat.arrB[:] = fill_value + 2
+
+    dat = np.zeros((10, 5), dtype=np.float32)
+    inp_struct = mystruct.dtype._typeclass.as_ctypes()(data=dat.__array_interface__['data'][0])
+
+    func = init_prog.compile()
+    func(mydat=inp_struct, fill_value=3, N=10, M=5)
+
+    assert np.allclose(dat[0, :], 5) and np.allclose(dat[1, :], 5)
+    assert np.allclose(dat[2, :], 3) and np.allclose(dat[3, :], 3)
+    assert np.allclose(dat[4, :], 4) and np.allclose(dat[5, :], 4)
+    assert np.allclose(dat[6, :], 3) and np.allclose(dat[7, :], 3)
+    assert np.allclose(dat[8, :], 3) and np.allclose(dat[9, :], 3)
+
+
+def test_type_annotation_reference():
+    N = dace.symbol('N')
+
+    @dace.program
+    def ref(A: dace.float64[N], B: dace.float64[N], T: dace.int32, out: dace.float64[N]):
+        ref1: dace.data.ArrayReference(A.dtype, A.shape) = A
+        ref2: dace.data.ArrayReference(A.dtype, A.shape) = B
+        if T <= 0:
+            out[:] = ref1[:] + 1
+        else:
+            out[:] = ref2[:] + 1
+
+    a = np.random.rand(20)
+    a_verif = a.copy()
+    b = np.random.rand(20)
+    b_verif = b.copy()
+    out = np.random.rand(20)
+    out_verif = out.copy()
+
+    ref(a, b, 1, out, N=20)
+    ref.f(a_verif, b_verif, 1, out_verif)
+    assert np.allclose(out, out_verif)
+
+    ref(a, b, -1, out, N=20)
+    ref.f(a_verif, b_verif, -1, out_verif)
+    assert np.allclose(out, out_verif)
+
+
 def test_unset_reference():
     sdfg = dace.SDFG('tester')
     sdfg.add_reference('ref', [20], dace.float64)
@@ -683,6 +749,8 @@ def test_ref2view_reconnection():
 
 
 if __name__ == '__main__':
+    test_frontend_reference()
+    test_type_annotation_reference()
     test_unset_reference()
     test_reference_branch()
     test_reference_sources_pass()


### PR DESCRIPTION
Co-authored by @tbennun 

## Issue:
When using references through the Python fontend, references were created without appropriate reference setting connector on the access nodes.

## Resolution:
This problem has been addressed, and a test has been added to expose the previous issue. Additionally, a small change now allows references to be explicitly type hinted in the frontend.