### PR TITLE
fix(frontend): give each slice memlet its own subset object

### DIFF
--- a/dace/autodiff/backward_pass_generator.py
+++ b/dace/autodiff/backward_pass_generator.py
@@ -740,11 +740,11 @@ class BackwardPassGenerator:
             # Create a new memlet that copies what memlet is writing to to the tmp
             new_memlet_subset = memlet.subset if memlet.data == forward_node.data else memlet.other_subset
             original_to_tmp_memlet = dace.Memlet(data=backward_node.data,
-                                                 subset=new_memlet_subset,
-                                                 other_subset=new_memlet_subset)
+                                                 subset=copy.deepcopy(new_memlet_subset),
+                                                 other_subset=copy.deepcopy(new_memlet_subset))
 
             # Remove the src_subset of the new memlet and replace the memlet in the edge
-            map_exit_memlet.subset = memlet.subset if memlet.data == forward_node.data else memlet.other_subset
+            map_exit_memlet.subset = copy.deepcopy(new_memlet_subset)
             map_exit_memlet.other_subset = None
             edge.data = map_exit_memlet
 
@@ -1761,14 +1761,15 @@ class BackwardPassGenerator:
                     # Special case for when the two access nodes are the same
                     if forward_node.data == dest_node.data and fwd_memlet.other_subset is not None:
                         new_memlet = dace.Memlet(data=self.reverse_map[forward_node].data,
-                                                 subset=fwd_memlet.other_subset,
-                                                 other_subset=fwd_memlet.subset)
+                                                 subset=copy.deepcopy(fwd_memlet.other_subset),
+                                                 other_subset=copy.deepcopy(fwd_memlet.subset))
                     else:
-                        new_memlet = dace.Memlet(data=self.reverse_map[forward_node].data,
-                                                 subset=fwd_memlet.subset
-                                                 if fwd_memlet.data == forward_node.data else fwd_memlet.other_subset,
-                                                 other_subset=fwd_memlet.other_subset
-                                                 if fwd_memlet.data == forward_node.data else fwd_memlet.subset)
+                        new_memlet = dace.Memlet(
+                            data=self.reverse_map[forward_node].data,
+                            subset=copy.deepcopy(fwd_memlet.subset if fwd_memlet.data ==
+                                                 forward_node.data else fwd_memlet.other_subset),
+                            other_subset=copy.deepcopy(fwd_memlet.other_subset if fwd_memlet.data ==
+                                                       forward_node.data else fwd_memlet.subset))
                     memlet = new_memlet
             if input_conn not in self.result_map[dest_node].required_grad_names:
                 continue

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -756,10 +756,10 @@ class AST_translator:
             if not found:
                 if local_name.name in write_names:
                     ast_utils.add_memlet_write(substate, mapped_name, internal_sdfg,
-                                               self.name_mapping[new_sdfg][local_name.name], memlet)
+                                               self.name_mapping[new_sdfg][local_name.name], dpcp(memlet))
                 if local_name.name in read_names:
                     ast_utils.add_memlet_read(substate, mapped_name, internal_sdfg,
-                                              self.name_mapping[new_sdfg][local_name.name], memlet)
+                                              self.name_mapping[new_sdfg][local_name.name], dpcp(memlet))
 
         for i in addedmemlets:
 

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -5601,8 +5601,12 @@ class ProgramVisitor(ExtNodeVisitor):
                                                   arrobj.storage,
                                                   find_new_name=True)
             wnode = self.current_state.add_write(tmp, debuginfo=self.current_lineinfo)
+            # ``Memlet.simple`` keeps the subset by reference, but ``rng`` may be a
+            # cached Range shared by sibling slice reads, so give this edge its own copy.
             self.current_state.add_nedge(
-                rnode, wnode, Memlet.simple(array, rng, num_accesses=rng.num_elements(), other_subset_str=other_subset))
+                rnode, wnode,
+                Memlet.simple(array, copy.deepcopy(rng), num_accesses=rng.num_elements(),
+                              other_subset_str=other_subset))
         return tmp, other_subset
 
     def _compute_output_shape_from_advanced_indexing(self, aname: str, expr: MemletExpr) -> List[symbolic.SymbolicType]:

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -674,6 +674,15 @@ def validate_state(state: 'dace.sdfg.SDFGState',
                 'rather than using multiple references to the same one', sdfg, state_id, eid)
         references.add(id(e.data))
 
+        for subset in (e.data.subset, e.data.other_subset):
+            if subset is None:
+                continue
+            if id(subset) in references:
+                raise InvalidSDFGEdgeError(
+                    f'Duplicate subset detected in memlet "{e.data}". Please copy objects '
+                    'rather than using multiple references to the same one', sdfg, state_id, eid)
+            references.add(id(subset))
+
         # Edge validation
         try:
             e.data.validate(sdfg, state)

--- a/dace/transformation/dataflow/gpu_transform_local_storage.py
+++ b/dace/transformation/dataflow/gpu_transform_local_storage.py
@@ -411,7 +411,7 @@ class GPUTransformLocalStorage(transformation.SingleStateTransformation):
 
                     if self.fullcopy:
                         edge.data.subset = sbs.Range.from_array(node.desc(sdfg))
-                    edge.data.other_subset = newmemlet.subset
+                    edge.data.other_subset = copy.deepcopy(newmemlet.subset)
                     graph.add_edge(edge.src, edge.src_conn, node, None, edge.data)
                     graph.remove_edge(edge)
 
@@ -490,7 +490,7 @@ class GPUTransformLocalStorage(transformation.SingleStateTransformation):
                     edge.data.wcr = None
                     if self.fullcopy:
                         edge.data.subset = sbs.Range.from_array(node.desc(sdfg))
-                    edge.data.other_subset = newmemlet.subset
+                    edge.data.other_subset = copy.deepcopy(newmemlet.subset)
                     graph.add_edge(node, None, edge.dst, edge.dst_conn, edge.data)
                     graph.remove_edge(edge)
 

--- a/tests/python_frontend/slice_subset_aliasing_test.py
+++ b/tests/python_frontend/slice_subset_aliasing_test.py
@@ -1,0 +1,55 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""The Python frontend must give each memlet its own ``Subset`` object.
+
+Repeated reads of the same array slice hit the access cache and shared one
+``Range`` object (``Memlet.simple`` stores the subset by reference), so an
+in-place subset rewrite on one edge corrupted the other.
+"""
+import numpy as np
+
+import dace
+
+N = dace.symbol('N')
+
+
+@dace.program
+def two_sibling_slice_reads(out: dace.float64[N, N], arr: dace.float64[N, N]):
+    """Reads ``arr[i, k]`` in two sibling ``k`` loops; the second hits the cache."""
+    for i in dace.map[0:N]:
+        for k in range(N):
+            out[i, k] = arr[i, k]
+        for k in range(N):
+            out[i, k] += arr[i, k]
+
+
+def test_frontend_memlets_do_not_share_subset_objects():
+    """No two memlets may share a subset (or other_subset) object."""
+    sdfg = two_sibling_slice_reads.to_sdfg(simplify=False)
+    seen = {}
+    for sd in sdfg.all_sdfgs_recursive():
+        for state in sd.all_states():
+            for e in state.edges():
+                if e.data is None:
+                    continue
+                for sub in (e.data.subset, e.data.other_subset):
+                    if sub is None:
+                        continue
+                    here = (state.label, e.data.data, str(sub))
+                    assert id(sub) not in seen, \
+                        f'subset object shared by two memlets: {seen[id(sub)]} and {here}'
+                    seen[id(sub)] = here
+
+
+def test_sibling_slice_reads_value_preserving():
+    """End-to-end value check for the shape that triggered the aliasing."""
+    n = 8
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((n, n)).astype(np.float64)
+    out = np.zeros((n, n))
+    two_sibling_slice_reads(out=out, arr=arr, N=n)
+    assert np.allclose(out, 2.0 * arr)
+
+
+if __name__ == '__main__':
+    test_frontend_memlets_do_not_share_subset_objects()
+    test_sibling_slice_reads_value_preserving()


### PR DESCRIPTION
## Problem

`ProgramVisitor.make_slice` builds the slice-read memlet with `Memlet.simple(array, rng, ...)`. `Memlet.simple` stores a passed-in `Subset` **by reference** (it does not copy), and `rng` is frequently the cached `Range` object handed back by the `accesses` cache on a repeated read of the same array slice.

So two sibling reads of the same slice (e.g. `arr[i, k]` in two loop bodies under a map) produce two distinct edges whose memlets **share one subset object**. That violates the invariant that each memlet owns its subset: any later in-place subset rewrite — loop-iterator renaming, symbol replacement, offsetting — on one edge silently corrupts the other.

### Reproducer

```python
N = dace.symbol('N')

@dace.program
def two_sibling_slice_reads(out: dace.float64[N, N], arr: dace.float64[N, N]):
    for i in dace.map[0:N]:
        for k in range(N):
            out[i, k] = arr[i, k]
        for k in range(N):
            out[i, k] += arr[i, k]
```

In the parsed SDFG, the two `arr[i, k]` read edges share a single `Range` subset object. A pass that rewrites a subset in place on one of them (the new test originally surfaced this through a loop-iterator rename) then corrupts the sibling.

## Fix

Deepcopy `rng` for the slice memlet's subset in `make_slice`, mirroring the `other_subset` deepcopy two lines above. This is a pure object-identity fix — subset values and the generated SDFG are unchanged.

## Test

`tests/python_frontend/slice_subset_aliasing_test.py` asserts that no two memlets in the parsed SDFG share a subset object, plus an end-to-end value check. Fails before the fix, passes after.