### PR TITLE
Remove debug code for serialization failure

### DIFF
--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -170,22 +170,29 @@ def generate_code(sdfg: SDFG, validate=True) -> List[CodeObject]:
         from dace.sdfg import SDFG
         import difflib
         import filecmp
+        import os
         import shutil
         import tempfile
         with tempfile.TemporaryDirectory() as tmp_dir:
             sdfg.save(f'{tmp_dir}/test.sdfg', hash=False)
             sdfg2 = SDFG.from_file(f'{tmp_dir}/test.sdfg')
             sdfg2.save(f'{tmp_dir}/test2.sdfg', hash=False)
-            print('Testing SDFG serialization...')
             if not filecmp.cmp(f'{tmp_dir}/test.sdfg', f'{tmp_dir}/test2.sdfg'):
                 with open(f'{tmp_dir}/test.sdfg', 'r') as f1:
                     with open(f'{tmp_dir}/test2.sdfg', 'r') as f2:
                         diff = difflib.unified_diff(f1.readlines(),
                                                     f2.readlines(),
-                                                    fromfile='test.sdfg  (first save)',
-                                                    tofile='test2.sdfg (after roundtrip)')
+                                                    fromfile='pre.sdfg',
+                                                    tofile='post.sdfg (after roundtrip)')
                 diff = ''.join(diff)
-                raise RuntimeError(f'SDFG serialization failed - files do not match:\n{diff}')
+                os.makedirs('_dacegraphs', exist_ok=True)
+                pre_path = os.path.abspath('_dacegraphs/serialization_failure_pre.sdfg')
+                post_path = os.path.abspath('_dacegraphs/serialization_failure_post.sdfg')
+                shutil.move(f'{tmp_dir}/test.sdfg', pre_path)
+                shutil.move(f'{tmp_dir}/test2.sdfg', post_path)
+                raise RuntimeError(f'SDFG serialization roundtrip mismatch for SDFG: \'{sdfg.name}\'.\n'
+                                   f'Files saved for inspection:\n  Pre:  {pre_path}\n  Post: {post_path}\n'
+                                   f'File diff:\n{diff}')
 
     if config.Config.get_bool('optimizer', 'detect_control_flow'):
         # NOTE: This should likely be done either earlier in the future, or changed entirely in modular codegen.


### PR DESCRIPTION
This looks like forgotten debug code to me? It moves the files to the main directory with the names `test.sdfg` and `test2.sdfg`. I suggest we remove this or move the files to `_dacegraphs` instead.