### PR TITLE
Fix a memory leak in MKL's batched MM library node expansion

### DIFF
--- a/dace/libraries/blas/nodes/batched_matmul.py
+++ b/dace/libraries/blas/nodes/batched_matmul.py
@@ -148,8 +148,7 @@ class ExpandBatchedMatMulMKL(ExpandTransformation):
         delete[] __mkl_BMM_A;
         delete[] __mkl_BMM_B;
         delete[] __mkl_BMM_C;
-        '''.format_map(
-            opt)
+        '''.format_map(opt)
 
         tasklet = dace.sdfg.nodes.Tasklet(node.name,
                                           node.in_connectors,


### PR DESCRIPTION
In addition to fixing a memory leak, this PR ensures less chance of name conflicts for the very generic variable names used by the node expansion.