### PR TITLE
Add MoveIfIntoMap transformation

### DIFF
--- a/dace/transformation/interstate/__init__.py
+++ b/dace/transformation/interstate/__init__.py
@@ -18,3 +18,4 @@ from .move_loop_into_map import MoveLoopIntoMap
 from .trivial_loop_elimination import TrivialLoopElimination
 from .multistate_inline import InlineMultistateSDFG
 from .move_assignment_outside_if import MoveAssignmentOutsideIf
+from .move_if_into_map import MoveIfIntoMap

--- a/dace/transformation/interstate/move_if_into_map.py
+++ b/dace/transformation/interstate/move_if_into_map.py
@@ -7,9 +7,9 @@ This exposes the two maps to fusion/collapsing passes that otherwise refuse to
 cross the conditional block.
 """
 import copy
-from typing import Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
-from dace import dtypes
+from dace import dtypes, memlet as mm, symbolic
 from dace import sdfg as sd
 from dace.properties import CodeBlock
 from dace.sdfg import utils as sdutil
@@ -71,7 +71,8 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
         return non_empty[0]
 
     @staticmethod
-    def _find_inner_map_pieces(branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
+    def _find_inner_map_pieces(
+            branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
         """Returns (map_entry, map_exit, inner_nsdfg) if ``branch_state`` has
         exactly one top-level map whose body is a single NestedSDFG (with
         access-node taps allowed around it)."""
@@ -156,14 +157,74 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
         branch_cfr: ControlFlowRegion = cond_block.branches[0][1]
         branch_state: SDFGState = self._single_meaningful_state(branch_cfr)  # type: ignore[assignment]
 
-        _, _, inner_nsdfg = self._find_inner_map_pieces(branch_state)  # type: ignore[misc]
+        inner_map_entry, _, inner_nsdfg = self._find_inner_map_pieces(branch_state)  # type: ignore[misc]
         inner_sdfg: sd.SDFG = inner_nsdfg.sdfg
 
-        cond_sym = enclosing_sdfg.add_symbol(f"{cond_block.label}_cond", dtypes.int32, find_new_name=True)
+        try:
+            cond_free_syms = {str(s) for s in branch_cond.get_free_symbols()}
+        except Exception:
+            cond_free_syms = set()
 
-        if cond_sym not in inner_sdfg.symbols:
-            inner_sdfg.add_symbol(cond_sym, dtypes.int32)
-        inner_nsdfg.symbol_mapping[cond_sym] = cond_sym
+        # Pull out any interstate-edge assignment feeding ``cond_block``
+        # whose LHS is referenced by the guard condition. Those assignments
+        # must move inside the inner NSDFG together with the condition they
+        # define so that none of them is left orphaned on the outer edges
+        # (they would otherwise add an always-true pre-state to the outer
+        # map body, blocking collapse).
+        in_edges = list(enclosing_sdfg.in_edges(cond_block))
+        moved_assignments: Dict[str, str] = {}
+        for e in in_edges:
+            for k in list(e.data.assignments.keys()):
+                if k in cond_free_syms:
+                    moved_assignments[k] = e.data.assignments[k]
+                    del e.data.assignments[k]
+
+        # Identify arrays referenced by the moved assignments -- they must
+        # be piped as inputs into the inner NSDFG so the moved-inside
+        # assignments can still evaluate.
+        arrays_to_pipe: Set[str] = set()
+        for sym, rhs in moved_assignments.items():
+            tmp_edge = InterstateEdge(assignments={sym: rhs})
+            for mmlt in tmp_edge.get_read_memlets(enclosing_sdfg.arrays):
+                arrays_to_pipe.add(mmlt.data)
+
+        piped_array_shape_syms: Set[str] = set()
+        for arr_name in arrays_to_pipe:
+            if arr_name not in inner_sdfg.arrays:
+                desc = copy.deepcopy(enclosing_sdfg.arrays[arr_name])
+                desc.transient = False
+                inner_sdfg.add_datadesc(arr_name, desc)
+            if arr_name not in inner_nsdfg.in_connectors:
+                inner_nsdfg.add_in_connector(arr_name)
+            piped_array_shape_syms.update(
+                str(s) for s in enclosing_sdfg.arrays[arr_name].free_symbols)
+
+        # Pipe free symbols that the condition and moved RHS expressions
+        # reference. Skip any names that now live as data descriptors OR
+        # that are themselves defined inside (LHS of a moved assignment).
+        syms_needed: Set[str] = set(cond_free_syms)
+        for rhs in moved_assignments.values():
+            try:
+                for s in symbolic.pystr_to_symbolic(rhs).free_symbols:
+                    syms_needed.add(str(s))
+            except Exception:
+                pass
+        syms_needed |= piped_array_shape_syms
+        syms_needed -= arrays_to_pipe
+        syms_needed -= set(moved_assignments.keys())
+        for sym_name in syms_needed:
+            if sym_name in enclosing_sdfg.symbols:
+                if sym_name not in inner_sdfg.symbols:
+                    inner_sdfg.add_symbol(sym_name, enclosing_sdfg.symbols[sym_name])
+                if sym_name not in inner_nsdfg.symbol_mapping:
+                    inner_nsdfg.symbol_mapping[sym_name] = sym_name
+
+        # Declare the moved-assignment LHS symbols inside the inner SDFG.
+        # They're defined by the pre-state's interstate edge below.
+        for sym in moved_assignments:
+            if sym not in inner_sdfg.symbols:
+                dtype = enclosing_sdfg.symbols.get(sym, dtypes.int32)
+                inner_sdfg.add_symbol(sym, dtype)
 
         new_body_cfr = ControlFlowRegion(label=f"{cond_block.label}_body")
         body_blocks = list(inner_sdfg.nodes())
@@ -174,40 +235,118 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
             copy_mapping[b] = new_b
             new_body_cfr.add_node(new_b, is_start_block=(b is original_start))
         for e in inner_sdfg.edges():
-            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst], copy.deepcopy(e.data))
+            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst],
+                                  copy.deepcopy(e.data))
 
         new_cond_block = ConditionalBlock(label=f"{cond_block.label}_moved")
-        new_cond_block.add_branch(CodeBlock(f"{cond_sym} == 1"), new_body_cfr)
+        new_cond_block.add_branch(CodeBlock(branch_cond.as_string), new_body_cfr)
 
         inner_sdfg.remove_nodes_from(body_blocks)
         inner_sdfg.add_node(new_cond_block, is_start_block=True, ensure_unique_name=True)
 
+        # If there are assignments to move, prepend a pre-state that
+        # materialises them via an interstate edge to ``new_cond_block``.
+        if moved_assignments:
+            inner_pre = inner_sdfg.add_state(f"{cond_block.label}_materialize")
+            inner_sdfg.add_edge(inner_pre, new_cond_block,
+                                InterstateEdge(assignments=dict(moved_assignments)))
+            inner_sdfg.start_block = inner_sdfg.node_id(inner_pre)
+
         new_branch_state = copy.deepcopy(branch_state)
         enclosing_sdfg.add_node(new_branch_state, ensure_unique_name=True)
 
-        in_edges = list(enclosing_sdfg.in_edges(cond_block))
+        # Wire the newly-needed array inputs through the copied inner map
+        # to the copied inner NSDFG node. The copied ``new_branch_state``
+        # has its own MapEntry/NestedSDFG; we look them up again.
+        if arrays_to_pipe:
+            copied_entry, _, copied_nsdfg = self._find_inner_map_pieces(new_branch_state)
+            for arr_name in arrays_to_pipe:
+                if arr_name not in copied_nsdfg.in_connectors:
+                    copied_nsdfg.add_in_connector(arr_name)
+                if "IN_" + arr_name not in copied_entry.in_connectors:
+                    copied_entry.add_in_connector("IN_" + arr_name)
+                if "OUT_" + arr_name not in copied_entry.out_connectors:
+                    copied_entry.add_out_connector("OUT_" + arr_name)
+                arr_read = new_branch_state.add_read(arr_name)
+                new_branch_state.add_edge(
+                    arr_read, None, copied_entry, "IN_" + arr_name,
+                    mm.Memlet.from_array(arr_name, enclosing_sdfg.arrays[arr_name]))
+                new_branch_state.add_edge(
+                    copied_entry, "OUT_" + arr_name, copied_nsdfg, arr_name,
+                    mm.Memlet.from_array(arr_name, enclosing_sdfg.arrays[arr_name]))
+
         out_edges = list(enclosing_sdfg.out_edges(cond_block))
         was_start = enclosing_sdfg.start_block is cond_block
 
-        cond_assignment = {cond_sym: branch_cond.as_string}
-
-        if len(in_edges) == 0:
-            pre_state = enclosing_sdfg.add_state(label=f"{cond_block.label}_materialize")
-            enclosing_sdfg.add_edge(pre_state, new_branch_state, InterstateEdge(assignments=cond_assignment))
-            if was_start:
-                enclosing_sdfg.start_block = enclosing_sdfg.node_id(pre_state)
-        else:
-            for e in in_edges:
-                new_data = copy.deepcopy(e.data)
-                for k, v in cond_assignment.items():
-                    new_data.assignments[k] = v
-                enclosing_sdfg.add_edge(e.src, new_branch_state, new_data)
+        # Wire in_edges to new_branch_state. If an edge has been emptied
+        # by the moved-inside step (no assignments, no condition), drop it
+        # and also drop its source state when the source is an empty
+        # placeholder that exists only to feed the ConditionalBlock.
+        states_to_try_remove: Set[SDFGState] = set()
+        for e in in_edges:
+            if e.data.is_unconditional() and not e.data.assignments:
+                states_to_try_remove.add(e.src) if isinstance(e.src, SDFGState) else None
                 enclosing_sdfg.remove_edge(e)
+            else:
+                enclosing_sdfg.add_edge(e.src, new_branch_state, copy.deepcopy(e.data))
+                enclosing_sdfg.remove_edge(e)
+
+        if was_start or not in_edges:
+            enclosing_sdfg.start_block = enclosing_sdfg.node_id(new_branch_state)
 
         for e in out_edges:
             enclosing_sdfg.add_edge(new_branch_state, e.dst, copy.deepcopy(e.data))
             enclosing_sdfg.remove_edge(e)
 
         enclosing_sdfg.remove_node(cond_block)
+
+        # Drop the moved symbols from the enclosing SDFG's symbol table if
+        # no interstate edge or nested SDFG symbol-mapping still uses them.
+        # Otherwise the enclosing SDFG would appear to require them as free
+        # symbols from its own parent, but they're now defined (and
+        # consumed) purely inside the inner NSDFG.
+        def _still_references(sdfg: sd.SDFG, name: str) -> bool:
+            # Only scan the enclosing SDFG's own top-level edges and
+            # direct-child NestedSDFG symbol_mappings; anything deeper is
+            # encapsulated and doesn't pull ``name`` out of this scope.
+            for e in sdfg.edges():
+                if not isinstance(e.data, InterstateEdge):
+                    continue
+                for v in e.data.assignments.values():
+                    try:
+                        if name in {str(s) for s in symbolic.pystr_to_symbolic(v).free_symbols}:
+                            return True
+                    except Exception:
+                        pass
+                if e.data.condition is not None:
+                    try:
+                        if name in {str(s) for s in e.data.condition.get_free_symbols()}:
+                            return True
+                    except Exception:
+                        pass
+            for state in sdfg.states():
+                for n in state.nodes():
+                    if isinstance(n, NestedSDFG):
+                        for v in n.symbol_mapping.values():
+                            try:
+                                if name in {str(s) for s in symbolic.pystr_to_symbolic(str(v)).free_symbols}:
+                                    return True
+                            except Exception:
+                                pass
+            return False
+
+        for sym in list(moved_assignments.keys()):
+            if sym in enclosing_sdfg.symbols and not _still_references(enclosing_sdfg, sym):
+                enclosing_sdfg.remove_symbol(sym)
+
+        # Drop empty placeholder pre-states that are no longer reachable.
+        for s in states_to_try_remove:
+            if (s in enclosing_sdfg.nodes() and s.is_empty()
+                    and enclosing_sdfg.in_degree(s) == 0
+                    and enclosing_sdfg.out_degree(s) == 0):
+                was_start_src = enclosing_sdfg.start_block is s
+                enclosing_sdfg.remove_node(s)
+                if was_start_src:
+                    enclosing_sdfg.start_block = enclosing_sdfg.node_id(new_branch_state)
 
         set_nested_sdfg_parent_references(sdfg)

--- a/dace/transformation/interstate/move_if_into_map.py
+++ b/dace/transformation/interstate/move_if_into_map.py
@@ -1,0 +1,218 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Transformation that pushes a conditional block through one level of map nesting.
+
+When a ``Map`` whose body is a single ``NestedSDFG`` guards an inner ``Map`` via
+a conditional block, the outer guard can be pushed inside the inner map's body.
+This exposes the two maps to fusion/collapsing passes that otherwise refuse to
+cross the conditional block.
+"""
+import copy
+from typing import Optional, Tuple
+
+from dace import dtypes
+from dace import sdfg as sd
+from dace.properties import CodeBlock
+from dace.sdfg import utils as sdutil
+from dace.sdfg.nodes import MapEntry, MapExit, NestedSDFG, AccessNode
+from dace.sdfg.sdfg import InterstateEdge
+from dace.sdfg.state import ConditionalBlock, ControlFlowRegion, SDFGState
+from dace.sdfg.utils import set_nested_sdfg_parent_references
+from dace.transformation import transformation
+
+
+@transformation.explicit_cf_compatible
+class MoveIfIntoMap(transformation.MultiStateTransformation):
+    """
+    Pushes a conditional block through a level of map nesting.
+
+    Matches the following structure::
+
+        outer_state (in some outer SDFG):
+            ... -> outer_map_entry -> outer_nsdfg -> outer_map_exit -> ...
+
+        outer_nsdfg.sdfg contents (possibly preceded by empty states):
+            ConditionalBlock(<cond>):
+                single branch with a control-flow region containing
+                    (optional empty states) -> branch_state
+                    branch_state contains:
+                        ... -> inner_map_entry -> inner_nsdfg -> inner_map_exit -> ...
+
+    After the transformation, the conditional block at the outer nested SDFG
+    level is replaced by ``branch_state`` (so the two maps become neighbours),
+    and a new conditional block with the original condition is placed *inside*
+    ``inner_nsdfg.sdfg`` wrapping its original contents. The condition value
+    is materialised as an ``int32`` symbol on the interstate edge leading to
+    the branch state and passed through to ``inner_nsdfg`` via
+    ``symbol_mapping`` so it is evaluated exactly once, at the outer level
+    where all its free symbols are still in scope.
+    """
+
+    cond_block = transformation.PatternNode(ConditionalBlock)
+
+    @classmethod
+    def expressions(cls):
+        return [sdutil.node_path_graph(cls.cond_block)]
+
+    # ---- Helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _single_meaningful_state(region: ControlFlowRegion) -> Optional[SDFGState]:
+        """Returns the single non-empty SDFGState inside ``region`` if the
+        region's other blocks are all empty SDFGStates, else None."""
+        blocks = list(region.nodes())
+        if not blocks:
+            return None
+        for b in blocks:
+            if not isinstance(b, SDFGState):
+                return None
+        non_empty = [s for s in blocks if not s.is_empty()]
+        if len(non_empty) != 1:
+            return None
+        return non_empty[0]
+
+    @staticmethod
+    def _find_inner_map_pieces(
+            branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
+        """Returns (map_entry, map_exit, inner_nsdfg) if ``branch_state`` has
+        exactly one top-level map whose body is a single NestedSDFG (with
+        access-node taps allowed around it)."""
+        map_entries = [n for n in branch_state.nodes() if isinstance(n, MapEntry)]
+        if len(map_entries) != 1:
+            return None
+        map_entry = map_entries[0]
+        map_exit = branch_state.exit_node(map_entry)
+
+        for node in branch_state.nodes():
+            if branch_state.entry_node(node) is not None:
+                continue
+            if node is map_entry or node is map_exit:
+                continue
+            if isinstance(node, AccessNode):
+                continue
+            return None
+
+        body = list(branch_state.all_nodes_between(map_entry, map_exit))
+        nsdfgs = [n for n in body if isinstance(n, NestedSDFG)]
+        if len(nsdfgs) != 1:
+            return None
+        inner_nsdfg = nsdfgs[0]
+
+        for node in body:
+            if node is inner_nsdfg:
+                continue
+            if isinstance(node, AccessNode):
+                continue
+            return None
+
+        return map_entry, map_exit, inner_nsdfg
+
+    # ---- Pattern matching ------------------------------------------------
+
+    def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
+        cond_block: ConditionalBlock = self.cond_block
+
+        if len(cond_block.branches) != 1:
+            return False
+        branch_cond, branch_cfr = cond_block.branches[0]
+        if branch_cond is None:
+            return False
+
+        parent_graph = cond_block.parent_graph
+        if not isinstance(parent_graph, sd.SDFG):
+            return False
+        enclosing_sdfg: sd.SDFG = parent_graph
+
+        if enclosing_sdfg.parent_nsdfg_node is None or enclosing_sdfg.parent is None:
+            return False
+        outer_state: SDFGState = enclosing_sdfg.parent
+        outer_nsdfg: NestedSDFG = enclosing_sdfg.parent_nsdfg_node
+
+        if outer_state.entry_node(outer_nsdfg) is None:
+            return False
+
+        for b in enclosing_sdfg.nodes():
+            if b is cond_block:
+                continue
+            if not isinstance(b, SDFGState) or not b.is_empty():
+                return False
+
+        if not isinstance(branch_cfr, ControlFlowRegion):
+            return False
+        branch_state = self._single_meaningful_state(branch_cfr)
+        if branch_state is None:
+            return False
+
+        if self._find_inner_map_pieces(branch_state) is None:
+            return False
+
+        return True
+
+    # ---- Application -----------------------------------------------------
+
+    def apply(self, graph: ControlFlowRegion, sdfg: sd.SDFG):
+        cond_block: ConditionalBlock = self.cond_block
+        enclosing_sdfg: sd.SDFG = cond_block.parent_graph  # type: ignore[assignment]
+
+        branch_cond: CodeBlock = cond_block.branches[0][0]
+        branch_cfr: ControlFlowRegion = cond_block.branches[0][1]
+        branch_state: SDFGState = self._single_meaningful_state(branch_cfr)  # type: ignore[assignment]
+
+        _, _, inner_nsdfg = self._find_inner_map_pieces(branch_state)  # type: ignore[misc]
+        inner_sdfg: sd.SDFG = inner_nsdfg.sdfg
+
+        cond_sym = enclosing_sdfg.add_symbol(f"{cond_block.label}_cond",
+                                             dtypes.int32,
+                                             find_new_name=True)
+
+        if cond_sym not in inner_sdfg.symbols:
+            inner_sdfg.add_symbol(cond_sym, dtypes.int32)
+        inner_nsdfg.symbol_mapping[cond_sym] = cond_sym
+
+        new_body_cfr = ControlFlowRegion(label=f"{cond_block.label}_body")
+        body_blocks = list(inner_sdfg.nodes())
+        original_start = inner_sdfg.start_block
+        copy_mapping = {}
+        for b in body_blocks:
+            new_b = copy.deepcopy(b)
+            copy_mapping[b] = new_b
+            new_body_cfr.add_node(new_b, is_start_block=(b is original_start))
+        for e in inner_sdfg.edges():
+            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst],
+                                  copy.deepcopy(e.data))
+
+        new_cond_block = ConditionalBlock(label=f"{cond_block.label}_moved")
+        new_cond_block.add_branch(CodeBlock(f"{cond_sym} == 1"), new_body_cfr)
+
+        inner_sdfg.remove_nodes_from(body_blocks)
+        inner_sdfg.add_node(new_cond_block, is_start_block=True, ensure_unique_name=True)
+
+        new_branch_state = copy.deepcopy(branch_state)
+        enclosing_sdfg.add_node(new_branch_state, ensure_unique_name=True)
+
+        in_edges = list(enclosing_sdfg.in_edges(cond_block))
+        out_edges = list(enclosing_sdfg.out_edges(cond_block))
+        was_start = enclosing_sdfg.start_block is cond_block
+
+        cond_assignment = {cond_sym: branch_cond.as_string}
+
+        if len(in_edges) == 0:
+            pre_state = enclosing_sdfg.add_state(label=f"{cond_block.label}_materialize")
+            enclosing_sdfg.add_edge(pre_state, new_branch_state,
+                                    InterstateEdge(assignments=cond_assignment))
+            if was_start:
+                enclosing_sdfg.start_block = enclosing_sdfg.node_id(pre_state)
+        else:
+            for e in in_edges:
+                new_data = copy.deepcopy(e.data)
+                for k, v in cond_assignment.items():
+                    new_data.assignments[k] = v
+                enclosing_sdfg.add_edge(e.src, new_branch_state, new_data)
+                enclosing_sdfg.remove_edge(e)
+
+        for e in out_edges:
+            enclosing_sdfg.add_edge(new_branch_state, e.dst, copy.deepcopy(e.data))
+            enclosing_sdfg.remove_edge(e)
+
+        enclosing_sdfg.remove_node(cond_block)
+
+        set_nested_sdfg_parent_references(sdfg)

--- a/dace/transformation/interstate/move_if_into_map.py
+++ b/dace/transformation/interstate/move_if_into_map.py
@@ -71,8 +71,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
         return non_empty[0]
 
     @staticmethod
-    def _find_inner_map_pieces(
-            branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
+    def _find_inner_map_pieces(branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
         """Returns (map_entry, map_exit, inner_nsdfg) if ``branch_state`` has
         exactly one top-level map whose body is a single NestedSDFG (with
         access-node taps allowed around it)."""
@@ -160,9 +159,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
         _, _, inner_nsdfg = self._find_inner_map_pieces(branch_state)  # type: ignore[misc]
         inner_sdfg: sd.SDFG = inner_nsdfg.sdfg
 
-        cond_sym = enclosing_sdfg.add_symbol(f"{cond_block.label}_cond",
-                                             dtypes.int32,
-                                             find_new_name=True)
+        cond_sym = enclosing_sdfg.add_symbol(f"{cond_block.label}_cond", dtypes.int32, find_new_name=True)
 
         if cond_sym not in inner_sdfg.symbols:
             inner_sdfg.add_symbol(cond_sym, dtypes.int32)
@@ -177,8 +174,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
             copy_mapping[b] = new_b
             new_body_cfr.add_node(new_b, is_start_block=(b is original_start))
         for e in inner_sdfg.edges():
-            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst],
-                                  copy.deepcopy(e.data))
+            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst], copy.deepcopy(e.data))
 
         new_cond_block = ConditionalBlock(label=f"{cond_block.label}_moved")
         new_cond_block.add_branch(CodeBlock(f"{cond_sym} == 1"), new_body_cfr)
@@ -197,8 +193,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
 
         if len(in_edges) == 0:
             pre_state = enclosing_sdfg.add_state(label=f"{cond_block.label}_materialize")
-            enclosing_sdfg.add_edge(pre_state, new_branch_state,
-                                    InterstateEdge(assignments=cond_assignment))
+            enclosing_sdfg.add_edge(pre_state, new_branch_state, InterstateEdge(assignments=cond_assignment))
             if was_start:
                 enclosing_sdfg.start_block = enclosing_sdfg.node_id(pre_state)
         else:

--- a/dace/transformation/interstate/move_if_into_map.py
+++ b/dace/transformation/interstate/move_if_into_map.py
@@ -71,8 +71,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
         return non_empty[0]
 
     @staticmethod
-    def _find_inner_map_pieces(
-            branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
+    def _find_inner_map_pieces(branch_state: SDFGState) -> Optional[Tuple[MapEntry, MapExit, NestedSDFG]]:
         """Returns (map_entry, map_exit, inner_nsdfg) if ``branch_state`` has
         exactly one top-level map whose body is a single NestedSDFG (with
         access-node taps allowed around it)."""
@@ -196,8 +195,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
                 inner_sdfg.add_datadesc(arr_name, desc)
             if arr_name not in inner_nsdfg.in_connectors:
                 inner_nsdfg.add_in_connector(arr_name)
-            piped_array_shape_syms.update(
-                str(s) for s in enclosing_sdfg.arrays[arr_name].free_symbols)
+            piped_array_shape_syms.update(str(s) for s in enclosing_sdfg.arrays[arr_name].free_symbols)
 
         # Pipe free symbols that the condition and moved RHS expressions
         # reference. Skip any names that now live as data descriptors OR
@@ -235,8 +233,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
             copy_mapping[b] = new_b
             new_body_cfr.add_node(new_b, is_start_block=(b is original_start))
         for e in inner_sdfg.edges():
-            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst],
-                                  copy.deepcopy(e.data))
+            new_body_cfr.add_edge(copy_mapping[e.src], copy_mapping[e.dst], copy.deepcopy(e.data))
 
         new_cond_block = ConditionalBlock(label=f"{cond_block.label}_moved")
         new_cond_block.add_branch(CodeBlock(branch_cond.as_string), new_body_cfr)
@@ -248,8 +245,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
         # materialises them via an interstate edge to ``new_cond_block``.
         if moved_assignments:
             inner_pre = inner_sdfg.add_state(f"{cond_block.label}_materialize")
-            inner_sdfg.add_edge(inner_pre, new_cond_block,
-                                InterstateEdge(assignments=dict(moved_assignments)))
+            inner_sdfg.add_edge(inner_pre, new_cond_block, InterstateEdge(assignments=dict(moved_assignments)))
             inner_sdfg.start_block = inner_sdfg.node_id(inner_pre)
 
         new_branch_state = copy.deepcopy(branch_state)
@@ -268,12 +264,10 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
                 if "OUT_" + arr_name not in copied_entry.out_connectors:
                     copied_entry.add_out_connector("OUT_" + arr_name)
                 arr_read = new_branch_state.add_read(arr_name)
-                new_branch_state.add_edge(
-                    arr_read, None, copied_entry, "IN_" + arr_name,
-                    mm.Memlet.from_array(arr_name, enclosing_sdfg.arrays[arr_name]))
-                new_branch_state.add_edge(
-                    copied_entry, "OUT_" + arr_name, copied_nsdfg, arr_name,
-                    mm.Memlet.from_array(arr_name, enclosing_sdfg.arrays[arr_name]))
+                new_branch_state.add_edge(arr_read, None, copied_entry, "IN_" + arr_name,
+                                          mm.Memlet.from_array(arr_name, enclosing_sdfg.arrays[arr_name]))
+                new_branch_state.add_edge(copied_entry, "OUT_" + arr_name, copied_nsdfg, arr_name,
+                                          mm.Memlet.from_array(arr_name, enclosing_sdfg.arrays[arr_name]))
 
         out_edges = list(enclosing_sdfg.out_edges(cond_block))
         was_start = enclosing_sdfg.start_block is cond_block
@@ -341,8 +335,7 @@ class MoveIfIntoMap(transformation.MultiStateTransformation):
 
         # Drop empty placeholder pre-states that are no longer reachable.
         for s in states_to_try_remove:
-            if (s in enclosing_sdfg.nodes() and s.is_empty()
-                    and enclosing_sdfg.in_degree(s) == 0
+            if (s in enclosing_sdfg.nodes() and s.is_empty() and enclosing_sdfg.in_degree(s) == 0
                     and enclosing_sdfg.out_degree(s) == 0):
                 was_start_src = enclosing_sdfg.start_block is s
                 enclosing_sdfg.remove_node(s)

--- a/tests/transformations/interstate/move_if_into_map_test.py
+++ b/tests/transformations/interstate/move_if_into_map_test.py
@@ -177,10 +177,161 @@ def test_move_if_into_map_no_apply_else_branch():
     assert applied == 0
 
 
+def test_move_if_into_map_no_race_with_upstream_symbol_assignment():
+    """If the ConditionalBlock's incoming interstate edge already assigns a
+    symbol that the guard condition reads (``_if_cond_24`` produced from
+    ``levmask[...]``), folding a new condition-symbol onto the same edge
+    would create a race (read + write of the same symbol in one edge).
+
+    The transformation avoids this by moving the condition evaluation
+    INSIDE the inner NSDFG: the ``ConditionalBlock`` placed around the
+    inner map body uses the original branch condition directly, and the
+    free symbols it reads are passed in through ``symbol_mapping``. The
+    outer/enclosing SDFG edges keep their pre-existing assignments
+    unchanged, so the outer map body stays collapse-friendly.
+
+    Structure built here:
+
+        outer_sdfg:
+            outer_state:
+                MapEntry(jb=1:M+1) -> NestedSDFG(mid) -> MapExit(jb)
+
+        mid (body of outer map, the ``enclosing_sdfg``):
+            pre --[{_if_cond_24: levmask[jb-1, 0]}]--> cb
+            cb: ConditionalBlock("(_if_cond_24 == 1)")
+                branch_state:
+                    MapEntry(jc=0:N) -> NestedSDFG(inner) -> MapExit(jc)
+
+        inner: out[jb, jc] = in[jb, jc] * 2
+    """
+    from dace import memlet as mm
+    from dace.properties import CodeBlock
+    from dace.sdfg import SDFG
+    from dace.sdfg.state import ControlFlowRegion
+
+    M_sym = dace.symbol("M")
+    N_sym = dace.symbol("N")
+
+    # --- inner SDFG (body of inner map) ---
+    inner = SDFG("inner_tester")
+    inner.add_array("a_in", [1], dace.float64)
+    inner.add_array("a_out", [1], dace.float64)
+    is_ = inner.add_state("s", is_start_block=True)
+    ir = is_.add_read("a_in")
+    iw = is_.add_write("a_out")
+    it = is_.add_tasklet("doub", {"x"}, {"y"}, "y = x * 2")
+    is_.add_edge(ir, None, it, "x", mm.Memlet("a_in[0]"))
+    is_.add_edge(it, "y", iw, None, mm.Memlet("a_out[0]"))
+
+    # --- mid SDFG (body of outer map, contains the ConditionalBlock) ---
+    mid = SDFG("mid_tester")
+    mid.add_array("A_in", [M_sym, N_sym], dace.float64)
+    mid.add_array("A_out", [M_sym, N_sym], dace.float64)
+    mid.add_array("levmask", [M_sym, N_sym], dace.int32)
+    mid.add_symbol("jb", dace.int32)
+    mid.add_symbol("_if_cond_24", dace.int32)
+
+    pre = mid.add_state("pre", is_start_block=True)
+    cb = ConditionalBlock("cb")
+    mid.add_node(cb)
+    mid.add_edge(pre, cb, dace.InterstateEdge(
+        assignments={"_if_cond_24": "levmask[jb, 0]"}))
+
+    branch_body = ControlFlowRegion("branch", sdfg=mid)
+    cb.add_branch(CodeBlock("(_if_cond_24 == 1)"), branch_body)
+    bstate = branch_body.add_state("branch_state", is_start_block=True)
+    ar = bstate.add_read("A_in")
+    aw = bstate.add_write("A_out")
+    me, mx = bstate.add_map("jc_map", {"jc": "0:N"})
+    me.add_in_connector("IN_a"); me.add_out_connector("OUT_a")
+    mx.add_in_connector("IN_a"); mx.add_out_connector("OUT_a")
+    ns = bstate.add_nested_sdfg(inner, {"a_in"}, {"a_out"})
+    bstate.add_edge(ar, None, me, "IN_a", mm.Memlet("A_in[0:M, 0:N]"))
+    bstate.add_edge(me, "OUT_a", ns, "a_in", mm.Memlet("A_in[jb, jc]"))
+    bstate.add_edge(ns, "a_out", mx, "IN_a", mm.Memlet("A_out[jb, jc]"))
+    bstate.add_edge(mx, "OUT_a", aw, None, mm.Memlet("A_out[0:M, 0:N]"))
+
+    # --- outer SDFG ---
+    outer = SDFG("outer_tester")
+    outer.add_array("A_in", [M_sym, N_sym], dace.float64)
+    outer.add_array("A_out", [M_sym, N_sym], dace.float64)
+    outer.add_array("levmask", [M_sym, N_sym], dace.int32)
+
+    ostate = outer.add_state("outer_state", is_start_block=True)
+    AR = ostate.add_read("A_in")
+    LR = ostate.add_read("levmask")
+    AW = ostate.add_write("A_out")
+    OE, OX = ostate.add_map("jb_map", {"jb": "0:M"})
+    for c in ("A_in", "levmask"):
+        OE.add_in_connector("IN_" + c); OE.add_out_connector("OUT_" + c)
+    OX.add_in_connector("IN_A_out"); OX.add_out_connector("OUT_A_out")
+    mid_node = ostate.add_nested_sdfg(mid, {"A_in", "levmask"}, {"A_out"})
+    ostate.add_edge(AR, None, OE, "IN_A_in", mm.Memlet("A_in[0:M, 0:N]"))
+    ostate.add_edge(LR, None, OE, "IN_levmask", mm.Memlet("levmask[0:M, 0:N]"))
+    ostate.add_edge(OE, "OUT_A_in", mid_node, "A_in", mm.Memlet("A_in[0:M, 0:N]"))
+    ostate.add_edge(OE, "OUT_levmask", mid_node, "levmask", mm.Memlet("levmask[0:M, 0:N]"))
+    ostate.add_edge(mid_node, "A_out", OX, "IN_A_out", mm.Memlet("A_out[0:M, 0:N]"))
+    ostate.add_edge(OX, "OUT_A_out", AW, None, mm.Memlet("A_out[0:M, 0:N]"))
+
+    outer.validate()
+
+    # The offending pre-transform edge: _if_cond_24 is assigned AND would be
+    # read on the same edge if MoveIfIntoMap put the condition there.
+    pre_found = False
+    for e, _ in outer.all_edges_recursive():
+        if isinstance(e.data, dace.InterstateEdge) and "_if_cond_24" in e.data.assignments:
+            pre_found = True
+            break
+    assert pre_found
+
+    applied = outer.apply_transformations_repeated(MoveIfIntoMap)
+    assert applied == 1, applied
+    outer.validate()  # Race condition would have thrown here.
+
+    # The enclosing edges must not gain a cond-symbol assignment that
+    # would race with ``_if_cond_24``.
+    for e, g in outer.all_edges_recursive():
+        if g is outer:  # only the outer SDFG, not nested ones
+            continue
+        if not isinstance(e.data, dace.InterstateEdge):
+            continue
+        if g.name == "mid_tester":  # the enclosing SDFG
+            for sym in e.data.assignments:
+                assert not sym.endswith("_cond"), (
+                    f"condition should be moved inside inner NSDFG, found {sym} on "
+                    f"mid-level edge: {e.data.assignments}")
+
+    # The inner NSDFG body should now contain a ConditionalBlock whose
+    # guard reads ``_if_cond_24`` (piped through symbol_mapping).
+    found_moved_cb = False
+    for g in outer.all_sdfgs_recursive():
+        if g.name.startswith("inner_tester"):
+            for block in g.nodes():
+                if isinstance(block, ConditionalBlock):
+                    guard = block.branches[0][0].as_string
+                    if "_if_cond_24" in guard:
+                        found_moved_cb = True
+    assert found_moved_cb, "no ConditionalBlock reading _if_cond_24 inside inner NSDFG"
+
+    # Numerical verification: the kernel computes ``A_out[jb, jc] = 2 *
+    # A_in[jb, jc]`` when ``levmask[jb, 0] == 1``, and leaves A_out at its
+    # initial value otherwise.
+    M_val, N_val = 4, 3
+    a_in = np.arange(M_val * N_val, dtype=np.float64).reshape(M_val, N_val).copy()
+    levmask = np.zeros((M_val, N_val), dtype=np.int32)
+    levmask[1:3, 0] = 1  # predicate fires for two of the four blocks
+    a_out = np.full((M_val, N_val), -1.0, dtype=np.float64)
+    expected = np.where(levmask[:, 0:1] == 1, 2 * a_in, a_out)
+
+    outer(A_in=a_in, A_out=a_out, levmask=levmask, M=M_val, N=N_val)
+    np.testing.assert_allclose(a_out, expected, rtol=1e-5, atol=1e-6)
+
+
 if __name__ == "__main__":
     test_move_if_into_map_basic()
     test_move_if_into_map_symbolic_condition()
     test_move_if_into_map_multiple_reads_and_writes()
     test_move_if_into_map_no_apply_missing_inner_map()
     test_move_if_into_map_no_apply_else_branch()
+    test_move_if_into_map_no_race_with_upstream_symbol_assignment()
     print("All tests passed.")

--- a/tests/transformations/interstate/move_if_into_map_test.py
+++ b/tests/transformations/interstate/move_if_into_map_test.py
@@ -234,8 +234,7 @@ def test_move_if_into_map_no_race_with_upstream_symbol_assignment():
     pre = mid.add_state("pre", is_start_block=True)
     cb = ConditionalBlock("cb")
     mid.add_node(cb)
-    mid.add_edge(pre, cb, dace.InterstateEdge(
-        assignments={"_if_cond_24": "levmask[jb, 0]"}))
+    mid.add_edge(pre, cb, dace.InterstateEdge(assignments={"_if_cond_24": "levmask[jb, 0]"}))
 
     branch_body = ControlFlowRegion("branch", sdfg=mid)
     cb.add_branch(CodeBlock("(_if_cond_24 == 1)"), branch_body)
@@ -243,8 +242,10 @@ def test_move_if_into_map_no_race_with_upstream_symbol_assignment():
     ar = bstate.add_read("A_in")
     aw = bstate.add_write("A_out")
     me, mx = bstate.add_map("jc_map", {"jc": "0:N"})
-    me.add_in_connector("IN_a"); me.add_out_connector("OUT_a")
-    mx.add_in_connector("IN_a"); mx.add_out_connector("OUT_a")
+    me.add_in_connector("IN_a")
+    me.add_out_connector("OUT_a")
+    mx.add_in_connector("IN_a")
+    mx.add_out_connector("OUT_a")
     ns = bstate.add_nested_sdfg(inner, {"a_in"}, {"a_out"})
     bstate.add_edge(ar, None, me, "IN_a", mm.Memlet("A_in[0:M, 0:N]"))
     bstate.add_edge(me, "OUT_a", ns, "a_in", mm.Memlet("A_in[jb, jc]"))
@@ -263,8 +264,10 @@ def test_move_if_into_map_no_race_with_upstream_symbol_assignment():
     AW = ostate.add_write("A_out")
     OE, OX = ostate.add_map("jb_map", {"jb": "0:M"})
     for c in ("A_in", "levmask"):
-        OE.add_in_connector("IN_" + c); OE.add_out_connector("OUT_" + c)
-    OX.add_in_connector("IN_A_out"); OX.add_out_connector("OUT_A_out")
+        OE.add_in_connector("IN_" + c)
+        OE.add_out_connector("OUT_" + c)
+    OX.add_in_connector("IN_A_out")
+    OX.add_out_connector("OUT_A_out")
     mid_node = ostate.add_nested_sdfg(mid, {"A_in", "levmask"}, {"A_out"})
     ostate.add_edge(AR, None, OE, "IN_A_in", mm.Memlet("A_in[0:M, 0:N]"))
     ostate.add_edge(LR, None, OE, "IN_levmask", mm.Memlet("levmask[0:M, 0:N]"))
@@ -297,9 +300,8 @@ def test_move_if_into_map_no_race_with_upstream_symbol_assignment():
             continue
         if g.name == "mid_tester":  # the enclosing SDFG
             for sym in e.data.assignments:
-                assert not sym.endswith("_cond"), (
-                    f"condition should be moved inside inner NSDFG, found {sym} on "
-                    f"mid-level edge: {e.data.assignments}")
+                assert not sym.endswith("_cond"), (f"condition should be moved inside inner NSDFG, found {sym} on "
+                                                   f"mid-level edge: {e.data.assignments}")
 
     # The inner NSDFG body should now contain a ConditionalBlock whose
     # guard reads ``_if_cond_24`` (piped through symbol_mapping).

--- a/tests/transformations/interstate/move_if_into_map_test.py
+++ b/tests/transformations/interstate/move_if_into_map_test.py
@@ -1,0 +1,186 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests for the MoveIfIntoMap transformation.
+
+These mirror the ICON ``_for_it_44`` motif: a conditional block that lives in
+the body of an outer map and guards an inner map. The transformation pushes
+the guard past the inner map so the two maps can be fused/collapsed by later
+passes.
+"""
+import copy
+
+import numpy as np
+
+import dace
+from dace.sdfg.nodes import NestedSDFG
+from dace.sdfg.state import ConditionalBlock
+from dace.transformation.interstate import MoveIfIntoMap
+
+
+def _count_conditional_blocks(sdfg: dace.SDFG) -> int:
+    total = 0
+    for node, _ in sdfg.all_nodes_recursive():
+        if isinstance(node, ConditionalBlock):
+            total += 1
+    return total
+
+
+def _inner_nsdfg_contains_conditional(outer_sdfg: dace.SDFG) -> bool:
+    """After applying the transformation the conditional block should live
+    inside an inner nested SDFG (the body of the innermost map)."""
+    for node, _ in outer_sdfg.all_nodes_recursive():
+        if not isinstance(node, NestedSDFG):
+            continue
+        inner = node.sdfg
+        for block in inner.nodes():
+            if isinstance(block, ConditionalBlock):
+                return True
+    return False
+
+
+def _run_and_compare(prog, inputs, expected_apps: int, simplify: bool = False):
+    sdfg: dace.SDFG = prog.to_sdfg(simplify=simplify)
+    sdfg.validate()
+
+    reference = copy.deepcopy(inputs)
+    sdfg(**reference)
+
+    sdfg2: dace.SDFG = prog.to_sdfg(simplify=simplify)
+    applied = sdfg2.apply_transformations_repeated(MoveIfIntoMap)
+    assert applied == expected_apps, f"expected {expected_apps} applications, got {applied}"
+    sdfg2.validate()
+
+    transformed = copy.deepcopy(inputs)
+    sdfg2(**transformed)
+
+    for key in reference:
+        np.testing.assert_allclose(transformed[key],
+                                   reference[key],
+                                   rtol=1e-5,
+                                   atol=1e-6,
+                                   err_msg=f"Mismatch for {key}")
+
+    return sdfg2
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_move_if_into_map_basic():
+    """Core _for_it_44-style pattern: outer map, scalar guard, inner map."""
+
+    N, M = 6, 5
+
+    @dace.program
+    def tester(A: dace.float64[N, M], cond: dace.int32):
+        for i in dace.map[0:N]:
+            if cond == 1:
+                for j in dace.map[0:M]:
+                    A[i, j] = A[i, j] + 1.0
+
+    rng = np.random.default_rng(0)
+    inputs_on = {
+        "A": rng.random((N, M)).copy(),
+        "cond": np.int32(1),
+    }
+    inputs_off = {
+        "A": rng.random((N, M)).copy(),
+        "cond": np.int32(0),
+    }
+
+    sdfg_on = _run_and_compare(tester, inputs_on, expected_apps=1)
+    _run_and_compare(tester, inputs_off, expected_apps=1)
+
+    assert _count_conditional_blocks(sdfg_on) == 1
+    assert _inner_nsdfg_contains_conditional(sdfg_on)
+
+
+def test_move_if_into_map_symbolic_condition():
+    """Condition uses a combination of map parameter and outer symbol."""
+
+    N, M = 8, 4
+
+    @dace.program
+    def tester(A: dace.float64[N, M], threshold: dace.int32):
+        for i in dace.map[0:N]:
+            if i < threshold:
+                for j in dace.map[0:M]:
+                    A[i, j] = A[i, j] * 2.0
+
+    rng = np.random.default_rng(1)
+    inputs = {
+        "A": rng.random((N, M)).copy(),
+        "threshold": np.int32(5),
+    }
+
+    sdfg = _run_and_compare(tester, inputs, expected_apps=1)
+    assert _inner_nsdfg_contains_conditional(sdfg)
+
+
+def test_move_if_into_map_multiple_reads_and_writes():
+    """Body has multiple access nodes on both sides of the inner nested SDFG."""
+
+    N, M = 4, 4
+
+    @dace.program
+    def tester(A: dace.float64[N, M], B: dace.float64[N, M], cond: dace.int32):
+        for i in dace.map[0:N]:
+            if cond == 1:
+                for j in dace.map[0:M]:
+                    A[i, j] = A[i, j] + B[i, j]
+
+    rng = np.random.default_rng(2)
+    inputs = {
+        "A": rng.random((N, M)).copy(),
+        "B": rng.random((N, M)).copy(),
+        "cond": np.int32(1),
+    }
+
+    sdfg = _run_and_compare(tester, inputs, expected_apps=1)
+    assert _inner_nsdfg_contains_conditional(sdfg)
+
+
+def test_move_if_into_map_no_apply_missing_inner_map():
+    """No inner map in the branch: should not match."""
+
+    N = 6
+
+    @dace.program
+    def tester(A: dace.float64[N], cond: dace.int32):
+        for i in dace.map[0:N]:
+            if cond == 1:
+                A[i] = A[i] + 1.0
+
+    sdfg: dace.SDFG = tester.to_sdfg(simplify=False)
+    applied = sdfg.apply_transformations_repeated(MoveIfIntoMap)
+    assert applied == 0
+
+
+def test_move_if_into_map_no_apply_else_branch():
+    """Conditional has an else branch -> not supported."""
+
+    N, M = 4, 4
+
+    @dace.program
+    def tester(A: dace.float64[N, M], cond: dace.int32):
+        for i in dace.map[0:N]:
+            if cond == 1:
+                for j in dace.map[0:M]:
+                    A[i, j] = A[i, j] + 1.0
+            else:
+                for j in dace.map[0:M]:
+                    A[i, j] = A[i, j] - 1.0
+
+    sdfg: dace.SDFG = tester.to_sdfg(simplify=False)
+    applied = sdfg.apply_transformations_repeated(MoveIfIntoMap)
+    assert applied == 0
+
+
+if __name__ == "__main__":
+    test_move_if_into_map_basic()
+    test_move_if_into_map_symbolic_condition()
+    test_move_if_into_map_multiple_reads_and_writes()
+    test_move_if_into_map_no_apply_missing_inner_map()
+    test_move_if_into_map_no_apply_else_branch()
+    print("All tests passed.")


### PR DESCRIPTION
Pushes a conditional block that guards an inner map from the outer map's nested SDFG down into the inner nested SDFG, so both maps become direct neighbours and can be collapsed/fused by subsequent passes. Mirrors the hand-written _for_it_44 rewrite from icon-artifacts/velocity as a proper pattern-matching MultiStateTransformation with a full can_be_applied check and numerical-verification tests.