### PR TITLE
Reduced Size of SDFG Folder

### DIFF
--- a/dace/codegen/codeobject.py
+++ b/dace/codegen/codeobject.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import re
+import dace
 from dace import sourcemap
 from dace.properties import (Property, DictProperty, SetProperty, make_properties)
 
@@ -45,9 +46,15 @@ class CodeObject(object):
         self.linkable = linkable
         self.environments = environments or set()
 
-        if language == 'cpp' and title == 'Frame' and sdfg:
-            sourcemap.create_maps(sdfg, code, self.target.target_name)
+        # NOTE: In an earlier version, the source maps were generated here. However,
+        #   this had the side effect that the build folder was generated containing
+        #   the source maps, i.e. the `map/` subfolder. However, no code was actually
+        #   dumped to disc. Another effect is that the generation of code would actually
+        #   overwrite the source map, thus it was moved to `generate_program_folder()`.
 
     @property
     def clean_code(self):
         return re.sub(r'[ \t]*////__(DACE:|CODEGEN;)[^\n]*', '', self.code)
+
+    def create_source_map(self, sdfg: 'dace.SDFG') -> None:
+        sourcemap.create_maps(sdfg, self.code, self.target.target_name)

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -39,8 +39,8 @@ class ReloadableDLL(object):
         """
         from dace.codegen.compiler import _get_stub_library_path
 
-        self._library_filename = pathlib.Path(library_filename).resolve()
-        self._stub_filename = _get_stub_library_path(kwargs.pop("libstub_path", self._library_filename))
+        self._library_filename = str(pathlib.Path(library_filename).resolve())
+        self._stub_filename = str(_get_stub_library_path(kwargs.pop("libstub_path", self._library_filename)))
         assert len(kwargs) == 0
 
         self._stub = None

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -40,7 +40,11 @@ class ReloadableDLL(object):
         from dace.codegen.compiler import _get_stub_library_path
 
         self._library_filename = str(pathlib.Path(library_filename).resolve())
-        self._stub_filename = str(_get_stub_library_path(kwargs.pop("libstub_path", self._library_filename)))
+
+        if "libstub_path" in kwargs:
+            self._stub_filename = str(pathlib.Path(kwargs.pop("libstub_path")).resolve())
+        else:
+            self._stub_filename = str(_get_stub_library_path(self._library_filename))
         assert len(kwargs) == 0
 
         self._stub = None

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -27,17 +27,40 @@ class ReloadableDLL(object):
     bypasses Python's dynamic library reloading issues.
     """
 
-    def __init__(self, library_filename, program_name):
+    def __init__(self, library_filename, *program_name, **kwargs):
         """
         Creates a new reloadable shared object.
 
+        The library filename must always be given, but the stub file can either be
+        found by specifing `program_name` or a path directly.
+
         :param library_filename: Path to library file.
-        :param program_name: Name of the DaCe program (for use in finding
-                             the stub library loader).
+        :param program_name: Name of the DaCe program (for use in finding the stub library loader).
+        :param libstub_path: Direct path of the libstub.
         """
-        self._stub_filename = os.path.join(os.path.dirname(os.path.realpath(library_filename)),
-                                           f'libdacestub_{program_name}.{Config.get("compiler", "library_extension")}')
         self._library_filename = os.path.realpath(library_filename)
+
+        prog_name, libstub_path = None, None
+        if len(program_name) != 0:
+            assert len(program_name) == 1
+            assert len(kwargs) == 0
+            prog_name = program_name[0]
+        elif "program_name" in kwargs:
+            assert len(kwargs) == 1
+            prog_name = kwargs["program_name"]
+        elif "libstub_path" in kwargs:
+            assert len(kwargs) == 1
+            libstub_path = kwargs["libstub_path"]
+        else:
+            raise ValueError("Not able to find everything.")
+
+        if prog_name is not None:
+            self._stub_filename = os.path.join(
+                os.path.dirname(os.path.realpath(library_filename)),
+                f'libdacestub_{prog_name}.{Config.get("compiler", "library_extension")}')
+        else:
+            self._stub_filename = os.path.realpath(libstub_path)
+
         self._stub = None
         self._lib = None
 
@@ -478,12 +501,14 @@ class CompiledSDFG(object):
 
         # Pickle the SDFG and arguments
         with tempfile.NamedTemporaryFile(mode='wb', delete=False) as f:
-            pickle.dump({
-                'library_path': self._lib._library_filename,
-                "sdfg": self.sdfg,
-                'args': args,
-                'kwargs': kwargs
-            }, f)
+            pickle.dump(
+                {
+                    'library_path': self._lib._library_filename,
+                    'stublibrary_path': self._lib._stub_filename,
+                    "sdfg": self.sdfg,
+                    'args': args,
+                    'kwargs': kwargs
+                }, f)
             temp_path = f.name
 
         # Call the SDFG in a separate process
@@ -498,9 +523,10 @@ Config.set('compiler', 'allow_view_arguments', value=True)  # Python 3.14+
 with open(r"{temp_path}", "rb") as f:
     data = pickle.load(f)
 library_path = data['library_path']
+libstub_path = data['stublibrary_path']
 sdfg = data['sdfg']
 
-lib = csd.ReloadableDLL(library_path, sdfg.name)
+lib = csd.ReloadableDLL(library_filename=library_path, libstub_path=libstub_path)
 obj = csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
 obj(*data['args'], **data['kwargs'])
 

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -27,39 +27,21 @@ class ReloadableDLL(object):
     bypasses Python's dynamic library reloading issues.
     """
 
-    def __init__(self, library_filename, *program_name, **kwargs):
-        """
-        Creates a new reloadable shared object.
+    def __init__(self, library_filename, **kwargs):
+        """Creates a new reloadable shared object.
 
-        The library filename must always be given, but the stub file can either be
-        found by specifing `program_name` or a path directly.
+        The path to the library must be given. The path of the stub library is inferred
+        from it. This means it is expected that it is located in the same folder,
+        see `_get_stub_library_path()` for more information.
 
         :param library_filename: Path to library file.
-        :param program_name: Name of the DaCe program (for use in finding the stub library loader).
-        :param libstub_path: Direct path of the libstub.
+        :param libstub_path: Optional path to the stub library.
         """
-        self._library_filename = os.path.realpath(library_filename)
+        from dace.codegen.compiler import _get_stub_library_path
 
-        prog_name, libstub_path = None, None
-        if len(program_name) != 0:
-            assert len(program_name) == 1
-            assert len(kwargs) == 0
-            prog_name = program_name[0]
-        elif "program_name" in kwargs:
-            assert len(kwargs) == 1
-            prog_name = kwargs["program_name"]
-        elif "libstub_path" in kwargs:
-            assert len(kwargs) == 1
-            libstub_path = kwargs["libstub_path"]
-        else:
-            raise ValueError("Not able to find everything.")
-
-        if prog_name is not None:
-            self._stub_filename = os.path.join(
-                os.path.dirname(os.path.realpath(library_filename)),
-                f'libdacestub_{prog_name}.{Config.get("compiler", "library_extension")}')
-        else:
-            self._stub_filename = os.path.realpath(libstub_path)
+        self._library_filename = pathlib.Path(library_filename).resolve()
+        self._stub_filename = _get_stub_library_path(kwargs.pop("libstub_path", self._library_filename))
+        assert len(kwargs) == 0
 
         self._stub = None
         self._lib = None

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -130,10 +130,6 @@ def generate_program_folder(
     with open(os.path.join(out_path, "dace_environments.csv"), "w") as env_file:
         env_file.write("\n".join(environments))
 
-    # Copy a full snapshot of configuration script
-    if folder_version in ["full"]:
-        Config.save(os.path.join(out_path, "dace.conf"), all=True)
-
     # Save the SDFG itself and its hash
     if sdfg is not None:
         if folder_version in ["full"]:
@@ -146,20 +142,26 @@ def generate_program_folder(
             with open(filepath, 'w') as hfile:
                 hfile.write(contents)
 
-    # The version file is always generated. In case it is missing we assume the old version.
-    with open(os.path.join(out_path, "VERSION"), "w") as version_file:
-        version_file.write(folder_version)
-
-    # Write cachedir tag
+    # Generate the parts of the folder that are exclusive to the full folder mode.
     if folder_version in ["full"]:
+
+        # Copy a full snapshot of configuration script
+        Config.save(os.path.join(out_path, "dace.conf"), all=True)
+
+        # Write cachedir tag
         cachedir_tag = os.path.join(out_path, "CACHEDIR.TAG")
         if not os.path.exists(cachedir_tag):
             with open(cachedir_tag, "w") as f:
-                f.write("""Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag created by DaCe.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/
-""")
+                f.write("\n".join([
+                    "Signature: 8a477f597d28d172789f06886806bc55",
+                    "# This file is a cache directory tag created by DaCe.",
+                    "# For information about cache directory tags, see:",
+                    "#	http://www.brynosaurus.com/cachedir/",
+                ]))
+
+    # The version file is always generated. In case it is missing we assume the old version.
+    with open(os.path.join(out_path, "VERSION"), "w") as version_file:
+        version_file.write(folder_version)
 
     return out_path
 

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -301,15 +301,13 @@ def configure_and_compile(
 
     # Get the names of the library files that were generated.
     #  Currently we are still in the full version.
-    lib_path, libstub_path = get_library_paths(object_folder=program_folder,
-                                               sdfg_name=program_name,
-                                               folder_version="full")
+    lib_path = get_binary_name(object_folder=program_folder, sdfg_name=program_name, folder_version="full")
+    libstub_path = _get_stub_library_path(lib_path)
 
     # In production mode, we are now deleting what we need and relocating it.
     if folder_version == "production":
         lib_path = pathlib.Path(shutil.move(src=lib_path, dst=program_folder))
         libstub_path = pathlib.Path(shutil.move(src=libstub_path, dst=program_folder))
-
         for to_delete in ["include", "src", "build"]:
             shutil.rmtree(os.path.join(build_folder, to_delete))
 
@@ -341,27 +339,6 @@ def load_from_file(sdfg, binary_filename):
         stacklevel=2,
     )
     return get_program_handle(library_path=binary_filename, sdfg=sdfg)
-
-
-def get_library_paths(
-    object_folder: str,
-    sdfg_name: str,
-    lib_extension: Optional[str] = None,
-    folder_version: Optional[str] = None,
-) -> Tuple[pathlib.Path, pathlib.Path]:
-    """Returns the i
-    Returns the standard paths of the to the binary object.
-
-    does not check if they exists.
-
-    """
-    lib_path = get_binary_name(object_folder=object_folder,
-                               sdfg_name=sdfg_name,
-                               lib_extension=lib_extension,
-                               folder_version=folder_version)
-    libstub_path = _get_stub_library_path(lib_path)
-
-    return lib_path, libstub_path
 
 
 def get_binary_name(

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -318,7 +318,7 @@ def configure_and_compile(
 
 def load_precompiled_sdfg(
     folder: Union[pathlib.Path, str],
-    sdfg: Optional[dace.SDFG] = None,
+    sdfg: Optional['dace.SDFG'] = None,
     folder_version: Optional[str] = None,
 ) -> csd.CompiledSDFG:
     """

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -365,6 +365,23 @@ def load_from_file(sdfg, binary_filename):
     return get_program_handle(library_path=binary_filename, sdfg=sdfg)
 
 
+def get_folder_version(object_folder: Union[pathlib.Path, str]) -> str:
+    """Inspect `object_folder` and determine which version the folder has.
+
+    This will inspect `VERSION` file and if not present assume `full`.
+    """
+    object_folder = pathlib.Path(object_folder)
+
+    if (object_folder / 'VERSION').exists():
+        with open(folder / 'VERSION', 'rt') as F:
+            folder_version = F.readline().strip()
+    else:
+        folder_version = "full"  # Old style full folder version.
+
+    assert folder_version in ["full", "production"]
+    return folder_version
+
+
 def get_binary_name(
     object_folder: Union[pathlib.Path, str],
     sdfg_name: str,
@@ -430,13 +447,7 @@ def load_precompiled_sdfg(
     if not folder.is_dir():
         raise NotADirectoryError(f'Can not load the SDFG from folder ``{folder}``.')
 
-    if (folder / 'VERSION').exists():
-        with open(folder / 'VERSION', 'rt') as F:
-            folder_version = F.readline().strip()
-    else:
-        folder_version = "full"  # Old style full folder version.
-    assert folder_version in ["full", "production"]
-
+    folder_version = get_folder_version(folder)
     if folder_version == "full" and (not (folder / "build").is_dir()):
         raise ValueError(f'Folder version was ``full`` but no ``build/`` folder found.')
 

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -130,8 +130,11 @@ def generate_program_folder(
         Config.save(os.path.join(out_path, "dace.conf"), all=True)
 
     # Save the SDFG itself and its hash
-    if folder_version in ["full"] and (sdfg is not None):
-        hash = sdfg.save(os.path.join(out_path, "program.sdfgz"), hash=True, compress=True)
+    if sdfg is not None:
+        if folder_version in ["full"]:
+            hash = sdfg.save(os.path.join(out_path, "program.sdfgz"), hash=True, compress=True)
+        else:
+            hash = sdfg.hash_sdfg()
         filepath = os.path.join(out_path, 'include', 'hash.h')
         contents = f'#define __HASH_{sdfg.name} "{hash}"\n'
         if not identical_file_exists(filepath, contents):
@@ -324,8 +327,13 @@ def configure_and_compile(
     if folder_version == "production":
         lib_path = pathlib.Path(shutil.move(src=lib_path, dst=program_folder))
         libstub_path = pathlib.Path(shutil.move(src=libstub_path, dst=program_folder))
-        for to_delete in ["include", "src", "build"]:
-            shutil.rmtree(os.path.join(build_folder, to_delete))
+        program_folder = pathlib.Path(program_folder)
+        # TODO: Find out where `map/` and `sample/` are generated and suppress their generation.
+        for to_delete in ["include", "src", "build", "map", "sample", "dace_environments.csv", "dace_files.csv"]:
+            if (program_folder / to_delete).is_dir():
+                shutil.rmtree(os.path.join(program_folder, to_delete))
+            else:
+                (program_folder / to_delete).unlink()
 
     return lib_path
 

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -107,10 +107,8 @@ def generate_program_folder(
 
     # Copy a full snapshot of configuration script
     if folder_version in ["full"]:
-        if config is not None:
-            config.save(os.path.join(out_path, "dace.conf"), all=True)
-        else:
-            Config.save(os.path.join(out_path, "dace.conf"), all=True)
+        config_source = Config if config is None else config
+        config.save(out_path / "dace.conf", all=True)
 
     # Save the SDFG itself and its hash
     if folder_version in ["full"] and (sdfg is not None):
@@ -121,10 +119,9 @@ def generate_program_folder(
             with open(filepath, 'w') as hfile:
                 hfile.write(contents)
 
-    # Write the version file.
-    if folder_version in ["full"]:
-        with open(os.path.join(out_path, "VERSION"), "w") as version_file:
-            version_file.write(folder_version)
+    # The version file is always generated. In case it is missing we assume the old version.
+    with open(os.path.join(out_path, "VERSION"), "w") as version_file:
+        version_file.write(folder_version)
 
     # Write cachedir tag
     if folder_version in ["full"]:
@@ -314,18 +311,26 @@ def configure_and_compile(
     return lib_path
 
 
-def get_program_handle(library_path: Union[pathlib.Path, str], sdfg: 'dace.SDFG') -> csd.CompiledSDFG:
-    """Generate a ``CompiledSDFG`` form a precompiled library.
+def get_program_handle(
+    library_path: Union[pathlib.Path, str],
+    sdfg: 'dace.SDFG',
+    stub_library_path: Union[pathlib.Path, str, None] = None,
+) -> csd.CompiledSDFG:
+    """Construct a  ``CompiledSDFG`` form a precompiled library directly.
+
+    This function is similar to the (preferred) ``load_precompiled_sdfg()``. However,
+    instead of passing the build folder of the SDFG to the function, the path to the
+    compiled library is passed directly.
 
     :param library_path: Path to the compiled library representing ``sdfg``.
-    :param sdfg: The SDFG.
-
-    :note: There is also ``load_precompiled_sdfg()``.
+    :param sdfg: The SDFG, will be referenced by the returned ``CompiledSDFG``.
+    :param stub_library_path: The path to the stub library.
     """
     library_path = pathlib.Path(library_path)
     if not library_path.is_file():
         raise FileNotFoundError('Compiled SDFG library not found: ' + library_path)
-    libstub_path = _get_stub_library_path(library_path)
+    libstub_path = _get_stub_library_path(library_path) if stub_library_path is None else pathlib.Path(
+        stub_library_path).resolve()
     assert libstub_path.is_file()
 
     lib = csd.ReloadableDLL(library_filename=library_path, libstub_path=libstub_path)
@@ -347,10 +352,7 @@ def get_binary_name(
     lib_extension: Optional[str] = None,
     folder_version: Optional[str] = None,
 ) -> pathlib.Path:
-    """Returns the path to the compiled library.
-
-    This returns the path to the library containing the compiled SDFG code.
-    The returned path is not resolved nor checked if it exists.
+    """Returns the supposed location of the compiled library given the boundary conditions.
 
     :param object_folder: The build folder of the SDFG, i.e. `sdfg.build_folder`.
     :param sdfg_name: The name of the SDFG, i.e. `sdfg.name`.
@@ -377,49 +379,43 @@ def get_binary_name(
 
 
 def _get_stub_library_path(sdfg_lib_path: Union[pathlib.Path, str]) -> pathlib.Path:
-    """Transforms the library path to the accompanying stub library.
-
-    The function will not resolve the path it will just manipulate the filename.
+    """Returns the supposed location of the compiled stub library given the path of the compiled library.
     """
     sdfg_lib_path = pathlib.Path(sdfg_lib_path)
     parent = sdfg_lib_path.parent
     lib_name = sdfg_lib_path.name
     assert lib_name.startswith('lib') and len(lib_name) > 3
 
-    return parent / ('libdacestub_' + lib_name[3:])
+    return sdfg_lib_path.parent / ('libdacestub_' + lib_name[3:])
 
 
 def load_precompiled_sdfg(
     folder: Union[pathlib.Path, str],
     sdfg: Optional['dace.SDFG'] = None,
-    folder_version: Optional[str] = None,
 ) -> csd.CompiledSDFG:
-    """Loads a precompiled SDFG from a folder.
+    """Loads a precompiled SDFG from ``folder``.
 
-    Loads a pre-compiled SDFG from an output folder (e.g. ".dacecache/program").
-    Folder must contain a file called "program.sdfgz" and a subfolder called
-    "build" with the shared object.
+    If ``sdfg`` is not given then the function expects to find the ``program.sdfg(z)``
+    dump file inside ``folder``. If the folder does not contain a ``VERSION`` file
+    it assumes that it is an old style ``full`` folder otherwise, the information
+    from ``VERSION`` is consulted.
 
     :param folder: Path to SDFG output folder, i.e. its build folder.
-    :param sdfg: If given then ``program.sdfg(z)`` does not need to be present. Optional.
-    :param fodler_version: Override the folder version. If not given, either the ``VERSION``
-                           file inside the folder or the configuration variable is used.
+    :param sdfg: If given then ``program.sdfg(z)`` does not need to be present.
     :return: A callable CompiledSDFG object.
+
+    :note: If ``sdfg`` is given then it is referenced by the returned ``CompiledSDFG``.
     """
     folder = pathlib.Path(folder)
 
     if not folder.is_dir():
         raise NotADirectoryError(f'Can not load the SDFG from folder ``{folder}``.')
 
-    # Now find the folder version.
-    #  The `VERSION` file takes precedence.
     if (folder / 'VERSION').exists():
         with open(folder / 'VERSION', 'rt') as F:
             folder_version = F.readline().strip()
-    elif folder_version is not None:
-        pass
     else:
-        folder_version = Config.get('compiler', 'build_folder_version')
+        folder_version = "full"  # Old style full folder version.
     assert folder_version in ["full", "production"]
 
     if folder_version == "full" and (not (folder / "build").is_dir()):
@@ -436,11 +432,8 @@ def load_precompiled_sdfg(
         else:
             raise ValueError(f"Could not locate the SDFG for `{folder}`.")
 
-    return csd.CompiledSDFG(
-        sdfg,
-        csd.ReloadableDLL(get_binary_name(folder, sdfg_name=sdfg.name, folder_version=folder_version)),
-        sdfg.arg_names,
-    )
+    return get_program_handle(library_path=get_binary_name(folder, sdfg_name=sdfg.name, folder_version=folder_version),
+                              sdfg=sdfg)
 
 
 def _get_or_eval(value_or_function: Union[T, Callable[[], T]]) -> T:

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -354,16 +354,9 @@ def load_precompiled_sdfg(
         folder_version = Config.get('compiler.build_folder_version')
     assert folder_version in ["full", "production"]
 
-    lib_path, libstub_path = get_library_paths(
-        object_folder=folder,
-        sdfg_name=sdfg.name,
-        lib_extension=None,
-        folder_version=folder_version,
-    )
-
     return csd.CompiledSDFG(
         sdfg,
-        csd.ReloadableDLL(library_filename=lib_path, libstub_path=libstub_path),
+        csd.ReloadableDLL(get_binary_name(folder, sdfg_name=sdfg.name, folder_version=folder_version)),
         sdfg.arg_names,
     )
 
@@ -489,33 +482,31 @@ def identical_file_exists(filename: str, file_contents: str):
     return True
 
 
-def get_program_handle(library_path, sdfg):
-    # TODO: consider removing it or `load_from_file()`.
-    lib = csd.ReloadableDLL(library_path, sdfg.name)
-    # Load and return the compiled function
+def get_program_handle(library_path: Union[pathlib.Path, str], sdfg: 'dace.SDFG') -> csd.CompiledSDFG:
+    """Generate a ``CompiledSDFG`` form a precompiled library.
+
+    :param library_path: Path to the compiled library representing ``sdfg``.
+    :param sdfg: The SDFG.
+
+    :note: There is also ``load_precompiled_sdfg()``.
+    """
+    library_path = pathlib.Path(library_path)
+    if not library_path.is_file():
+        raise FileNotFoundError('Compiled SDFG library not found: ' + library_path)
+    libstub_path = _get_stub_library_path(library_path)
+    assert libstub_path.is_file()
+
+    lib = csd.ReloadableDLL(library_filename=library_path, libstub_path=libstub_path)
     return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
 
 
 def load_from_file(sdfg, binary_filename):
-    # TODO: consider removing it or `get_program_handle()`.
-    if not os.path.isfile(binary_filename):
-        raise FileNotFoundError('File not found: ' + binary_filename)
-
-    # Load the generated library
-    lib = csd.ReloadableDLL(binary_filename, sdfg.name)
-
-    # Load and return the compiled function
-    return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
-
-
-def get_binary_name(object_folder, object_name, lib_extension=None) -> str:
-    # TODO: consider removing it.
-    if lib_extension is None:
-        lib_extension = Config.get('compiler', 'library_extension')
-
-    name = None
-    name = os.path.join(object_folder, "build", 'lib%s.%s' % (object_name, lib_extension))
-    return name
+    warnings.warn(
+        'Used deprecated ``load_from_file()`` function, use ``get_program_handle()`` instead.',
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_program_handle(library_path=binary_filename, sdfg=sdfg)
 
 
 def get_library_paths(
@@ -524,15 +515,43 @@ def get_library_paths(
     lib_extension: Optional[str] = None,
     folder_version: Optional[str] = None,
 ) -> Tuple[pathlib.Path, pathlib.Path]:
-    """Returns the standard paths of the to the binary object.
+    """Returns the i
+    Returns the standard paths of the to the binary object.
 
     does not check if they exists.
 
     """
+    lib_path = get_binary_name(object_folder=object_folder,
+                               sdfg_name=sdfg_name,
+                               lib_extension=lib_extension,
+                               folder_version=folder_version)
+    libstub_path = _get_stub_library_path(lib_path)
+
+    return lib_path, libstub_path
+
+
+def get_binary_name(
+    object_folder: Union[pathlib.Path, str],
+    sdfg_name: str,
+    lib_extension: Optional[str] = None,
+    folder_version: Optional[str] = None,
+) -> pathlib.Path:
+    """Returns the path to the compiled library.
+
+    This returns the path to the library containing the compiled SDFG code.
+    The returned path is not resolved nor checked if it exists.
+
+    :param object_folder: The build folder of the SDFG, i.e. `sdfg.build_folder`.
+    :param sdfg_name: The name of the SDFG, i.e. `sdfg.name`.
+    :param lib_extension: The extension of the library, i.e. file extension.
+                          If not given the config option `compiler.library_extension` is used.
+    :param folder_version: The version of the build folder. If not given the config option
+                           `compiler.build_folder_version` is used.
+    """
     if lib_extension is None:
         lib_extension = Config.get('compiler', 'library_extension')
     if folder_version is None:
-        folder_version = Config.get('compiler.build_folder_version')
+        folder_version = Config.get('compiler', 'build_folder_version')
 
     folder_hirarchy = [object_folder]
     if folder_version == 'full':
@@ -543,10 +562,20 @@ def get_library_paths(
     else:
         raise ValueError(f"Unknown folder version '{folder_version}' found.")
 
-    lib_path = pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
-    libstub_path = pathlib.Path(os.path.join(*folder_hirarchy, f'libdacestub_{sdfg_name}.{lib_extension}'))
+    return pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
 
-    return lib_path, libstub_path
+
+def _get_stub_library_path(sdfg_lib_path: Union[pathlib.Path, str]) -> pathlib.Path:
+    """Transforms the library path to the accompanying stub library.
+
+    The function will not resolve the path it will just manipulate the filename.
+    """
+    sdfg_lib_path = pathlib.Path(sdfg_lib_path)
+    parent = sdfg_lib_path.parent
+    lib_name = sdfg_lib_path.name
+    assert lib_name.startswith('lib') and len(lib_name) > 3
+
+    return parent / ('libdacestub_' + lib_name[3:])
 
 
 def _run_liveoutput(command, output_stream=None, **kwargs):

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -418,7 +418,9 @@ def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool = Fa
             folder_version = F.readline().strip()
         return folder_version
     else:
-        # Test if this is an old style folder.
+        # This is to check an old style folder, i.e. a cache folder that was generated before
+        #  the `VERSION` file was introduced. We do some small sanity checks.
+        # TODO: Phase out this feature, after there are no old style caches.
         found_sub_folder = False
         for sub_folder in ["build", "map", "src", "include", "sample"]:
             if (object_folder / sub_folder).is_dir():

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -108,7 +108,7 @@ def generate_program_folder(
     # Copy a full snapshot of configuration script
     if folder_version in ["full"]:
         config_source = Config if config is None else config
-        config.save(out_path / "dace.conf", all=True)
+        config_source.save(out_path / "dace.conf", all=True)
 
     # Save the SDFG itself and its hash
     if folder_version in ["full"] and (sdfg is not None):

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -339,7 +339,7 @@ def load_precompiled_sdfg(
     else:
         for name in ['program.sdfgz', 'program.sdfg']:
             if (folder / name).exists():
-                sdfg = SDFG.from_file(folder / name)
+                sdfg = dace.SDFG.from_file(folder / name)
                 break
         else:
             raise ValueError(f"Could not locate the SDFG for `{folder}`.")

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -41,11 +41,13 @@ def generate_program_folder(
     :param sdfg: The SDFG to generate the program folder for.
     :param code_objects: List of generated code objects.
     :param out_path: The folder in which the build files should be written.
+    :param folder_version: Version of the program folder that should be generated,
+                           if not given ``compiler.build_folder_version`` is used.
     :return: Path to the program folder.
     """
 
     if folder_version is None:
-        folder_version = Config.get('compiler.build_folder_version')
+        folder_version = Config.get('compiler', 'build_folder_version')
 
     src_path = os.path.join(out_path, "src")
     filelist = list()

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -386,6 +386,9 @@ def get_folder_version(object_folder: Union[pathlib.Path, str]) -> str:
     else:
         folder_version = "full"  # Old style full folder version.
 
+    if folder_version == "full" and (not (object_folder / "build").is_dir()):
+        raise ValueError('Folder version was ``full`` but no ``build/`` folder found.')
+
     assert folder_version in ["full", "production"]
     return folder_version
 
@@ -456,8 +459,6 @@ def load_precompiled_sdfg(
         raise NotADirectoryError(f'Can not load the SDFG from folder ``{folder}``.')
 
     folder_version = get_folder_version(folder)
-    if folder_version == "full" and (not (folder / "build").is_dir()):
-        raise ValueError(f'Folder version was ``full`` but no ``build/`` folder found.')
 
     # Try to find the sdfg from disc, if not given.
     if sdfg is not None:

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -44,7 +44,25 @@ def generate_program_folder(
     :param folder_version: Version of the program folder that should be generated,
                            if not given ``compiler.build_folder_version`` is used.
     :return: Path to the program folder.
+
+    :note: The ``config`` argument is retained for compatibility and should not be used.
     """
+
+    # NOTE: In older version the argument `config` could be a used to pass a custom
+    #   "configuration" (probably a `dict`) object, that would then be written to
+    #   `dace.conf` inside the folder. If nothing was provided the content of the
+    #   global `dace.Config` would be used. However, since _everything_ is consulting
+    #   `dace.Config` for advice, an external configuration, i.e. settings different
+    #   from `dace.Config` can not take effect and storing it is wrong. Thus this
+    #   feature was dropped.
+    if config is not None:
+        warnings.warn(
+            'Passed a not `None` `config` argument to `generate_program_folder()`.'
+            ' This has no effect and will be ignored. Instead `dace.Config` will'
+            ' be used.',
+            category=UserWarning,
+            stacklevel=2,
+        )
 
     if folder_version is None:
         folder_version = Config.get('compiler', 'build_folder_version')
@@ -109,8 +127,7 @@ def generate_program_folder(
 
     # Copy a full snapshot of configuration script
     if folder_version in ["full"]:
-        config_source = Config if config is None else config
-        config_source.save(out_path / "dace.conf", all=True)
+        Config.save(os.path.join(out_path, "dace.conf"), all=True)
 
     # Save the SDFG itself and its hash
     if folder_version in ["full"] and (sdfg is not None):

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -10,7 +10,8 @@ import shutil
 import shlex
 import subprocess
 import re
-from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar, Union
+import pathlib
+from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar, Union, Optional
 import warnings
 
 import dace
@@ -24,15 +25,27 @@ from dace.codegen.target import make_absolute
 T = TypeVar('T')
 
 
-def generate_program_folder(sdfg, code_objects: List[CodeObject], out_path: str, config=None):
-    """ Writes all files required to configure and compile the DaCe program
-        into the specified folder.
+def generate_program_folder(
+    sdfg,
+    code_objects: List[CodeObject],
+    out_path: str,
+    config=None,
+    folder_version: Optional[str] = None,
+) -> str:
+    """Writes all files required to configure and compile the DaCe program into the specified folder.
 
-        :param sdfg: The SDFG to generate the program folder for.
-        :param code_objects: List of generated code objects.
-        :param out_path: The folder in which the build files should be written.
-        :return: Path to the program folder.
+    This function respects the ``compiler.build_folder_version`` configuration variable,
+    thus depending on its value the content might be different. However, in any case
+    the source files are always generated.
+
+    :param sdfg: The SDFG to generate the program folder for.
+    :param code_objects: List of generated code objects.
+    :param out_path: The folder in which the build files should be written.
+    :return: Path to the program folder.
     """
+
+    if folder_version is None:
+        folder_version = Config.get('compiler.build_folder_version')
 
     src_path = os.path.join(out_path, "src")
     filelist = list()
@@ -78,6 +91,7 @@ def generate_program_folder(sdfg, code_objects: List[CodeObject], out_path: str,
             filelist.append("{},{},{}".format(target_name, target_type, basename))
 
     # Write list of files
+    #  Needed to communicate with `configure_and_compile()`, deleted in production mode.
     with open(os.path.join(out_path, "dace_files.csv"), "w") as filelist_file:
         filelist_file.write("\n".join(filelist))
 
@@ -87,17 +101,19 @@ def generate_program_folder(sdfg, code_objects: List[CodeObject], out_path: str,
         environments |= obj.environments
 
     # Write list of environments
+    #  Needed to communicate with `configure_and_compile()`, deleted in production mode.
     with open(os.path.join(out_path, "dace_environments.csv"), "w") as env_file:
         env_file.write("\n".join(environments))
 
     # Copy a full snapshot of configuration script
-    if config is not None:
-        config.save(os.path.join(out_path, "dace.conf"), all=True)
-    else:
-        Config.save(os.path.join(out_path, "dace.conf"), all=True)
+    if folder_version in ["full"]:
+        if config is not None:
+            config.save(os.path.join(out_path, "dace.conf"), all=True)
+        else:
+            Config.save(os.path.join(out_path, "dace.conf"), all=True)
 
-    if sdfg is not None:
-        # Save the SDFG itself and its hash
+    # Save the SDFG itself and its hash
+    if folder_version in ["full"] and (sdfg is not None):
         hash = sdfg.save(os.path.join(out_path, "program.sdfgz"), hash=True, compress=True)
         filepath = os.path.join(out_path, 'include', 'hash.h')
         contents = f'#define __HASH_{sdfg.name} "{hash}"\n'
@@ -105,11 +121,17 @@ def generate_program_folder(sdfg, code_objects: List[CodeObject], out_path: str,
             with open(filepath, 'w') as hfile:
                 hfile.write(contents)
 
+    # Write the version file.
+    if folder_version in ["full"]:
+        with open(os.path.join(out_path, "VERSION"), "w") as version_file:
+            version_file.write(folder_version)
+
     # Write cachedir tag
-    cachedir_tag = os.path.join(out_path, "CACHEDIR.TAG")
-    if not os.path.exists(cachedir_tag):
-        with open(cachedir_tag, "w") as f:
-            f.write("""Signature: 8a477f597d28d172789f06886806bc55
+    if folder_version in ["full"]:
+        cachedir_tag = os.path.join(out_path, "CACHEDIR.TAG")
+        if not os.path.exists(cachedir_tag):
+            with open(cachedir_tag, "w") as f:
+                f.write("""Signature: 8a477f597d28d172789f06886806bc55
 # This file is a cache directory tag created by DaCe.
 # For information about cache directory tags, see:
 #	http://www.brynosaurus.com/cachedir/
@@ -118,17 +140,28 @@ def generate_program_folder(sdfg, code_objects: List[CodeObject], out_path: str,
     return out_path
 
 
-def configure_and_compile(program_folder, program_name=None, output_stream=None):
-    """ Configures and compiles a DaCe program in the specified folder into a
-        shared library file.
-
-        :param program_folder: Folder containing all files necessary to build,
-                               equivalent to what was passed to
-                               `generate_program_folder`.
-        :param output_stream: Additional output stream to write to (used for
-                              other clients such as the vscode extension).
-        :return: Path to the compiled shared library file.
+def configure_and_compile(
+    program_folder,
+    program_name=None,
+    output_stream=None,
+    folder_version: Optional[str] = None,
+) -> pathlib.Path:
     """
+    Configures and compiles a DaCe program in the specified folder into a shared library file.
+
+    This function respects the ``compiler.build_folder_version`` configuration variable,
+    thus depending on its value the content might be different.
+
+    :param program_folder: Folder containing all files necessary to build, equivalent to
+                           what was passed to `generate_program_folder`.
+    :param output_stream: Additional output stream to write to (used for other clients
+                          such as the vscode extension).
+    :return: Path to the compiled shared library file.
+    """
+
+    if folder_version is None:
+        folder_version = Config.get('compiler.build_folder_version')
+    assert folder_version in ["full", "production"]
 
     if program_name is None:
         program_name = os.path.basename(program_folder)
@@ -139,8 +172,9 @@ def configure_and_compile(program_folder, program_name=None, output_stream=None)
     build_folder = os.path.join(program_folder, "build")
     os.makedirs(build_folder, exist_ok=True)
 
-    # Prepare performance report folder
-    os.makedirs(os.path.join(program_folder, "perf"), exist_ok=True)
+    # Prepare performance report folder if requested.
+    if folder_version == "full":
+        os.makedirs(os.path.join(program_folder, "perf"), exist_ok=True)
 
     # Read list of DaCe files to compile.
     # We do this instead of iterating over source files in the directory to
@@ -228,6 +262,7 @@ def configure_and_compile(program_folder, program_name=None, output_stream=None)
         print(f'Running CMake: {cmake_command}')
 
     cmake_filename = os.path.join(build_folder, 'cmake_configure.sh')
+
     ##############################################
     # Configure
     try:
@@ -264,10 +299,72 @@ def configure_and_compile(program_folder, program_name=None, output_stream=None)
         else:
             raise cgx.CompilationError('Compiler failure:\n' + ex.output)
 
-    shared_library_path = os.path.join(build_folder, "lib{}.{}".format(program_name,
-                                                                       Config.get('compiler', 'library_extension')))
+    # Get the names of the library files that were generated.
+    #  Currently we are still in the full version.
+    lib_path, libstub_path = get_library_paths(object_folder=program_folder,
+                                               sdfg_name=program_name,
+                                               folder_version="full")
 
-    return shared_library_path
+    # In production mode, we are now deleting what we need and relocating it.
+    if folder_version == "production":
+        lib_path = pathlib.Path(shutil.move(src=lib_path, dst=program_folder))
+        libstub_path = pathlib.Path(shutil.move(src=libstub_path, dst=program_folder))
+
+        for to_delete in ["include", "src", "build"]:
+            shutil.rmtree(os.path.join(build_folder, to_delete))
+
+    return lib_path
+
+
+def load_precompiled_sdfg(
+    folder: Union[pathlib.Path, str],
+    sdfg: Optional[dace.SDFG] = None,
+    folder_version: Optional[str] = None,
+) -> csd.CompiledSDFG:
+    """
+    Loads a pre-compiled SDFG from an output folder (e.g. ".dacecache/program").
+    Folder must contain a file called "program.sdfgz" and a subfolder called
+    "build" with the shared object.
+
+    :param folder: Path to SDFG output folder.
+    :return: A callable CompiledSDFG object.
+    """
+    folder = pathlib.Path(folder)
+
+    # TODO: Find out what should happen with `dace.sdfg.utils.load_precompiled_sdfg()`.
+
+    # Try to find the sdfg from disc, if not given.
+    if sdfg is not None:
+        assert isinstance(sdfg, dace.SDFG)
+    else:
+        for name in ['program.sdfgz', 'program.sdfg']:
+            if (folder / name).exists():
+                sdfg = SDFG.from_file(folder / name)
+                break
+        else:
+            raise ValueError(f"Could not locate the SDFG for `{folder}`.")
+
+    # Now find the folder version.
+    if folder_version is not None:
+        pass
+    elif (folder / 'VERSION').exists():
+        raise NotImplementedError()
+    else:
+        folder_version = Config.get('compiler.build_folder_version')
+    assert folder_version in ["full", "production"]
+
+    lib_path, libstub_path = get_library_paths(
+        object_folder=folder,
+        sdfg_name=sdfg.name,
+        lib_extension=None,
+        folder_version=folder_version,
+    )
+
+    return csd.CompiledSDFG(
+        sdfg,
+        csd.ReloadableDLL(library_filename=lib_path, libstub_path=libstub_path),
+        sdfg.arg_names,
+    )
 
 
 def _get_or_eval(value_or_function: Union[T, Callable[[], T]]) -> T:
@@ -392,12 +489,14 @@ def identical_file_exists(filename: str, file_contents: str):
 
 
 def get_program_handle(library_path, sdfg):
+    # TODO: consider removing it or `load_from_file()`.
     lib = csd.ReloadableDLL(library_path, sdfg.name)
     # Load and return the compiled function
     return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
 
 
 def load_from_file(sdfg, binary_filename):
+    # TODO: consider removing it or `get_program_handle()`.
     if not os.path.isfile(binary_filename):
         raise FileNotFoundError('File not found: ' + binary_filename)
 
@@ -408,10 +507,45 @@ def load_from_file(sdfg, binary_filename):
     return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
 
 
-def get_binary_name(object_folder, object_name, lib_extension=Config.get('compiler', 'library_extension')):
+def get_binary_name(object_folder, object_name, lib_extension=None) -> str:
+    # TODO: consider removing it.
+    if lib_extension is None:
+        lib_extension = Config.get('compiler', 'library_extension')
+
     name = None
     name = os.path.join(object_folder, "build", 'lib%s.%s' % (object_name, lib_extension))
     return name
+
+
+def get_library_paths(
+    object_folder: str,
+    sdfg_name: str,
+    lib_extension: Optional[str] = None,
+    folder_version: Optional[str] = None,
+) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Returns the standard paths of the to the binary object.
+
+    does not check if they exists.
+
+    """
+    if lib_extension is None:
+        lib_extension = Config.get('compiler', 'library_extension')
+    if folder_version is None:
+        folder_version = Config.get('compiler.build_folder_version')
+
+    folder_hirarchy = [object_folder]
+    if folder_version == 'full':
+        folder_hirarchy.append('build')
+    elif folder_version == 'production':
+        # Nothing to add, they are on the top.
+        pass
+    else:
+        raise ValueError(f"Unknown folder version '{folder_version}' found.")
+
+    lib_path = pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
+    libstub_path = pathlib.Path(os.path.join(*folder_hirarchy, f'libdacestub_{sdfg_name}.{lib_extension}'))
+
+    return lib_path, libstub_path
 
 
 def _run_liveoutput(command, output_stream=None, **kwargs):

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -408,6 +408,23 @@ def load_precompiled_sdfg(
     """
     folder = pathlib.Path(folder)
 
+    if not folder.is_dir():
+        raise NotADirectoryError(f'Can not load the SDFG from folder ``{folder}``.')
+
+    # Now find the folder version.
+    #  The `VERSION` file takes precedence.
+    if (folder / 'VERSION').exists():
+        with open(folder / 'VERSION', 'rt') as F:
+            folder_version = F.readline().strip()
+    elif folder_version is not None:
+        pass
+    else:
+        folder_version = Config.get('compiler', 'build_folder_version')
+    assert folder_version in ["full", "production"]
+
+    if folder_version == "full" and (not (folder / "build").is_dir()):
+        raise ValueError(f'Folder version was ``full`` but no ``build/`` folder found.')
+
     # Try to find the sdfg from disc, if not given.
     if sdfg is not None:
         assert isinstance(sdfg, dace.SDFG)
@@ -418,16 +435,6 @@ def load_precompiled_sdfg(
                 break
         else:
             raise ValueError(f"Could not locate the SDFG for `{folder}`.")
-
-    # Now find the folder version.
-    if folder_version is not None:
-        pass
-    elif (folder / 'VERSION').exists():
-        with open(folder / 'VERSION', 'rt') as F:
-            folder_version = F.readline().strip()
-    else:
-        folder_version = Config.get('compiler', 'build_folder_version')
-    assert folder_version in ["full", "production"]
 
     return csd.CompiledSDFG(
         sdfg,

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -110,6 +110,11 @@ def generate_program_folder(
         if code_object.linkable == True:
             filelist.append("{},{},{}".format(target_name, target_type, basename))
 
+        # Generate the source map.
+        if sdfg and (folder_version in ["full"]):
+            if code_object.language == 'cpp' and code_object.title == 'Frame':
+                code_object.create_source_map(sdfg)
+
     # Write list of files
     #  Needed to communicate with `configure_and_compile()`, deleted in production mode.
     with open(os.path.join(out_path, "dace_files.csv"), "w") as filelist_file:
@@ -328,8 +333,8 @@ def configure_and_compile(
         lib_path = pathlib.Path(shutil.move(src=lib_path, dst=program_folder))
         libstub_path = pathlib.Path(shutil.move(src=libstub_path, dst=program_folder))
         program_folder = pathlib.Path(program_folder)
-        # TODO: Find out where `map/` and `sample/` are generated and suppress their generation.
-        for to_delete in ["include", "src", "build", "map", "sample", "dace_environments.csv", "dace_files.csv"]:
+        # TODO: Find out where `sample/` are generated and suppress their generation.
+        for to_delete in ["include", "src", "build", "sample", "dace_environments.csv", "dace_files.csv"]:
             if (program_folder / to_delete).is_dir():
                 shutil.rmtree(os.path.join(program_folder, to_delete))
             else:

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -316,22 +316,120 @@ def configure_and_compile(
     return lib_path
 
 
+def get_program_handle(library_path: Union[pathlib.Path, str], sdfg: 'dace.SDFG') -> csd.CompiledSDFG:
+    """Generate a ``CompiledSDFG`` form a precompiled library.
+
+    :param library_path: Path to the compiled library representing ``sdfg``.
+    :param sdfg: The SDFG.
+
+    :note: There is also ``load_precompiled_sdfg()``.
+    """
+    library_path = pathlib.Path(library_path)
+    if not library_path.is_file():
+        raise FileNotFoundError('Compiled SDFG library not found: ' + library_path)
+    libstub_path = _get_stub_library_path(library_path)
+    assert libstub_path.is_file()
+
+    lib = csd.ReloadableDLL(library_filename=library_path, libstub_path=libstub_path)
+    return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
+
+
+def load_from_file(sdfg, binary_filename):
+    warnings.warn(
+        'Used deprecated ``load_from_file()`` function, use ``get_program_handle()`` instead.',
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_program_handle(library_path=binary_filename, sdfg=sdfg)
+
+
+def get_library_paths(
+    object_folder: str,
+    sdfg_name: str,
+    lib_extension: Optional[str] = None,
+    folder_version: Optional[str] = None,
+) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Returns the i
+    Returns the standard paths of the to the binary object.
+
+    does not check if they exists.
+
+    """
+    lib_path = get_binary_name(object_folder=object_folder,
+                               sdfg_name=sdfg_name,
+                               lib_extension=lib_extension,
+                               folder_version=folder_version)
+    libstub_path = _get_stub_library_path(lib_path)
+
+    return lib_path, libstub_path
+
+
+def get_binary_name(
+    object_folder: Union[pathlib.Path, str],
+    sdfg_name: str,
+    lib_extension: Optional[str] = None,
+    folder_version: Optional[str] = None,
+) -> pathlib.Path:
+    """Returns the path to the compiled library.
+
+    This returns the path to the library containing the compiled SDFG code.
+    The returned path is not resolved nor checked if it exists.
+
+    :param object_folder: The build folder of the SDFG, i.e. `sdfg.build_folder`.
+    :param sdfg_name: The name of the SDFG, i.e. `sdfg.name`.
+    :param lib_extension: The extension of the library, i.e. file extension.
+                          If not given the config option `compiler.library_extension` is used.
+    :param folder_version: The version of the build folder. If not given the config option
+                           `compiler.build_folder_version` is used.
+    """
+    if lib_extension is None:
+        lib_extension = Config.get('compiler', 'library_extension')
+    if folder_version is None:
+        folder_version = Config.get('compiler', 'build_folder_version')
+
+    folder_hirarchy = [object_folder]
+    if folder_version == 'full':
+        folder_hirarchy.append('build')
+    elif folder_version == 'production':
+        # Nothing to add, they are on the top.
+        pass
+    else:
+        raise ValueError(f"Unknown folder version '{folder_version}' found.")
+
+    return pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
+
+
+def _get_stub_library_path(sdfg_lib_path: Union[pathlib.Path, str]) -> pathlib.Path:
+    """Transforms the library path to the accompanying stub library.
+
+    The function will not resolve the path it will just manipulate the filename.
+    """
+    sdfg_lib_path = pathlib.Path(sdfg_lib_path)
+    parent = sdfg_lib_path.parent
+    lib_name = sdfg_lib_path.name
+    assert lib_name.startswith('lib') and len(lib_name) > 3
+
+    return parent / ('libdacestub_' + lib_name[3:])
+
+
 def load_precompiled_sdfg(
     folder: Union[pathlib.Path, str],
     sdfg: Optional['dace.SDFG'] = None,
     folder_version: Optional[str] = None,
 ) -> csd.CompiledSDFG:
-    """
+    """Loads a precompiled SDFG from a folder.
+
     Loads a pre-compiled SDFG from an output folder (e.g. ".dacecache/program").
     Folder must contain a file called "program.sdfgz" and a subfolder called
     "build" with the shared object.
 
-    :param folder: Path to SDFG output folder.
+    :param folder: Path to SDFG output folder, i.e. its build folder.
+    :param sdfg: If given then ``program.sdfg(z)`` does not need to be present. Optional.
+    :param fodler_version: Override the folder version. If not given, either the ``VERSION``
+                           file inside the folder or the configuration variable is used.
     :return: A callable CompiledSDFG object.
     """
     folder = pathlib.Path(folder)
-
-    # TODO: Find out what should happen with `dace.sdfg.utils.load_precompiled_sdfg()`.
 
     # Try to find the sdfg from disc, if not given.
     if sdfg is not None:
@@ -351,7 +449,7 @@ def load_precompiled_sdfg(
         with open(folder / 'VERSION', 'rt') as F:
             folder_version = F.readline().strip()
     else:
-        folder_version = Config.get('compiler.build_folder_version')
+        folder_version = Config.get('compiler', 'build_folder_version')
     assert folder_version in ["full", "production"]
 
     return csd.CompiledSDFG(
@@ -480,102 +578,6 @@ def identical_file_exists(filename: str, file_contents: str):
         return False
 
     return True
-
-
-def get_program_handle(library_path: Union[pathlib.Path, str], sdfg: 'dace.SDFG') -> csd.CompiledSDFG:
-    """Generate a ``CompiledSDFG`` form a precompiled library.
-
-    :param library_path: Path to the compiled library representing ``sdfg``.
-    :param sdfg: The SDFG.
-
-    :note: There is also ``load_precompiled_sdfg()``.
-    """
-    library_path = pathlib.Path(library_path)
-    if not library_path.is_file():
-        raise FileNotFoundError('Compiled SDFG library not found: ' + library_path)
-    libstub_path = _get_stub_library_path(library_path)
-    assert libstub_path.is_file()
-
-    lib = csd.ReloadableDLL(library_filename=library_path, libstub_path=libstub_path)
-    return csd.CompiledSDFG(sdfg, lib, sdfg.arg_names)
-
-
-def load_from_file(sdfg, binary_filename):
-    warnings.warn(
-        'Used deprecated ``load_from_file()`` function, use ``get_program_handle()`` instead.',
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return get_program_handle(library_path=binary_filename, sdfg=sdfg)
-
-
-def get_library_paths(
-    object_folder: str,
-    sdfg_name: str,
-    lib_extension: Optional[str] = None,
-    folder_version: Optional[str] = None,
-) -> Tuple[pathlib.Path, pathlib.Path]:
-    """Returns the i
-    Returns the standard paths of the to the binary object.
-
-    does not check if they exists.
-
-    """
-    lib_path = get_binary_name(object_folder=object_folder,
-                               sdfg_name=sdfg_name,
-                               lib_extension=lib_extension,
-                               folder_version=folder_version)
-    libstub_path = _get_stub_library_path(lib_path)
-
-    return lib_path, libstub_path
-
-
-def get_binary_name(
-    object_folder: Union[pathlib.Path, str],
-    sdfg_name: str,
-    lib_extension: Optional[str] = None,
-    folder_version: Optional[str] = None,
-) -> pathlib.Path:
-    """Returns the path to the compiled library.
-
-    This returns the path to the library containing the compiled SDFG code.
-    The returned path is not resolved nor checked if it exists.
-
-    :param object_folder: The build folder of the SDFG, i.e. `sdfg.build_folder`.
-    :param sdfg_name: The name of the SDFG, i.e. `sdfg.name`.
-    :param lib_extension: The extension of the library, i.e. file extension.
-                          If not given the config option `compiler.library_extension` is used.
-    :param folder_version: The version of the build folder. If not given the config option
-                           `compiler.build_folder_version` is used.
-    """
-    if lib_extension is None:
-        lib_extension = Config.get('compiler', 'library_extension')
-    if folder_version is None:
-        folder_version = Config.get('compiler', 'build_folder_version')
-
-    folder_hirarchy = [object_folder]
-    if folder_version == 'full':
-        folder_hirarchy.append('build')
-    elif folder_version == 'production':
-        # Nothing to add, they are on the top.
-        pass
-    else:
-        raise ValueError(f"Unknown folder version '{folder_version}' found.")
-
-    return pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
-
-
-def _get_stub_library_path(sdfg_lib_path: Union[pathlib.Path, str]) -> pathlib.Path:
-    """Transforms the library path to the accompanying stub library.
-
-    The function will not resolve the path it will just manipulate the filename.
-    """
-    sdfg_lib_path = pathlib.Path(sdfg_lib_path)
-    parent = sdfg_lib_path.parent
-    lib_name = sdfg_lib_path.name
-    assert lib_name.startswith('lib') and len(lib_name) > 3
-
-    return parent / ('libdacestub_' + lib_name[3:])
 
 
 def _run_liveoutput(command, output_stream=None, **kwargs):

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -11,7 +11,7 @@ import shlex
 import subprocess
 import re
 import pathlib
-from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar, Union, Optional
+from typing import Any, Callable, Dict, List, Literal, Set, Tuple, TypeVar, Union, Optional, overload
 import warnings
 
 import dace
@@ -380,24 +380,61 @@ def load_from_file(sdfg, binary_filename):
     return get_program_handle(library_path=binary_filename, sdfg=sdfg)
 
 
-def get_folder_version(object_folder: Union[pathlib.Path, str]) -> str:
+@overload
+def get_folder_version(object_folder: Union[pathlib.Path, str], probe: Literal[False] = False) -> str:
+    ...
+
+
+@overload
+def get_folder_version(object_folder: Union[pathlib.Path, str], probe: Literal[True]) -> Optional[str]:
+    ...
+
+
+@overload
+def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool) -> Optional[str]:
+    ...
+
+
+def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool = False) -> Optional[str]:
     """Inspect `object_folder` and determine which version the folder has.
 
-    This will inspect `VERSION` file and if not present assume `full`.
+    If the function find the ``VERSION`` file it will examine it to get the version.
+    If the version file is absent the function assumes that it is the full format,
+    however, it performs some checks to ensure that.
+
+    The function also has the optional argument ``probe`` if given and the folder
+    version could not be inferred the function will return ``None`` instead of
+    generating an error.
     """
     object_folder = pathlib.Path(object_folder)
+
+    if not object_folder.is_dir():
+        if probe:
+            return None
+        raise NotADirectoryError("The build folder does not exists.")
 
     if (object_folder / 'VERSION').exists():
         with open(object_folder / 'VERSION', 'rt') as F:
             folder_version = F.readline().strip()
+        return folder_version
     else:
-        folder_version = "full"  # Old style full folder version.
+        # Test if this is an old style folder.
+        found_sub_folder = False
+        for sub_folder in ["build", "map", "src", "include", "sample"]:
+            if (object_folder / sub_folder).is_dir():
+                found_sub_folder = True
+            elif found_sub_folder:
+                raise NotADirectoryError(f'Expected that folder ``{object_folder}`` contains ``{sub_folder}``')
 
-    if folder_version == "full" and (not (object_folder / "build").is_dir()):
-        raise ValueError('Folder version was ``full`` but no ``build/`` folder found.')
-
-    assert folder_version in ["full", "production"]
-    return folder_version
+        if found_sub_folder:
+            # All expected folders where found, so expect that this is a 'full' format folder.
+            return "full"
+        elif probe:
+            # None of the files where found. Thus this is probably an empty folder that just exist.
+            return None
+        else:
+            # Up for discussion what to do here.
+            raise NotADirectoryError(f'``{object_folder}`` does not appear to be a valid build folder.')
 
 
 def get_binary_name(

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -348,7 +348,8 @@ def load_precompiled_sdfg(
     if folder_version is not None:
         pass
     elif (folder / 'VERSION').exists():
-        raise NotImplementedError()
+        with open(folder / 'VERSION', 'rt') as F:
+            folder_version = F.readline().strip()
     else:
         folder_version = Config.get('compiler.build_folder_version')
     assert folder_version in ["full", "production"]

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -373,7 +373,7 @@ def get_folder_version(object_folder: Union[pathlib.Path, str]) -> str:
     object_folder = pathlib.Path(object_folder)
 
     if (object_folder / 'VERSION').exists():
-        with open(folder / 'VERSION', 'rt') as F:
+        with open(object_folder / 'VERSION', 'rt') as F:
             folder_version = F.readline().strip()
     else:
         folder_version = "full"  # Old style full folder version.

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -111,7 +111,7 @@ def generate_program_folder(
             filelist.append("{},{},{}".format(target_name, target_type, basename))
 
         # Generate the source map.
-        if sdfg and (folder_version in ["full"]):
+        if sdfg and (folder_version in ["development"]):
             if code_object.language == 'cpp' and code_object.title == 'Frame':
                 code_object.create_source_map(sdfg)
 
@@ -132,7 +132,7 @@ def generate_program_folder(
 
     # Save the SDFG itself and its hash
     if sdfg is not None:
-        if folder_version in ["full"]:
+        if folder_version in ["development"]:
             hash = sdfg.save(os.path.join(out_path, "program.sdfgz"), hash=True, compress=True)
         else:
             hash = sdfg.hash_sdfg()
@@ -142,8 +142,8 @@ def generate_program_folder(
             with open(filepath, 'w') as hfile:
                 hfile.write(contents)
 
-    # Generate the parts of the folder that are exclusive to the full folder mode.
-    if folder_version in ["full"]:
+    # Generate the parts of the folder that are exclusive to the development folder mode.
+    if folder_version in ["development"]:
 
         # Copy a full snapshot of configuration script
         Config.save(os.path.join(out_path, "dace.conf"), all=True)
@@ -187,7 +187,7 @@ def configure_and_compile(
 
     if folder_version is None:
         folder_version = Config.get('compiler.build_folder_version')
-    assert folder_version in ["full", "production"]
+    assert folder_version in ["development", "production"]
 
     if program_name is None:
         program_name = os.path.basename(program_folder)
@@ -199,7 +199,7 @@ def configure_and_compile(
     os.makedirs(build_folder, exist_ok=True)
 
     # Prepare performance report folder if requested.
-    if folder_version == "full":
+    if folder_version == "development":
         os.makedirs(os.path.join(program_folder, "perf"), exist_ok=True)
 
     # Read list of DaCe files to compile.
@@ -326,8 +326,8 @@ def configure_and_compile(
             raise cgx.CompilationError('Compiler failure:\n' + ex.output)
 
     # Get the names of the library files that were generated.
-    #  Currently we are still in the full version.
-    lib_path = get_binary_name(object_folder=program_folder, sdfg_name=program_name, folder_version="full")
+    #  Currently we are still in the `development` folder mode.
+    lib_path = get_binary_name(object_folder=program_folder, sdfg_name=program_name, folder_version="development")
     libstub_path = _get_stub_library_path(lib_path)
 
     # In production mode, we are now deleting what we need and relocating it.
@@ -399,8 +399,8 @@ def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool = Fa
     """Inspect `object_folder` and determine which version the folder has.
 
     If the function find the ``VERSION`` file it will examine it to get the version.
-    If the version file is absent the function assumes that it is the full format,
-    however, it performs some checks to ensure that.
+    If the version file is absent the function assumes that it is the ``development``
+    format, however, some sanity checks are performed.
 
     The function also has the optional argument ``probe`` if given and the folder
     version could not be inferred the function will return ``None`` instead of
@@ -429,8 +429,8 @@ def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool = Fa
                 raise NotADirectoryError(f'Expected that folder ``{object_folder}`` contains ``{sub_folder}``')
 
         if found_sub_folder:
-            # All expected folders where found, so expect that this is a 'full' format folder.
-            return "full"
+            # All expected folders where found, so expect that this is a 'development' format folder.
+            return "development"
         elif probe:
             # None of the files where found. Thus this is probably an empty folder that just exist.
             return None
@@ -460,7 +460,7 @@ def get_binary_name(
         folder_version = Config.get('compiler', 'build_folder_version')
 
     folder_hirarchy = [object_folder]
-    if folder_version == 'full':
+    if folder_version == 'development':
         folder_hirarchy.append('build')
     elif folder_version == 'production':
         # Nothing to add, they are on the top.
@@ -490,7 +490,7 @@ def load_precompiled_sdfg(
 
     If ``sdfg`` is not given then the function expects to find the ``program.sdfg(z)``
     dump file inside ``folder``. If the folder does not contain a ``VERSION`` file
-    it assumes that it is an old style ``full`` folder otherwise, the information
+    it assumes that it is an old style ``development`` folder otherwise, the information
     from ``VERSION`` is consulted.
 
     :param folder: Path to SDFG output folder, i.e. its build folder.

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -115,6 +115,16 @@ required:
                     If enabled, does not recompile code generated from SDFGs
                     if shared library (.so/.dll) file is present.
 
+            build_folder_version:
+                type: str
+                default: full
+                title: Version of the build folder
+                description: >
+                  Determine the content of the build folder that should be created.
+                  The supported values are `full`, which generates the full version.
+                  The value `production` will only retain the compiled files, which
+                  are at the top level of the folder.
+
             library_prefix:
                 type: str
                 default: ""

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -117,14 +117,14 @@ required:
 
             build_folder_version:
                 type: str
-                default: full
+                default: development
                 title: Version of the build folder
                 description: >
                   Determine the content of the build folder that should be created.
-                  The supported values are `full`, which generates the original
-                  version that includes everything. Furthermore, `production` is
-                  supported, in this version only the compiled libraries and the
-                  version file is pressent.
+                  The supported values are `development`, that includes everything
+                  The second mode, that is currently supported is `production`.
+                  In this mode only the compiled library and the version file is
+                  present.
 
             library_prefix:
                 type: str

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -121,9 +121,10 @@ required:
                 title: Version of the build folder
                 description: >
                   Determine the content of the build folder that should be created.
-                  The supported values are `full`, which generates the full version.
-                  The value `production` will only retain the compiled files, which
-                  are at the top level of the folder.
+                  The supported values are `full`, which generates the original
+                  version that includes everything. Furthermore, `production` is
+                  supported, in this version only the compiled libraries and the
+                  version file is pressent.
 
             library_prefix:
                 type: str

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -807,8 +807,8 @@ class DaceProgram(pycommon.SDFGConvertible):
         :param args: Optional compile-time arguments.
         :param kwargs: Optional compile-time keyword arguments.
         """
-        from dace.sdfg import utils as sdutil  # Avoid import loop
-        csdfg = sdutil.load_precompiled_sdfg(path)
+        from dace.codegen import compiler as sdfg_compiler  # Avoid import loop
+        csdfg = sdfg_compiler.load_precompiled_sdfg(path)
         _, cachekey = self._load_sdfg(None, *args, **kwargs)
 
         # Update SDFG cache with the SDFG and compiled version

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2451,7 +2451,7 @@ class SDFG(ControlFlowRegion):
         for k, v in symbols.items():
             self.add_constant(str(k), v)
 
-    def is_loaded(self) -> bool:
+    def is_loaded(self, folder_version: Optional[str] = None) -> bool:
         """
         Returns True if the SDFG binary is already loaded in the current process.
         Returns `False` if the file does not exist.
@@ -2459,11 +2459,17 @@ class SDFG(ControlFlowRegion):
         # Avoid import loops
         from dace.codegen import compiled_sdfg as cs, compiler
 
+        build_folder = self.build_folder
+        if folder_version is None:
+            folder_version = compiler.get_folder_version(build_folder, probe=True)
+        if folder_version is None:
+            folder_version = Config.get('compiler', 'build_folder_version')
+
         # Note here is kind of a "leak". The issue is that while the library is not
         #  loaded the stub library is loaded. However, it is never unloaded, because
         #  the `unload()` function is not called. This is technically not an issue
         #  as `ctypes` will do that at some later point.
-        binary_filename = compiler.get_binary_name(self.build_folder, self.name)
+        binary_filename = compiler.get_binary_name(self.build_folder, self.name, folder_version=folder_version)
         dll = cs.ReloadableDLL(binary_filename)
         return dll.is_loaded()
 
@@ -2485,10 +2491,9 @@ class SDFG(ControlFlowRegion):
         build_folder = self.build_folder
 
         # Get the folder version, but if the folder already exist, then use the `VERSION` file.
-        if os.path.isdir(build_folder):
-            folder_version = compiler.get_folder_version(build_folder)
-        else:
-            folder_version = Config.get('compiler.build_folder_version')
+        folder_version = compiler.get_folder_version(build_folder, probe=True)
+        if folder_version is None:
+            folder_version = Config.get('compiler', 'build_folder_version')
 
         if not self._recompile or Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists
@@ -2520,7 +2525,7 @@ class SDFG(ControlFlowRegion):
 
             # Rename SDFG to avoid runtime issues with clashing names
             index = 0
-            while sdfg.is_loaded():
+            while sdfg.is_loaded(folder_version=folder_version):
                 sdfg.name = f'{self.name}_{index}'
                 index += 1
             if self.name != sdfg.name and Config.get_bool('debugprint'):

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2488,9 +2488,9 @@ class SDFG(ControlFlowRegion):
 
         if not self._recompile or Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists
-            lib_path, _ = compiler.get_binary_name(object_folder=build_folder,
-                                                   sdfg_name=self.name,
-                                                   folder_version=folder_version)
+            lib_path = compiler.get_binary_name(object_folder=build_folder,
+                                                sdfg_name=self.name,
+                                                folder_version=folder_version)
             if lib_path.is_file():
                 return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2488,9 +2488,9 @@ class SDFG(ControlFlowRegion):
 
         if not self._recompile or Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists
-            lib_path, _ = compiler.get_library_paths(object_folder=build_folder,
-                                                     sdfg_name=self.name,
-                                                     folder_version=folder_version)
+            lib_path, _ = compiler.get_binary_name(object_folder=build_folder,
+                                                   sdfg_name=self.name,
+                                                   folder_version=folder_version)
             if lib_path.is_file():
                 return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2497,7 +2497,7 @@ class SDFG(ControlFlowRegion):
                     #   The reason is that if code is generated the `CompiledSDFG.sdfg` attribute
                     #   of the returned handle is deepcopied. This means that changes to `self`
                     #   will not affect the attribute. But currently this is the case.
-                    return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
+                    return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self)
                 return
 
         ############################
@@ -2558,7 +2558,7 @@ class SDFG(ControlFlowRegion):
 
         # Get the function handle
         if return_program_handle:
-            return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=sdfg, folder_version=folder_version)
+            return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=sdfg)
 
     def argument_typecheck(self, args, kwargs, types_only=False):
         """ Checks if arguments and keyword arguments match the SDFG

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1783,6 +1783,11 @@ class SDFG(ControlFlowRegion):
         :param verbose: Be verbose, `False` by default.
         """
         from dace.cli.sdfv import view
+
+        # Ensure external nested SDFGs are loaded.
+        for _ in self.all_sdfgs_recursive(load_ext=True):
+            pass
+
         view(self, filename=filename, verbose=verbose)
 
     @staticmethod

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2493,6 +2493,10 @@ class SDFG(ControlFlowRegion):
                                                 folder_version=folder_version)
             if lib_path.is_file():
                 if return_program_handle:
+                    # NOTE: We should not pass `self` as `sdfg` argument, but instead deepcopy it.
+                    #   The reason is that if code is generated the `CompiledSDFG.sdfg` attribute
+                    #   of the returned handle is deepcopied. This means that changes to `self`
+                    #   will not affect the attribute. But currently this is the case.
                     return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
                 return
 
@@ -2540,6 +2544,7 @@ class SDFG(ControlFlowRegion):
         else:
             # The code was already generated, just load the program folder
             program_folder = build_folder
+            # NOTE: See the note above about deepcopying.
             sdfg = self
 
         # Compile the code and get the shared library path

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2448,12 +2448,17 @@ class SDFG(ControlFlowRegion):
 
     def is_loaded(self) -> bool:
         """
-        Returns True if the SDFG binary is already loaded in the current
-        process.
+        Returns True if the SDFG binary is already loaded in the current process.
+        Returns `False` if the file does not exist.
         """
         # Avoid import loops
         from dace.codegen import compiled_sdfg as cs, compiler
 
+        # Note here is kind of a "leak". The issue is that while the library is not
+        #  loaded the stub library is loaded. However, it is never unloaded, because
+        #  the `unload()` function is not called. This is probably not an issue, but
+        #  it is not super nice.
+        # TODO: Fix
         binary_filename = compiler.get_binary_name(self.build_folder, self.name)
         dll = cs.ReloadableDLL(binary_filename, self.name)
         return dll.is_loaded()
@@ -2475,11 +2480,15 @@ class SDFG(ControlFlowRegion):
         # Compute build folder path before running codegen
         build_folder = self.build_folder
 
+        folder_version = Config.get('compiler.build_folder_version')
+
         if not self._recompile or Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists
-            binary_filename = compiler.get_binary_name(build_folder, self.name)
-            if os.path.isfile(binary_filename):
-                return compiler.load_from_file(self, binary_filename)
+            lib_path, _ = compiler.get_library_paths(object_folder=build_folder,
+                                                     sdfg_name=self.name,
+                                                     folder_version=folder_version)
+            if lib_path.is_file():
+                return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
 
         ############################
         # DaCe Compilation Process #
@@ -2509,6 +2518,7 @@ class SDFG(ControlFlowRegion):
                 sdfg.fill_scope_connectors()
 
                 # Generate code for the program by traversing the SDFG state by state
+                #  It is not yet written to disc.
                 program_objects = codegen.generate_code(sdfg, validate=validate)
             except Exception:
                 fpath = os.path.join('_dacegraphs', 'failing.sdfgz')
@@ -2517,14 +2527,17 @@ class SDFG(ControlFlowRegion):
                 raise
 
             # Generate the program folder and write the source files
-            program_folder = compiler.generate_program_folder(sdfg, program_objects, build_folder)
+            program_folder = compiler.generate_program_folder(sdfg,
+                                                              program_objects,
+                                                              build_folder,
+                                                              folder_version=folder_version)
         else:
             # The code was already generated, just load the program folder
             program_folder = build_folder
             sdfg = self
 
         # Compile the code and get the shared library path
-        shared_library = compiler.configure_and_compile(program_folder, sdfg.name)
+        shared_library = compiler.configure_and_compile(program_folder, sdfg.name, folder_version=folder_version)
 
         # If provided, save output to path or filename
         if output_file is not None:
@@ -2534,7 +2547,7 @@ class SDFG(ControlFlowRegion):
 
         # Get the function handle
         if return_program_handle:
-            return compiler.get_program_handle(shared_library, sdfg)
+            return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
 
     def argument_typecheck(self, args, kwargs, types_only=False):
         """ Checks if arguments and keyword arguments match the SDFG

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2484,7 +2484,11 @@ class SDFG(ControlFlowRegion):
         # Compute build folder path before running codegen
         build_folder = self.build_folder
 
-        folder_version = Config.get('compiler.build_folder_version')
+        # Get the folder version, but if the folder already exist, then use the `VERSION` file.
+        if os.path.isdir(build_folder):
+            folder_version = get_folder_version(build_folder)
+        else:
+            folder_version = Config.get('compiler.build_folder_version')
 
         if not self._recompile or Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2486,7 +2486,7 @@ class SDFG(ControlFlowRegion):
 
         # Get the folder version, but if the folder already exist, then use the `VERSION` file.
         if os.path.isdir(build_folder):
-            folder_version = get_folder_version(build_folder)
+            folder_version = compiler.get_folder_version(build_folder)
         else:
             folder_version = Config.get('compiler.build_folder_version')
 

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2492,7 +2492,9 @@ class SDFG(ControlFlowRegion):
                                                 sdfg_name=self.name,
                                                 folder_version=folder_version)
             if lib_path.is_file():
-                return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
+                if return_program_handle:
+                    return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
+                return
 
         ############################
         # DaCe Compilation Process #

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2547,7 +2547,7 @@ class SDFG(ControlFlowRegion):
 
         # Get the function handle
         if return_program_handle:
-            return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=self, folder_version=folder_version)
+            return compiler.load_precompiled_sdfg(folder=build_folder, sdfg=sdfg, folder_version=folder_version)
 
     def argument_typecheck(self, args, kwargs, types_only=False):
         """ Checks if arguments and keyword arguments match the SDFG

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2461,11 +2461,10 @@ class SDFG(ControlFlowRegion):
 
         # Note here is kind of a "leak". The issue is that while the library is not
         #  loaded the stub library is loaded. However, it is never unloaded, because
-        #  the `unload()` function is not called. This is probably not an issue, but
-        #  it is not super nice.
-        # TODO: Fix
+        #  the `unload()` function is not called. This is technically not an issue
+        #  as `ctypes` will do that at some later point.
         binary_filename = compiler.get_binary_name(self.build_folder, self.name)
-        dll = cs.ReloadableDLL(binary_filename, self.name)
+        dll = cs.ReloadableDLL(binary_filename)
         return dll.is_loaded()
 
     def compile(self, output_file=None, validate=True, return_program_handle=True) -> 'CompiledSDFG':

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1682,9 +1682,8 @@ def distributed_compile(sdfg: SDFG, comm, *, validate: bool = True) -> csdfg.Com
     :param validate: If True, validates the SDFG prior to generating code.
     :return: Compiled SDFG.
     :note: This method can be used only if the module mpi4py is installed.
+    :todo: Relocate this function to `dace.codegen.compiler`.
     """
-
-    # TODO: Think if it should be relocated to `codegen`
 
     rank = comm.Get_rank()
     func = None

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1699,7 +1699,7 @@ def distributed_compile(sdfg: SDFG, comm, *, validate: bool = True) -> csdfg.Com
 
     # Loads compiled SDFG.
     if rank > 0:
-        func = load_precompiled_sdfg(folder)
+        func = sdfg_compiler.load_precompiled_sdfg(folder)
 
     comm.Barrier()
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1662,7 +1662,7 @@ def inline_sdfgs(sdfg: SDFG, permissive: bool = False, progress: bool = None, mu
     return counter
 
 
-def load_precompiled_sdfg(folder: str) -> csdfg.CompiledSDFG:
+def load_precompiled_sdfg(folder: str, folder_version: Optional[str] = None) -> csdfg.CompiledSDFG:
     """
     Loads a pre-compiled SDFG from an output folder (e.g. ".dacecache/program").
     Folder must contain a file called "program.sdfgz" and a subfolder called
@@ -1680,10 +1680,13 @@ def load_precompiled_sdfg(folder: str) -> csdfg.CompiledSDFG:
     if sdfg is None:
         raise ValueError(f"Pre-compiled SDFG not found in `{folder}`.")
 
-    suffix = config.Config.get('compiler', 'library_extension')
+    # TODO(phimuell): The build folder must be specified here to `folder`.
+    lib_path, libstub_path = csdfg.get_library_paths(object_folder=folder,
+                                                     sdfg=sdfg.name,
+                                                     folder_version=folder_version)
     return csdfg.CompiledSDFG(
         sdfg,
-        csdfg.ReloadableDLL(os.path.join(folder, 'build', f'lib{sdfg.name}.{suffix}'), sdfg.name),
+        csdfg.ReloadableDLL(library_filename=lib_path, libstub_path=libstub_path),
         sdfg.arg_names,
     )
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -9,7 +9,7 @@ import networkx as nx
 import time
 
 import dace.sdfg.nodes
-from dace.codegen import compiled_sdfg as csdfg
+from dace.codegen import compiled_sdfg as csdfg, compiler as sdfg_compiler
 from dace.sdfg.graph import MultiConnectorEdge
 from dace.sdfg.sdfg import SDFG, InterstateEdge
 from dace.sdfg.nodes import Node, NestedSDFG
@@ -1681,9 +1681,9 @@ def load_precompiled_sdfg(folder: str, folder_version: Optional[str] = None) -> 
         raise ValueError(f"Pre-compiled SDFG not found in `{folder}`.")
 
     # TODO(phimuell): The build folder must be specified here to `folder`.
-    lib_path, libstub_path = csdfg.get_library_paths(object_folder=folder,
-                                                     sdfg=sdfg.name,
-                                                     folder_version=folder_version)
+    lib_path, libstub_path = sdfg_compiler.get_library_paths(object_folder=folder,
+                                                             sdfg=sdfg.name,
+                                                             folder_version=folder_version)
     return csdfg.CompiledSDFG(
         sdfg,
         csdfg.ReloadableDLL(library_filename=lib_path, libstub_path=libstub_path),
@@ -1701,6 +1701,8 @@ def distributed_compile(sdfg: SDFG, comm, *, validate: bool = True) -> csdfg.Com
     :return: Compiled SDFG.
     :note: This method can be used only if the module mpi4py is installed.
     """
+
+    # TODO: Think if it should be relocated to `codegen`
 
     rank = comm.Get_rank()
     func = None

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1663,7 +1663,13 @@ def inline_sdfgs(sdfg: SDFG, permissive: bool = False, progress: bool = None, mu
 
 
 def load_precompiled_sdfg(*args, **kwargs) -> csdfg.CompiledSDFG:
-    # Deprecated use the one in `dace.codegen.compiler`.
+
+    warnings.warn(
+        'Used deprecated ``dace.sdfg.utils.load_precompiled_sdfg()`` function, use the one from ``dace.codegen.compiler`` instead.',
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     return sdfg_compiler.load_precompiled_sdfg(*args, **kwargs)
 
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1662,7 +1662,7 @@ def inline_sdfgs(sdfg: SDFG, permissive: bool = False, progress: bool = None, mu
     return counter
 
 
-def load_precompiled_sdfg(*args, **kwargs) -> csd.CompiledSDFG:
+def load_precompiled_sdfg(*args, **kwargs) -> csdfg.CompiledSDFG:
     # Deprecated use the one in `dace.codegen.compiler`.
     return sdfg_compiler.load_precompiled_sdfg(*args, **kwargs)
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1662,33 +1662,9 @@ def inline_sdfgs(sdfg: SDFG, permissive: bool = False, progress: bool = None, mu
     return counter
 
 
-def load_precompiled_sdfg(folder: str, folder_version: Optional[str] = None) -> csdfg.CompiledSDFG:
-    """
-    Loads a pre-compiled SDFG from an output folder (e.g. ".dacecache/program").
-    Folder must contain a file called "program.sdfgz" and a subfolder called
-    "build" with the shared object.
-
-    :param folder: Path to SDFG output folder.
-    :return: A callable CompiledSDFG object.
-    """
-    sdfg: SDFG | None = None
-    if os.path.exists(os.path.join(folder, 'program.sdfgz')):
-        sdfg = SDFG.from_file(os.path.join(folder, 'program.sdfgz'))
-    elif os.path.exists(os.path.join(folder, 'program.sdfg')):
-        # attempt to load uncompressed sdfg (backwards compatibility)
-        sdfg = SDFG.from_file(os.path.join(folder, 'program.sdfg'))
-    if sdfg is None:
-        raise ValueError(f"Pre-compiled SDFG not found in `{folder}`.")
-
-    # TODO(phimuell): The build folder must be specified here to `folder`.
-    lib_path, libstub_path = sdfg_compiler.get_library_paths(object_folder=folder,
-                                                             sdfg=sdfg.name,
-                                                             folder_version=folder_version)
-    return csdfg.CompiledSDFG(
-        sdfg,
-        csdfg.ReloadableDLL(library_filename=lib_path, libstub_path=libstub_path),
-        sdfg.arg_names,
-    )
+def load_precompiled_sdfg(*args, **kwargs) -> csd.CompiledSDFG:
+    # Deprecated use the one in `dace.codegen.compiler`.
+    return sdfg_compiler.load_precompiled_sdfg(*args, **kwargs)
 
 
 def distributed_compile(sdfg: SDFG, comm, *, validate: bool = True) -> csdfg.CompiledSDFG:

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -136,8 +136,11 @@ def test_production_folder_version():
     version_file.unlink()
     assert not version_file.exists()
 
-    with pytest.raises(ValueError, match=re.escape('Folder version was ``full`` but no ``build/`` folder found.')):
+    with pytest.raises(NotADirectoryError,
+                       match=re.escape(f'``{build_folder}`` does not appear to be a valid build folder.')):
         sdfg_compiler.get_folder_version(build_folder)
+
+    assert sdfg_compiler.get_folder_version(build_folder, probe=True) is None
 
 
 def _test_already_loaded_and_comple_again_impl(folder_version: str) -> None:

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -2,8 +2,14 @@
 import numpy as np
 import pytest
 import uuid
+import pathlib
+import copy
+import re
+
+from typing import Tuple
 
 import dace
+from dace.codegen import compiler as sdfg_compiler
 
 
 def _make_test_sdfg() -> dace.SDFG:
@@ -35,18 +41,110 @@ def _make_test_sdfg() -> dace.SDFG:
     return sdfg
 
 
-def _perform_compile_test_for(version: str):
-    a, b, c = (np.array(np.random.rand(10), copy=True, dtype=dace.float64.as_numpy_dtype()) for _ in range(3))
-    ref = a + b
+def _load_and_run_sdfg(build_folder, sdfg):
+    res = {name: np.array(np.random.rand(10), copy=True, dtype=np.float64) for name in "abc"}
+    ref = copy.deepcopy(res)
+    ref["c"] = ref["a"] + ref["b"]
+
+    csdfg = sdfg_compiler.load_precompiled_sdfg(build_folder, sdfg)
+    csdfg(**res)
+
+    assert all(np.allclose(ref[n], res[n]) for n in res.keys())
+
+
+def test_full_folder_version():
     with dace.config.temporary_config() as Config:
-        Config.set('compiler', 'build_folder_version', value=version)
+        Config.set('compiler', 'build_folder_version', value="full")
         sdfg = _make_test_sdfg()
-        csdfg = sdfg.compile()
-        # PERFROM INSPECTION OF THE FOLDER
+        build_folder = pathlib.Path(sdfg.build_folder)
+        assert not build_folder.exists()
 
-        csdfg(a=a, b=b, c=c)
-        assert np.allclose(c, ref)
+        not_csdfg = sdfg.compile(return_program_handle=False)
+        assert not_csdfg is None
+
+    assert build_folder.exists()
+    assert sdfg_compiler.get_folder_version(build_folder) == "full"
+
+    expected_files = {
+        "build": pathlib.Path.is_dir,
+        "include": pathlib.Path.is_dir,
+        "map": pathlib.Path.is_dir,
+        "perf": pathlib.Path.is_dir,
+        "sample": pathlib.Path.is_dir,
+        "src": pathlib.Path.is_dir,
+        "CACHEDIR.TAG": pathlib.Path.is_file,
+        "dace.conf": pathlib.Path.is_file,
+        "dace_files.csv": pathlib.Path.is_file,
+        "dace_environments.csv": pathlib.Path.is_file,
+        "program.sdfgz": pathlib.Path.is_file,
+        "VERSION": pathlib.Path.is_file,
+    }
+
+    for found_path in build_folder.iterdir():
+        found_file = found_path.name
+        assert found_file in expected_files
+        assert expected_files[found_file](found_path)
+
+    # Now run it.
+    _load_and_run_sdfg(build_folder, sdfg)
+
+    # Special case for full is that if there is no `VERSION` it is still full.
+    version_file = build_folder / "VERSION"
+    assert version_file.exists()
+    version_file.unlink()
+    assert not version_file.exists()
+    assert sdfg_compiler.get_folder_version(build_folder) == "full"
 
 
-def test_w():
-    _perform_compile_test_for("full")
+def test_production_folder_version():
+    with dace.config.temporary_config() as Config:
+        Config.set('compiler', 'build_folder_version', value="production")
+        sdfg = _make_test_sdfg()
+        build_folder = pathlib.Path(sdfg.build_folder)
+        assert not build_folder.exists()
+
+        not_csdfg = sdfg.compile(return_program_handle=False)
+        assert not_csdfg is None
+
+    assert build_folder.exists()
+    assert sdfg_compiler.get_folder_version(build_folder) == "production"
+
+    lib_path = sdfg_compiler.get_binary_name(build_folder, sdfg_name=sdfg.name, folder_version="production")
+    libstub_path = sdfg_compiler._get_stub_library_path(lib_path.name)
+
+    expected_files = {
+        "VERSION": pathlib.Path.is_file,
+        lib_path.name: pathlib.Path.is_file,
+        libstub_path.name: pathlib.Path.is_file,
+    }
+
+    for found_path in build_folder.iterdir():
+        found_file = found_path.name
+        assert found_file in expected_files
+        assert expected_files[found_file](found_path)
+
+    # Now run it.
+    _load_and_run_sdfg(build_folder, sdfg)
+
+    # If we delete the VERSION file we will get an error.
+    version_file = build_folder / "VERSION"
+    assert version_file.exists()
+    version_file.unlink()
+    assert not version_file.exists()
+
+    with pytest.raises(ValueError, match=re.escape('Folder version was ``full`` but no ``build/`` folder found.')):
+        sdfg_compiler.get_folder_version(build_folder)
+
+
+def test_reload_folder():
+    # Similar to `test_reload()` but with multiple versions.
+    #  Probably update that test.
+    pass
+
+
+def test_aleard_loaded_and_comple_again():
+    pass
+
+
+def test_build_with_scheme_one_and_then_switch():
+    pass

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -56,9 +56,9 @@ def _load_and_run_sdfg(build_folder, sdfg):
     _run_sdfg(csdfg)
 
 
-def test_full_folder_version():
+def test_development_folder_version():
     with dace.config.temporary_config() as Config:
-        Config.set('compiler', 'build_folder_version', value="full")
+        Config.set('compiler', 'build_folder_version', value="development")
         sdfg = _make_test_sdfg()
         build_folder = pathlib.Path(sdfg.build_folder)
         assert not build_folder.exists()
@@ -67,7 +67,7 @@ def test_full_folder_version():
         assert not_csdfg is None
 
     assert build_folder.exists()
-    assert sdfg_compiler.get_folder_version(build_folder) == "full"
+    assert sdfg_compiler.get_folder_version(build_folder) == "development"
 
     expected_files = {
         "build": pathlib.Path.is_dir,
@@ -92,12 +92,12 @@ def test_full_folder_version():
     # Now run it.
     _load_and_run_sdfg(build_folder, sdfg)
 
-    # Special case for full is that if there is no `VERSION` it is still full.
+    # Special case for development is that if there is no `VERSION` it is still development.
     version_file = build_folder / "VERSION"
     assert version_file.exists()
     version_file.unlink()
     assert not version_file.exists()
-    assert sdfg_compiler.get_folder_version(build_folder) == "full"
+    assert sdfg_compiler.get_folder_version(build_folder) == "development"
 
 
 def test_production_folder_version():
@@ -211,19 +211,19 @@ def _test_build_with_scheme_one_and_then_switch_impl(
 
 def test_build_with_scheme_one_and_then_switch():
     _test_build_with_scheme_one_and_then_switch_impl(
-        version1="full",
+        version1="development",
         version2="production",
     )
     _test_build_with_scheme_one_and_then_switch_impl(
         version1="production",
-        version2="full",
+        version2="development",
     )
 
 
 def test_already_loaded_and_comple_again():
     _test_build_with_scheme_one_and_then_switch_impl(
-        version1="full",
-        version2="full",
+        version1="development",
+        version2="development",
     )
     _test_build_with_scheme_one_and_then_switch_impl(
         version1="production",
@@ -232,7 +232,7 @@ def test_already_loaded_and_comple_again():
 
 
 if __name__ == '__main__':
-    test_full_folder_version()
+    test_development_folder_version()
     test_production_folder_version()
     test_already_loaded_and_comple_again()
     test_build_with_scheme_one_and_then_switch()

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -41,15 +41,19 @@ def _make_test_sdfg() -> dace.SDFG:
     return sdfg
 
 
-def _load_and_run_sdfg(build_folder, sdfg):
+def _run_sdfg(csdfg):
     res = {name: np.array(np.random.rand(10), copy=True, dtype=np.float64) for name in "abc"}
     ref = copy.deepcopy(res)
     ref["c"] = ref["a"] + ref["b"]
 
-    csdfg = sdfg_compiler.load_precompiled_sdfg(build_folder, sdfg)
     csdfg(**res)
 
     assert all(np.allclose(ref[n], res[n]) for n in res.keys())
+
+
+def _load_and_run_sdfg(build_folder, sdfg):
+    csdfg = sdfg_compiler.load_precompiled_sdfg(build_folder, sdfg)
+    _run_sdfg(csdfg)
 
 
 def test_full_folder_version():
@@ -136,14 +140,48 @@ def test_production_folder_version():
         sdfg_compiler.get_folder_version(build_folder)
 
 
-def test_reload_folder():
-    # Similar to `test_reload()` but with multiple versions.
-    #  Probably update that test.
-    pass
+def _test_already_loaded_and_comple_again_impl(folder_version: str) -> None:
+    with dace.config.temporary_config() as conf:
+        conf.set('compiler', 'build_folder_version', value=folder_version)
+
+        sdfg = _make_test_sdfg()
+        build_folder = pathlib.Path(sdfg.build_folder).resolve()
+        assert not build_folder.exists()
+
+        csdfg1 = sdfg.compile()
+
+    assert sdfg_compiler.get_folder_version(build_folder) == folder_version
+
+    # Note this should ensure that new code is generate and it is not just loaded.
+    conf.set('compiler', 'use_cache', value=False)
+    sdfg._recompile = True
+    sdfg.regenerate_code = True
+
+    csdfg2 = sdfg.compile()
+    lib1_path = pathlib.Path(csdfg1.filename)
+    lib2_path = pathlib.Path(csdfg2.filename)
+
+    assert sdfg_compiler.get_folder_version(build_folder) == folder_version
+    assert lib1_path != lib2_path
+    assert lib1_path.exists()
+    assert lib2_path.exists()
+    assert str(lib1_path).startswith(str(build_folder))
+    assert str(lib2_path).startswith(str(build_folder))
+
+    if folder_version == "production":
+        assert lib1_path.parent == build_folder
+        assert lib2_path.parent == build_folder
+    else:
+        assert str(lib1_path).startswith(str(build_folder))
+        assert str(lib2_path).startswith(str(build_folder))
+
+    _run_sdfg(csdfg1)
+    _run_sdfg(csdfg2)
 
 
-def test_aleard_loaded_and_comple_again():
-    pass
+def test_already_loaded_and_comple_again():
+    _test_already_loaded_and_comple_again_impl("full")
+    _test_already_loaded_and_comple_again_impl("production")
 
 
 def test_build_with_scheme_one_and_then_switch():

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -153,13 +153,14 @@ def _test_already_loaded_and_comple_again_impl(folder_version: str) -> None:
     assert sdfg_compiler.get_folder_version(build_folder) == folder_version
 
     # Note this should ensure that new code is generate and it is not just loaded.
-    conf.set('compiler', 'use_cache', value=False)
-    sdfg._recompile = True
-    sdfg.regenerate_code = True
+    with dace.config.temporary_config() as conf:
+        conf.set('compiler', 'use_cache', value=False)
+        sdfg._recompile = True
+        sdfg.regenerate_code = True
 
-    csdfg2 = sdfg.compile()
-    lib1_path = pathlib.Path(csdfg1.filename)
-    lib2_path = pathlib.Path(csdfg2.filename)
+        csdfg2 = sdfg.compile()
+        lib1_path = pathlib.Path(csdfg1.filename)
+        lib2_path = pathlib.Path(csdfg2.filename)
 
     assert sdfg_compiler.get_folder_version(build_folder) == folder_version
     assert lib1_path != lib2_path
@@ -184,11 +185,85 @@ def test_already_loaded_and_comple_again():
     _test_already_loaded_and_comple_again_impl("production")
 
 
+def _test_build_with_scheme_one_and_then_switch_impl(
+    version1: str,
+    version2: str,
+) -> None:
+    with dace.config.temporary_config() as conf:
+        conf.set('compiler', 'build_folder_version', value=version1)
+
+        sdfg = _make_test_sdfg()
+        build_folder = pathlib.Path(sdfg.build_folder).resolve()
+        assert not build_folder.exists()
+
+        csdfg1 = sdfg.compile()
+
+    lib1_path = pathlib.Path(csdfg1.filename)
+    assert sdfg_compiler.get_folder_version(build_folder) == version1
+    assert lib1_path.exists()
+
+    with dace.config.temporary_config() as conf:
+        conf.set('compiler', 'build_folder_version', value=version1)
+
+        # This is for ensuring that the code is actually regenerated.
+        conf.set('compiler', 'use_cache', value=False)
+        sdfg._recompile = True
+        sdfg.regenerate_code = True
+
+        csdfg2 = sdfg.compile()
+
+    lib2_path = pathlib.Path(csdfg2.filename)
+
+    assert sdfg_compiler.get_folder_version(build_folder) == version1
+    assert csdfg1.sdfg.name != csdfg2.sdfg.name
+    assert lib1_path != lib2_path
+    assert lib1_path.exists()  # Still existing.
+    assert lib2_path.exists()
+    assert str(lib1_path).startswith(str(build_folder))
+    assert str(lib2_path).startswith(str(build_folder))
+
+    if version1 == "production":
+        assert lib1_path.parent == build_folder
+        assert lib2_path.parent == build_folder
+        libstub1_path = sdfg_compiler._get_stub_library_path(lib1_path.name)
+        libstub2_path = sdfg_compiler._get_stub_library_path(lib2_path.name)
+
+        expected_files = {
+            "VERSION": pathlib.Path.is_file,
+            lib1_path.name: pathlib.Path.is_file,
+            libstub1_path.name: pathlib.Path.is_file,
+            lib2_path.name: pathlib.Path.is_file,
+            libstub2_path.name: pathlib.Path.is_file,
+        }
+        for found_path in build_folder.iterdir():
+            found_file = found_path.name
+            assert found_file in expected_files
+            assert expected_files[found_file](found_path)
+
+    else:
+        assert str(lib1_path).startswith(str(build_folder / "build"))
+        assert str(lib2_path).startswith(str(build_folder / "build"))
+        assert (build_folder / "build").is_dir()
+        assert (build_folder / "src").is_dir()
+        assert (build_folder / "include").is_dir()
+
+    _run_sdfg(csdfg1)
+    _run_sdfg(csdfg2)
+
+
 def test_build_with_scheme_one_and_then_switch():
-    pass
+    _test_build_with_scheme_one_and_then_switch_impl(
+        version1="full",
+        version2="production",
+    )
+    _test_build_with_scheme_one_and_then_switch_impl(
+        version1="production",
+        version2="full",
+    )
 
 
 if __name__ == '__main__':
     test_full_folder_version()
     test_production_folder_version()
     test_already_loaded_and_comple_again()
+    test_build_with_scheme_one_and_then_switch()

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -1,0 +1,52 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+import numpy as np
+import pytest
+import uuid
+
+import dace
+
+
+def _make_test_sdfg() -> dace.SDFG:
+    sdfg = dace.SDFG("test_sdfg_" + str(uuid.uuid1()).replace("-", "_"))
+    state = sdfg.add_state()
+    for name in "abc":
+        sdfg.add_array(
+            name,
+            shape=(10, ),
+            dtype=dace.float64,
+            transient=False,
+        )
+
+    state.add_mapped_tasklet(
+        "comp",
+        map_ranges={"__i": "0:10"},
+        inputs={
+            "__in1": dace.Memlet("a[__i]"),
+            "__in2": dace.Memlet("b[__i]"),
+        },
+        outputs={
+            "__out": dace.Memlet("c[__i]"),
+        },
+        code="__out = __in1 + __in2",
+        external_edges=True,
+    )
+    sdfg.validate()
+
+    return sdfg
+
+
+def _perform_compile_test_for(version: str):
+    a, b, c = (np.array(np.random.rand(10), copy=True, dtype=dace.float64.as_numpy_dtype()) for _ in range(3))
+    ref = a + b
+    with dace.config.temporary_config() as Config:
+        Config.set('compiler', 'build_folder_version', value=version)
+        sdfg = _make_test_sdfg()
+        csdfg = sdfg.compile()
+        # PERFROM INSPECTION OF THE FOLDER
+
+        csdfg(a=a, b=b, c=c)
+        assert np.allclose(c, ref)
+
+
+def test_w():
+    _perform_compile_test_for("full")

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -186,3 +186,9 @@ def test_already_loaded_and_comple_again():
 
 def test_build_with_scheme_one_and_then_switch():
     pass
+
+
+if __name__ == '__main__':
+    test_full_folder_version()
+    test_production_folder_version()
+    test_already_loaded_and_comple_again()

--- a/tests/compile_folder_version_test.py
+++ b/tests/compile_folder_version_test.py
@@ -143,51 +143,6 @@ def test_production_folder_version():
     assert sdfg_compiler.get_folder_version(build_folder, probe=True) is None
 
 
-def _test_already_loaded_and_comple_again_impl(folder_version: str) -> None:
-    with dace.config.temporary_config() as conf:
-        conf.set('compiler', 'build_folder_version', value=folder_version)
-
-        sdfg = _make_test_sdfg()
-        build_folder = pathlib.Path(sdfg.build_folder).resolve()
-        assert not build_folder.exists()
-
-        csdfg1 = sdfg.compile()
-
-    assert sdfg_compiler.get_folder_version(build_folder) == folder_version
-
-    # Note this should ensure that new code is generate and it is not just loaded.
-    with dace.config.temporary_config() as conf:
-        conf.set('compiler', 'use_cache', value=False)
-        sdfg._recompile = True
-        sdfg.regenerate_code = True
-
-        csdfg2 = sdfg.compile()
-        lib1_path = pathlib.Path(csdfg1.filename)
-        lib2_path = pathlib.Path(csdfg2.filename)
-
-    assert sdfg_compiler.get_folder_version(build_folder) == folder_version
-    assert lib1_path != lib2_path
-    assert lib1_path.exists()
-    assert lib2_path.exists()
-    assert str(lib1_path).startswith(str(build_folder))
-    assert str(lib2_path).startswith(str(build_folder))
-
-    if folder_version == "production":
-        assert lib1_path.parent == build_folder
-        assert lib2_path.parent == build_folder
-    else:
-        assert str(lib1_path).startswith(str(build_folder))
-        assert str(lib2_path).startswith(str(build_folder))
-
-    _run_sdfg(csdfg1)
-    _run_sdfg(csdfg2)
-
-
-def test_already_loaded_and_comple_again():
-    _test_already_loaded_and_comple_again_impl("full")
-    _test_already_loaded_and_comple_again_impl("production")
-
-
 def _test_build_with_scheme_one_and_then_switch_impl(
     version1: str,
     version2: str,
@@ -262,6 +217,17 @@ def test_build_with_scheme_one_and_then_switch():
     _test_build_with_scheme_one_and_then_switch_impl(
         version1="production",
         version2="full",
+    )
+
+
+def test_already_loaded_and_comple_again():
+    _test_build_with_scheme_one_and_then_switch_impl(
+        version1="full",
+        version2="full",
+    )
+    _test_build_with_scheme_one_and_then_switch_impl(
+        version1="production",
+        version2="production",
     )
 
 

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -56,10 +56,26 @@ def test_reload():
 
 
 def test_load_precompiled():
+    for folder_version in ["full", "production"]:
+        with dace.config.temporary_config() as conf:
+            conf.set('compiler', 'build_folder_version', value=folder_version)
+            _load_precompiled_impl(
+                test_name="test_load_precompiled",
+                folder_version=folder_version,
+            )
+
+
+def _load_precompiled_impl(test_name: str, folder_version: str) -> None:
     prog = program_generator(10, 2.0)
     sdfg = prog.to_sdfg()
+    sdfg.name = f'{test_name}_{sdfg.name}_{folder_version}'
+
     func1 = sdfg.compile()
-    func2 = load_precompiled_sdfg(sdfg.build_folder)
+
+    if folder_version == "production":
+        func2 = load_precompiled_sdfg(sdfg.build_folder, sdfg=sdfg)
+    elif folder_version == "full":
+        func2 = load_precompiled_sdfg(sdfg.build_folder)
 
     inp = np.random.rand(10).astype(np.float64)
     output_one = np.zeros(10, dtype=np.float64)

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import pytest
+import pathlib
 
 import dace
 from dace.frontend.python.parser import DaceProgram
@@ -32,14 +33,18 @@ def test_reload():
     prog_one = program_generator(10, 2.0)
     prog_two = program_generator(20, 4.0)
 
-    # This should create two libraries for the two SDFGs, as they compile over
-    # the same folder
+    # This should create two libraries for the two SDFGs, as they compile over the same folder
     func1 = prog_one.compile()
     try:
         func2 = prog_two.compile()
     except CompilationError:
         # On some systems (e.g., Windows), the file will be locked, so compilation will fail
         pytest.skip('Compilation failed due to locked file. Skipping test.')
+
+    lib1_path = pathlib.Path(func1.filename)
+    lib2_path = pathlib.Path(func2.filename)
+    assert lib1_path != lib2_path
+    assert lib1_path.parent == lib2_path.parent
 
     func1(input=array_one, output=output_one)
     func2(input=array_two, output=output_two)
@@ -62,6 +67,11 @@ def test_load_precompiled():
 
     func1(input=inp, output=output_one)
     func2(input=inp, output=output_two)
+
+    lib1_path = pathlib.Path(func1.filename)
+    lib2_path = pathlib.Path(func2.filename)
+    assert lib1_path != lib2_path
+    assert lib1_path.parent == lib2_path.parent
 
     assert (np.allclose(output_one, output_two))
 

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -1,8 +1,10 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import pytest
+
 import dace
 from dace.frontend.python.parser import DaceProgram
 from dace.codegen.exceptions import CompilationError
-from dace.sdfg.utils import load_precompiled_sdfg
+from dace.sdfg.compiler import load_precompiled_sdfg
 import numpy as np
 
 
@@ -22,8 +24,6 @@ def program_generator(size: int, factor: float) -> DaceProgram:
 
 
 def test_reload():
-    print('Reloadable DaCe program test')
-
     array_one = np.random.rand(10).astype(np.float64)
     array_two = np.random.rand(20).astype(np.float64)
     output_one = np.zeros(10, dtype=np.float64)
@@ -38,10 +38,8 @@ def test_reload():
     try:
         func2 = prog_two.compile()
     except CompilationError:
-        # On some systems (e.g., Windows), the file will be locked, so
-        # compilation will fail
-        print('Compilation failed due to locked file. Skipping test.')
-        return
+        # On some systems (e.g., Windows), the file will be locked, so compilation will fail
+        pytest.skip('Compilation failed due to locked file. Skipping test.')
 
     func1(input=array_one, output=output_one)
     func2(input=array_two, output=output_two)

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -56,7 +56,7 @@ def test_reload():
 
 
 def test_load_precompiled():
-    for folder_version in ["full", "production"]:
+    for folder_version in ["development", "production"]:
         with dace.config.temporary_config() as conf:
             conf.set('compiler', 'build_folder_version', value=folder_version)
             _load_precompiled_impl(
@@ -74,7 +74,7 @@ def _load_precompiled_impl(test_name: str, folder_version: str) -> None:
 
     if folder_version == "production":
         func2 = load_precompiled_sdfg(sdfg.build_folder, sdfg=sdfg)
-    elif folder_version == "full":
+    elif folder_version == "development":
         func2 = load_precompiled_sdfg(sdfg.build_folder)
 
     inp = np.random.rand(10).astype(np.float64)

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -4,7 +4,7 @@ import pytest
 import dace
 from dace.frontend.python.parser import DaceProgram
 from dace.codegen.exceptions import CompilationError
-from dace.sdfg.compiler import load_precompiled_sdfg
+from dace.codegen.compiler import load_precompiled_sdfg
 import numpy as np
 
 

--- a/tests/parse_state_struct_test.py
+++ b/tests/parse_state_struct_test.py
@@ -40,7 +40,7 @@ def _cuda_helper():
     compiler.generate_program_folder(None, [program, dummy_cuda_target], BUILD_PATH)
     compiler.configure_and_compile(BUILD_PATH)
 
-    checker_dll = compiled_sdfg.ReloadableDLL(compiler.get_binary_name(BUILD_PATH, "cuda_helper"), "cuda_helper")
+    checker_dll = compiled_sdfg.ReloadableDLL(compiler.get_binary_name(BUILD_PATH, "cuda_helper"))
 
     class CudaHelper:
 


### PR DESCRIPTION
The initial idea was to reduce the size of the cache folder, by only storing the components that are needed.
To this end the code generator was modified such that different versions of build folder could be generated.
Currently there are only two versions:
- `development`: Which is the old full version, i.e. everything in a single folder.
- `production`: This is a reduced folder and only contains the libraries (stub and program library) as well the version.

The implementation has two parts. First `generate_program_folder()` was modified such that it only generates the parts that are absolutely needed, such as source files and anything else would not be generated in the first place.
Then `compile_and_configure()` was modified such that it would remove the parts that are no longer needed (an example would be the source files which are needed for compilation but not afterwards).

The changes are backwards compatible. Thus, caches that were generated _before_ this PR will still work, but they should be phased out.
The changes are also done in a way that it should be simple to add new modes later, if their need arises.

In Addition:
- Also fixes that `sdfg.view()` fails if there are external SDFGs ([727cfb1](https://github.com/spcl/dace/pull/2331/commits/727cfb1190fe801da286031ca251a1743d7d31dd))
- `sdfg.generate_code()` no longer generates the source maps as a side effect and writes them to disc. Instead they are generated by the `generate_program_folder()` ([5e1694b](https://github.com/spcl/dace/pull/2331/commits/5e1694b09b831e68c10c81c8a51e6708bd9bc81a)).
- Dumping of the configuration in the build folder ([eb54062](https://github.com/spcl/dace/pull/2331/commits/eb540625fe7ed01699bf73458caeaf1e53feb625)).
- Miscellaneous refactoring in the `ReloadableDLL`, that changed its interface.