### PR TITLE
StateFusionExtended: refuse unsafe write-after-read fusion

### DIFF
--- a/dace/transformation/interstate/state_fusion_with_happens_before.py
+++ b/dace/transformation/interstate/state_fusion_with_happens_before.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
 """ State fusion transformation """
 
 from typing import Dict, List, Set
@@ -381,6 +381,17 @@ class StateFusionExtended(transformation.MultiStateTransformation):
                                                              nodes_second, True, False):
                                     return False
 
+                                # Same-cc write-after-read: first reads ``d``,
+                                # second writes it, ``d`` not a first output.
+                                # Safe fusion would need a dependency edge to
+                                # every first-state sink reading ``d``; refuse
+                                # instead and keep the two states separate.
+                                if d in fused_cc.first_inputs:
+                                    nodes_first_read = [n for n in first_input if n.data == d]
+                                    if StateFusionExtended.memlets_intersect(first_state, nodes_first_read, True,
+                                                                             second_state, nodes_second, False):
+                                        return False
+
                         continue
                     # If an input/output of a connected component in the first
                     # state is an output of another connected component in the
@@ -390,13 +401,17 @@ class StateFusionExtended(transformation.MultiStateTransformation):
                         if d in other_cc.second_outputs:
                             # Check for intersection (if None, fusion is ok)
                             nodes_second = [n for n in second_output if n.data == d]
-                            # Read-Write race
+                            # Read-Write race (write-after-read / anti-
+                            # dependency): the first state reads ``d`` and the
+                            # second writes it. Safely fusing would require a
+                            # dependency edge to every first-state sink reading
+                            # ``d`` (arbitrarily fanned out); refuse instead and
+                            # keep the two states separate.
                             if d in fused_cc.first_inputs:
                                 nodes_first = [n for n in first_input if n.data == d]
                                 if StateFusionExtended.memlets_intersect(first_state, nodes_first, True, second_state,
                                                                          nodes_second, False):
-                                    self.connections_to_make.append([nodes_first, nodes_second])
-                                    #return False
+                                    return False
                             # Write-Write race
                             if d in fused_cc.first_outputs:
                                 nodes_first = [n for n in first_output if n.data == d]

--- a/tests/transformations/state_fusion_extended_test.py
+++ b/tests/transformations/state_fusion_extended_test.py
@@ -1,3 +1,4 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
 from dace import SDFG, InterstateEdge, Memlet
 from dace import dtypes
 from dace.transformation.interstate import StateFusionExtended
@@ -61,5 +62,52 @@ def test_extended_fusion():
     assert sdfg.number_of_nodes() == 1
 
 
+def test_extended_fusion_refuses_unsafe_write_after_read():
+    """A read state followed by an in-place write of the same array must
+    not be fused (write-after-read / anti-dependency).
+
+    ``s1`` reads ``A[k]`` in two tasklets; the later ``s2`` does
+    ``A[k] = A[k] + 1``. Safely fusing would need a dependency edge to
+    every first-state sink reading ``A`` (arbitrarily fanned out), so
+    ``StateFusionExtended`` must refuse and leave the two states
+    separate; the interstate edge then keeps the write ordered after the
+    reads. Previously it fused without that ordering and the write
+    clobbered the still-pending reads.
+    """
+    sdfg = SDFG('state_fusion_war_ordering')
+    sdfg.add_array('A', [8], dtypes.float64)
+    sdfg.add_array('B', [8], dtypes.float64)
+    sdfg.add_array('C', [8], dtypes.float64)
+    sdfg.add_symbol('k', dtypes.int64)
+
+    s1 = sdfg.add_state('read_A', is_start_block=True)
+    s2 = sdfg.add_state('increment_A')
+    sdfg.add_edge(s1, s2, InterstateEdge())
+
+    ar_b = s1.add_read('A')
+    bw = s1.add_write('B')
+    tb = s1.add_tasklet('rb', {'_in'}, {'_out'}, '_out = _in')
+    s1.add_edge(ar_b, None, tb, '_in', Memlet('A[k]'))
+    s1.add_edge(tb, '_out', bw, None, Memlet('B[k]'))
+
+    ar_c = s1.add_read('A')
+    cw = s1.add_write('C')
+    tc = s1.add_tasklet('rc', {'_in'}, {'_out'}, '_out = _in')
+    s1.add_edge(ar_c, None, tc, '_in', Memlet('A[k]'))
+    s1.add_edge(tc, '_out', cw, None, Memlet('C[k]'))
+
+    ar2 = s2.add_read('A')
+    aw2 = s2.add_write('A')
+    ti = s2.add_tasklet('inc', {'_in'}, {'_out'}, '_out = _in + 1.0')
+    s2.add_edge(ar2, None, ti, '_in', Memlet('A[k]'))
+    s2.add_edge(ti, '_out', aw2, None, Memlet('A[k]'))
+    sdfg.validate()
+
+    applied = sdfg.apply_transformations_repeated(StateFusionExtended)
+    assert applied == 0, 'write-after-read fusion must be refused'
+    assert sdfg.number_of_nodes() == 2, 'the two states must remain separate'
+
+
 if __name__ == '__main__':
     test_extended_fusion()
+    test_extended_fusion_refuses_unsafe_write_after_read()


### PR DESCRIPTION
## Refuse state fusion that breaks happens-before ordering

After `StateFusion` runs, some graphs become incorrect because a
happens-before dependency before the fused states is lost.

Pattern this fixes:
<img width="304" height="496" alt="Pattern" src="https://github.com/user-attachments/assets/1f4cdb9a-4856-4b06-bfa3-3e469783d367" />

Buggy result after fusion:
<img width="1108" height="530" alt="Buggy after fusion" src="https://github.com/user-attachments/assets/9b5e8069-5527-46ca-b7d6-70749337acac" />

One possible fix is to insert explicit dependency edges, but that bloats the
graph and is not, in my view, a good approach:
<img width="734" height="602" alt="Dependency-edge alternative" src="https://github.com/user-attachments/assets/80cfce82-c3f8-4979-904a-54863c388d05" />

**Current approach:** refuse the fusion in this case, leaving the graph
correct rather than producing an invalid one.