### PR TITLE
Add a config option for storing lineinfo into the SDFG

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -212,7 +212,7 @@ required:
                 description: >
                     Specify the default data types to use in generating code.
                     If "Python", Python's semantics will be followed (i.e., `float`  and `int`
-                    are represented using 64 bits). If the property is set to "C", C's semantcs will be
+                    are represented using 64 bits). If the property is set to "C", C's semantics will be
                     used (`float` and `int` are represented using 32bits).
 
             unique_functions:
@@ -261,6 +261,18 @@ required:
                 description: >
                     If set, specifies additional arguments to the initial invocation
                     of ``cmake``.
+
+            lineinfo:
+                type: str
+                default: "inspect"
+                title: Add line info
+                description: >
+                    Wether or not to add line info from the parsed code in the
+                    generated SDFG. Valid options are `inspect` and `none`.
+                    "inspect": During parsing, inspect the python call stack and
+                    automatically add line info from the parsed source code in the
+                    resulting SDFG.
+                    "none": Do not save any line info in the resulting SDFG.
 
             #############################################
             # CPU compiler

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -9,8 +9,8 @@ import inspect
 import itertools
 import warnings
 import sympy
-from typing import (TYPE_CHECKING, Any, AnyStr, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union,
-                    overload)
+from typing import (TYPE_CHECKING, Any, AnyStr, Callable, Dict, Iterable, Iterator, List, Literal, Optional, Set, Tuple,
+                    Union, overload)
 
 import dace
 from dace.frontend.python import astutils
@@ -39,20 +39,34 @@ if TYPE_CHECKING:
 NodeT = Union[nd.Node, 'ControlFlowBlock']
 EdgeT = Union[MultiConnectorEdge[mm.Memlet], Edge['dace.sdfg.InterstateEdge']]
 GraphT = Union['ControlFlowRegion', 'SDFGState']
+ConfigurableDebugInfo = Literal["config", "inspect", "none"] | dtypes.DebugInfo | None
 
 
-def _getdebuginfo(old_dinfo=None) -> dtypes.DebugInfo:
-    """ Returns a DebugInfo object for the position that called this function.
+def _get_debug_info(
+    debug_info: ConfigurableDebugInfo,
+    default_lineinfo: dtypes.DebugInfo | None,
+) -> dtypes.DebugInfo | None:
+    """...TODO..."""
 
-        :param old_dinfo: Another DebugInfo object that will override the
-                          return value of this function
-        :return: DebugInfo containing line number and calling file.
-    """
-    if old_dinfo is not None:
-        return old_dinfo
+    if isinstance(debug_info, dtypes.DebugInfo):
+        warnings.warn(
+            "Passing debug_info of type DebugInfo is deprecated. Use one of `'config'`, `'inspect'`, or `'none'` instead.",
+            DeprecationWarning,
+            stacklevel=3)
+        return debug_info
 
-    caller = inspect.getframeinfo(inspect.stack()[2][0], context=0)
-    return dtypes.DebugInfo(caller.lineno, 0, caller.lineno, 0, caller.filename)
+    if debug_info is None:
+        warnings.warn("Passing debug_info=None is deprecated", DeprecationWarning, stacklevel=3)
+
+    do_inspect = debug_info == "inspect" or debug_info == "config"  # TODO: (if config and config is not release)
+    if (debug_info is None or do_inspect) and default_lineinfo is not None:
+        return default_lineinfo
+
+    if do_inspect:
+        caller = inspect.getframeinfo(inspect.stack()[2][0], context=0)
+        return dtypes.DebugInfo(caller.lineno, 0, caller.lineno, 0, caller.filename)
+
+    return None
 
 
 def _make_iterators(ndrange):
@@ -1617,7 +1631,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
 
     # Dynamic SDFG creation API
     ##############################
-    def add_read(self, array_or_stream_name: str, debuginfo: Optional[dtypes.DebugInfo] = None) -> nd.AccessNode:
+    def add_read(self, array_or_stream_name: str, debuginfo: ConfigurableDebugInfo = "config") -> nd.AccessNode:
         """
         Adds an access node to this SDFG state (alias of ``add_access``).
 
@@ -1626,10 +1640,9 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         :return: An array access node.
         :see: add_access
         """
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
         return self.add_access(array_or_stream_name, debuginfo=debuginfo)
 
-    def add_write(self, array_or_stream_name: str, debuginfo: Optional[dtypes.DebugInfo] = None) -> nd.AccessNode:
+    def add_write(self, array_or_stream_name: str, debuginfo: ConfigurableDebugInfo = "config") -> nd.AccessNode:
         """
         Adds an access node to this SDFG state (alias of ``add_access``).
 
@@ -1638,17 +1651,16 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         :return: An array access node.
         :see: add_access
         """
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
         return self.add_access(array_or_stream_name, debuginfo=debuginfo)
 
-    def add_access(self, array_or_stream_name: str, debuginfo: Optional[dtypes.DebugInfo] = None) -> nd.AccessNode:
+    def add_access(self, array_or_stream_name: str, debuginfo: ConfigurableDebugInfo = "config") -> nd.AccessNode:
         """ Adds an access node to this SDFG state.
 
             :param array_or_stream_name: The name of the array/stream.
             :param debuginfo: Source line information for this access node.
             :return: An array access node.
         """
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
         node = nd.AccessNode(array_or_stream_name, debuginfo=debuginfo)
         self.add_node(node)
         return node
@@ -1666,10 +1678,10 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         code_exit: str = "",
         location: dict = None,
         side_effects: Optional[bool] = None,
-        debuginfo=None,
+        debuginfo: ConfigurableDebugInfo = "config",
     ):
         """ Adds a tasklet to the SDFG state. """
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
 
         # Make dictionary of autodetect connector types from set
         if isinstance(inputs, (set, collections.abc.KeysView)):
@@ -1715,7 +1727,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         symbol_mapping: Dict[str, Any] = None,
         name=None,
         location: Optional[Dict[str, symbolic.SymbolicType]] = None,
-        debuginfo: Optional[dtypes.DebugInfo] = None,
+        debuginfo: ConfigurableDebugInfo = "config",
         external_path: Optional[str] = None,
     ):
         """
@@ -1738,7 +1750,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         """
         if name is None:
             name = sdfg.label
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
 
         if sdfg is None and external_path is None:
             raise ValueError('Neither an SDFG nor an external SDFG path has been provided')
@@ -1802,7 +1814,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         ndrange: Union[Dict[str, Union[str, sbs.Subset]], List[Tuple[str, Union[str, sbs.Subset]]]],
         schedule=dtypes.ScheduleType.Default,
         unroll=False,
-        debuginfo=None,
+        debuginfo: ConfigurableDebugInfo = "config",
     ) -> Tuple[nd.MapEntry, nd.MapExit]:
         """ Adds a map entry and map exit.
 
@@ -1814,21 +1826,23 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
 
             :return: (map_entry, map_exit) node 2-tuple
         """
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
         map = nd.Map(name, *_make_iterators(ndrange), schedule=schedule, unroll=unroll, debuginfo=debuginfo)
         map_entry = nd.MapEntry(map)
         map_exit = nd.MapExit(map)
         self.add_nodes_from([map_entry, map_exit])
         return map_entry, map_exit
 
-    def add_consume(self,
-                    name,
-                    elements: Tuple[str, str],
-                    condition: str = None,
-                    schedule=dtypes.ScheduleType.Default,
-                    chunksize=1,
-                    debuginfo=None,
-                    language=dtypes.Language.Python) -> Tuple[nd.ConsumeEntry, nd.ConsumeExit]:
+    def add_consume(
+        self,
+        name,
+        elements: Tuple[str, str],
+        condition: str = None,
+        schedule=dtypes.ScheduleType.Default,
+        chunksize=1,
+        debuginfo: ConfigurableDebugInfo = "config",
+        language=dtypes.Language.Python,
+    ) -> Tuple[nd.ConsumeEntry, nd.ConsumeExit]:
         """ Adds consume entry and consume exit nodes.
 
             :param name:      Label
@@ -1850,7 +1864,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
                             "(PE_index, num_PEs)")
         pe_tuple = (elements[0], SymbolicProperty.from_string(elements[1]))
 
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
         if condition is not None:
             condition = CodeBlock(condition, language)
         consume = nd.Consume(name, pe_tuple, condition, schedule, chunksize, debuginfo=debuginfo)
@@ -1860,24 +1874,23 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         self.add_nodes_from([entry, exit])
         return entry, exit
 
-    def add_mapped_tasklet(self,
-                           name: str,
-                           map_ranges: Union[Dict[str, Union[str, sbs.Subset]], List[Tuple[str, Union[str,
-                                                                                                      sbs.Subset]]]],
-                           inputs: Dict[str, mm.Memlet],
-                           code: str,
-                           outputs: Dict[str, mm.Memlet],
-                           schedule=dtypes.ScheduleType.Default,
-                           unroll_map=False,
-                           location=None,
-                           language=dtypes.Language.Python,
-                           debuginfo=None,
-                           external_edges=False,
-                           input_nodes: Optional[Union[Dict[str, nd.AccessNode], List[nd.AccessNode],
-                                                       Set[nd.AccessNode]]] = None,
-                           output_nodes: Optional[Union[Dict[str, nd.AccessNode], List[nd.AccessNode],
-                                                        Set[nd.AccessNode]]] = None,
-                           propagate=True) -> Tuple[nd.Tasklet, nd.MapEntry, nd.MapExit]:
+    def add_mapped_tasklet(
+        self,
+        name: str,
+        map_ranges: Union[Dict[str, Union[str, sbs.Subset]], List[Tuple[str, Union[str, sbs.Subset]]]],
+        inputs: Dict[str, mm.Memlet],
+        code: str,
+        outputs: Dict[str, mm.Memlet],
+        schedule=dtypes.ScheduleType.Default,
+        unroll_map=False,
+        location=None,
+        language=dtypes.Language.Python,
+        debuginfo: ConfigurableDebugInfo = "config",
+        external_edges=False,
+        input_nodes: Optional[Union[Dict[str, nd.AccessNode], List[nd.AccessNode], Set[nd.AccessNode]]] = None,
+        output_nodes: Optional[Union[Dict[str, nd.AccessNode], List[nd.AccessNode], Set[nd.AccessNode]]] = None,
+        propagate=True,
+    ) -> Tuple[nd.Tasklet, nd.MapEntry, nd.MapExit]:
         """ Convenience function that adds a map entry, tasklet, map exit,
             and the respective edges to external arrays.
 
@@ -1910,7 +1923,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :return: tuple of (tasklet, map_entry, map_exit)
         """
         map_name = name + "_map"
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
 
         # Create appropriate dictionaries from inputs
         tinputs = {k: None for k, v in inputs.items()}
@@ -2030,7 +2043,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         axes,
         identity=None,
         schedule=dtypes.ScheduleType.Default,
-        debuginfo=None,
+        debuginfo: ConfigurableDebugInfo = "config",
     ) -> 'dace.libraries.standard.Reduce':
         """ Adds a reduction node.
 
@@ -2044,7 +2057,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :return: A Reduce node
         """
         import dace.libraries.standard as stdlib  # Avoid import loop
-        debuginfo = _getdebuginfo(debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
         result = stdlib.Reduce('Reduce', wcr, axes, identity, schedule=schedule, debuginfo=debuginfo)
         self.add_node(result)
         return result

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -39,26 +39,35 @@ if TYPE_CHECKING:
 NodeT = Union[nd.Node, 'ControlFlowBlock']
 EdgeT = Union[MultiConnectorEdge[mm.Memlet], Edge['dace.sdfg.InterstateEdge']]
 GraphT = Union['ControlFlowRegion', 'SDFGState']
-ConfigurableDebugInfo = Literal["config", "inspect", "none"] | dtypes.DebugInfo | None
+ConfigurableDebugInfo = Literal["config"] | dtypes.DebugInfo | None
 
 
 def _get_debug_info(
     debug_info: ConfigurableDebugInfo,
     default_lineinfo: dtypes.DebugInfo | None,
 ) -> dtypes.DebugInfo | None:
-    """...TODO..."""
+    """Returns a DebugInfo from the stack, if configured.
+
+    If lineinfo is configured in the config, this function inspects the python
+    stacktrace and returns a DebugInfo object for the position that called this
+    function. `default_lineinfo` has precedence, if given.
+    """
 
     if isinstance(debug_info, dtypes.DebugInfo):
         warnings.warn(
-            "Passing debug_info of type DebugInfo is deprecated. Use one of `'config'`, `'inspect'`, or `'none'` instead.",
+            "Passing debug_info of type DebugInfo is deprecated. Pass `'config'` and set `compiler.lineinfo` in your DaCe config.",
             DeprecationWarning,
             stacklevel=3)
         return debug_info
 
     if debug_info is None:
-        warnings.warn("Passing debug_info=None is deprecated", DeprecationWarning, stacklevel=3)
+        warnings.warn(
+            "Passing debug_info=None is deprecated. Pass `'config'` and set `compiler.lineinfo` in your DaCe config.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
-    do_inspect = debug_info == "inspect" or debug_info == "config"  # TODO: (if config and config is not release)
+    do_inspect = dace.Config.get("compiler", "lineinfo") == "inspect" if debug_info == "config" else False
     if (debug_info is None or do_inspect) and default_lineinfo is not None:
         return default_lineinfo
 

--- a/tests/python_frontend/debug_info_test.py
+++ b/tests/python_frontend/debug_info_test.py
@@ -1,0 +1,68 @@
+from dace import SDFG, SDFGState
+from dace import dtypes
+from dace.config import Config, temporary_config
+
+import pytest
+
+
+@pytest.fixture()
+def state() -> SDFGState:
+    """Setup a simple SDFG for testing and return the state."""
+
+    sdfg = SDFG("tester")
+    sdfg.add_array("A", [10], dtypes.int64)
+    sdfg.add_array("B", [15], dtypes.int64)
+
+    return sdfg.add_state("start_here", is_start_block=True)
+
+
+def test_config_compiler_lineinfo_none(state: SDFGState) -> None:
+    with temporary_config():
+        Config.set(*["compiler", "lineinfo"], value="none")
+        node = state.add_access("A")
+        assert node.debuginfo is None
+
+
+def test_config_compiler_lineinfo_inspect(state: SDFGState) -> None:
+    # Ensure "inspect" is the default configuration
+    assert Config.get(*["compiler", "lineinfo"]) == "inspect"
+
+    # Add an access and expect debug info to be added (from this file)
+    node = state.add_access("A")
+    assert node.debuginfo is not None
+    assert node.debuginfo.filename == __file__
+
+
+def test_using_default_lineinfo(state: SDFGState) -> None:
+    line = 42
+    filename = "my/test/path.py"
+    state._default_lineinfo = dtypes.DebugInfo(start_line=line, filename=filename)
+
+    read_A = state.add_read("A")
+    assert read_A.debuginfo is not None
+    assert read_A.debuginfo.filename == filename
+    assert read_A.debuginfo.start_line == line
+
+    with pytest.deprecated_call():
+        read_B = state.add_read("B", None)
+    assert read_B.debuginfo is not None
+    assert read_B.debuginfo.filename == filename
+    assert read_B.debuginfo.start_line == line
+
+
+def test_passing_debug_info_warns(state: SDFGState) -> None:
+    with pytest.deprecated_call():
+        state.add_access("A", debuginfo=dtypes.DebugInfo(start_line=42))
+
+
+def test_passing_None_warns(state: SDFGState) -> None:
+    with pytest.deprecated_call():
+        state.add_access("A", debuginfo=None)
+
+
+if __name__ == "__main__":
+    test_config_compiler_lineinfo_none()
+    test_config_compiler_lineinfo_inspect()
+    test_using_default_lineinfo()
+    test_passing_debug_info_warns()
+    test_passing_None_warns()


### PR DESCRIPTION
When we build an SDFG, there's the option to store `DebugInfo` with some SDFG nodes. For example, this `DebugInfo` can be used to store file & line information of parsed code when building an SDFG. When using the SDFG API, the default is to inspect the python stack and extract file & line information from there. These calls to `inspect` can/will be expensive, especially for bigger graphs.

This PR proposes to add a configuration option, `compiler.lineinfo`, to drive this behavior from a single place. The defaults are kept as is, i.e. we keep inspecting the stack by default. However, the config option allows a central pace to turn `DebugInfo` off, which could be configured in production scenarios.
