### PR TITLE
Do not merge: Disable AddThreadBlockMap transformation in cuda codegen

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -164,7 +164,8 @@ class CUDACodeGen(TargetCodeGenerator):
         # Identify kernels with inserted GPU_ThreadBlock-scheduled maps
         old_nodes = set(node for node, _ in sdfg.all_nodes_recursive())
 
-        sdfg.apply_transformations_once_everywhere(AddThreadBlockMap, )
+        # Disable `AddThreadBlockMap` because it causes a cuda codegen error in gt4py unittest
+        # sdfg.apply_transformations_once_everywhere(AddThreadBlockMap, )
 
         new_nodes = set(node for node, _ in sdfg.all_nodes_recursive()) - old_nodes
 


### PR DESCRIPTION
Disable `AddThreadBlockMap` because it causes a cuda codegen error in gt4py unittest:
`sympy.printing.codeprinter.PrintMethodNotImplementedError: Unsupported by <class 'sympy.printing.pycode.PythonCodePrinter'>: int_floor`

This error is caused by an invalid map range:
```
str(rng[1])
'Min(b_i_IDim_gtx_horizontal + 63, int_floor(upper_i, 2) - 1) (~b_i_IDim_gtx_horizontal + 63)'
```