### PR TITLE
Made `self._lastargs[0]` Mutable Again

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -556,10 +556,12 @@ with open(r"{temp_path}", "wb") as f:
         callparams = tuple((carg, aname) for arg, carg, aname in zip(arglist, cargs, argnames)
                            if not (symbolic.issymbolic(arg) and (hasattr(arg, 'name') and arg.name in constants)))
 
-        # NOTE: Since it is technically allowed to modify `self.lastargs[...]` we do not
-        #   turn it into a `tuple` but a `list`.
+        # NOTE: While it makes sense to modify `self._lastargs[0]` it does not make sense to
+        #   modify `self._lastargs[1]`, i.e. `initargs`, because it is only used the first time.
+        #   The reason why modification of `self._lastargs[0]` is useful that it allows fast
+        #   dispatch from Python, for example in GT4Py.next.
         newargs = [carg for carg, aname in callparams]
-        initargs = [carg for carg, aname in callparams if aname in symbols]
+        initargs = tuple(carg for carg, aname in callparams if aname in symbols)
 
         self._lastargs = (newargs, initargs)
         return self._lastargs


### PR DESCRIPTION
Before [PR#2185](https://github.com/spcl/dace/pull/2185) `self._lastargs` could be updated, GT4Py was using this to enable fast calls from Python to SDFGs.
This PR reenables this possibility, by turning `self._lastargs[0]` into a `list`.
Note that `self._lastargs[1]` and `self._lastargs` itself remained `tuple`s as it does not make sense to manipulate them.