### PR TITLE
Default-typed parsing for serialized constants

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -100,9 +100,10 @@ required:
                 title: Default-type untyped serialized constants
                 description: >
                     When deserializing symbolic expressions, give untyped
-                    literals a default DaCe type (``5`` -> ``int64``,
-                    ``5.0`` -> ``float64``, ``True`` -> ``bool``,
-                    ``4j`` -> ``complex128``) instead of plain SymPy numbers.
+                    literals a default DaCe type instead of plain SymPy numbers:
+                    integers and floats follow ``compiler.default_data_types``
+                    (e.g. ``5`` -> int32/int64, ``5.0`` -> float32/float64),
+                    ``True``/``False`` -> ``bool``, and ``4j`` -> ``complex128``.
 
             match_exception:
                 type: bool

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -102,12 +102,12 @@ required:
                     When deserializing symbolic expressions, give untyped
                     literals a default DaCe type instead of plain SymPy numbers:
                     integers and floats follow ``compiler.default_data_types``
-                    (e.g. ``5`` -> int32/int64, ``5.0`` -> float32/float64),
-                    ``True``/``False`` -> ``bool``, and ``4j`` -> ``complex128``.
-                    Off by default: when enabled, serialize/deserialize is no
-                    longer idempotent for plain literals (rationals are rewritten
-                    as typed-constant arithmetic) and literal ``True``/``False``
-                    become numeric constants rather than boolean conditions.
+                    (e.g. ``5`` -> int32/int64, ``5.0`` -> float32/float64) and
+                    ``4j`` -> ``complex128``. ``True``/``False`` are always kept
+                    as SymPy booleans. Off by default: when enabled,
+                    serialize/deserialize is no longer idempotent for plain
+                    literals (rationals are rewritten as typed-constant
+                    arithmetic).
 
             match_exception:
                 type: bool

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -104,6 +104,10 @@ required:
                     integers and floats follow ``compiler.default_data_types``
                     (e.g. ``5`` -> int32/int64, ``5.0`` -> float32/float64),
                     ``True``/``False`` -> ``bool``, and ``4j`` -> ``complex128``.
+                    Off by default: when enabled, serialize/deserialize is no
+                    longer idempotent for plain literals (rationals are rewritten
+                    as typed-constant arithmetic) and literal ``True``/``False``
+                    become numeric constants rather than boolean conditions.
 
             match_exception:
                 type: bool

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -94,6 +94,16 @@ required:
                     is treated as strictly positive. This is necessary
                     for certain Range evaluations using Subgraph Fusion.
 
+            default_typed_constants:
+                type: bool
+                default: false
+                title: Default-type untyped serialized constants
+                description: >
+                    When deserializing symbolic expressions, give untyped
+                    literals a default DaCe type (``5`` -> ``int64``,
+                    ``5.0`` -> ``float64``, ``True`` -> ``bool``,
+                    ``4j`` -> ``complex128``) instead of plain SymPy numbers.
+
             match_exception:
                 type: bool
                 default: false

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -1277,6 +1277,12 @@ TYPECLASS_TO_LITERAL_SUFFIX = {
 
 LITERAL_SUFFIX_TO_TYPECLASS = {v: k for k, v in TYPECLASS_TO_LITERAL_SUFFIX.items()}
 
+# Inverse of ``typeclass.ctype`` for fixed-width types, to parse C++ cast fallbacks.
+CTYPE_TO_TYPECLASS = {
+    t.ctype: t
+    for t in (int8, int16, int32, int64, uint8, uint16, uint32, uint64, float16, float32, float64)
+}
+
 TYPECLASS_TO_CPP_LITERAL_SUFFIX = {
     float32: 'f',
     uint32: 'U',

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -1277,8 +1277,7 @@ TYPECLASS_TO_LITERAL_SUFFIX = {
 
 LITERAL_SUFFIX_TO_TYPECLASS = {v: k for k, v in TYPECLASS_TO_LITERAL_SUFFIX.items()}
 
-# Inverse of _CTYPES restricted to numeric types, to parse the C++ printer's
-# cast fallbacks (e.g. ``double(5)``).
+# Inverse of _CTYPES for numeric types, to parse C++ cast fallbacks.
 CTYPE_TO_TYPECLASS = {
     ctype: dtype_to_typeclass(nptype)
     for nptype, ctype in _CTYPES.items()

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -1277,10 +1277,12 @@ TYPECLASS_TO_LITERAL_SUFFIX = {
 
 LITERAL_SUFFIX_TO_TYPECLASS = {v: k for k, v in TYPECLASS_TO_LITERAL_SUFFIX.items()}
 
-# Inverse of ``typeclass.ctype`` for fixed-width types, to parse C++ cast fallbacks.
+# Inverse of _CTYPES restricted to numeric types, to parse the C++ printer's
+# cast fallbacks (e.g. ``double(5)``).
 CTYPE_TO_TYPECLASS = {
-    t.ctype: t
-    for t in (int8, int16, int32, int64, uint8, uint16, uint32, uint64, float16, float32, float64)
+    ctype: dtype_to_typeclass(nptype)
+    for nptype, ctype in _CTYPES.items()
+    if nptype is not None and (numpy.issubdtype(nptype, numpy.integer) or numpy.issubdtype(nptype, numpy.floating))
 }
 
 TYPECLASS_TO_CPP_LITERAL_SUFFIX = {

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -14,6 +14,7 @@ import sympy.printing.str
 import packaging.version as packaging_version
 
 from dace import dtypes
+from dace.config import Config
 
 DEFAULT_SYMBOL_TYPE = dtypes.int32
 _NAME_TOKENS = re.compile(r'[a-zA-Z_][a-zA-Z_0-9]*')
@@ -1880,13 +1881,7 @@ def serialize_symbolic(expr: Union[SymbolicType, int, float, numpy.number]) -> s
 
 
 @lru_cache(maxsize=16384)
-def deserialize_symbolic(expr, default_constants: bool = False) -> SymbolicType:
-    """
-    Deserialize a string produced by :func:`serialize_symbolic`.
-
-    :param default_constants: If True, untyped literals become default-typed
-                              ``TypedConstant`` s (``5`` -> ``int64``, ``5.0`` -> ``float64``).
-    """
+def _deserialize_symbolic(expr, default_typed_constants: bool) -> SymbolicType:
     if isinstance(expr, (SymExpr, sympy.Basic)):
         return expr
     if isinstance(expr, numpy.generic):
@@ -1907,7 +1902,12 @@ def deserialize_symbolic(expr, default_constants: bool = False) -> SymbolicType:
     expr = _SERIALIZED_SYMBOL.sub(lambda m: f'{_SERIALIZED_SYMBOL_PREFIX}{m.group("name")}', expr)
     expr = _SERIALIZED_TYPED_CONSTANT.sub(
         lambda m: f'__dace_typed_const__({m.group("value")!r}, {m.group("suffix")!r})', expr)
-    return _SerializedSymbolicParser(default_constants=default_constants).visit(ast.parse(expr, mode='eval'))
+    return _SerializedSymbolicParser(default_constants=default_typed_constants).visit(ast.parse(expr, mode='eval'))
+
+
+def deserialize_symbolic(expr) -> SymbolicType:
+    """Deserialize a string produced by :func:`serialize_symbolic`."""
+    return _deserialize_symbolic(expr, Config.get_bool('optimizer', 'default_typed_constants'))
 
 
 def pystr_to_symbolic(expr, symbol_map=None, simplify=None) -> sympy.Basic:

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -254,6 +254,10 @@ class UndefinedSymbol(symbol):
 class TypedConstant(sympy.AtomicExpr):
     """A typed constant value that participates in symbolic expressions.
 
+    The value is always a real ``Integer``/``Float``; the ``dtype`` is a tag.
+    Genuine complex/boolean constant values are not supported (only the dtype
+    tag round-trips, via the ``dace.<dtype>(value)`` form).
+
     Examples
     --------
     >>> from dace import symbolic, int16
@@ -515,7 +519,11 @@ def _typed_constant_to_string(expr: TypedConstant) -> str:
         value = _format_float(float(expr.value))
     else:
         value = sympy.printing.str.sstr(expr.value)
-    return f'{value}{_typed_constant_suffix(expr.dtype)}'
+    if expr.dtype in dtypes.TYPECLASS_TO_LITERAL_SUFFIX:
+        return f'{value}{_typed_constant_suffix(expr.dtype)}'
+    # dtypes without a literal suffix (complex, bool) round-trip via the
+    # parseable cast form ``dace.<dtype>(value)``.
+    return f'dace.{expr.dtype.to_string()}({value})'
 
 
 def _symbol_default_assumptions(expr: symbol) -> Dict[str, Any]:

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -478,6 +478,10 @@ def _sympy_constant_value(value):
         return sympy.Integer(value)
     if isinstance(value, float):
         return sympy.Float(value)
+    if isinstance(value, (complex, numpy.complexfloating)):
+        return sympy.Float(value.real) + sympy.Float(value.imag) * sympy.I
+    if isinstance(value, sympy.Expr) and value.is_number and value.is_real is False:
+        return value
     raise TypeError(f'Unsupported typed constant value {value!r}')
 
 
@@ -496,6 +500,8 @@ def _infer_typed_constant_dtype(value) -> dtypes.typeclass:
         return DEFAULT_SYMBOL_TYPE
     if isinstance(value, float):
         return dtypes.float64
+    if isinstance(value, (complex, numpy.complexfloating)):
+        return dtypes.complex128
     raise TypeError(f'Cannot infer a DaCe dtype for {value!r}')
 
 
@@ -518,6 +524,11 @@ def _format_float(value: float) -> str:
 
 
 def _typed_constant_to_string(expr: TypedConstant) -> str:
+    if expr.dtype in (dtypes.complex64, dtypes.complex128):
+        re = _format_float(float(sympy.re(expr.value)))
+        im = _format_float(float(sympy.im(expr.value)))
+        literal = f'complex({re}, {im})'
+        return literal if expr.dtype == dtypes.complex128 else f'dace.{expr.dtype.to_string()}({literal})'
     if isinstance(expr.value, sympy.Float):
         value = _format_float(float(expr.value))
     else:
@@ -1633,6 +1644,8 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
 
     def visit_Constant(self, node):
         if isinstance(node.value, bool):
+            if self._default_constants:
+                return TypedConstant(int(node.value), dtypes.bool_)
             return sympy.true if node.value else sympy.false
         if node.value is None:
             return symbol('NoneSymbol')
@@ -1644,6 +1657,9 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
             if self._default_constants:
                 return TypedConstant(node.value, dtypes.typeclass(float))
             return sympy.Float(node.value)
+        if isinstance(node.value, complex):
+            if self._default_constants:
+                return TypedConstant(node.value, dtypes.complex128)
         raise TypeError(f'Unsupported literal {node.value!r}')
 
     def visit_UnaryOp(self, node):
@@ -1703,6 +1719,11 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
 
         if (isinstance(node.func, ast.Name) and node.func.id in dtypes.CTYPE_TO_TYPECLASS and len(node.args) == 1):
             return _cast_symbolic_value(self.visit(node.args[0]), dtypes.CTYPE_TO_TYPECLASS[node.func.id])
+
+        if isinstance(node.func, ast.Name) and node.func.id == 'complex' and len(node.args) == 2:
+            re = self.visit(node.args[0])
+            im = self.visit(node.args[1])
+            return TypedConstant(complex(float(re), float(im)), dtypes.complex128)
 
         func = self._resolve_function(node.func)
         args = [self.visit(arg) for arg in node.args]

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -310,7 +310,6 @@ class TypedConstant(sympy.AtomicExpr):
 
     @property
     def _prec(self):
-        # Read by sympy._should_evalf when is_Float (e.g. Min/Max construction).
         return self.value._prec
 
     @property

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -309,6 +309,11 @@ class TypedConstant(sympy.AtomicExpr):
         return self.value.is_Float
 
     @property
+    def _prec(self):
+        # Read by sympy._should_evalf when is_Float (e.g. Min/Max construction).
+        return self.value._prec
+
+    @property
     def is_integer(self):
         return self.value.is_integer
 
@@ -1428,18 +1433,6 @@ class PythonOpToSympyConverter(ast.NodeTransformer):
         return ast.copy_location(new_node, node)
 
 
-# Default typeclasses for untyped literals (matches dtypes.typeclass(int|float)).
-_DEFAULT_INTEGER_TYPECLASS = dtypes.int64
-_DEFAULT_FLOAT_TYPECLASS = dtypes.float64
-
-# C++ ctype spelling (e.g. ``double(5)``) -> typeclass, to parse cast fallbacks.
-_CPP_CTYPE_TO_TYPECLASS = {
-    t.ctype: t
-    for t in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint8, dtypes.uint16, dtypes.uint32,
-              dtypes.uint64, dtypes.float16, dtypes.float32, dtypes.float64)
-}
-
-
 class _SerializedSymbolicParser(ast.NodeVisitor):
     """
     Parser for the deterministic expression strings produced by
@@ -1636,11 +1629,11 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
             return symbol('NoneSymbol')
         if isinstance(node.value, int):
             if self._default_constants:
-                return TypedConstant(node.value, _DEFAULT_INTEGER_TYPECLASS)
+                return TypedConstant(node.value, dtypes.typeclass(int))
             return sympy.Integer(node.value)
         if isinstance(node.value, float):
             if self._default_constants:
-                return TypedConstant(node.value, _DEFAULT_FLOAT_TYPECLASS)
+                return TypedConstant(node.value, dtypes.typeclass(float))
             return sympy.Float(node.value)
         raise TypeError(f'Unsupported literal {node.value!r}')
 
@@ -1699,8 +1692,8 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
             args = [self.visit(arg) for arg in node.args]
             return SymExpr(*args)
 
-        if (isinstance(node.func, ast.Name) and node.func.id in _CPP_CTYPE_TO_TYPECLASS and len(node.args) == 1):
-            return _cast_symbolic_value(self.visit(node.args[0]), _CPP_CTYPE_TO_TYPECLASS[node.func.id])
+        if (isinstance(node.func, ast.Name) and node.func.id in dtypes.CTYPE_TO_TYPECLASS and len(node.args) == 1):
+            return _cast_symbolic_value(self.visit(node.args[0]), dtypes.CTYPE_TO_TYPECLASS[node.func.id])
 
         func = self._resolve_function(node.func)
         args = [self.visit(arg) for arg in node.args]

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -255,8 +255,9 @@ class UndefinedSymbol(symbol):
 class TypedConstant(sympy.AtomicExpr):
     """A typed constant value that participates in symbolic expressions.
 
-    The value is always a real ``Integer``/``Float`` (booleans as ``0``/``1``);
-    the ``dtype`` is a tag. Complex constant values are not supported.
+    The value is a real ``Integer``/``Float`` (booleans stored as ``0``/``1``),
+    or ``re + im*I`` when the ``dtype`` is complex. The ``dtype`` is a type tag;
+    complex constants must be numeric (symbolic real/imag parts are unsupported).
 
     Examples
     --------
@@ -496,7 +497,7 @@ def _infer_typed_constant_dtype(value) -> dtypes.typeclass:
     if isinstance(value, sympy.Float):
         return dtypes.float64
     if isinstance(value, (bool, numpy.bool_)):
-        return dtypes.dtype_to_typeclass(numpy.bool_)
+        return dtypes.bool_
     if isinstance(value, int) and not isinstance(value, bool):
         return DEFAULT_SYMBOL_TYPE
     if isinstance(value, float):

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1645,8 +1645,8 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
 
     def visit_Constant(self, node):
         if isinstance(node.value, bool):
-            if self._default_constants:
-                return TypedConstant(int(node.value), dtypes.bool_)
+            # Never default-type booleans: a literal True/False is usually a
+            # control condition, and a numeric constant is not a SymPy Boolean.
             return sympy.true if node.value else sympy.false
         if node.value is None:
             return symbol('NoneSymbol')

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -527,9 +527,8 @@ def _typed_constant_to_string(expr: TypedConstant) -> str:
     if expr.dtype in (dtypes.complex64, dtypes.complex128):
         re = _format_float(float(sympy.re(expr.value)))
         im = _format_float(float(sympy.im(expr.value)))
-        literal = f'complex({re}, {im})'
-        return literal if expr.dtype == dtypes.complex128 else f'dace.{expr.dtype.to_string()}({literal})'
-    if isinstance(expr.value, sympy.Float):
+        value = f'complex({re}, {im})'
+    elif isinstance(expr.value, sympy.Float):
         value = _format_float(float(expr.value))
     else:
         value = sympy.printing.str.sstr(expr.value)

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -495,8 +495,22 @@ def _typed_constant_suffix(dtype: dtypes.typeclass) -> str:
         raise TypeError(f'Unsupported typed constant dtype {dtype.to_string()}') from ex
 
 
+def _format_float(value: float) -> str:
+    # Shortest round-trip form, keeping one fractional digit (5.0, not 5 or 5.000...).
+    s = f'{float(value):.15g}'
+    if 'e' in s or 'E' in s:
+        return s
+    if '.' not in s:
+        return s + '.0'
+    int_part, frac_part = s.split('.')
+    return f'{int_part}.{frac_part.rstrip("0") or "0"}'
+
+
 def _typed_constant_to_string(expr: TypedConstant) -> str:
-    value = sympy.printing.str.sstr(expr.value)
+    if isinstance(expr.value, sympy.Float):
+        value = _format_float(float(expr.value))
+    else:
+        value = sympy.printing.str.sstr(expr.value)
     return f'{value}{_typed_constant_suffix(expr.dtype)}'
 
 
@@ -1414,6 +1428,18 @@ class PythonOpToSympyConverter(ast.NodeTransformer):
         return ast.copy_location(new_node, node)
 
 
+# Default typeclasses for untyped literals (matches dtypes.typeclass(int|float)).
+_DEFAULT_INTEGER_TYPECLASS = dtypes.int64
+_DEFAULT_FLOAT_TYPECLASS = dtypes.float64
+
+# C++ ctype spelling (e.g. ``double(5)``) -> typeclass, to parse cast fallbacks.
+_CPP_CTYPE_TO_TYPECLASS = {
+    t.ctype: t
+    for t in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint8, dtypes.uint16, dtypes.uint32,
+              dtypes.uint64, dtypes.float16, dtypes.float32, dtypes.float64)
+}
+
+
 class _SerializedSymbolicParser(ast.NodeVisitor):
     """
     Parser for the deterministic expression strings produced by
@@ -1424,6 +1450,9 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
     typed-symbol metadata instead of depending on SymPy's automatic
     simplification and constructor caches.
     """
+
+    def __init__(self, default_constants: bool = False):
+        self._default_constants = default_constants
 
     @staticmethod
     def _python_bool(value):
@@ -1606,8 +1635,12 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
         if node.value is None:
             return symbol('NoneSymbol')
         if isinstance(node.value, int):
+            if self._default_constants:
+                return TypedConstant(node.value, _DEFAULT_INTEGER_TYPECLASS)
             return sympy.Integer(node.value)
         if isinstance(node.value, float):
+            if self._default_constants:
+                return TypedConstant(node.value, _DEFAULT_FLOAT_TYPECLASS)
             return sympy.Float(node.value)
         raise TypeError(f'Unsupported literal {node.value!r}')
 
@@ -1665,6 +1698,9 @@ class _SerializedSymbolicParser(ast.NodeVisitor):
         if isinstance(node.func, ast.Name) and node.func.id == 'SymExpr':
             args = [self.visit(arg) for arg in node.args]
             return SymExpr(*args)
+
+        if (isinstance(node.func, ast.Name) and node.func.id in _CPP_CTYPE_TO_TYPECLASS and len(node.args) == 1):
+            return _cast_symbolic_value(self.visit(node.args[0]), _CPP_CTYPE_TO_TYPECLASS[node.func.id])
 
         func = self._resolve_function(node.func)
         args = [self.visit(arg) for arg in node.args]
@@ -1737,7 +1773,7 @@ class DaceSympySerializer(sympy.printing.str.StrPrinter):
         return super()._print_Integer(expr)
 
     def _print_Float(self, expr):
-        return super()._print_Float(expr)
+        return _format_float(float(sympy_numeric_fix(expr)))
 
     def _print_Add(self, expr):
         flat_args = []
@@ -1822,7 +1858,13 @@ def serialize_symbolic(expr: Union[SymbolicType, int, float, numpy.number]) -> s
 
 
 @lru_cache(maxsize=16384)
-def deserialize_symbolic(expr) -> SymbolicType:
+def deserialize_symbolic(expr, default_constants: bool = False) -> SymbolicType:
+    """
+    Deserialize a string produced by :func:`serialize_symbolic`.
+
+    :param default_constants: If True, untyped literals become default-typed
+                              ``TypedConstant`` s (``5`` -> ``int64``, ``5.0`` -> ``float64``).
+    """
     if isinstance(expr, (SymExpr, sympy.Basic)):
         return expr
     if isinstance(expr, numpy.generic):
@@ -1843,7 +1885,7 @@ def deserialize_symbolic(expr) -> SymbolicType:
     expr = _SERIALIZED_SYMBOL.sub(lambda m: f'{_SERIALIZED_SYMBOL_PREFIX}{m.group("name")}', expr)
     expr = _SERIALIZED_TYPED_CONSTANT.sub(
         lambda m: f'__dace_typed_const__({m.group("value")!r}, {m.group("suffix")!r})', expr)
-    return _SerializedSymbolicParser().visit(ast.parse(expr, mode='eval'))
+    return _SerializedSymbolicParser(default_constants=default_constants).visit(ast.parse(expr, mode='eval'))
 
 
 def pystr_to_symbolic(expr, symbol_map=None, simplify=None) -> sympy.Basic:

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -254,9 +254,8 @@ class UndefinedSymbol(symbol):
 class TypedConstant(sympy.AtomicExpr):
     """A typed constant value that participates in symbolic expressions.
 
-    The value is always a real ``Integer``/``Float``; the ``dtype`` is a tag.
-    Genuine complex/boolean constant values are not supported (only the dtype
-    tag round-trips, via the ``dace.<dtype>(value)`` form).
+    The value is always a real ``Integer``/``Float`` (booleans as ``0``/``1``);
+    the ``dtype`` is a tag. Complex constant values are not supported.
 
     Examples
     --------
@@ -473,6 +472,8 @@ def _sympy_constant_value(value):
         return sympy.Integer(int(value))
     if isinstance(value, numpy.floating):
         return sympy.Float(float(value))
+    if isinstance(value, (bool, numpy.bool_)):
+        return sympy.Integer(int(value))
     if isinstance(value, int) and not isinstance(value, bool):
         return sympy.Integer(value)
     if isinstance(value, float):
@@ -489,6 +490,8 @@ def _infer_typed_constant_dtype(value) -> dtypes.typeclass:
         return DEFAULT_SYMBOL_TYPE
     if isinstance(value, sympy.Float):
         return dtypes.float64
+    if isinstance(value, (bool, numpy.bool_)):
+        return dtypes.dtype_to_typeclass(numpy.bool_)
     if isinstance(value, int) and not isinstance(value, bool):
         return DEFAULT_SYMBOL_TYPE
     if isinstance(value, float):
@@ -521,8 +524,7 @@ def _typed_constant_to_string(expr: TypedConstant) -> str:
         value = sympy.printing.str.sstr(expr.value)
     if expr.dtype in dtypes.TYPECLASS_TO_LITERAL_SUFFIX:
         return f'{value}{_typed_constant_suffix(expr.dtype)}'
-    # dtypes without a literal suffix (complex, bool) round-trip via the
-    # parseable cast form ``dace.<dtype>(value)``.
+    # Suffix-less dtypes (complex, bool) round-trip via the cast form.
     return f'dace.{expr.dtype.to_string()}({value})'
 
 

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -255,9 +255,9 @@ class UndefinedSymbol(symbol):
 class TypedConstant(sympy.AtomicExpr):
     """A typed constant value that participates in symbolic expressions.
 
-    The value is a real ``Integer``/``Float`` (booleans stored as ``0``/``1``),
-    or ``re + im*I`` when the ``dtype`` is complex. The ``dtype`` is a type tag;
-    complex constants must be numeric (symbolic real/imag parts are unsupported).
+    The value is a real ``Integer``/``Float``, or ``re + im*I`` when the
+    ``dtype`` is complex. The ``dtype`` is a type tag; complex constants must
+    be numeric (symbolic real/imag parts are unsupported).
 
     Examples
     --------
@@ -474,8 +474,6 @@ def _sympy_constant_value(value):
         return sympy.Integer(int(value))
     if isinstance(value, numpy.floating):
         return sympy.Float(float(value))
-    if isinstance(value, (bool, numpy.bool_)):
-        return sympy.Integer(int(value))
     if isinstance(value, int) and not isinstance(value, bool):
         return sympy.Integer(value)
     if isinstance(value, float):
@@ -496,8 +494,6 @@ def _infer_typed_constant_dtype(value) -> dtypes.typeclass:
         return DEFAULT_SYMBOL_TYPE
     if isinstance(value, sympy.Float):
         return dtypes.float64
-    if isinstance(value, (bool, numpy.bool_)):
-        return dtypes.bool_
     if isinstance(value, int) and not isinstance(value, bool):
         return DEFAULT_SYMBOL_TYPE
     if isinstance(value, float):

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -127,7 +127,7 @@ def test_complex_constant_parse_save_roundtrip():
     assert complex(sympy.re(tc.value), sympy.im(tc.value)) == complex(3.0, 4.2)
 
     serialized = symbolic.serialize_symbolic(tc)
-    assert serialized == 'complex(3.0, 4.2)'
+    assert serialized == 'dace.complex128(complex(3.0, 4.2))'
     restored = symbolic.deserialize_symbolic(serialized)
     assert restored.dtype == dace.complex128
     assert symbolic.serialize_symbolic(restored) == serialized

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -6,9 +6,14 @@ import pytest
 import dace
 from dace import subsets, symbolic
 from dace.codegen.common import sym2cpp
+from dace.config import set_temporary
 from dace.properties import DictProperty, ListProperty
 from dace.sdfg.infer_types import infer_connector_types
 import sympy
+
+
+def _default_typed_constants(value=True):
+    return set_temporary('optimizer', 'default_typed_constants', value=value)
 
 
 def test_symbolic_serialization_roundtrip_preserves_metadata():
@@ -142,12 +147,12 @@ def test_complex_constant_parse_save_roundtrip():
 def test_default_constants_map_bool_and_complex():
     """Under ``default_constants``: True/False -> bool, complex literal ->
     complex128. Without the flag, booleans stay ``sympy.true``/``false``."""
-    b = symbolic.deserialize_symbolic('True', default_constants=True)
-    assert isinstance(b, symbolic.TypedConstant) and b.dtype == dace.bool_ and int(b.value) == 1
-    assert symbolic.deserialize_symbolic('False', default_constants=True).value == 0
-
-    c = symbolic.deserialize_symbolic('4j', default_constants=True)
-    assert isinstance(c, symbolic.TypedConstant) and c.dtype == dace.complex128
+    with _default_typed_constants():
+        b = symbolic.deserialize_symbolic('True')
+        assert isinstance(b, symbolic.TypedConstant) and b.dtype == dace.bool_ and int(b.value) == 1
+        assert symbolic.deserialize_symbolic('False').value == 0
+        c = symbolic.deserialize_symbolic('4j')
+        assert isinstance(c, symbolic.TypedConstant) and c.dtype == dace.complex128
 
     assert symbolic.deserialize_symbolic('True') is sympy.true
 
@@ -370,7 +375,8 @@ def test_default_constants_off_by_default_keeps_plain_literals():
         ('5.0', 5.0, 'double'),  # bare float -> float64
     ])
 def test_default_constants_type_untyped_literals(text, value, ctype):
-    restored = symbolic.deserialize_symbolic(text, default_constants=True)
+    with _default_typed_constants():
+        restored = symbolic.deserialize_symbolic(text)
     assert isinstance(restored, symbolic.TypedConstant)
     assert restored.dtype.ctype == ctype
     assert float(restored.value) == value
@@ -387,22 +393,25 @@ def test_default_constants_type_untyped_literals(text, value, ctype):
 def test_cpp_ctype_cast_parses_to_typed_constant(text, ctype):
     """``double(5)``/``int(5)`` (the C++ printer's cast fallback) must round-trip
     into a TypedConstant, both with and without default-constant typing."""
-    for default_constants in (False, True):
-        restored = symbolic.deserialize_symbolic(text, default_constants=default_constants)
-        assert isinstance(restored, symbolic.TypedConstant), (text, default_constants)
+    for flag in (False, True):
+        with _default_typed_constants(flag):
+            restored = symbolic.deserialize_symbolic(text)
+        assert isinstance(restored, symbolic.TypedConstant), (text, flag)
         assert restored.dtype.ctype == ctype
 
 
 def test_typed_suffix_still_wins_over_default():
     """An explicit ``5i32``/``5.0f64`` suffix is unaffected by default typing."""
-    assert symbolic.deserialize_symbolic('5i16', default_constants=True).dtype == dace.int16
-    assert symbolic.deserialize_symbolic('5.0f32', default_constants=True).dtype == dace.float32
+    with _default_typed_constants():
+        assert symbolic.deserialize_symbolic('5i16').dtype == dace.int16
+        assert symbolic.deserialize_symbolic('5.0f32').dtype == dace.float32
 
 
 def test_default_constants_in_expression():
     """In a non-evaluating context the parser types the constant as float64
     and leaves the symbol untouched."""
-    restored = symbolic.deserialize_symbolic('$N + 5.0', default_constants=True)
+    with _default_typed_constants():
+        restored = symbolic.deserialize_symbolic('$N + 5.0')
     consts = list(restored.atoms(symbolic.TypedConstant))
     assert len(consts) == 1 and consts[0].dtype == dace.float64
     assert any(isinstance(a, symbolic.symbol) for a in restored.atoms(symbolic.symbol))
@@ -411,7 +420,8 @@ def test_default_constants_in_expression():
 def test_default_typed_float_constant_in_min_is_robust():
     """The interstate-edge shape ``Min(5.0, N)``: a float64 default constant
     must survive sympy.Min construction. Currently raises AttributeError."""
-    restored = symbolic.deserialize_symbolic('Min(5.0, $N)', default_constants=True)
+    with _default_typed_constants():
+        restored = symbolic.deserialize_symbolic('Min(5.0, $N)')
     consts = list(restored.atoms(symbolic.TypedConstant))
     assert len(consts) == 1 and consts[0].dtype == dace.float64
 

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -92,6 +92,20 @@ def test_complex_symbol_roundtrip_preserves_dtype():
     assert restored_sym.dtype == dace.complex128
 
 
+@pytest.mark.parametrize('dtype', [dace.complex64, dace.complex128, dace.bool])
+def test_suffixless_dtype_constant_roundtrips_via_cast_form(dtype):
+    """A constant whose dtype has no literal suffix (complex/bool) serializes
+    via the parseable ``dace.<dtype>(value)`` form and round-trips."""
+    tc = symbolic.deserialize_symbolic(f'dace.{dtype.to_string()}(5)')
+    assert isinstance(tc, symbolic.TypedConstant) and tc.dtype == dtype
+
+    serialized = symbolic.serialize_symbolic(tc)
+    restored = symbolic.deserialize_symbolic(serialized)
+    assert isinstance(restored, symbolic.TypedConstant)
+    assert restored.dtype == dtype and int(restored.value) == 5
+    assert symbolic.serialize_symbolic(restored) == serialized
+
+
 def test_sym2cpp_emits_uint64_literals():
     expr = symbolic.TypedConstant(np.uint64(1)) + symbolic.symbol('N', dtype=dace.uint64)
 

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -106,6 +106,19 @@ def test_suffixless_dtype_constant_roundtrips_via_cast_form(dtype):
     assert symbolic.serialize_symbolic(restored) == serialized
 
 
+@pytest.mark.parametrize('value', [True, False, np.bool_(True)])
+def test_bool_typed_constant_construction_and_roundtrip(value):
+    """Boolean values are accepted (stored as 0/1) and round-trip with bool dtype."""
+    tc = symbolic.TypedConstant(value)
+    assert isinstance(tc, symbolic.TypedConstant)
+    assert tc.dtype == dace.bool_
+    assert int(tc.value) == int(value)
+
+    restored = symbolic.deserialize_symbolic(symbolic.serialize_symbolic(tc))
+    assert isinstance(restored, symbolic.TypedConstant)
+    assert restored.dtype == dace.bool_ and int(restored.value) == int(value)
+
+
 def test_sym2cpp_emits_uint64_literals():
     expr = symbolic.TypedConstant(np.uint64(1)) + symbolic.symbol('N', dtype=dace.uint64)
 

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -97,9 +97,9 @@ def test_complex_symbol_roundtrip_preserves_dtype():
     assert restored_sym.dtype == dace.complex128
 
 
-@pytest.mark.parametrize('dtype', [dace.complex64, dace.complex128, dace.bool])
+@pytest.mark.parametrize('dtype', [dace.complex64, dace.complex128])
 def test_suffixless_dtype_constant_roundtrips_via_cast_form(dtype):
-    """A constant whose dtype has no literal suffix (complex/bool) serializes
+    """A constant whose dtype has no literal suffix (complex) serializes
     via the parseable ``dace.<dtype>(value)`` form and round-trips."""
     tc = symbolic.deserialize_symbolic(f'dace.{dtype.to_string()}(5)')
     assert isinstance(tc, symbolic.TypedConstant) and tc.dtype == dtype
@@ -109,19 +109,6 @@ def test_suffixless_dtype_constant_roundtrips_via_cast_form(dtype):
     assert isinstance(restored, symbolic.TypedConstant)
     assert restored.dtype == dtype and int(restored.value) == 5
     assert symbolic.serialize_symbolic(restored) == serialized
-
-
-@pytest.mark.parametrize('value', [True, False, np.bool_(True)])
-def test_bool_typed_constant_construction_and_roundtrip(value):
-    """Boolean values are accepted (stored as 0/1) and round-trip with bool dtype."""
-    tc = symbolic.TypedConstant(value)
-    assert isinstance(tc, symbolic.TypedConstant)
-    assert tc.dtype == dace.bool_
-    assert int(tc.value) == int(value)
-
-    restored = symbolic.deserialize_symbolic(symbolic.serialize_symbolic(tc))
-    assert isinstance(restored, symbolic.TypedConstant)
-    assert restored.dtype == dace.bool_ and int(restored.value) == int(value)
 
 
 def test_complex_constant_parse_save_roundtrip():

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -337,9 +337,6 @@ def test_default_constants_in_expression():
     assert any(isinstance(a, symbolic.symbol) for a in restored.atoms(symbolic.symbol))
 
 
-@pytest.mark.xfail(strict=True,
-                   reason="TypedConstant lacks ._prec, so a float-valued TypedConstant crashes "
-                   "sympy._should_evalf inside Min/Max construction (separate TypedConstant defect)")
 def test_default_typed_float_constant_in_min_is_robust():
     """The interstate-edge shape ``Min(5.0, N)``: a float64 default constant
     must survive sympy.Min construction. Currently raises AttributeError."""

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -285,5 +285,68 @@ def test_plain_python_integer_deserialization_uses_sympy_integer(value):
     assert isinstance(restored, sympy.Integer)
 
 
+def test_default_constants_off_by_default_keeps_plain_literals():
+    """Existing behavior must be unchanged when ``default_constants`` is unset."""
+    assert symbolic.deserialize_symbolic('5') == sympy.Integer(5)
+    assert isinstance(symbolic.deserialize_symbolic('5'), sympy.Integer)
+    assert isinstance(symbolic.deserialize_symbolic('5.0'), sympy.Float)
+
+
+@pytest.mark.parametrize(
+    'text,value,ctype',
+    [
+        ('5', 5, 'int64_t'),  # bare int -> int64 (matches dtypes.typeclass(int))
+        ('5.0', 5.0, 'double'),  # bare float -> float64
+    ])
+def test_default_constants_type_untyped_literals(text, value, ctype):
+    restored = symbolic.deserialize_symbolic(text, default_constants=True)
+    assert isinstance(restored, symbolic.TypedConstant)
+    assert restored.dtype.ctype == ctype
+    assert float(restored.value) == value
+
+
+@pytest.mark.parametrize(
+    'text,ctype',
+    [
+        ('double(5)', 'double'),  # float64 cast-wrapper form
+        ('int(5)', 'int'),  # int32 cast-wrapper form
+        ('float(5)', 'float'),  # float32
+        ('int64_t(5)', 'int64_t'),  # explicit-suffix dtype as a ctype cast
+    ])
+def test_cpp_ctype_cast_parses_to_typed_constant(text, ctype):
+    """``double(5)``/``int(5)`` (the C++ printer's cast fallback) must round-trip
+    into a TypedConstant, both with and without default-constant typing."""
+    for default_constants in (False, True):
+        restored = symbolic.deserialize_symbolic(text, default_constants=default_constants)
+        assert isinstance(restored, symbolic.TypedConstant), (text, default_constants)
+        assert restored.dtype.ctype == ctype
+
+
+def test_typed_suffix_still_wins_over_default():
+    """An explicit ``5i32``/``5.0f64`` suffix is unaffected by default typing."""
+    assert symbolic.deserialize_symbolic('5i16', default_constants=True).dtype == dace.int16
+    assert symbolic.deserialize_symbolic('5.0f32', default_constants=True).dtype == dace.float32
+
+
+def test_default_constants_in_expression():
+    """In a non-evaluating context the parser types the constant as float64
+    and leaves the symbol untouched."""
+    restored = symbolic.deserialize_symbolic('$N + 5.0', default_constants=True)
+    consts = list(restored.atoms(symbolic.TypedConstant))
+    assert len(consts) == 1 and consts[0].dtype == dace.float64
+    assert any(isinstance(a, symbolic.symbol) for a in restored.atoms(symbolic.symbol))
+
+
+@pytest.mark.xfail(strict=True,
+                   reason="TypedConstant lacks ._prec, so a float-valued TypedConstant crashes "
+                   "sympy._should_evalf inside Min/Max construction (separate TypedConstant defect)")
+def test_default_typed_float_constant_in_min_is_robust():
+    """The interstate-edge shape ``Min(5.0, N)``: a float64 default constant
+    must survive sympy.Min construction. Currently raises AttributeError."""
+    restored = symbolic.deserialize_symbolic('Min(5.0, $N)', default_constants=True)
+    consts = list(restored.atoms(symbolic.TypedConstant))
+    assert len(consts) == 1 and consts[0].dtype == dace.float64
+
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -144,15 +144,15 @@ def test_complex_constant_parse_save_roundtrip():
     assert r64.dtype == dace.complex64 and symbolic.serialize_symbolic(r64) == s64
 
 
-def test_default_constants_map_bool_and_complex():
-    """Under ``default_constants``: True/False -> bool, complex literal ->
-    complex128. Without the flag, booleans stay ``sympy.true``/``false``."""
+def test_default_constants_map_complex_not_bool():
+    """Under ``default_typed_constants`` a complex literal -> complex128, but
+    ``True``/``False`` are always left as SymPy booleans (a literal boolean is
+    a control condition, not a numeric constant)."""
     with _default_typed_constants():
-        b = symbolic.deserialize_symbolic('True')
-        assert isinstance(b, symbolic.TypedConstant) and b.dtype == dace.bool_ and int(b.value) == 1
-        assert symbolic.deserialize_symbolic('False').value == 0
         c = symbolic.deserialize_symbolic('4j')
         assert isinstance(c, symbolic.TypedConstant) and c.dtype == dace.complex128
+        assert symbolic.deserialize_symbolic('True') is sympy.true
+        assert symbolic.deserialize_symbolic('False') is sympy.false
 
     assert symbolic.deserialize_symbolic('True') is sympy.true
 

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -81,6 +81,17 @@ def test_symbol_name_clash_roundtrip():
     assert restored_sym.dtype == dace.uint64
 
 
+def test_complex_symbol_roundtrip_preserves_dtype():
+    expr = symbolic.symbol('c', dtype=dace.complex128)
+
+    restored = symbolic.deserialize_symbolic(symbolic.serialize_symbolic(expr))
+
+    restored_sym = next(iter(restored.free_symbols))
+    assert isinstance(restored_sym, symbolic.symbol)
+    assert restored_sym.name == 'c'
+    assert restored_sym.dtype == dace.complex128
+
+
 def test_sym2cpp_emits_uint64_literals():
     expr = symbolic.TypedConstant(np.uint64(1)) + symbolic.symbol('N', dtype=dace.uint64)
 

--- a/tests/symbolic_serialization_test.py
+++ b/tests/symbolic_serialization_test.py
@@ -119,6 +119,39 @@ def test_bool_typed_constant_construction_and_roundtrip(value):
     assert restored.dtype == dace.bool_ and int(restored.value) == int(value)
 
 
+def test_complex_constant_parse_save_roundtrip():
+    """``complex(re, im)`` parses to a complex128 TypedConstant and round-trips;
+    a complex64 constant preserves its dtype via the cast-wrapped form."""
+    tc = symbolic.deserialize_symbolic('complex(3.0, 4.2)')
+    assert isinstance(tc, symbolic.TypedConstant) and tc.dtype == dace.complex128
+    assert complex(sympy.re(tc.value), sympy.im(tc.value)) == complex(3.0, 4.2)
+
+    serialized = symbolic.serialize_symbolic(tc)
+    assert serialized == 'complex(3.0, 4.2)'
+    restored = symbolic.deserialize_symbolic(serialized)
+    assert restored.dtype == dace.complex128
+    assert symbolic.serialize_symbolic(restored) == serialized
+
+    c64 = symbolic.TypedConstant(complex(1, 2), dace.complex64)
+    s64 = symbolic.serialize_symbolic(c64)
+    assert s64 == 'dace.complex64(complex(1.0, 2.0))'
+    r64 = symbolic.deserialize_symbolic(s64)
+    assert r64.dtype == dace.complex64 and symbolic.serialize_symbolic(r64) == s64
+
+
+def test_default_constants_map_bool_and_complex():
+    """Under ``default_constants``: True/False -> bool, complex literal ->
+    complex128. Without the flag, booleans stay ``sympy.true``/``false``."""
+    b = symbolic.deserialize_symbolic('True', default_constants=True)
+    assert isinstance(b, symbolic.TypedConstant) and b.dtype == dace.bool_ and int(b.value) == 1
+    assert symbolic.deserialize_symbolic('False', default_constants=True).value == 0
+
+    c = symbolic.deserialize_symbolic('4j', default_constants=True)
+    assert isinstance(c, symbolic.TypedConstant) and c.dtype == dace.complex128
+
+    assert symbolic.deserialize_symbolic('True') is sympy.true
+
+
 def test_sym2cpp_emits_uint64_literals():
     expr = symbolic.TypedConstant(np.uint64(1)) + symbolic.symbol('N', dtype=dace.uint64)
 


### PR DESCRIPTION
Adds an opt-in `default_constants` flag to `deserialize_symbolic`: untyped literals become default-typed `TypedConstant` (`5`->`int64`, `5.0`->`float64`, matching `dtypes.typeclass`), and C++ ctype casts (`double(5)`, `int(5)`) parse back into a `TypedConstant`. Default is off, so existing callers are unchanged. Also formats serialized/codegen floats in shortest round-trip form (`5.0f64` instead of `5.00000000000000f64`).

A `TypedConstant` missing `_prec` (crashes float constants inside `sympy.Min`/`Max`) is documented as a strict xfail.