### PR TITLE
[Minor | Python parser] Verbose error message for subscript into list of unsupported types

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -5510,7 +5510,12 @@ class ProgramVisitor(ExtNodeVisitor):
                 except (TypeError, ValueError):
                     pass  # Passthrough to exception
 
-            raise DaceSyntaxError(self, node.value, 'Subscripted object cannot be a tuple')
+            raise DaceSyntaxError(
+                self, node.value,
+                f'Subscript {[t[1] for t in node_parsed]} unsupported. '
+                'DaCe supports sequence of dace.data or an attribute of a dace.data. '
+                'Try `dace.unroll` for more complex types.'
+            )
         array, arrtype = node_parsed[0]
         if arrtype == 'str' or arrtype in dtypes._CTYPES:
             raise DaceSyntaxError(self, node, 'Type "%s" cannot be sliced' % arrtype)

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -5511,11 +5511,9 @@ class ProgramVisitor(ExtNodeVisitor):
                     pass  # Passthrough to exception
 
             raise DaceSyntaxError(
-                self, node.value,
-                f'Subscript {[t[1] for t in node_parsed]} unsupported. '
+                self, node.value, f'Subscript {[t[1] for t in node_parsed]} unsupported. '
                 'DaCe supports sequence of dace.data or an attribute of a dace.data. '
-                'Try `dace.unroll` for more complex types.'
-            )
+                'Try `dace.unroll` for more complex types.')
         array, arrtype = node_parsed[0]
         if arrtype == 'str' or arrtype in dtypes._CTYPES:
             raise DaceSyntaxError(self, node, 'Type "%s" cannot be sliced' % arrtype)


### PR DESCRIPTION
Enhance the error message in parser when failing to understand a Sequence of non supported object.

Closes: https://github.com/spcl/dace/issues/2332