### PR TITLE
[v1 Maintenance] `networkx` under 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(name='dace',
       },
       include_package_data=True,
       install_requires=[
-          'numpy < 2.0', 'networkx >= 2.5', 'astunparse', 'sympy >= 1.9', 'pyyaml', 'ply',
+          'numpy < 2.0', 'networkx >= 2.5, <= 3.5', 'astunparse', 'sympy >= 1.9', 'pyyaml', 'ply',
           'fparser == 0.2.0', 'aenum >= 3.1', 'dataclasses; python_version < "3.7"', 'dill',
           'pyreadline;platform_system=="Windows"', 'typing-compat; python_version < "3.8"', 'packaging'
       ] + cmake_requires,


### PR DESCRIPTION
Backporting the findings of an exploding `networkx` that was dealt with on mainline with #2235 