### PR TITLE
Updated `invoke_compiled_sdfg_call_hooks`

### DIFF
--- a/dace/hooks.py
+++ b/dace/hooks.py
@@ -273,7 +273,7 @@ class invoke_compiled_sdfg_call_hooks(contextlib.AbstractContextManager):
             for hook in _COMPILED_SDFG_CALL_HOOKS:
                 if hook is None:
                     continue
-                new_compiled_sdfg = stack.enter_context(hook(compiled_sdfg, args))
+                new_compiled_sdfg = stack.enter_context(hook(compiled_sdfg, self.args))
                 if new_compiled_sdfg is not None:
                     compiled_sdfg = new_compiled_sdfg
             return compiled_sdfg


### PR DESCRIPTION
`invoke_compiled_sdfg_call_hooks` is used to add hooks at call time to the `CompiledSDFG` object, for this `conextlib.contextmanager` is used, to implement it as context manager.
This function is on the hot path and using `contextmanager` adds a non negligible overhead, thus this PR implements the full context manager object which is faster, especially in the case that no hook is registered.