### PR TITLE
F2dace/fix parameter array

### DIFF
--- a/dace/frontend/fortran/ast_desugaring.py
+++ b/dace/frontend/fortran/ast_desugaring.py
@@ -29,7 +29,7 @@ from fparser.two.Fortran2003 import Program_Stmt, Module_Stmt, Function_Stmt, Su
     Deallocate_Stmt, Close_Stmt, Goto_Stmt, Continue_Stmt, Format_Stmt, Stmt_Function_Stmt, Internal_Subprogram_Part, \
     Private_Components_Stmt, Generic_Spec, Language_Binding_Spec, Type_Attr_Spec, Suffix, Proc_Component_Def_Stmt, \
     Proc_Decl, End_Type_Stmt, End_Interface_Stmt, Procedure_Declaration_Stmt, Pointer_Assignment_Stmt, Cycle_Stmt, \
-    Equiv_Operand, Case_Value_Range_List, Ac_Value_List
+    Equiv_Operand, Case_Value_Range_List, Ac_Value_List, Explicit_Shape_Spec_List
 from fparser.two.Fortran2008 import Procedure_Stmt, Type_Declaration_Stmt, Error_Stop_Stmt
 from fparser.two.utils import Base, walk, BinaryOpBase, UnaryOpBase, NumberBase, BlockBase
 
@@ -639,13 +639,12 @@ def _eval_real_literal(x: Union[Signed_Real_Literal_Constant, Real_Literal_Const
 def _const_eval_basic_type(expr: Base, alias_map: SPEC_TABLE) -> Optional[NUMPY_TYPES]:
     if isinstance(expr, (Part_Ref, Data_Ref)):
         name_node = expr.children[0]
-        # Only support scalar array accesses for now
+        # TODO: Support multidimensional array access.
         if (len(expr.children) > 1 and isinstance(expr.children[1], Section_Subscript_List)):
             subsc = expr.children[1]
             if (len(subsc.children) == 1):
-                # TODO index offset correction
                 idx = _const_eval_basic_type(subsc.children[0], alias_map)
-                if not idx:
+                if idx is None:
                     # Array index is not constant
                     return None
                 # This is just copied behavior from 'Name'
@@ -659,12 +658,23 @@ def _const_eval_basic_type(expr: Base, alias_map: SPEC_TABLE) -> Optional[NUMPY_
                 if not isinstance(decl, Entity_Decl):
                     # Is not even a data entity.
                     return None
+                # Find array declaration bounds
+                shape = singular(children_of_type(decl, Explicit_Shape_Spec_List))
+                shape = singular(children_of_type(shape, Explicit_Shape_Spec)).children
+                assert len(shape) == 2
+                assert shape[1] is not None
+                lbound = 1
+                if shape[0] is not None:
+                    lbound = _const_eval_basic_type(shape[0], alias_map)
+                ubound = _const_eval_basic_type(shape[1], alias_map)
+                if lbound is None or ubound is None:
+                    # Shape is not constant
+                    return None
                 typ = find_type_of_entity(decl, alias_map)
                 if not typ or not typ.const:
                     # Does not have a constant type.
                     return None
                 init = atmost_one(children_of_type(decl, Initialization))
-                # TODO: Add ref.
                 _, iexpr = init.children
                 if f"{iexpr}" == 'NULL()':
                     # We don't have good representation of "null pointer".
@@ -674,8 +684,8 @@ def _const_eval_basic_type(expr: Base, alias_map: SPEC_TABLE) -> Optional[NUMPY_
                     # Expect an Ac_Value_List
                     _, acvall, _ = iexpr.children
                     if (isinstance(acvall, Ac_Value_List)):
-                        # TODO Bounds check here, but idx is non-normalized anyway so all of this is wrong no matter what
-                        return _const_eval_basic_type(acvall.children[idx-1], alias_map)
+                        assert lbound <= idx and idx <= ubound, f"Array index {idx} is out of bounds in {decl.name}"
+                        return _const_eval_basic_type(acvall.children[idx-lbound], alias_map)
         # Fail otherwise
         return None
     elif isinstance(expr, Name):
@@ -3664,6 +3674,9 @@ def consolidate_global_data_into_arg(ast: Program, always_add_global_data_arg: b
         for tdecl in children_of_type(spart, Type_Declaration_Stmt):
             typ, attr, decl = tdecl.children
             if 'PARAMETER' in f"{attr}":
+                # Parameter arrays cannot always be resolved, the indices may not be constant.
+                # Keep the array declaration but remove the PARAMETER attribute to avoid
+                # confusing the internal AST builder later.
                 attr.items = [spec for spec in attr.children if spec.string != 'PARAMETER']
                 if not attr.items:
                     tdecl.items = (typ, None, decl)

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -3069,7 +3069,7 @@ def run_fparser_transformations(ast: Program, cfg: ParseConfig):
 
     if cfg.consolidate_global_data:
         print("FParser Op: Consolidating the global variables of the AST...")
-        ast = consolidate_global_data_into_arg(ast, cfg.entry_points)
+        ast = consolidate_global_data_into_arg(ast)
         ast = prune_coarsely(ast, cfg.do_not_prune)
         _checkpoint_ast(cfg, 'ast_v4.f90', ast)
 

--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1738,11 +1738,14 @@ contains
         y = -4.0, &
         z = 3.0
     real, parameter :: arr(3) = [3, 4, 5]
+    real, parameter :: weird(-1:1) = [3, 4, 5]
     res1 = unk ** x
     res2 = unk ** y
     res3 = unk ** z
     res4 = arr(1)
     res5 = arr(1) + arr(2) + arr(3)
+    res4 = weird(0)
+    res5 = weird(1) + weird(0) - weird(-1)
   end subroutine foo
 end module main
 """).check_with_gfortran().get()
@@ -1761,11 +1764,14 @@ MODULE main
     REAL :: res1, res2, res3, res4, res5, unk
     REAL, PARAMETER :: x = - (7.0), y = - 4.0, z = 3.0
     REAL, PARAMETER :: arr(3) = [3, 4, 5]
+    REAL, PARAMETER :: weird(- 1 : 1) = [3, 4, 5]
     res1 = unk ** (- 7.0)
     res2 = unk ** (- 4.0)
     res3 = unk ** 3.0
     res4 = 3
     res5 = 12
+    res4 = 4
+    res5 = 6
   END SUBROUTINE foo
 END MODULE main
 """.strip()


### PR DESCRIPTION
This PR extends the `_const_eval_basic_type` transformation in the Fortran parser to propagate elements from
global constant `PARAMETER` arrays throughout the AST.

Given that the parameter array does not change and the declaration and definition are available in the same AST node, the transformation can handle array index offsets. The transformation also performs bounds checks to assert that referenced indices are valid.

Additionally, we avoid discarding `PARAMETER` arrays in `consolidate_global_data_into_arg`, given that variable array references `par_arr(var)` cannot be resolved. Our fix ensures that the array definition remains in the AST/SDFG for later use and does not get pruned prematurely. 