### PR TITLE
ci: update codecov action to support node24

### DIFF
--- a/.github/workflows/general-ci.yml
+++ b/.github/workflows/general-ci.yml
@@ -106,7 +106,7 @@ jobs:
         ./tests/xform_test.sh
         coverage combine .; coverage report; coverage xml
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/ml-ci.yml
+++ b/.github/workflows/ml-ci.yml
@@ -56,7 +56,7 @@ jobs:
         pytest --cov-report=xml --cov=dace --tb=short --timeout_method thread --timeout=600 -v -m "(torch or onnx or autodiff) and not gpu"
         ./codecov
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true


### PR DESCRIPTION
## Description

This PR updates the action `codecov/codecov-action` from `v5` to `v6`. This step is needed to support GHA runners based on node24.

<img width="1655" height="428" alt="image" src="https://github.com/user-attachments/assets/0901bf1b-2285-4394-b005-4b64b855233e" />

The only change in the codecov action between `v5` and `v6` is to support GHA runners based on node24. The update should come without any issues.

More information can be found [here](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).