### PR TITLE
test: rename min warps per eu test file

### DIFF
--- a/tests/codegen/gpu_min_warps_per_eu_test.py
+++ b/tests/codegen/gpu_min_warps_per_eu_test.py
@@ -1,15 +1,14 @@
-# Copyright 2019-2023 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
 
 import dace
 import pytest
 
 
 @pytest.mark.gpu
-def test_min_warps_per_eu():
-    B = 2
+def test_min_warps_per_eu() -> None:
 
     @dace.program
-    def prog(a: dace.float64[100, 20] @ dace.StorageType.GPU_Global):
+    def prog(a: dace.float64[100, 20] @ dace.StorageType.GPU_Global) -> None:
         for i, j in dace.map[0:100, 0:20] @ dace.ScheduleType.GPU_Device:
             a[i, j] = 1
 


### PR DESCRIPTION
## Description

This is a follow-up from https://github.com/spcl/dace/pull/2346. By convention, pytest searches for tests in files ending with `_test.py` (unless otherwise configured). The new min warps by eu test was thus never running on CI:

- gpu test run [before 2346 merged](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5985887337886893/5392709053677205/-/jobs/14116323037) shows 307 test cases executed
- gpu test run [after 2346 merged](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5985887337886893/5392709053677205/-/jobs/14139835937) still shows 307 test cases executed

With this rename, it will be picked up and the number of gpu tests executed should increase to 308.

