### PR TITLE
Add support for CUDA 13

### DIFF
--- a/dace/runtime/include/dace/cuda/multidim_gbar.cuh
+++ b/dace/runtime/include/dace/cuda/multidim_gbar.cuh
@@ -87,7 +87,11 @@ public:
         // Threadfence and syncthreads to make sure global writes are visible before
         // thread-0 reports in with its sync counter
         __threadfence();
+        #if __CUDACC_VER_MAJOR__ >= 13
+        __syncthreads();
+        #else
         CTA_SYNC();
+        #endif
 
         int linear_tid = threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.y * blockDim.x;
         int linear_blockid = blockIdx.x + blockIdx.y * gridDim.x + blockIdx.z * gridDim.y * gridDim.x;
@@ -102,7 +106,11 @@ public:
                 d_vol_sync[linear_blockid] = 1;
             }
 
+            #if __CUDACC_VER_MAJOR__ >= 13
+            __syncthreads();
+            #else
             CTA_SYNC();
+            #endif
 
             // Wait for everyone else to report in
             for (int peer_block = linear_tid; peer_block < grid; peer_block += block)
@@ -113,7 +121,11 @@ public:
                 }
             }
 
+            #if __CUDACC_VER_MAJOR__ >= 13
+            __syncthreads();
+            #else
             CTA_SYNC();
+            #endif
 
             // Let everyone know it's safe to proceed
             for (int peer_block = linear_tid; peer_block < grid; peer_block += block)
@@ -135,7 +147,11 @@ public:
                 }
             }
 
+            #if __CUDACC_VER_MAJOR__ >= 13
+            __syncthreads();
+            #else
             CTA_SYNC();
+            #endif
         }
     }
 };


### PR DESCRIPTION
The current version of DaCe only supports CUDA 12 since CUDA 13 has a few breaking changes.

This PR updates the runtime headers according to https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html, replacing classes that moved from cub to thrust.

As I have no way of testing on CUDA 12, I have conservatively left the old code intact using preprocessor macros.

Tested on CUDA 13.1