### PR TITLE
Attempt to make properties faster

### DIFF
--- a/dace/distr_types.py
+++ b/dace/distr_types.py
@@ -451,9 +451,9 @@ class RedistrArray(object):
         tmp += f"""
             if (__state->{array_b.pgrid}_valid) {{
         """
-        grid_a = sdfg.process_grids[array_a.pgrid]
+        grid_a = sdfg.pgrids[array_a.pgrid]
         if grid_a.is_subgrid:
-            pgrid_a = sdfg.process_grids[grid_a.parent_grid]
+            pgrid_a = sdfg.pgrids[grid_a.parent_grid]
             tmp += f"""
                 int pgrid_exact_coords[{len(pgrid_a.shape)}];
                 dace::comm::cart_coords({grid_a.exact_grid}, {len(pgrid_a.shape)}, __state->{pgrid_a.name}_dims, pgrid_exact_coords);
@@ -520,9 +520,9 @@ class RedistrArray(object):
         tmp += f"""
             if (__state->{array_a.pgrid}_valid) {{
         """
-        grid_b = sdfg.process_grids[array_b.pgrid]
+        grid_b = sdfg.pgrids[array_b.pgrid]
         if grid_b.is_subgrid:
-            pgrid_b = sdfg.process_grids[grid_b.parent_grid]
+            pgrid_b = sdfg.pgrids[grid_b.parent_grid]
             tmp += f"""
                 int pgrid_exact_coords[{len(pgrid_b.shape)}];
                 dace::comm::cart_coords({grid_b.exact_grid}, {len(pgrid_b.shape)}, __state->{pgrid_b.name}_dims, pgrid_exact_coords);

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -4654,7 +4654,7 @@ class ProgramVisitor(ExtNodeVisitor):
         # Avoid cast of output pointers to scalars in code generation
         for cname in outargs:
             if (cname in self.sdfg.arrays and tuple(self.sdfg.arrays[cname].shape) == (1, )):
-                tasklet._out_connectors[f'__out_{cname}'] = dtypes.pointer(self.sdfg.arrays[cname].dtype)
+                tasklet.out_connectors[f'__out_{cname}'] = dtypes.pointer(self.sdfg.arrays[cname].dtype)
 
         # Setup arguments in graph
         for arg in dtypes.deduplicate(args):

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1369,10 +1369,7 @@ class ProgramVisitor(ExtNodeVisitor):
         result.update(self.sdfg.arrays)
 
         # MPI-related stuff
-        result.update({
-            v: self.sdfg.process_grids[v]
-            for k, v in self.variables.items() if v in self.sdfg.process_grids
-        })
+        result.update({v: self.sdfg.pgrids[v] for k, v in self.variables.items() if v in self.sdfg.pgrids})
         try:
             from mpi4py import MPI
             result.update({k: v for k, v in self.globals.items() if isinstance(v, MPI.Comm)})
@@ -5194,8 +5191,8 @@ class ProgramVisitor(ExtNodeVisitor):
 
         result = []
         for operand in operands:
-            if isinstance(operand, str) and operand in self.sdfg.process_grids:
-                result.append((operand, type(self.sdfg.process_grids[operand]).__name__))
+            if isinstance(operand, str) and operand in self.sdfg.pgrids:
+                result.append((operand, type(self.sdfg.pgrids[operand]).__name__))
             elif isinstance(operand, str) and operand in self.sdfg.arrays:
                 result.append((operand, type(self.sdfg.arrays[operand])))
             elif isinstance(operand, str) and operand in self.scope_arrays:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -3604,11 +3604,10 @@ class ProgramVisitor(ExtNodeVisitor):
 
             new_data, rng = None, None
             dtype_keys = tuple(dtypes.dtype_to_typeclass().keys())
-            if not (
-                    result in self.sdfg.symbols or symbolic.issymbolic(result) or isinstance(result, dtype_keys) or
-                (isinstance(result, str) and any(
-                    result in x
-                    for x in [self.sdfg.arrays, self.sdfg._pgrids, self.sdfg._subarrays, self.sdfg._rdistrarrays]))):
+            if not (result in self.sdfg.symbols or symbolic.issymbolic(result) or isinstance(result, dtype_keys) or
+                    (isinstance(result, str) and any(
+                        result in x
+                        for x in [self.sdfg.arrays, self.sdfg.pgrids, self.sdfg.subarrays, self.sdfg.rdistrarrays]))):
                 raise DaceSyntaxError(
                     self, node, "In assignments, the rhs may only be "
                     "data, numerical/boolean constants "
@@ -3632,7 +3631,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         true_name, new_data = self.sdfg.add_scalar(true_name, ttype, transient=True, find_new_name=True)
                     self.variables[name] = true_name
                     defined_vars[name] = true_name
-                if any(result in x for x in [self.sdfg._pgrids, self.sdfg._rdistrarrays, self.sdfg._subarrays]):
+                if any(result in x for x in [self.sdfg.pgrids, self.sdfg.rdistrarrays, self.sdfg.subarrays]):
                     # NOTE: In previous versions some `pgrid` and subgrid related replacement function,
                     #   see `dace/frontend/common/distr.py`, created dummy variables with the same name
                     #   as the entities, such as process grids, they created. Thus the frontend was

--- a/dace/memlet.py
+++ b/dace/memlet.py
@@ -207,17 +207,17 @@ class Memlet(object):
         node = object.__new__(Memlet)
 
         # Immutable objects are: Python strings, integer, boolean but also SymPy expressions, i.e. symbols.
-        node._volume = self._volume
-        node._dynamic = self._dynamic
-        node._subset = dcpy(self._subset, memo=memo)
-        node._other_subset = dcpy(self._other_subset, memo=memo)
-        node._data = self._data
-        node._wcr = dcpy(self._wcr, memo=memo)
-        node._wcr_nonatomic = self._wcr_nonatomic
-        node._debuginfo = dcpy(self._debuginfo, memo=memo)
-        node._wcr_nonatomic = self._wcr_nonatomic
-        node._allow_oob = self._allow_oob
-        node._guid = generate_element_id(node)
+        node.volume = self.volume
+        node.dynamic = self.dynamic
+        node.subset = dcpy(self.subset, memo=memo)
+        node.other_subset = dcpy(self.other_subset, memo=memo)
+        node.data = self.data
+        node.wcr = dcpy(self.wcr, memo=memo)
+        node.wcr_nonatomic = self.wcr_nonatomic
+        node.debuginfo = dcpy(self.debuginfo, memo=memo)
+        node.wcr_nonatomic = self.wcr_nonatomic
+        node.allow_oob = self.allow_oob
+        node.guid = generate_element_id(node)
 
         # TODO: Since we set the `.sdfg` and friends to `None` we should probably also set this to `None`.
         node._is_data_src = self._is_data_src
@@ -305,7 +305,7 @@ class Memlet(object):
             else:
                 result.volume = num_accesses
         else:
-            result.volume = result._subset.num_elements()
+            result.volume = result.subset.num_elements()
 
         if wcr_str is not None:
             if isinstance(wcr_str, ast.AST):
@@ -413,10 +413,10 @@ class Memlet(object):
         is_data_src = False
         is_data_dst = False
         if isinstance(path[0].src, AccessNode):
-            if path[0].src.data == self._data:
+            if path[0].src.data == self.data:
                 is_data_src = True
         if isinstance(path[-1].dst, AccessNode):
-            if path[-1].dst.data == self._data:
+            if path[-1].dst.data == self.data:
                 is_data_dst = True
         if is_data_src and is_data_dst:
             # In case both point to the same array,

--- a/dace/optimization/data_layout_tuner.py
+++ b/dace/optimization/data_layout_tuner.py
@@ -143,7 +143,7 @@ class DataLayoutTuner(cutout_tuner.CutoutTuner):
         modified_arrays, new_arrays = config
 
         # Modify data layout prior to calling
-        cutout._arrays = new_arrays
+        cutout.arrays = new_arrays
         for marray in modified_arrays:
             arguments[marray] = dt.make_array_from_descriptor(cutout.arrays[marray], arguments[marray])
 

--- a/dace/properties.py
+++ b/dace/properties.py
@@ -142,11 +142,6 @@ class Property(Generic[T]):
             # Called on the class rather than an instance, so return the
             # property object itself
             return self
-        # If a custom getter is specified, use it
-        if self.getter:
-            return self.getter(obj)
-        if not hasattr(self, "attr_name"):
-            raise RuntimeError("Attribute name not set")
         # Otherwise look for attribute prefixed by "_"
         return getattr(obj, "_" + self.attr_name)
 

--- a/dace/sdfg/analysis/cutout.py
+++ b/dace/sdfg/analysis/cutout.py
@@ -841,8 +841,8 @@ def _create_alibi_access_node_for_edge(target_sdfg: SDFG, target_state: SDFGStat
     original_edge.data
     access_size = original_edge.data.subset.size_exact()
     container_name = '__cutout_' + str(original_edge.data.data)
-    container_name = data.find_new_name(container_name, target_sdfg._arrays.keys())
-    original_array = original_sdfg._arrays[original_edge.data.data]
+    container_name = data.find_new_name(container_name, target_sdfg.arrays.keys())
+    original_array = original_sdfg.arrays[original_edge.data.data]
     memlet_str = ''
     if original_edge.data.subset.num_elements_exact() > 1:
         access_size = original_edge.data.subset.size_exact()

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -65,6 +65,8 @@ class Node(object):
             if k == 'guid':  # Skip ID
                 continue
             setattr(result, k, dcpy(v, memo))
+        # Generate new guid for the copy
+        result.guid = graph.generate_element_id(result)
         return result
 
     def validate(self, sdfg, state):
@@ -303,15 +305,15 @@ class AccessNode(Node):
 
     def __deepcopy__(self, memo):
         node = object.__new__(AccessNode)
-        node._data = self._data
-        node._setzero = self._setzero
-        node._instrument = self._instrument
-        node._instrument_condition = dcpy(self._instrument_condition, memo=memo)
-        node._in_connectors = dcpy(self._in_connectors, memo=memo)
-        node._out_connectors = dcpy(self._out_connectors, memo=memo)
-        node._debuginfo = dcpy(self._debuginfo, memo=memo)
+        node.data = self.data
+        node.setzero = self.setzero
+        node.instrument = self.instrument
+        node.instrument_condition = dcpy(self.instrument_condition, memo=memo)
+        node.in_connectors = dcpy(self.in_connectors, memo=memo)
+        node.out_connectors = dcpy(self.out_connectors, memo=memo)
+        node.debuginfo = dcpy(self.debuginfo, memo=memo)
 
-        node._guid = graph.generate_element_id(node)
+        node.guid = graph.generate_element_id(node)
 
         return node
 
@@ -656,6 +658,8 @@ class NestedSDFG(CodeNode):
             setattr(result, k, dcpy(v, memo))
         if result._sdfg is not None:
             result._sdfg.parent_nsdfg_node = result
+        # Generate new guid for the copy
+        result.guid = graph.generate_element_id(result)
         return result
 
     @staticmethod
@@ -1077,8 +1081,7 @@ class Map(object):
 
     def __str__(self):
         return self.label + "[" + ", ".join(
-            ["{}={}".format(i, r)
-             for i, r in zip(self._params, [sbs.Range.dim_to_string(d) for d in self._range])]) + "]"
+            ["{}={}".format(i, r) for i, r in zip(self.params, [sbs.Range.dim_to_string(d) for d in self.range])]) + "]"
 
     def __repr__(self):
         return type(self).__name__ + ' (' + self.__str__() + ')'

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -656,8 +656,8 @@ class NestedSDFG(CodeNode):
             if k in ('guid', ):
                 continue
             setattr(result, k, dcpy(v, memo))
-        if result._sdfg is not None:
-            result._sdfg.parent_nsdfg_node = result
+        if result.sdfg is not None:
+            result.sdfg.parent_nsdfg_node = result
         # Generate new guid for the copy
         result.guid = graph.generate_element_id(result)
         return result

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -457,7 +457,7 @@ class Tasklet(CodeNode):
 
     @property
     def name(self):
-        return self._label
+        return self.label
 
     def validate(self, sdfg: 'dace.sdfg.SDFG', state: 'dace.sdfg.SDFGState'):
         if not dtypes.validate_name(self.label):
@@ -1295,9 +1295,9 @@ class Consume(object):
     def __str__(self):
         if self.condition is not None:
             return ("%s [%s=0:%s], Condition: %s" %
-                    (self._label, self.pe_index, self.num_pes, CodeProperty.to_string(self.condition)))
+                    (self.label, self.pe_index, self.num_pes, CodeProperty.to_string(self.condition)))
         else:
-            return ("%s [%s=0:%s]" % (self._label, self.pe_index, self.num_pes))
+            return ("%s [%s=0:%s]" % (self.label, self.pe_index, self.num_pes))
 
     def validate(self, sdfg, state, node):
         if not dtypes.validate_name(self.label):

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -220,6 +220,8 @@ class InterstateEdge(object):
             if k == 'guid':  # Skip ID
                 continue
             setattr(result, k, copy.deepcopy(v, memo))
+        # Generate new guid for the copy
+        result.guid = generate_element_id(result)
         return result
 
     @staticmethod
@@ -571,7 +573,7 @@ class SDFG(ControlFlowRegion):
         for k, v in self.__dict__.items():
             # Skip derivative attributes and GUID
             if k in ('_cached_start_block', '_edges', '_nodes', '_parent', '_parent_sdfg', '_parent_nsdfg_node',
-                     '_cfg_list', '_transformation_hist', 'guid'):
+                     '_cfg_list', 'transformation_hist', 'guid'):
                 continue
             setattr(result, k, copy.deepcopy(v, memo))
         # Copy edges and nodes
@@ -585,8 +587,8 @@ class SDFG(ControlFlowRegion):
             else:
                 setattr(result, k, None)
         # Copy SDFG list and transformation history
-        if hasattr(self, '_transformation_hist'):
-            setattr(result, '_transformation_hist', copy.deepcopy(self._transformation_hist, memo))
+        if hasattr(self, 'transformation_hist'):
+            setattr(result, 'transformation_hist', copy.deepcopy(self.transformation_hist, memo))
         result._cfg_list = []
         if self._parent_sdfg is None:
             # Avoid import loops
@@ -596,6 +598,9 @@ class SDFG(ControlFlowRegion):
             fixed = FixNestedSDFGReferences().apply_pass(result, {})
             if fixed:
                 warnings.warn(f'Fixed {fixed} nested SDFG parent references during deep copy.')
+
+        # Generate new guid for the copy
+        result.guid = generate_element_id(result)
 
         return result
 

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1313,6 +1313,10 @@ class ControlFlowBlock(BlockGraphView, abc.ABC):
             else:
                 setattr(result, k, None)
 
+        # Generate new guid for the copy
+        from dace.sdfg import graph
+        result.guid = graph.generate_element_id(result)
+
         return result
 
     @property

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1554,7 +1554,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         from dace.sdfg import SDFG
         arrays = set(n.data for n in self.data_nodes())
         sdfg = SDFG(self.label)
-        sdfg._arrays = dace.sdfg.NestedDict({k: self.sdfg.arrays[k] for k in arrays})
+        sdfg.arrays = dace.sdfg.NestedDict({k: self.sdfg.arrays[k] for k in arrays})
         sdfg.add_node(self)
 
         return sdfg._repr_html_()
@@ -2367,8 +2367,8 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             'The "SDFGState.add_array" API is deprecated, please '
             'use "SDFG.add_array" and "SDFGState.add_access"', DeprecationWarning)
         # Workaround to allow this legacy API
-        if name in self.sdfg._arrays:
-            del self.sdfg._arrays[name]
+        if name in self.sdfg.arrays:
+            del self.sdfg.arrays[name]
         self.sdfg.add_array(name,
                             shape,
                             dtype,
@@ -2400,8 +2400,8 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             'The "SDFGState.add_stream" API is deprecated, please '
             'use "SDFG.add_stream" and "SDFGState.add_access"', DeprecationWarning)
         # Workaround to allow this legacy API
-        if name in self.sdfg._arrays:
-            del self.sdfg._arrays[name]
+        if name in self.sdfg.arrays:
+            del self.sdfg.arrays[name]
         self.sdfg.add_stream(
             name,
             dtype,
@@ -2429,8 +2429,8 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             'The "SDFGState.add_scalar" API is deprecated, please '
             'use "SDFG.add_scalar" and "SDFGState.add_access"', DeprecationWarning)
         # Workaround to allow this legacy API
-        if name in self.sdfg._arrays:
-            del self.sdfg._arrays[name]
+        if name in self.sdfg.arrays:
+            del self.sdfg.arrays[name]
         self.sdfg.add_scalar(name, dtype, storage, transient, lifetime, debuginfo)
         return self.add_access(name, debuginfo)
 

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -252,7 +252,7 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
 
         # Check the names of data descriptors and co.
         seen_names: Set[str] = set()
-        for obj_names in [sdfg.arrays.keys(), sdfg.symbols.keys(), sdfg._rdistrarrays.keys(), sdfg._subarrays.keys()]:
+        for obj_names in [sdfg.arrays.keys(), sdfg.symbols.keys(), sdfg.rdistrarrays.keys(), sdfg.subarrays.keys()]:
             if not seen_names.isdisjoint(obj_names):
                 raise InvalidSDFGError(
                     f'Found duplicated names: "{seen_names.intersection(obj_names)}". Please ensure '
@@ -275,7 +275,7 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
                 warnings.warn(f'Found constant "{const_name}" that does not refer to an array or a symbol.')
 
         # Validate data descriptors
-        for name, desc in sdfg._arrays.items():
+        for name, desc in sdfg.arrays.items():
             if id(desc) in references:
                 raise InvalidSDFGError(
                     f'Duplicate data descriptor object detected: "{name}". Please copy objects '

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -436,7 +436,7 @@ def validate_state(state: 'dace.sdfg.SDFGState',
             'rather than using multiple references to the same one', sdfg, state_id)
     references.add(id(state))
 
-    if not dtypes.validate_name(state._label):
+    if not dtypes.validate_name(state.label):
         raise InvalidSDFGError("Invalid state name", sdfg, state_id)
 
     if state.sdfg != sdfg:

--- a/dace/serialize.py
+++ b/dace/serialize.py
@@ -98,7 +98,7 @@ def to_json(obj):
         # If the object knows how to convert itself, let it. By calling the
         # method directly on the type, this works for both static and
         # non-static implementations of to_json.
-        return type(obj).to_json(obj)
+        return obj.to_json()
     elif type(obj) in {bool, int, float, list, dict, str}:
         # Some types are natively understood by JSON
         return obj

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -755,8 +755,8 @@ def state_fission(
     for second_state_boundary_node in boundary_nodes:
         first_state_boundary_node = first_nodes_map[second_state_boundary_node]
         assert second_state.in_degree(second_state_boundary_node) == 0
-        first_state_boundary_node._out_connectors.clear()
-        second_state_boundary_node._in_connectors.clear()
+        first_state_boundary_node.out_connectors.clear()
+        second_state_boundary_node.in_connectors.clear()
 
     # Remove isolated nodes.
     # TODO(phimuell): Is this the best approach, it might be a bit too far reaching.

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1887,12 +1887,12 @@ def _change_sdfg_type(sdfg: SDFG, from_type: typeclass, to_type: typeclass, swap
             swaps_count += 1
 
     # Swap structures and structure views
-    for array_desc in sdfg._arrays.values():
+    for array_desc in sdfg.arrays.values():
         if _is_structure(array_desc) or _is_structure_view(array_desc):
             swaps_count = _change_structure_type(array_desc, from_type, to_type, swaps_count)
 
     # Change dace.data.struct field types
-    for array_desc in sdfg._arrays.values():
+    for array_desc in sdfg.arrays.values():
         if _is_structure(array_desc):
             if _is_pointer(array_desc.dtype):
                 if isinstance(array_desc.dtype.base_type, dtypes.struct):

--- a/dace/transformation/interstate/multistate_inline.py
+++ b/dace/transformation/interstate/multistate_inline.py
@@ -161,7 +161,7 @@ class InlineMultistateSDFG(transformation.SingleStateTransformation):
             sdfg.append_exit_code(code.code, loc)
 
         # Callbacks and other types
-        sdfg._callback_mapping.update(nsdfg.callback_mapping)
+        sdfg.callback_mapping.update(nsdfg.callback_mapping)
 
         # Environments
         for nstate in nsdfg.states():

--- a/dace/transformation/interstate/sdfg_nesting.py
+++ b/dace/transformation/interstate/sdfg_nesting.py
@@ -263,7 +263,7 @@ class InlineSDFG(transformation.SingleStateTransformation):
             sdfg.append_exit_code(code.code, loc)
 
         # Callbacks and other types
-        sdfg._callback_mapping.update(nsdfg.callback_mapping)
+        sdfg.callback_mapping.update(nsdfg.callback_mapping)
 
         # Environments
         for node in nstate.nodes():

--- a/dace/transformation/subgraph/expansion.py
+++ b/dace/transformation/subgraph/expansion.py
@@ -308,7 +308,7 @@ class MultiExpansion(transformation.SubgraphTransformation):
             for edge in dynamic_edges:
                 # Remove old edge and connector
                 graph.remove_edge(edge)
-                edge.dst._in_connectors.remove(edge.dst_conn)
+                edge.dst.in_connectors.remove(edge.dst_conn)
 
                 # Propagate to each range it belongs to
                 path = []


### PR DESCRIPTION
Move property getters/setters to enclosing class. If a property does not have a custom getter/setter, do not use a Python descriptor (which would make getting properties faster).
