### PR TITLE
Fix infinite loop bug in isolate_nested_sdfg

### DIFF
--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -827,6 +827,7 @@ def isolate_nested_sdfg(
         node_to_process = to_visit.pop()
         if node_to_process in visited:
             continue
+        visited.add(node_to_process)
         pre_nodes.add(node_to_process)
         to_visit.extend(iedge.src for iedge in state.in_edges(node_to_process))
 


### PR DESCRIPTION
The `visited` set in the `isolate_nested_sdfg` is initialized but never filled. This leads to an infinite loop when calling `simplify` on some graphs.