### PR TITLE
MapFusion: only warn when class is instantiated

### DIFF
--- a/dace/transformation/dataflow/map_fusion.py
+++ b/dace/transformation/dataflow/map_fusion.py
@@ -1,24 +1,21 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 
-import dace
 import warnings
-from dace.transformation import dataflow as dftrans
+from typing import Any
 
-try:
-    from warnings import deprecated
-except ImportError:
-
-    def deprecated(msg):
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        return lambda cls: cls
+from dace.transformation.dataflow import MapFusionVertical
 
 
-@deprecated('MapFusion is deprecated please use MapFusionVertical instead.')
-class MapFusion(dftrans.MapFusionVertical):
+class MapFusion(MapFusionVertical):
     """Compatibility layer for deprecated `MapFusion` name.
 
     Before there was `MapFusionHorizontal` there was only `MapFusion`, which performed the
     same operations as `MapFusionVertical`. To enable a smooth transition, this deprecated
     alias is provided.
     """
-    pass
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Deprecated: use `MapFusionVertical` instead."""
+        super().__init__(*args, **kwargs)
+
+        warnings.warn('MapFusion is deprecated please use MapFusionVertical instead.', DeprecationWarning, stacklevel=2)

--- a/dace/transformation/dataflow/map_fusion_vertical.py
+++ b/dace/transformation/dataflow/map_fusion_vertical.py
@@ -70,7 +70,7 @@ class MapFusionVertical(transformation.SingleStateTransformation):
     :param assume_always_shared: Handle all intermediate nodes as if they were classified as
         "shared", see `partition_first_outputs()` for more.
     :param require_exclusive_intermediates: If `True` then the transformation will only apply
-        if all intermediates are "eclusive", i.e., can be removed, see `partition_first_outputs()`.
+        if all intermediates are "exclusive", i.e., can be removed, see `partition_first_outputs()`.
     :param require_all_intermediates: If `True` then the transformation will only apply if
         all outputs of the first Map are intermediate, i.e., are consumed by the second Map.
     :param consolidate_edges_only_if_not_extending: If `True` the transformation will only

--- a/tests/buffer_tiling_test.py
+++ b/tests/buffer_tiling_test.py
@@ -2,7 +2,6 @@
 import numpy as np
 
 import dace
-from dace.sdfg import nodes
 from dace.transformation.dataflow import BufferTiling
 
 I = dace.symbol("I")

--- a/tests/transformations/map_fusion_vertical_test.py
+++ b/tests/transformations/map_fusion_vertical_test.py
@@ -7,12 +7,11 @@ import dace
 import copy
 import uuid
 import pytest
-import gc
 import uuid
 
 from dace import SDFG, SDFGState, data as dace_data, symbolic as dace_symbolic
 from dace.sdfg import nodes
-from dace.transformation.dataflow import MapFusionVertical, MapExpansion
+from dace.transformation.dataflow import MapFusion, MapFusionVertical, MapExpansion
 
 
 def count_nodes(
@@ -3215,6 +3214,11 @@ def test_map_fusion_stable_label(forward_fusion: bool):
     assert all(np.allclose(ref[k], res[k]) for k in ref)
 
 
+def test_map_fusion_is_deprecated() -> None:
+    with pytest.deprecated_call(match="MapFusion is deprecated"):
+        MapFusion()
+
+
 if __name__ == '__main__':
     test_fusion_intrinsic_memlet_direction()
     test_fusion_dynamic_producer()
@@ -3262,3 +3266,4 @@ if __name__ == '__main__':
     test_map_fusion_multiple_top_level_connections_with_shared_intermediate(False)
     test_map_fusion_stable_label(forward_fusion=True)
     test_map_fusion_stable_label(forward_fusion=False)
+    test_map_fusion_is_deprecated()


### PR DESCRIPTION
`MapFusion` is deprecated and `MapFusionVertical` should be used instead. `MapFusion` remains in the cobase as a compatibility layer for backwards compatibility.

This PR changes the way how `MapFusion` is deprecated. Previously, a warning would be emitted whenever the class was loaded (e.g. when access from `dace/transformation/dataflow/__init__.py`. Depending on how verbose pytest is configured, one would thus see a deprecation warning even if `MapFusion` was never actually used/instantiated. The PR suggests to only emit a warning upon class init.

The unrelated change in `tests/buffer_tiling_test.py` (unused import) is because I used test in there to make sure the warning disappears.

/cc @philip-paul-mueller FYI