### PR TITLE
Drop support for python versions < 3.10

### DIFF
--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -76,8 +76,6 @@ import six
 import sys
 import ast
 import numpy as np
-import os
-import tokenize
 import warnings
 
 import sympy
@@ -86,12 +84,6 @@ from numbers import Number
 from six import StringIO
 from dace import dtypes
 from dace.sdfg import type_inference
-
-BytesConstant = ast.Constant
-EllipsisConstant = ast.Constant
-NameConstant = ast.Constant
-NumConstant = ast.Constant
-StrConstant = ast.Constant
 
 # Large float and imaginary literals get turned into infinities in the AST.
 # We unparse those infinities to INFSTR.
@@ -570,7 +562,7 @@ class CPPUnparser:
             self.write('/* async */ ')
 
         if getattr(t, "returns", False):
-            if isinstance(t.returns, NameConstant):
+            if isinstance(t.returns, ast.Constant):
                 if t.returns.value is None:
                     self.write('void')
                 else:
@@ -717,9 +709,6 @@ class CPPUnparser:
             self.write(_py2c_reserved[t.id])
         else:
             self.write(t.id)
-
-    def _NameConstant(self, t):
-        self.write(_py2c_nameconst[t.value])
 
     def _Repr(self, t):
         raise NotImplementedError('Invalid C++')
@@ -887,12 +876,12 @@ class CPPUnparser:
             self.write(")")
         # Special cases for powers
         elif t.op.__class__.__name__ == 'Pow':
-            if isinstance(t.right, (NumConstant, ast.Constant, ast.UnaryOp)):
+            if isinstance(t.right, (ast.Constant, ast.UnaryOp)):
                 power = None
-                if isinstance(t.right, (NumConstant, ast.Constant)):
+                if isinstance(t.right, ast.Constant):
                     power = t.right.value
                 elif isinstance(t.right, ast.UnaryOp) and isinstance(t.right.op, ast.USub):
-                    if isinstance(t.right.operand, (NumConstant, ast.Constant)):
+                    if isinstance(t.right.operand, ast.Constant):
                         power = -(t.right.operand.value)
 
                 if power is not None and int(power) == power:

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -8,12 +8,9 @@ import inspect
 import numbers
 import numpy
 import sympy
-import sys
 from typing import Any, Dict, List, Optional, Set, Union
 
 from dace import symbolic
-
-NumConstant = ast.Constant
 
 
 def _remove_outer_indentation(src: str):
@@ -424,10 +421,6 @@ def copy_tree(node: ast.AST) -> ast.AST:
 
     class Copier(ast.NodeTransformer):
 
-        def visit_Num(self, node):
-            # Ignore n
-            return ast.copy_location(ast.Num(n=node.n), node)
-
         def visit_Constant(self, node):
             # Ignore value
             return ast.copy_location(ast.Constant(value=node.value, kind=node.kind), node)
@@ -676,10 +669,7 @@ class ConstantExtractor(ast.NodeTransformer):
             raise SyntaxError
         return self.generic_visit(node)
 
-    def visit_Constant(self, node):
-        return self.visit_Num(node)
-
-    def visit_Num(self, node: NumConstant):
+    def visit_Constant(self, node: ast.Constant):
         newname = f'__uu{self.id}'
         self.gvars[newname] = node.value
         self.id += 1

--- a/dace/frontend/python/memlet_parser.py
+++ b/dace/frontend/python/memlet_parser.py
@@ -1,8 +1,6 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
 import copy
-import sys
-from collections import namedtuple
 from typing import Any, Dict, List, Optional, Tuple, Union
 from dataclasses import dataclass
 
@@ -14,13 +12,6 @@ from dace.symbolic import pystr_to_symbolic, SymbolicType
 from dace.frontend.python.common import DaceSyntaxError
 
 MemletType = Union[ast.Call, ast.Attribute, ast.Subscript, ast.Name]
-
-_simple_ast_nodes = (ast.Constant, ast.Name)
-BytesConstant = ast.Constant
-EllipsisConstant = ast.Constant
-NameConstant = ast.Constant
-NumConstant = ast.Constant
-StrConstant = ast.Constant
 
 
 @dataclass
@@ -101,7 +92,7 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
 
     # Count new axes
     num_new_axes = sum(1 for dim in ast_ndslice
-                       if (dim is None or (isinstance(dim, (ast.Constant, NameConstant)) and dim.value is None)))
+                       if (dim is None or (isinstance(dim, ast.Constant) and dim.value is None)))
 
     for dim in ast_ndslice:
         if isinstance(dim, (str, list, slice)):
@@ -136,7 +127,7 @@ def _fill_missing_slices(das, ast_ndslice, array, indices):
                 ndslice[j] = (0, array.shape[j] - 1, 1)
                 idx += 1
                 new_idx += 1
-        elif (dim is None or (isinstance(dim, (ast.Constant, NameConstant)) and dim.value is None)):
+        elif (dim is None or (isinstance(dim, ast.Constant) and dim.value is None)):
             new_axes.append(new_idx)
             new_idx += 1
             # NOTE: Do not increment idx here

--- a/dace/frontend/python/ndloop.py
+++ b/dace/frontend/python/ndloop.py
@@ -1,24 +1,17 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 """ A single generator that creates an N-dimensional for loop in Python. """
 import itertools
-import numpy as np
-from typing import List, Tuple, Union
-
-# Python 3 compatibility for xrange
-try:
-    xxrange = xrange
-except NameError:
-    xxrange = range
+from typing import Tuple, Union
 
 
 def slicetoxrange(s):
     """ Helper function that turns a slice into a range (for iteration). """
     if isinstance(s, int):
-        return xxrange(s, s + 1)
+        return range(s, s + 1)
 
     ifnone = lambda a, b: b if a is None else a
 
-    return xxrange(ifnone(s.start, 0), s.stop, ifnone(s.step, 1))
+    return range(ifnone(s.start, 0), s.stop, ifnone(s.step, 1))
 
 
 def NDLoop(ndslice, internal_function, *args, **kwargs):

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -8,22 +8,15 @@ import numbers
 import numpy
 import re
 import sympy
-import sys
 import warnings
 
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import dace
-from dace import data, dtypes, subsets, symbolic, sdfg as sd
+from dace import data, dtypes, symbolic, sdfg
 from dace.config import Config
 from dace.sdfg import SDFG
 from dace.frontend.python import astutils
 from dace.frontend.python.common import (DaceSyntaxError, SDFGConvertible, SDFGClosure, StringLiteral)
-
-BytesConstant = ast.Constant
-EllipsisConstant = ast.Constant
-NameConstant = ast.Constant
-NumConstant = ast.Constant
-StrConstant = ast.Constant
 
 
 class DaceRecursionError(Exception):
@@ -142,14 +135,6 @@ class RewriteSympyEquality(ast.NodeTransformer):
             node.value = bool(node.value)
         elif isinstance(node.value, numpy.number):
             node.value = node.value.item()
-        return self.generic_visit(node)
-
-    # Compatibility for Python 3.7
-    def visit_Num(self, node):
-        if isinstance(node.n, numpy.bool_):
-            node.n = bool(node.n)
-        elif isinstance(node.n, numpy.number):
-            node.n = node.n.item()
         return self.generic_visit(node)
 
 
@@ -1381,7 +1366,7 @@ class CallTreeResolver(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call):
         # Only parse calls to parsed SDFGConvertibles
-        if not isinstance(node.func, (NumConstant, ast.Constant)):
+        if not isinstance(node.func, ast.Constant):
             self.seen_calls.add(astutils.unparse(node.func))
             return self.generic_visit(node)
         if hasattr(node.func, 'oldnode'):

--- a/dace/libraries/stencil/subscript_converter.py
+++ b/dace/libraries/stencil/subscript_converter.py
@@ -1,15 +1,7 @@
 # Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
-import sys
 from collections import defaultdict
 from typing import Tuple
-
-_simple_ast_nodes = (ast.Constant, ast.Name)
-BytesConstant = ast.Constant
-EllipsisConstant = ast.Constant
-NameConstant = ast.Constant
-NumConstant = ast.Constant
-StrConstant = ast.Constant
 
 Index = type(None)
 ExtSlice = type(None)
@@ -81,7 +73,7 @@ class SubscriptConverter(ast.NodeTransformer):
         index_tuple = node.slice
         if isinstance(index_tuple, (ast.Subscript, Index)):
             index_tuple = index_tuple.value
-        if isinstance(index_tuple, (ast.Constant, NumConstant)):
+        if isinstance(index_tuple, ast.Constant):
             index_tuple = (index_tuple, )
         if isinstance(index_tuple, ast.Tuple):
             index_tuple = index_tuple.elts

--- a/dace/sdfg/analysis/writeset_underapproximation.py
+++ b/dace/sdfg/analysis/writeset_underapproximation.py
@@ -6,7 +6,6 @@ Pass derived from ``propagation.py`` that under-approximates write-sets of for-l
 import copy
 from dataclasses import dataclass, field
 import itertools
-import sys
 import warnings
 from collections import defaultdict
 from typing import Dict, List, Set, Tuple, Union

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -2,7 +2,6 @@
 import ast
 from collections import Counter
 from functools import lru_cache
-import sys
 import sympy
 import pickle
 import re

--- a/tests/python_frontend/method_test.py
+++ b/tests/python_frontend/method_test.py
@@ -3,7 +3,6 @@
 import pytest
 import dace
 import numpy as np
-import sys
 import time
 
 


### PR DESCRIPTION
In particular, this get rid of a bunch of if/else blocks with breaking changes in python 3.8 and 3.9.