### PR TITLE
Fix a bunch of typos in comments

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -262,7 +262,7 @@ class InterstateEdge(object):
         #       - condition = 'i < 10', assignments = {'i': '3'}
         #       - assignments = {'j': 'i + 1', 'i': '3'}
         #       The new algorithm below addresses the issue by iterating over the edge's condition and assignments and
-        #       exlcuding keys from being considered "defined" if they have been already read.
+        #       excluding keys from being considered "defined" if they have been already read.
 
         # Symbols in conditions are always free, because the condition is executed before the assignments
         cond_symbols = set(map(str, dace.symbolic.symbols_in_ast(self.condition.code[0])))
@@ -1097,7 +1097,7 @@ class SDFG(ControlFlowRegion):
     def call_with_instrumented_data(self, dreport: 'InstrumentedDataReport', *args, **kwargs):
         """
         Invokes an SDFG with an instrumented data report, generating and compiling code if necessary.
-        Arguments given as ``args`` and ``kwargs`` will be overriden by the data containers defined in the report.
+        Arguments given as ``args`` and ``kwargs`` will be overridden by the data containers defined in the report.
 
         :param dreport: The instrumented data report to use upon calling.
         :param args: Arguments to call SDFG with.

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -32,7 +32,7 @@ def bounding_box_cover_exact(subset_a, subset_b, approximation=False) -> bool:
     and `False` otherwise.
 
     :param subset_a: The first subset, the one that should cover.
-    :param subset_b: The second subset, the one that should be convered.
+    :param subset_b: The second subset, the one that should be covered.
     :param approximation: If `True` then use the approximated bounds.
     """
     min_elements_a = subset_a.min_element_approx() if approximation else subset_a.min_element()
@@ -73,7 +73,7 @@ def bounding_box_symbolic_positive(subset_a, subset_b, approximation=False) -> b
     and `False` otherwise.
 
     :param subset_a: The first subset, the one that should cover.
-    :param subset_b: The second subset, the one that should be convered.
+    :param subset_b: The second subset, the one that should be covered.
     :param approximation: If `True` then use the approximated bounds.
 
     :note: In previous versions this function raised `TypeError` in some cases
@@ -646,7 +646,7 @@ class Range(Subset):
                 # Open parenthesis found, increase count by 1
                 if token[i] == '(':
                     count += 1
-                # Closing parenthesis found, decrease cound by 1
+                # Closing parenthesis found, decrease count by 1
                 elif token[i] == ')':
                     count -= 1
                 # Move to the next character
@@ -1267,7 +1267,7 @@ class SubsetUnion(Subset):
 
         if isinstance(other, SubsetUnion):
             for subset in self.subset_list:
-                # check if ther is a subset in self that covers every subset in other
+                # check if there is a subset in self that covers every subset in other
                 if all(subset.covers(s) for s in other.subset_list):
                     return True
             # return False if that's not the case for any of the subsets in self
@@ -1285,7 +1285,7 @@ class SubsetUnion(Subset):
 
         if isinstance(other, SubsetUnion):
             for subset in self.subset_list:
-                # check if ther is a subset in self that covers every subset in other
+                # check if there is a subset in self that covers every subset in other
                 if all(subset.covers_precise(s) for s in other.subset_list):
                     return True
             # return False if that's not the case for any of the subsets in self

--- a/dace/transformation/dataflow/map_expansion.py
+++ b/dace/transformation/dataflow/map_expansion.py
@@ -34,7 +34,7 @@ class MapExpansion(pm.SingleStateTransformation):
                                   dtype=dtypes.ScheduleType,
                                   default=dtypes.ScheduleType.Sequential,
                                   allow_none=True)
-    expansion_limit = Property(desc="How many unidimensional maps will be creaed, known as k. "
+    expansion_limit = Property(desc="How many unidimensional maps will be created, known as k. "
                                "If None, the default no limit is in place.",
                                dtype=int,
                                allow_none=True,

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -971,6 +971,7 @@ def unsqueeze_memlet(internal_memlet: Memlet,
                      external_offset: Tuple[int] = None) -> Memlet:
     """ Unsqueezes and offsets a memlet, as per the semantics of nested
         SDFGs.
+
         :param internal_memlet: The internal memlet (inside nested SDFG) before modification.
         :param external_memlet: The external memlet before modification.
         :param preserve_minima: Do not change the subset's minimum elements.

--- a/dace/transformation/passes/constant_propagation.py
+++ b/dace/transformation/passes/constant_propagation.py
@@ -33,7 +33,7 @@ class ConstantPropagation(ppl.Pass):
 
     CATEGORY: str = 'Simplification'
 
-    recursive = properties.Property(dtype=bool, default=True, desc='Propagagte recursively through nested SDFGs')
+    recursive = properties.Property(dtype=bool, default=True, desc='Propagate recursively through nested SDFGs')
     progress = properties.Property(dtype=bool, default=None, allow_none=True, desc='Show progress')
 
     def modifies(self) -> ppl.Modifies:
@@ -201,7 +201,7 @@ class ConstantPropagation(ppl.Pass):
         if loop in post_constants and post_constants[loop] is not None:
             if loop.update_statement is not None and (loop.inverted and loop.update_before_condition
                                                       or not loop.inverted):
-                # Replace the RHS of the update experssion
+                # Replace the RHS of the update expression
                 post_mapping = {
                     k: v
                     for k, v in post_constants[loop].items()


### PR DESCRIPTION
As part of bringing our schedule tree branch from `v1/maintenance` to `main` (see https://github.com/spcl/dace/pull/2262), I have fixed a couple of typos. I'd like to pull these out into a separate PR to keep the schedule tree PR as small as possible (which will still be large once done).