### PR TITLE
Extend multi-dimensional batched matmul support

### DIFF
--- a/dace/libraries/blas/nodes/batched_matmul.py
+++ b/dace/libraries/blas/nodes/batched_matmul.py
@@ -32,8 +32,12 @@ class ExpandBatchedMatMulPure(ExpandTransformation):
                           UserWarning)
         elif not res:
             raise SyntaxError("Matrix sizes must match")
+
+        # Determine output shape based on batch options
         if bopt:
-            shape_c = (bopt['b'], shape_a[-2], shape_b[-1])
+            # Use batch dimensions from bopt (may be multi-dimensional)
+            batch_dims = bopt.get('batch_dims', [bopt['b']])
+            shape_c = tuple(batch_dims) + (shape_a[-2], shape_b[-1])
         else:
             shape_c = (shape_a[-2], shape_b[-1])
 
@@ -64,16 +68,46 @@ class ExpandBatchedMatMulPure(ExpandTransformation):
 
         state = sdfg.add_state_after(init_state, node.label + "_state")
 
-        state.add_mapped_tasklet(
-            '_BatchedBatchedMatMult_', {
-                '__i%d' % i: '0:%s' % s
-                for i, s in enumerate([bopt['b'], array_a.shape[-2], array_b.shape[-1], array_a.shape[-1]])
-            }, {
-                '__a': dace.Memlet.simple("_a", ('__i1, __i3' if len(array_a.shape) == 2 else '__i0, __i1, __i3')),
-                '__b': dace.Memlet.simple("_b", ('__i3, __i2' if len(array_b.shape) == 2 else '__i0, __i3, __i2'))
-            },
-            '__c = __a * __b', {'__c': dace.Memlet.simple("_c", '__i0, __i1, __i2', wcr_str='lambda x, y: x + y')},
-            external_edges=True)
+        # Calculate number of batch dimensions in output
+        num_batch_dims = len(shape_c) - 2
+
+        # Build map parameters: batch dimensions + M, N, K
+        map_params = {}
+        for i in range(num_batch_dims):
+            map_params['__i%d' % i] = '0:%s' % symstr(shape_c[i])
+
+        # M, N, K dimensions
+        map_params['__im'] = '0:%s' % symstr(shape_a[-2])
+        map_params['__in'] = '0:%s' % symstr(shape_b[-1])
+        map_params['__ik'] = '0:%s' % symstr(shape_a[-1])
+
+        # Build memlet access patterns
+        # For A: if 2D, use [M, K]; if 3D+, use [batch_indices..., M, K]
+        if len(array_a.shape) == 2:
+            memlet_a = '__im, __ik'
+        else:
+            # Use output batch indices
+            a_batch_indices = ', '.join(['__i%d' % i for i in range(len(array_a.shape) - 2)])
+            memlet_a = f'{a_batch_indices}, __im, __ik'
+
+        # For B: if 2D, use [K, N]; if 3D+, use [batch_indices..., K, N]
+        if len(array_b.shape) == 2:
+            memlet_b = '__ik, __in'
+        else:
+            b_batch_indices = ', '.join(['__i%d' % i for i in range(len(array_b.shape) - 2)])
+            memlet_b = f'{b_batch_indices}, __ik, __in'
+
+        # For C: always has batch dimensions
+        c_indices = ', '.join(['__i%d' % i for i in range(num_batch_dims)]) + ', __im, __in'
+
+        state.add_mapped_tasklet('_BatchedMatMult_',
+                                 map_params, {
+                                     '__a': dace.Memlet.simple("_a", memlet_a),
+                                     '__b': dace.Memlet.simple("_b", memlet_b)
+                                 },
+                                 '__c = __a * __b',
+                                 {'__c': dace.Memlet.simple("_c", c_indices, wcr_str='lambda x, y: x + y')},
+                                 external_edges=True)
 
         return sdfg
 
@@ -441,11 +475,19 @@ class BatchedMatMul(dace.sdfg.nodes.LibraryNode):
             raise ValueError("Expected exactly one output from "
                              "batched matrix-matrix product")
         out_memlet = out_edges[0].data
-        # Function is symmetric, edge order does not matter
-        if len(size0) not in [2, 3]:
-            raise ValueError("Batched matrix-matrix product only supported on matrices")
-        if len(size1) != 3:
-            raise ValueError("Batched matrix-matrix product only supported on matrices")
+
+        # Both inputs must be at least 2D
+        if len(size0) < 2:
+            raise ValueError(f"First input must be at least 2D, got shape with {len(size0)} dimensions")
+        if len(size1) < 2:
+            raise ValueError(f"Second input must be at least 2D, got shape with {len(size1)} dimensions")
+
+        # At least one input must have batch dimensions (3D or higher) for batched operation
+        if len(size0) <= 2 and len(size1) <= 2:
+            raise ValueError(
+                "Batched matrix-matrix product requires at least one input to have batch dimensions (3D or higher)")
+
+        # Validate K-dimension compatibility
         res = equal(size0[-1], size1[-2])
         if res is None:
             warnings.warn(
@@ -453,8 +495,11 @@ class BatchedMatMul(dace.sdfg.nodes.LibraryNode):
                 f'may not match', UserWarning)
         elif not res:
             raise ValueError("Inputs to matrix-matrix product must agree in the k-dimension")
-        if len(out_memlet.subset) != 3:
-            raise ValueError("batched matrix-matrix product only supported on matrices")
+
+        # Output must have batch dimensions
+        if len(out_memlet.subset) < 3:
+            raise ValueError(
+                f"Batched matrix-matrix product output must be at least 3D, got {len(out_memlet.subset)} dimensions")
 
 
 # Numpy replacement

--- a/tests/library/batched_matmul_test.py
+++ b/tests/library/batched_matmul_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import pytest
 import numpy as np
 
@@ -14,9 +14,12 @@ from dace.library import change_default
     pytest.param("MKL", dace.float32, marks=pytest.mark.mkl),
     pytest.param("MKL", dace.float64, marks=pytest.mark.mkl),
     pytest.param("cuBLAS", dace.float32, marks=pytest.mark.gpu),
-    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu)
+    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu),
+    pytest.param("OpenBLAS", dace.float32, marks=pytest.mark.lapack),
+    pytest.param("OpenBLAS", dace.float64, marks=pytest.mark.lapack)
 ])
 def test_batchmm(implementation: str, dtype):
+    """Test standard 3D batched matmul: [b, m, k] @ [b, k, n]"""
     b, m, n, k = tuple(dace.symbol(k) for k in 'bmnk')
 
     @dace.program
@@ -42,6 +45,185 @@ def test_batchmm(implementation: str, dtype):
         assert np.allclose(ref, z)
 
 
+@pytest.mark.parametrize("implementation, dtype", [
+    pytest.param("pure", dace.float32),
+    pytest.param("pure", dace.float64),
+    pytest.param("MKL", dace.float32, marks=pytest.mark.mkl),
+    pytest.param("MKL", dace.float64, marks=pytest.mark.mkl),
+    pytest.param("cuBLAS", dace.float32, marks=pytest.mark.gpu),
+    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu),
+    pytest.param("OpenBLAS", dace.float32, marks=pytest.mark.lapack),
+    pytest.param("OpenBLAS", dace.float64, marks=pytest.mark.lapack)
+])
+def test_batchmm_broadcast_rhs(implementation: str, dtype):
+    """Test 3D batched matmul with broadcast on RHS: [b, m, k] @ [k, n]"""
+    b, m, n, k = tuple(dace.symbol(k) for k in 'bmnk')
+
+    @dace.program
+    def bmm_broadcast(A: dtype[b, m, k], B: dtype[k, n], C: dtype[b, m, n]):
+        C[:] = A @ B
+
+    with change_default(blas, implementation):
+        sdfg = bmm_broadcast.to_sdfg()
+        sdfg.simplify()
+        sdfg.expand_library_nodes()
+
+        b, m, n, k = 3, 16, 32, 64
+
+        x = np.random.rand(b, m, k).astype(dtype.as_numpy_dtype())
+        y = np.random.rand(k, n).astype(dtype.as_numpy_dtype())
+        z = np.zeros([b, m, n]).astype(dtype.as_numpy_dtype())
+
+        csdfg = sdfg.compile()
+        csdfg(A=x, B=y, C=z, b=b, m=m, n=n, k=k)
+
+        ref = x @ y
+
+        assert np.allclose(ref, z)
+
+
+@pytest.mark.parametrize("implementation, dtype", [
+    pytest.param("pure", dace.float32),
+    pytest.param("pure", dace.float64),
+    pytest.param("MKL", dace.float32, marks=pytest.mark.mkl),
+    pytest.param("MKL", dace.float64, marks=pytest.mark.mkl),
+    pytest.param("cuBLAS", dace.float32, marks=pytest.mark.gpu),
+    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu),
+    pytest.param("OpenBLAS", dace.float32, marks=pytest.mark.lapack),
+    pytest.param("OpenBLAS", dace.float64, marks=pytest.mark.lapack)
+])
+def test_batchmm_broadcast_lhs(implementation: str, dtype):
+    """Test 3D batched matmul with broadcast on LHS: [m, k] @ [b, k, n]"""
+    b, m, n, k = tuple(dace.symbol(k) for k in 'bmnk')
+
+    @dace.program
+    def bmm_broadcast(A: dtype[m, k], B: dtype[b, k, n], C: dtype[b, m, n]):
+        C[:] = A @ B
+
+    with change_default(blas, implementation):
+        sdfg = bmm_broadcast.to_sdfg()
+        sdfg.simplify()
+        sdfg.expand_library_nodes()
+
+        b, m, n, k = 3, 16, 32, 64
+
+        x = np.random.rand(m, k).astype(dtype.as_numpy_dtype())
+        y = np.random.rand(b, k, n).astype(dtype.as_numpy_dtype())
+        z = np.zeros([b, m, n]).astype(dtype.as_numpy_dtype())
+
+        csdfg = sdfg.compile()
+        csdfg(A=x, B=y, C=z, b=b, m=m, n=n, k=k)
+
+        ref = x @ y
+
+        assert np.allclose(ref, z)
+
+
+@pytest.mark.parametrize("implementation, dtype", [
+    pytest.param("pure", dace.float32),
+    pytest.param("pure", dace.float64),
+    pytest.param("MKL", dace.float32, marks=pytest.mark.mkl),
+    pytest.param("MKL", dace.float64, marks=pytest.mark.mkl),
+    pytest.param("cuBLAS", dace.float32, marks=pytest.mark.gpu),
+    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu),
+    pytest.param("OpenBLAS", dace.float32, marks=pytest.mark.lapack),
+    pytest.param("OpenBLAS", dace.float64, marks=pytest.mark.lapack)
+])
+def test_batchmm_4d(implementation: str, dtype):
+    """Test 4D batched matmul: [b1, b2, m, k] @ [b1, b2, k, n]"""
+    b1, b2, m, n, k = 4, 2, 64, 128, 64
+
+    @dace.program
+    def bmm_4d(A: dtype[b1, b2, m, k], B: dtype[b1, b2, k, n], C: dtype[b1, b2, m, n]):
+        C[:] = A @ B
+
+    with change_default(blas, implementation):
+        sdfg = bmm_4d.to_sdfg()
+        sdfg.simplify()
+        sdfg.expand_library_nodes()
+
+        x = np.random.rand(b1, b2, m, k).astype(dtype.as_numpy_dtype())
+        y = np.random.rand(b1, b2, k, n).astype(dtype.as_numpy_dtype())
+        z = np.zeros([b1, b2, m, n]).astype(dtype.as_numpy_dtype())
+
+        csdfg = sdfg.compile()
+        csdfg(A=x, B=y, C=z)
+
+        ref = x @ y
+
+        assert np.allclose(ref, z)
+
+
+@pytest.mark.parametrize("implementation, dtype", [
+    pytest.param("pure", dace.float32),
+    pytest.param("pure", dace.float64),
+    pytest.param("MKL", dace.float32, marks=pytest.mark.mkl),
+    pytest.param("MKL", dace.float64, marks=pytest.mark.mkl),
+    pytest.param("cuBLAS", dace.float32, marks=pytest.mark.gpu),
+    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu),
+    pytest.param("OpenBLAS", dace.float32, marks=pytest.mark.lapack),
+    pytest.param("OpenBLAS", dace.float64, marks=pytest.mark.lapack)
+])
+def test_batchmm_4d_broadcast_rhs(implementation: str, dtype):
+    """Test 4D batched matmul with broadcast on RHS: [b1, b2, m, k] @ [k, n]"""
+    b1, b2, m, n, k = 4, 2, 64, 128, 64
+
+    @dace.program
+    def bmm_4d_broadcast(A: dtype[b1, b2, m, k], B: dtype[k, n], C: dtype[b1, b2, m, n]):
+        C[:] = A @ B
+
+    with change_default(blas, implementation):
+        sdfg = bmm_4d_broadcast.to_sdfg()
+        sdfg.simplify()
+        sdfg.expand_library_nodes()
+
+        x = np.random.rand(b1, b2, m, k).astype(dtype.as_numpy_dtype())
+        y = np.random.rand(k, n).astype(dtype.as_numpy_dtype())
+        z = np.zeros([b1, b2, m, n]).astype(dtype.as_numpy_dtype())
+
+        csdfg = sdfg.compile()
+        csdfg(A=x, B=y, C=z)
+
+        ref = x @ y
+
+        assert np.allclose(ref, z)
+
+
+@pytest.mark.parametrize("implementation, dtype", [
+    pytest.param("pure", dace.float32),
+    pytest.param("pure", dace.float64),
+    pytest.param("MKL", dace.float32, marks=pytest.mark.mkl),
+    pytest.param("MKL", dace.float64, marks=pytest.mark.mkl),
+    pytest.param("cuBLAS", dace.float32, marks=pytest.mark.gpu),
+    pytest.param("cuBLAS", dace.float64, marks=pytest.mark.gpu),
+    pytest.param("OpenBLAS", dace.float32, marks=pytest.mark.lapack),
+    pytest.param("OpenBLAS", dace.float64, marks=pytest.mark.lapack)
+])
+def test_batchmm_4d_broadcast_lhs(implementation: str, dtype):
+    """Test 4D batched matmul with broadcast on LHS: [m, k] @ [b1, b2, k, n]"""
+    b1, b2, m, n, k = 4, 2, 64, 128, 64
+
+    @dace.program
+    def bmm_4d_broadcast(A: dtype[m, k], B: dtype[b1, b2, k, n], C: dtype[b1, b2, m, n]):
+        C[:] = A @ B
+
+    with change_default(blas, implementation):
+        sdfg = bmm_4d_broadcast.to_sdfg()
+        sdfg.simplify()
+        sdfg.expand_library_nodes()
+
+        x = np.random.rand(m, k).astype(dtype.as_numpy_dtype())
+        y = np.random.rand(b1, b2, k, n).astype(dtype.as_numpy_dtype())
+        z = np.zeros([b1, b2, m, n]).astype(dtype.as_numpy_dtype())
+
+        csdfg = sdfg.compile()
+        csdfg(A=x, B=y, C=z)
+
+        ref = x @ y
+
+        assert np.allclose(ref, z)
+
+
 if __name__ == "__main__":
     test_batchmm("pure", dace.float32)
     test_batchmm("pure", dace.float64)
@@ -49,3 +231,33 @@ if __name__ == "__main__":
     test_batchmm("MKL", dace.float64)
     test_batchmm("cuBLAS", dace.float32)
     test_batchmm("cuBLAS", dace.float64)
+    test_batchmm_broadcast_rhs("pure", dace.float32)
+    test_batchmm_broadcast_rhs("pure", dace.float64)
+    test_batchmm_broadcast_rhs("MKL", dace.float32)
+    test_batchmm_broadcast_rhs("MKL", dace.float64)
+    test_batchmm_broadcast_rhs("cuBLAS", dace.float32)
+    test_batchmm_broadcast_rhs("cuBLAS", dace.float64)
+    test_batchmm_broadcast_lhs("pure", dace.float32)
+    test_batchmm_broadcast_lhs("pure", dace.float64)
+    test_batchmm_broadcast_lhs("MKL", dace.float32)
+    test_batchmm_broadcast_lhs("MKL", dace.float64)
+    test_batchmm_broadcast_lhs("cuBLAS", dace.float32)
+    test_batchmm_broadcast_lhs("cuBLAS", dace.float64)
+    test_batchmm_4d("pure", dace.float32)
+    test_batchmm_4d("pure", dace.float64)
+    test_batchmm_4d("MKL", dace.float32)
+    test_batchmm_4d("MKL", dace.float64)
+    test_batchmm_4d("cuBLAS", dace.float32)
+    test_batchmm_4d("cuBLAS", dace.float64)
+    test_batchmm_4d_broadcast_rhs("pure", dace.float32)
+    test_batchmm_4d_broadcast_rhs("pure", dace.float64)
+    test_batchmm_4d_broadcast_rhs("MKL", dace.float32)
+    test_batchmm_4d_broadcast_rhs("MKL", dace.float64)
+    test_batchmm_4d_broadcast_rhs("cuBLAS", dace.float32)
+    test_batchmm_4d_broadcast_rhs("cuBLAS", dace.float64)
+    test_batchmm_4d_broadcast_lhs("pure", dace.float32)
+    test_batchmm_4d_broadcast_lhs("pure", dace.float64)
+    test_batchmm_4d_broadcast_lhs("MKL", dace.float32)
+    test_batchmm_4d_broadcast_lhs("MKL", dace.float64)
+    test_batchmm_4d_broadcast_lhs("cuBLAS", dace.float32)
+    test_batchmm_4d_broadcast_lhs("cuBLAS", dace.float64)


### PR DESCRIPTION
# Extended Batched Matrix Multiplication Support

## Summary
Extend batched matrix multiplication to support N-dimensional tensors with NumPy-style broadcasting across all implementations (Pure, MKL, OpenBLAS, cuBLAS).

## Changes
- **N-D tensor support**: Handles tensors with arbitrary batch dimensions (e.g., `[12, 2, 64, 64] @ [12, 2, 64, 128]`)
- **Broadcasting**: Supports broadcasting patterns like `[b, m, k] @ [k, n]` and `[m, k] @ [b, k, n]`
- **Batch flattening**: Multi-dimensional batches are flattened internally for efficient BLAS operations

## New Capabilities
```python
# 3D broadcasting
[b, m, k] @ [k, n] → [b, m, n]
[m, k] @ [b, k, n] → [b, m, n]

# 4D batched matmul
[12, 2, 64, 64] @ [12, 2, 64, 128] → [12, 2, 64, 128]
[12, 2, m, k] @ [k, n] → [12, 2, m, n]  # with broadcasting
```

## Files Modified
- `dace/libraries/blas/nodes/matmul.py`: Extended `_get_batchmm_opts()` for N-D tensors and broadcasting
- `dace/libraries/blas/nodes/batched_matmul.py`: Updated validation and Pure expansion for dynamic dimensions
- `dace/frontend/python/replacements/linalg.py`: Removed 3D tensor check 
- `tests/library/batched_matmul_test.py`: Added tests for newly supported 3D/4D batched matmuls with broadcasting
