### PR TITLE
Avoid DebugInfo warnings (take two)

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -9,8 +9,8 @@ import inspect
 import itertools
 import warnings
 import sympy
-from typing import (TYPE_CHECKING, Any, AnyStr, Callable, Dict, Iterable, Iterator, List, Literal, Optional, Set, Tuple,
-                    Union, overload)
+from typing import (TYPE_CHECKING, Any, AnyStr, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union,
+                    overload)
 
 import dace
 from dace.frontend.python import astutils
@@ -39,39 +39,22 @@ if TYPE_CHECKING:
 NodeT = Union[nd.Node, 'ControlFlowBlock']
 EdgeT = Union[MultiConnectorEdge[mm.Memlet], Edge['dace.sdfg.InterstateEdge']]
 GraphT = Union['ControlFlowRegion', 'SDFGState']
-ConfigurableDebugInfo = Literal["config"] | dtypes.DebugInfo | None
 
 
-def _get_debug_info(
-    debug_info: ConfigurableDebugInfo,
-    default_lineinfo: dtypes.DebugInfo | None,
-) -> dtypes.DebugInfo | None:
+def _get_debug_info(explicit_lineinfo: dtypes.DebugInfo | None) -> dtypes.DebugInfo | None:
     """Returns a DebugInfo from the stack, if configured.
 
     If lineinfo is configured in the config, this function inspects the python
     stacktrace and returns a DebugInfo object for the position that called this
-    function. `default_lineinfo` has precedence, if given.
+    function. `explicit_lineinfo` has precedence, if given.
     """
+    if dace.Config.get("compiler", "lineinfo") == "none":
+        return None
 
-    if isinstance(debug_info, dtypes.DebugInfo):
-        warnings.warn(
-            "Passing debug_info of type DebugInfo is deprecated. Pass `'config'` and set `compiler.lineinfo` in your DaCe config.",
-            DeprecationWarning,
-            stacklevel=3)
-        return debug_info
+    if explicit_lineinfo is not None:
+        return explicit_lineinfo
 
-    if debug_info is None:
-        warnings.warn(
-            "Passing debug_info=None is deprecated. Pass `'config'` and set `compiler.lineinfo` in your DaCe config.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-    do_inspect = dace.Config.get("compiler", "lineinfo") == "inspect" if debug_info == "config" else False
-    if (debug_info is None or do_inspect) and default_lineinfo is not None:
-        return default_lineinfo
-
-    if do_inspect:
+    if dace.Config.get("compiler", "lineinfo") == "inspect":
         caller = inspect.getframeinfo(inspect.stack()[2][0], context=0)
         return dtypes.DebugInfo(caller.lineno, 0, caller.lineno, 0, caller.filename)
 
@@ -1669,7 +1652,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :param debuginfo: Source line information for this access node.
             :return: An array access node.
         """
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
         node = nd.AccessNode(array_or_stream_name, debuginfo=debuginfo)
         self.add_node(node)
         return node
@@ -1690,7 +1673,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         debuginfo: Optional[dtypes.DebugInfo] = None,
     ):
         """ Adds a tasklet to the SDFG state. """
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
 
         # Make dictionary of autodetect connector types from set
         if isinstance(inputs, (set, collections.abc.KeysView)):
@@ -1759,7 +1742,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         """
         if name is None:
             name = sdfg.label
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
 
         if sdfg is None and external_path is None:
             raise ValueError('Neither an SDFG nor an external SDFG path has been provided')
@@ -1835,7 +1818,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
 
             :return: (map_entry, map_exit) node 2-tuple
         """
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
         map = nd.Map(name, *_make_iterators(ndrange), schedule=schedule, unroll=unroll, debuginfo=debuginfo)
         map_entry = nd.MapEntry(map)
         map_exit = nd.MapExit(map)
@@ -1873,7 +1856,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
                             "(PE_index, num_PEs)")
         pe_tuple = (elements[0], SymbolicProperty.from_string(elements[1]))
 
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
         if condition is not None:
             condition = CodeBlock(condition, language)
         consume = nd.Consume(name, pe_tuple, condition, schedule, chunksize, debuginfo=debuginfo)
@@ -1932,7 +1915,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :return: tuple of (tasklet, map_entry, map_exit)
         """
         map_name = name + "_map"
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
 
         # Create appropriate dictionaries from inputs
         tinputs = {k: None for k, v in inputs.items()}
@@ -2066,7 +2049,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :return: A Reduce node
         """
         import dace.libraries.standard as stdlib  # Avoid import loop
-        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
+        debuginfo = _get_debug_info(debuginfo or self._default_lineinfo)
         result = stdlib.Reduce('Reduce', wcr, axes, identity, schedule=schedule, debuginfo=debuginfo)
         self.add_node(result)
         return result

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1280,7 +1280,7 @@ class ControlFlowBlock(BlockGraphView, abc.ABC):
     def sub_regions(self) -> List['AbstractControlFlowRegion']:
         return []
 
-    def set_default_lineinfo(self, lineinfo: dace.dtypes.DebugInfo):
+    def set_default_lineinfo(self, lineinfo: Optional[dace.dtypes.DebugInfo]) -> None:
         """
         Sets the default source line information to be lineinfo, or None to
         revert to default mode.
@@ -1640,7 +1640,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
 
     # Dynamic SDFG creation API
     ##############################
-    def add_read(self, array_or_stream_name: str, debuginfo: ConfigurableDebugInfo = "config") -> nd.AccessNode:
+    def add_read(self, array_or_stream_name: str, debuginfo: Optional[dtypes.DebugInfo] = None) -> nd.AccessNode:
         """
         Adds an access node to this SDFG state (alias of ``add_access``).
 
@@ -1651,7 +1651,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         """
         return self.add_access(array_or_stream_name, debuginfo=debuginfo)
 
-    def add_write(self, array_or_stream_name: str, debuginfo: ConfigurableDebugInfo = "config") -> nd.AccessNode:
+    def add_write(self, array_or_stream_name: str, debuginfo: Optional[dtypes.DebugInfo] = None) -> nd.AccessNode:
         """
         Adds an access node to this SDFG state (alias of ``add_access``).
 
@@ -1662,14 +1662,14 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         """
         return self.add_access(array_or_stream_name, debuginfo=debuginfo)
 
-    def add_access(self, array_or_stream_name: str, debuginfo: ConfigurableDebugInfo = "config") -> nd.AccessNode:
+    def add_access(self, array_or_stream_name: str, debuginfo: Optional[dtypes.DebugInfo] = None) -> nd.AccessNode:
         """ Adds an access node to this SDFG state.
 
             :param array_or_stream_name: The name of the array/stream.
             :param debuginfo: Source line information for this access node.
             :return: An array access node.
         """
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
         node = nd.AccessNode(array_or_stream_name, debuginfo=debuginfo)
         self.add_node(node)
         return node
@@ -1687,10 +1687,10 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         code_exit: str = "",
         location: dict = None,
         side_effects: Optional[bool] = None,
-        debuginfo: ConfigurableDebugInfo = "config",
+        debuginfo: Optional[dtypes.DebugInfo] = None,
     ):
         """ Adds a tasklet to the SDFG state. """
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
 
         # Make dictionary of autodetect connector types from set
         if isinstance(inputs, (set, collections.abc.KeysView)):
@@ -1736,7 +1736,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         symbol_mapping: Dict[str, Any] = None,
         name=None,
         location: Optional[Dict[str, symbolic.SymbolicType]] = None,
-        debuginfo: ConfigurableDebugInfo = "config",
+        debuginfo: Optional[dtypes.DebugInfo] = None,
         external_path: Optional[str] = None,
     ):
         """
@@ -1759,7 +1759,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         """
         if name is None:
             name = sdfg.label
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
 
         if sdfg is None and external_path is None:
             raise ValueError('Neither an SDFG nor an external SDFG path has been provided')
@@ -1823,7 +1823,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         ndrange: Union[Dict[str, Union[str, sbs.Subset]], List[Tuple[str, Union[str, sbs.Subset]]]],
         schedule=dtypes.ScheduleType.Default,
         unroll=False,
-        debuginfo: ConfigurableDebugInfo = "config",
+        debuginfo: Optional[dtypes.DebugInfo] = None,
     ) -> Tuple[nd.MapEntry, nd.MapExit]:
         """ Adds a map entry and map exit.
 
@@ -1835,7 +1835,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
 
             :return: (map_entry, map_exit) node 2-tuple
         """
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
         map = nd.Map(name, *_make_iterators(ndrange), schedule=schedule, unroll=unroll, debuginfo=debuginfo)
         map_entry = nd.MapEntry(map)
         map_exit = nd.MapExit(map)
@@ -1849,7 +1849,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         condition: str = None,
         schedule=dtypes.ScheduleType.Default,
         chunksize=1,
-        debuginfo: ConfigurableDebugInfo = "config",
+        debuginfo: Optional[dtypes.DebugInfo] = None,
         language=dtypes.Language.Python,
     ) -> Tuple[nd.ConsumeEntry, nd.ConsumeExit]:
         """ Adds consume entry and consume exit nodes.
@@ -1873,7 +1873,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
                             "(PE_index, num_PEs)")
         pe_tuple = (elements[0], SymbolicProperty.from_string(elements[1]))
 
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
         if condition is not None:
             condition = CodeBlock(condition, language)
         consume = nd.Consume(name, pe_tuple, condition, schedule, chunksize, debuginfo=debuginfo)
@@ -1894,7 +1894,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         unroll_map=False,
         location=None,
         language=dtypes.Language.Python,
-        debuginfo: ConfigurableDebugInfo = "config",
+        debuginfo: Optional[dtypes.DebugInfo] = None,
         external_edges=False,
         input_nodes: Optional[Union[Dict[str, nd.AccessNode], List[nd.AccessNode], Set[nd.AccessNode]]] = None,
         output_nodes: Optional[Union[Dict[str, nd.AccessNode], List[nd.AccessNode], Set[nd.AccessNode]]] = None,
@@ -1932,7 +1932,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :return: tuple of (tasklet, map_entry, map_exit)
         """
         map_name = name + "_map"
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
 
         # Create appropriate dictionaries from inputs
         tinputs = {k: None for k, v in inputs.items()}
@@ -2052,7 +2052,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         axes,
         identity=None,
         schedule=dtypes.ScheduleType.Default,
-        debuginfo: ConfigurableDebugInfo = "config",
+        debuginfo: Optional[dtypes.DebugInfo] = None,
     ) -> 'dace.libraries.standard.Reduce':
         """ Adds a reduction node.
 
@@ -2066,7 +2066,7 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             :return: A Reduce node
         """
         import dace.libraries.standard as stdlib  # Avoid import loop
-        debuginfo = _get_debug_info(debuginfo, self._default_lineinfo)
+        debuginfo = _get_debug_info("config", debuginfo or self._default_lineinfo)
         result = stdlib.Reduce('Reduce', wcr, axes, identity, schedule=schedule, debuginfo=debuginfo)
         self.add_node(result)
         return result

--- a/tests/python_frontend/debug_info_test.py
+++ b/tests/python_frontend/debug_info_test.py
@@ -43,26 +43,13 @@ def test_using_default_lineinfo(state: SDFGState) -> None:
     assert read_A.debuginfo.filename == filename
     assert read_A.debuginfo.start_line == line
 
-    with pytest.deprecated_call():
-        read_B = state.add_read("B", None)
+    read_B = state.add_read("B", debuginfo=None)
     assert read_B.debuginfo is not None
     assert read_B.debuginfo.filename == filename
     assert read_B.debuginfo.start_line == line
-
-
-def test_passing_debug_info_warns(state: SDFGState) -> None:
-    with pytest.deprecated_call():
-        state.add_access("A", debuginfo=dtypes.DebugInfo(start_line=42))
-
-
-def test_passing_None_warns(state: SDFGState) -> None:
-    with pytest.deprecated_call():
-        state.add_access("A", debuginfo=None)
 
 
 if __name__ == "__main__":
     test_config_compiler_lineinfo_none()
     test_config_compiler_lineinfo_inspect()
     test_using_default_lineinfo()
-    test_passing_debug_info_warns()
-    test_passing_None_warns()


### PR DESCRIPTION
## Description

In PR https://github.com/spcl/dace/pull/2321 we introduced a way to turn of automatic stack inspection when adding a node to a state without explicitly stating debug info (such as file name, line info, ...). Since merging this PR, we get a ton of `DeprecationWarning`s from code added in `_get_debug_info()`.

In a first attempt (see PR https://github.com/spcl/dace/pull/2344), we tried to work around the issue by setting `._default_line_info` on the state. This method proved to be very verbose and unnecessarily complicates parsing, where we have a legitimate use-case for explicitly passing along an explicit `DebugInfo`.

This PR suggests to keep the API of `state.add_*()` functions as before, partially reverting changes from PR https://github.com/spcl/dace/pull/2321. Doing so, we can drop the deprecation warnings because nothing changes.