### PR TITLE
Fix pytest-xdist race on octave parsetab.py generation

### DIFF
--- a/dace/frontend/octave/parse.py
+++ b/dace/frontend/octave/parse.py
@@ -675,7 +675,7 @@ def p_error(p):
     raise ValueError("Unexpected EOF")
 
 
-parser = yacc.yacc(start="top")
+parser = yacc.yacc(start="top", write_tables=False, debug=False)
 
 
 def parse(buf, debug=False):


### PR DESCRIPTION
yacc.yacc() defaults to write_tables=True with no locking, so under pytest -n 32 all workers race to write dace/frontend/octave/parsetab.py at module import time. One worker reads a half-written file and crashes with SyntaxError: '[' was never closed.