### PR TITLE
Remove unused pointers from structs.

### DIFF
--- a/tests/fortran/ast_desugaring_test.py
+++ b/tests/fortran/ast_desugaring_test.py
@@ -1586,6 +1586,7 @@ module lib
   type T
     integer :: data(4) = 8
     integer, pointer :: ptr(:) => null()
+    integer, pointer :: unused_T_ptr(:) => null()
   end type T
 end module lib
 


### PR DESCRIPTION
This PR fixes a bug where unused pointer definitions inside `TYPE`s are not pruned correctly, causing a crash later in the pipeline.