### PR TITLE
Rename `build_folder_version` to `build_folder_mode`

### DIFF
--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -30,19 +30,19 @@ def generate_program_folder(
     code_objects: List[CodeObject],
     out_path: str,
     config=None,
-    folder_version: Optional[str] = None,
+    folder_mode: Optional[str] = None,
 ) -> str:
     """Writes all files required to configure and compile the DaCe program into the specified folder.
 
-    This function respects the ``compiler.build_folder_version`` configuration variable,
+    This function respects the ``compiler.build_folder_mode`` configuration variable,
     thus depending on its value the content might be different. However, in any case
     the source files are always generated.
 
     :param sdfg: The SDFG to generate the program folder for.
     :param code_objects: List of generated code objects.
     :param out_path: The folder in which the build files should be written.
-    :param folder_version: Version of the program folder that should be generated,
-                           if not given ``compiler.build_folder_version`` is used.
+    :param folder_mode: Version of the program folder that should be generated,
+                           if not given ``compiler.build_folder_mode`` is used.
     :return: Path to the program folder.
 
     :note: The ``config`` argument is retained for compatibility and should not be used.
@@ -64,8 +64,8 @@ def generate_program_folder(
             stacklevel=2,
         )
 
-    if folder_version is None:
-        folder_version = Config.get('compiler', 'build_folder_version')
+    if folder_mode is None:
+        folder_mode = Config.get('compiler', 'build_folder_mode')
 
     src_path = os.path.join(out_path, "src")
     filelist = list()
@@ -111,7 +111,7 @@ def generate_program_folder(
             filelist.append("{},{},{}".format(target_name, target_type, basename))
 
         # Generate the source map.
-        if sdfg and (folder_version in ["development"]):
+        if sdfg and (folder_mode in ["development"]):
             if code_object.language == 'cpp' and code_object.title == 'Frame':
                 code_object.create_source_map(sdfg)
 
@@ -132,7 +132,7 @@ def generate_program_folder(
 
     # Save the SDFG itself and its hash
     if sdfg is not None:
-        if folder_version in ["development"]:
+        if folder_mode in ["development"]:
             hash = sdfg.save(os.path.join(out_path, "program.sdfgz"), hash=True, compress=True)
         else:
             hash = sdfg.hash_sdfg()
@@ -142,26 +142,26 @@ def generate_program_folder(
             with open(filepath, 'w') as hfile:
                 hfile.write(contents)
 
+    # Write cachedir tag
+    cachedir_tag = os.path.join(out_path, "CACHEDIR.TAG")
+    if not os.path.exists(cachedir_tag):
+        with open(cachedir_tag, "w") as f:
+            f.write("\n".join([
+                "Signature: 8a477f597d28d172789f06886806bc55",
+                "# This file is a cache directory tag created by DaCe.",
+                "# For information about cache directory tags, see:",
+                "#	http://www.brynosaurus.com/cachedir/",
+            ]))
+
     # Generate the parts of the folder that are exclusive to the development folder mode.
-    if folder_version in ["development"]:
+    if folder_mode in ["development"]:
 
         # Copy a full snapshot of configuration script
         Config.save(os.path.join(out_path, "dace.conf"), all=True)
 
-        # Write cachedir tag
-        cachedir_tag = os.path.join(out_path, "CACHEDIR.TAG")
-        if not os.path.exists(cachedir_tag):
-            with open(cachedir_tag, "w") as f:
-                f.write("\n".join([
-                    "Signature: 8a477f597d28d172789f06886806bc55",
-                    "# This file is a cache directory tag created by DaCe.",
-                    "# For information about cache directory tags, see:",
-                    "#	http://www.brynosaurus.com/cachedir/",
-                ]))
-
     # The version file is always generated. In case it is missing we assume the old version.
     with open(os.path.join(out_path, "VERSION"), "w") as version_file:
-        version_file.write(folder_version)
+        version_file.write(folder_mode)
 
     return out_path
 
@@ -170,12 +170,12 @@ def configure_and_compile(
     program_folder,
     program_name=None,
     output_stream=None,
-    folder_version: Optional[str] = None,
+    folder_mode: Optional[str] = None,
 ) -> pathlib.Path:
     """
     Configures and compiles a DaCe program in the specified folder into a shared library file.
 
-    This function respects the ``compiler.build_folder_version`` configuration variable,
+    This function respects the ``compiler.build_folder_mode`` configuration variable,
     thus depending on its value the content might be different.
 
     :param program_folder: Folder containing all files necessary to build, equivalent to
@@ -185,9 +185,9 @@ def configure_and_compile(
     :return: Path to the compiled shared library file.
     """
 
-    if folder_version is None:
-        folder_version = Config.get('compiler.build_folder_version')
-    assert folder_version in ["development", "production"]
+    if folder_mode is None:
+        folder_mode = Config.get('compiler.build_folder_mode')
+    assert folder_mode in ["development", "production"]
 
     if program_name is None:
         program_name = os.path.basename(program_folder)
@@ -199,7 +199,7 @@ def configure_and_compile(
     os.makedirs(build_folder, exist_ok=True)
 
     # Prepare performance report folder if requested.
-    if folder_version == "development":
+    if folder_mode == "development":
         os.makedirs(os.path.join(program_folder, "perf"), exist_ok=True)
 
     # Read list of DaCe files to compile.
@@ -327,11 +327,11 @@ def configure_and_compile(
 
     # Get the names of the library files that were generated.
     #  Currently we are still in the `development` folder mode.
-    lib_path = get_binary_name(object_folder=program_folder, sdfg_name=program_name, folder_version="development")
+    lib_path = get_binary_name(object_folder=program_folder, sdfg_name=program_name, folder_mode="development")
     libstub_path = _get_stub_library_path(lib_path)
 
     # In production mode, we are now deleting what we need and relocating it.
-    if folder_version == "production":
+    if folder_mode == "production":
         lib_path = pathlib.Path(shutil.move(src=lib_path, dst=program_folder))
         libstub_path = pathlib.Path(shutil.move(src=libstub_path, dst=program_folder))
         program_folder = pathlib.Path(program_folder)
@@ -381,21 +381,21 @@ def load_from_file(sdfg, binary_filename):
 
 
 @overload
-def get_folder_version(object_folder: Union[pathlib.Path, str], probe: Literal[False] = False) -> str:
+def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: Literal[False] = False) -> str:
     ...
 
 
 @overload
-def get_folder_version(object_folder: Union[pathlib.Path, str], probe: Literal[True]) -> Optional[str]:
+def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: Literal[True]) -> Optional[str]:
     ...
 
 
 @overload
-def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool) -> Optional[str]:
+def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: bool) -> Optional[str]:
     ...
 
 
-def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool = False) -> Optional[str]:
+def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: bool = False) -> Optional[str]:
     """Inspect `object_folder` and determine which version the folder has.
 
     If the function find the ``VERSION`` file it will examine it to get the version.
@@ -415,8 +415,8 @@ def get_folder_version(object_folder: Union[pathlib.Path, str], probe: bool = Fa
 
     if (object_folder / 'VERSION').exists():
         with open(object_folder / 'VERSION', 'rt') as F:
-            folder_version = F.readline().strip()
-        return folder_version
+            folder_mode = F.readline().strip()
+        return folder_mode
     else:
         # This is to check an old style folder, i.e. a cache folder that was generated before
         #  the `VERSION` file was introduced. We do some small sanity checks.
@@ -443,7 +443,7 @@ def get_binary_name(
     object_folder: Union[pathlib.Path, str],
     sdfg_name: str,
     lib_extension: Optional[str] = None,
-    folder_version: Optional[str] = None,
+    folder_mode: Optional[str] = None,
 ) -> pathlib.Path:
     """Returns the supposed location of the compiled library given the boundary conditions.
 
@@ -451,22 +451,22 @@ def get_binary_name(
     :param sdfg_name: The name of the SDFG, i.e. `sdfg.name`.
     :param lib_extension: The extension of the library, i.e. file extension.
                           If not given the config option `compiler.library_extension` is used.
-    :param folder_version: The version of the build folder. If not given the config option
-                           `compiler.build_folder_version` is used.
+    :param folder_mode: The version of the build folder. If not given the config option
+                           `compiler.build_folder_mode` is used.
     """
     if lib_extension is None:
         lib_extension = Config.get('compiler', 'library_extension')
-    if folder_version is None:
-        folder_version = Config.get('compiler', 'build_folder_version')
+    if folder_mode is None:
+        folder_mode = Config.get('compiler', 'build_folder_mode')
 
     folder_hirarchy = [object_folder]
-    if folder_version == 'development':
+    if folder_mode == 'development':
         folder_hirarchy.append('build')
-    elif folder_version == 'production':
+    elif folder_mode == 'production':
         # Nothing to add, they are on the top.
         pass
     else:
-        raise ValueError(f"Unknown folder version '{folder_version}' found.")
+        raise ValueError(f"Unknown folder version '{folder_mode}' found.")
 
     return pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
 
@@ -504,7 +504,7 @@ def load_precompiled_sdfg(
     if not folder.is_dir():
         raise NotADirectoryError(f'Can not load the SDFG from folder ``{folder}``.')
 
-    folder_version = get_folder_version(folder)
+    folder_mode = get_folder_mode(folder)
 
     # Try to find the sdfg from disc, if not given.
     if sdfg is not None:
@@ -517,7 +517,7 @@ def load_precompiled_sdfg(
         else:
             raise ValueError(f"Could not locate the SDFG for `{folder}`.")
 
-    return get_program_handle(library_path=get_binary_name(folder, sdfg_name=sdfg.name, folder_version=folder_version),
+    return get_program_handle(library_path=get_binary_name(folder, sdfg_name=sdfg.name, folder_mode=folder_mode),
                               sdfg=sdfg)
 
 

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -41,8 +41,8 @@ def generate_program_folder(
     :param sdfg: The SDFG to generate the program folder for.
     :param code_objects: List of generated code objects.
     :param out_path: The folder in which the build files should be written.
-    :param folder_mode: Version of the program folder that should be generated,
-                           if not given ``compiler.build_folder_mode`` is used.
+    :param folder_mode: Mode for saving build files in the program folder; if not
+                        given, ``compiler.build_folder_mode`` is used.
     :return: Path to the program folder.
 
     :note: The ``config`` argument is retained for compatibility and should not be used.
@@ -159,8 +159,8 @@ def generate_program_folder(
         # Copy a full snapshot of configuration script
         Config.save(os.path.join(out_path, "dace.conf"), all=True)
 
-    # The version file is always generated. In case it is missing we assume the old version.
-    with open(os.path.join(out_path, "VERSION"), "w") as version_file:
+    # The folder mode file is always generated. In case it is missing we assume the old version.
+    with open(os.path.join(out_path, "FOLDER_MODE"), "w") as version_file:
         version_file.write(folder_mode)
 
     return out_path
@@ -396,14 +396,14 @@ def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: bool) -> Opt
 
 
 def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: bool = False) -> Optional[str]:
-    """Inspect `object_folder` and determine which version the folder has.
+    """Inspect `object_folder` and determine which save mode the folder has.
 
-    If the function find the ``VERSION`` file it will examine it to get the version.
-    If the version file is absent the function assumes that it is the ``development``
+    If the function finds the ``FOLDER_MODE`` file it will examine it to get the save mode.
+    If the folder mode file is absent the function assumes that it is the ``development``
     format, however, some sanity checks are performed.
 
     The function also has the optional argument ``probe`` if given and the folder
-    version could not be inferred the function will return ``None`` instead of
+    save mode could not be inferred the function will return ``None`` instead of
     generating an error.
     """
     object_folder = pathlib.Path(object_folder)
@@ -413,13 +413,13 @@ def get_folder_mode(object_folder: Union[pathlib.Path, str], probe: bool = False
             return None
         raise NotADirectoryError("The build folder does not exists.")
 
-    if (object_folder / 'VERSION').exists():
-        with open(object_folder / 'VERSION', 'rt') as F:
+    if (object_folder / 'FOLDER_MODE').exists():
+        with open(object_folder / 'FOLDER_MODE', 'rt') as F:
             folder_mode = F.readline().strip()
         return folder_mode
     else:
         # This is to check an old style folder, i.e. a cache folder that was generated before
-        #  the `VERSION` file was introduced. We do some small sanity checks.
+        #  the `FOLDER_MODE` file was introduced. We do some small sanity checks.
         # TODO: Phase out this feature, after there are no old style caches.
         found_sub_folder = False
         for sub_folder in ["build", "map", "src", "include", "sample"]:
@@ -451,8 +451,8 @@ def get_binary_name(
     :param sdfg_name: The name of the SDFG, i.e. `sdfg.name`.
     :param lib_extension: The extension of the library, i.e. file extension.
                           If not given the config option `compiler.library_extension` is used.
-    :param folder_mode: The version of the build folder. If not given the config option
-                           `compiler.build_folder_mode` is used.
+    :param folder_mode: The save mode for the build folder. If not given the config
+                        option `compiler.build_folder_mode` is used.
     """
     if lib_extension is None:
         lib_extension = Config.get('compiler', 'library_extension')
@@ -466,7 +466,7 @@ def get_binary_name(
         # Nothing to add, they are on the top.
         pass
     else:
-        raise ValueError(f"Unknown folder version '{folder_mode}' found.")
+        raise ValueError(f"Unknown folder mode '{folder_mode}' found.")
 
     return pathlib.Path(os.path.join(*folder_hirarchy, f'lib{sdfg_name}.{lib_extension}'))
 
@@ -489,9 +489,9 @@ def load_precompiled_sdfg(
     """Loads a precompiled SDFG from ``folder``.
 
     If ``sdfg`` is not given then the function expects to find the ``program.sdfg(z)``
-    dump file inside ``folder``. If the folder does not contain a ``VERSION`` file
+    dump file inside ``folder``. If the folder does not contain a ``FOLDER_MODE`` file
     it assumes that it is an old style ``development`` folder otherwise, the information
-    from ``VERSION`` is consulted.
+    from ``FOLDER_MODE`` is consulted.
 
     :param folder: Path to SDFG output folder, i.e. its build folder.
     :param sdfg: If given then ``program.sdfg(z)`` does not need to be present.

--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -41,8 +41,8 @@ def generate_program_folder(
     :param sdfg: The SDFG to generate the program folder for.
     :param code_objects: List of generated code objects.
     :param out_path: The folder in which the build files should be written.
-    :param folder_mode: Mode for saving build files in the program folder; if not
-                        given, ``compiler.build_folder_mode`` is used.
+    :param folder_mode: Select which files should be saved in the program build folder;
+                        if not given, ``compiler.build_folder_mode`` is used.
     :return: Path to the program folder.
 
     :note: The ``config`` argument is retained for compatibility and should not be used.

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -123,7 +123,7 @@ required:
                   Selects which content should be saved in the build folder.
                   Two modes are currently supported: `development`, that includes
                   everything; and `production`, that saves only the compiled library
-                  and the version file.
+                  and the folder mode file.
 
             library_prefix:
                 type: str

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -115,16 +115,15 @@ required:
                     If enabled, does not recompile code generated from SDFGs
                     if shared library (.so/.dll) file is present.
 
-            build_folder_version:
+            build_folder_mode:
                 type: str
                 default: development
-                title: Version of the build folder
+                title: Save mode for the build folder
                 description: >
-                  Determine the content of the build folder that should be created.
-                  The supported values are `development`, that includes everything
-                  The second mode, that is currently supported is `production`.
-                  In this mode only the compiled library and the version file is
-                  present.
+                  Selects which content should be saved in the build folder.
+                  Two modes are currently supported: `development`, that includes
+                  everything; and `production`, that saves only the compiled library
+                  and the version file.
 
             library_prefix:
                 type: str

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2487,7 +2487,7 @@ class SDFG(ControlFlowRegion):
         # Compute build folder path before running codegen
         build_folder = self.build_folder
 
-        # Get the folder version, but if the folder already exist, then use the `VERSION` file.
+        # Get the folder mode, but if the folder already exists, then use the `FOLDER_MODE` file.
         folder_mode = compiler.get_folder_mode(build_folder, probe=True)
         if folder_mode is None:
             folder_mode = Config.get('compiler', 'build_folder_mode')

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2448,7 +2448,7 @@ class SDFG(ControlFlowRegion):
         for k, v in symbols.items():
             self.add_constant(str(k), v)
 
-    def is_loaded(self, folder_version: Optional[str] = None) -> bool:
+    def is_loaded(self, folder_mode: Optional[str] = None) -> bool:
         """
         Returns True if the SDFG binary is already loaded in the current process.
         Returns `False` if the file does not exist.
@@ -2457,16 +2457,16 @@ class SDFG(ControlFlowRegion):
         from dace.codegen import compiled_sdfg as cs, compiler
 
         build_folder = self.build_folder
-        if folder_version is None:
-            folder_version = compiler.get_folder_version(build_folder, probe=True)
-        if folder_version is None:
-            folder_version = Config.get('compiler', 'build_folder_version')
+        if folder_mode is None:
+            folder_mode = compiler.get_folder_mode(build_folder, probe=True)
+        if folder_mode is None:
+            folder_mode = Config.get('compiler', 'build_folder_mode')
 
         # Note here is kind of a "leak". The issue is that while the library is not
         #  loaded the stub library is loaded. However, it is never unloaded, because
         #  the `unload()` function is not called. This is technically not an issue
         #  as `ctypes` will do that at some later point.
-        binary_filename = compiler.get_binary_name(self.build_folder, self.name, folder_version=folder_version)
+        binary_filename = compiler.get_binary_name(self.build_folder, self.name, folder_mode=folder_mode)
         dll = cs.ReloadableDLL(binary_filename)
         return dll.is_loaded()
 
@@ -2488,15 +2488,15 @@ class SDFG(ControlFlowRegion):
         build_folder = self.build_folder
 
         # Get the folder version, but if the folder already exist, then use the `VERSION` file.
-        folder_version = compiler.get_folder_version(build_folder, probe=True)
-        if folder_version is None:
-            folder_version = Config.get('compiler', 'build_folder_version')
+        folder_mode = compiler.get_folder_mode(build_folder, probe=True)
+        if folder_mode is None:
+            folder_mode = Config.get('compiler', 'build_folder_mode')
 
         if not self._recompile or Config.get_bool('compiler', 'use_cache'):
             # Try to see if a cached version of the binary exists
             lib_path = compiler.get_binary_name(object_folder=build_folder,
                                                 sdfg_name=self.name,
-                                                folder_version=folder_version)
+                                                folder_mode=folder_mode)
             if lib_path.is_file():
                 if return_program_handle:
                     # NOTE: We should not pass `self` as `sdfg` argument, but instead deepcopy it.
@@ -2522,7 +2522,7 @@ class SDFG(ControlFlowRegion):
 
             # Rename SDFG to avoid runtime issues with clashing names
             index = 0
-            while sdfg.is_loaded(folder_version=folder_version):
+            while sdfg.is_loaded(folder_mode=folder_mode):
                 sdfg.name = f'{self.name}_{index}'
                 index += 1
             if self.name != sdfg.name and Config.get_bool('debugprint'):
@@ -2546,7 +2546,7 @@ class SDFG(ControlFlowRegion):
             program_folder = compiler.generate_program_folder(sdfg,
                                                               program_objects,
                                                               build_folder,
-                                                              folder_version=folder_version)
+                                                              folder_mode=folder_mode)
         else:
             # The code was already generated, just load the program folder
             program_folder = build_folder
@@ -2554,7 +2554,7 @@ class SDFG(ControlFlowRegion):
             sdfg = self
 
         # Compile the code and get the shared library path
-        shared_library = compiler.configure_and_compile(program_folder, sdfg.name, folder_version=folder_version)
+        shared_library = compiler.configure_and_compile(program_folder, sdfg.name, folder_mode=folder_mode)
 
         # If provided, save output to path or filename
         if output_file is not None:

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1781,10 +1781,6 @@ class SDFG(ControlFlowRegion):
         """
         from dace.cli.sdfv import view
 
-        # Ensure external nested SDFGs are loaded.
-        for _ in self.all_sdfgs_recursive(load_ext=True):
-            pass
-
         view(self, filename=filename, verbose=verbose)
 
     @staticmethod

--- a/tests/compile_folder_mode_test.py
+++ b/tests/compile_folder_mode_test.py
@@ -75,11 +75,11 @@ def test_development_folder_mode():
         "sample": pathlib.Path.is_dir,
         "src": pathlib.Path.is_dir,
         "CACHEDIR.TAG": pathlib.Path.is_file,
+        "FOLDER_MODE": pathlib.Path.is_file,
         "dace.conf": pathlib.Path.is_file,
         "dace_files.csv": pathlib.Path.is_file,
         "dace_environments.csv": pathlib.Path.is_file,
         "program.sdfgz": pathlib.Path.is_file,
-        "VERSION": pathlib.Path.is_file,
     }
 
     for found_path in build_folder.iterdir():
@@ -90,8 +90,8 @@ def test_development_folder_mode():
     # Now run it.
     _load_and_run_sdfg(build_folder, sdfg)
 
-    # Special case for development is that if there is no `VERSION` it is still development.
-    version_file = build_folder / "VERSION"
+    # Special case for development is that if there is no `FOLDER_MODE` it is still development.
+    version_file = build_folder / "FOLDER_MODE"
     assert version_file.exists()
     version_file.unlink()
     assert not version_file.exists()
@@ -116,7 +116,7 @@ def test_production_folder_mode():
 
     expected_files = {
         "CACHEDIR.TAG": pathlib.Path.is_file,
-        "VERSION": pathlib.Path.is_file,
+        "FOLDER_MODE": pathlib.Path.is_file,
         lib_path.name: pathlib.Path.is_file,
         libstub_path.name: pathlib.Path.is_file,
     }
@@ -129,8 +129,8 @@ def test_production_folder_mode():
     # Now run it.
     _load_and_run_sdfg(build_folder, sdfg)
 
-    # If we delete the VERSION file we will get an error.
-    version_file = build_folder / "VERSION"
+    # If we delete the FOLDER_MODE file we will get an error.
+    version_file = build_folder / "FOLDER_MODE"
     assert version_file.exists()
     version_file.unlink()
     assert not version_file.exists()
@@ -187,7 +187,7 @@ def _test_build_with_scheme_one_and_then_switch_impl(
 
         expected_files = {
             "CACHEDIR.TAG": pathlib.Path.is_file,
-            "VERSION": pathlib.Path.is_file,
+            "FOLDER_MODE": pathlib.Path.is_file,
             lib1_path.name: pathlib.Path.is_file,
             libstub1_path.name: pathlib.Path.is_file,
             lib2_path.name: pathlib.Path.is_file,

--- a/tests/compile_folder_mode_test.py
+++ b/tests/compile_folder_mode_test.py
@@ -54,9 +54,9 @@ def _load_and_run_sdfg(build_folder, sdfg):
     _run_sdfg(csdfg)
 
 
-def test_development_folder_version():
+def test_development_folder_mode():
     with dace.config.temporary_config() as Config:
-        Config.set('compiler', 'build_folder_version', value="development")
+        Config.set('compiler', 'build_folder_mode', value="development")
         sdfg = _make_test_sdfg()
         build_folder = pathlib.Path(sdfg.build_folder)
         assert not build_folder.exists()
@@ -65,7 +65,7 @@ def test_development_folder_version():
         assert not_csdfg is None
 
     assert build_folder.exists()
-    assert sdfg_compiler.get_folder_version(build_folder) == "development"
+    assert sdfg_compiler.get_folder_mode(build_folder) == "development"
 
     expected_files = {
         "build": pathlib.Path.is_dir,
@@ -95,12 +95,12 @@ def test_development_folder_version():
     assert version_file.exists()
     version_file.unlink()
     assert not version_file.exists()
-    assert sdfg_compiler.get_folder_version(build_folder) == "development"
+    assert sdfg_compiler.get_folder_mode(build_folder) == "development"
 
 
-def test_production_folder_version():
+def test_production_folder_mode():
     with dace.config.temporary_config() as Config:
-        Config.set('compiler', 'build_folder_version', value="production")
+        Config.set('compiler', 'build_folder_mode', value="production")
         sdfg = _make_test_sdfg()
         build_folder = pathlib.Path(sdfg.build_folder)
         assert not build_folder.exists()
@@ -109,12 +109,13 @@ def test_production_folder_version():
         assert not_csdfg is None
 
     assert build_folder.exists()
-    assert sdfg_compiler.get_folder_version(build_folder) == "production"
+    assert sdfg_compiler.get_folder_mode(build_folder) == "production"
 
-    lib_path = sdfg_compiler.get_binary_name(build_folder, sdfg_name=sdfg.name, folder_version="production")
+    lib_path = sdfg_compiler.get_binary_name(build_folder, sdfg_name=sdfg.name, folder_mode="production")
     libstub_path = sdfg_compiler._get_stub_library_path(lib_path.name)
 
     expected_files = {
+        "CACHEDIR.TAG": pathlib.Path.is_file,
         "VERSION": pathlib.Path.is_file,
         lib_path.name: pathlib.Path.is_file,
         libstub_path.name: pathlib.Path.is_file,
@@ -136,9 +137,9 @@ def test_production_folder_version():
 
     with pytest.raises(NotADirectoryError,
                        match=re.escape(f'``{build_folder}`` does not appear to be a valid build folder.')):
-        sdfg_compiler.get_folder_version(build_folder)
+        sdfg_compiler.get_folder_mode(build_folder)
 
-    assert sdfg_compiler.get_folder_version(build_folder, probe=True) is None
+    assert sdfg_compiler.get_folder_mode(build_folder, probe=True) is None
 
 
 def _test_build_with_scheme_one_and_then_switch_impl(
@@ -146,7 +147,7 @@ def _test_build_with_scheme_one_and_then_switch_impl(
     version2: str,
 ) -> None:
     with dace.config.temporary_config() as conf:
-        conf.set('compiler', 'build_folder_version', value=version1)
+        conf.set('compiler', 'build_folder_mode', value=version1)
 
         sdfg = _make_test_sdfg()
         build_folder = pathlib.Path(sdfg.build_folder).resolve()
@@ -155,11 +156,11 @@ def _test_build_with_scheme_one_and_then_switch_impl(
         csdfg1 = sdfg.compile()
 
     lib1_path = pathlib.Path(csdfg1.filename)
-    assert sdfg_compiler.get_folder_version(build_folder) == version1
+    assert sdfg_compiler.get_folder_mode(build_folder) == version1
     assert lib1_path.exists()
 
     with dace.config.temporary_config() as conf:
-        conf.set('compiler', 'build_folder_version', value=version1)
+        conf.set('compiler', 'build_folder_mode', value=version1)
 
         # This is for ensuring that the code is actually regenerated.
         conf.set('compiler', 'use_cache', value=False)
@@ -170,7 +171,7 @@ def _test_build_with_scheme_one_and_then_switch_impl(
 
     lib2_path = pathlib.Path(csdfg2.filename)
 
-    assert sdfg_compiler.get_folder_version(build_folder) == version1
+    assert sdfg_compiler.get_folder_mode(build_folder) == version1
     assert csdfg1.sdfg.name != csdfg2.sdfg.name
     assert lib1_path != lib2_path
     assert lib1_path.exists()  # Still existing.
@@ -185,6 +186,7 @@ def _test_build_with_scheme_one_and_then_switch_impl(
         libstub2_path = sdfg_compiler._get_stub_library_path(lib2_path.name)
 
         expected_files = {
+            "CACHEDIR.TAG": pathlib.Path.is_file,
             "VERSION": pathlib.Path.is_file,
             lib1_path.name: pathlib.Path.is_file,
             libstub1_path.name: pathlib.Path.is_file,
@@ -230,7 +232,7 @@ def test_already_loaded_and_comple_again():
 
 
 if __name__ == '__main__':
-    test_development_folder_version()
-    test_production_folder_version()
+    test_development_folder_mode()
+    test_production_folder_mode()
     test_already_loaded_and_comple_again()
     test_build_with_scheme_one_and_then_switch()

--- a/tests/lib_reuse_test.py
+++ b/tests/lib_reuse_test.py
@@ -56,25 +56,25 @@ def test_reload():
 
 
 def test_load_precompiled():
-    for folder_version in ["development", "production"]:
+    for folder_mode in ["development", "production"]:
         with dace.config.temporary_config() as conf:
-            conf.set('compiler', 'build_folder_version', value=folder_version)
+            conf.set('compiler', 'build_folder_mode', value=folder_mode)
             _load_precompiled_impl(
                 test_name="test_load_precompiled",
-                folder_version=folder_version,
+                folder_mode=folder_mode,
             )
 
 
-def _load_precompiled_impl(test_name: str, folder_version: str) -> None:
+def _load_precompiled_impl(test_name: str, folder_mode: str) -> None:
     prog = program_generator(10, 2.0)
     sdfg = prog.to_sdfg()
-    sdfg.name = f'{test_name}_{sdfg.name}_{folder_version}'
+    sdfg.name = f'{test_name}_{sdfg.name}_{folder_mode}'
 
     func1 = sdfg.compile()
 
-    if folder_version == "production":
+    if folder_mode == "production":
         func2 = load_precompiled_sdfg(sdfg.build_folder, sdfg=sdfg)
-    elif folder_version == "development":
+    elif folder_mode == "development":
         func2 = load_precompiled_sdfg(sdfg.build_folder)
 
     inp = np.random.rand(10).astype(np.float64)


### PR DESCRIPTION
Two changes:
- Rename `build_folder_version` to `build_folder_mode`.
- Write folder mode to file `FOLDER_MODE` instead of `VERSION`.
- Always save the `CACHEDIR.TAG` file .