### PR TITLE
Support undefined variables in memlet propagation

### DIFF
--- a/dace/sdfg/analysis/schedule_tree/treenodes.py
+++ b/dace/sdfg/analysis/schedule_tree/treenodes.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass, field
 from dace import nodes, data, subsets
 from dace.properties import CodeBlock
 from dace.sdfg import InterstateEdge
-from dace.sdfg.state import ConditionalBlock, LoopRegion, SDFGState
+from dace.sdfg.state import LoopRegion, SDFGState
+from dace.sdfg.state import SDFGState
 from dace.symbolic import symbol
 from dace.memlet import Memlet
 from typing import TYPE_CHECKING, Dict, Iterator, List, Literal, Optional, Set, Union

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1430,7 +1430,7 @@ def propagate_memlet(dfg_state,
     # Propagate subset
     if isinstance(entry_node, nodes.MapEntry):
         mapnode = entry_node.map
-        return propagate_subset(aggdata, arr, mapnode.params, mapnode.range, defined_vars, use_dst=use_dst)
+        return propagate_subset(aggdata, arr, mapnode.params, mapnode.range, defined_variables=defined_vars, use_dst=use_dst)
 
     elif isinstance(entry_node, nodes.ConsumeEntry):
         # Nothing to analyze/propagate in consume
@@ -1449,6 +1449,7 @@ def propagate_subset(memlets: List[Memlet],
                      arr: data.Data,
                      params: List[str],
                      rng: subsets.Subset,
+                     *,
                      defined_variables: Set[symbolic.SymbolicType] = None,
                      undefined_variables: Set[symbolic.SymbolicType] = None,
                      use_dst: bool = False) -> Memlet:
@@ -1487,6 +1488,8 @@ def propagate_subset(memlets: List[Memlet],
 
     if undefined_variables:
         defined_variables = defined_variables - set(symbolic.pystr_to_symbolic(p) for p in undefined_variables)
+    else:
+        undefined_variables = set()
 
     # Propagate subset
     variable_context = [defined_variables, [symbolic.pystr_to_symbolic(p) for p in params]]
@@ -1530,7 +1533,7 @@ def propagate_subset(memlets: List[Memlet],
                     fsyms = _freesyms(sdim)
                     fsyms_str = set(map(str, fsyms))
                     contains_params |= len(fsyms_str & paramset) != 0
-                    contains_undefs |= len(fsyms - defined_variables) != 0
+                    contains_undefs |= len(fsyms & undefined_variables) != 0
                 if contains_params or contains_undefs:
                     tmp_subset_rng.append(ea)
                 else:

--- a/tests/passes/writeset_underapproximation_test.py
+++ b/tests/passes/writeset_underapproximation_test.py
@@ -384,7 +384,7 @@ def test_map_in_loop():
 def test_map_in_loop_multiplied_indices_first_dimension():
     """
     Map nested in a loop that writes to array. Subscript expression
-      of array access multiplies two indicies in first dimension
+      of array access multiplies two indices in first dimension
     --> Approximated write-set of loop to array is empty
     """
 
@@ -417,7 +417,7 @@ def test_map_in_loop_multiplied_indices_first_dimension():
 def test_map_in_loop_multiplied_indices_second_dimension():
     """
     Map nested in a loop that writes to array. Subscript expression
-      of array access multiplies two indicies in second dimension
+      of array access multiplies two indices in second dimension
     --> Approximated write-set of loop to array is empty
     """
     sdfg = dace.SDFG("nested")


### PR DESCRIPTION
Another breakout from the schedule tree work (PR #2262).

This PR adds support for undefined variables in memlet propagation as added by Tal in commits https://github.com/spcl/dace/pull/1466/commits/3c1a7864f4698ea4473195e3b6546854f060c190 and https://github.com/spcl/dace/pull/1466/commits/5eac791ae646b11ca0ab89f295d05b3c5456f251.