### PR TITLE
Fix error raised for malformed conditional blocks

### DIFF
--- a/dace/transformation/passes/dead_state_elimination.py
+++ b/dace/transformation/passes/dead_state_elimination.py
@@ -169,7 +169,12 @@ class DeadStateElimination(ppl.Pass):
         for i, (cond, branch) in enumerate(block.branches):
             if cond is None:
                 if not i == len(block.branches) - 1:
-                    raise InvalidSDFGNodeError('Conditional block detected, where else branch is not the last branch')
+                    raise InvalidSDFGNodeError(
+                        'Conditional block detected, where else branch is not the last branch.',
+                        sdfg=block.sdfg,
+                        state_id=block.block_id,
+                        node_id=None,
+                    )
                 break
             # If an unconditional branch is found, ignore all other branches that follow this one.
             if self._is_definitely_true(symbolic.pystr_to_symbolic(cond.as_string), block.sdfg):


### PR DESCRIPTION
This PR fixes an error raised inside dead state elimination when a malformed conditional block is detected. Previously, the error wouldn't be raised correctly because `InvalidSDFGNodeError` was missing the required arguments `sdfg`, `state_id`, and `node_id`.