### PR TITLE
Fix arglist and loop2map carried symbol

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1427,20 +1427,17 @@ class SDFG(ControlFlowRegion):
                                                 free_syms=free_syms,
                                                 used_before_assignment=used_before_assignment,
                                                 with_contents=with_contents)
-        # Expand array-descriptor stride/shape/offset symbols into the free
-        # set. Without this, a ``ConditionalBlock`` guard or memlet subset
-        # referencing ``A[i, j]`` leaves the symbols used in ``A`` 's strides
-        # out of the computed free-symbol set, causing
-        # ``generate_nsdfg_header`` to emit a nested function signature
-        # missing those symbols, ceating an invalid SDFG.
+        # A used array needs its stride/shape/offset symbols in the free set, but a
+        # merely-declared one must not leak its shape symbol into the signature
+        # (issue #2382). ``read_and_write_sets`` already reports exactly the arrays
+        # that are used -- read or written, including those referenced only by a
+        # code-block guard/condition -- so expand the extent symbols of those alone.
         res_free, res_defined, res_before = result
         if with_contents:
-            for desc in self.arrays.values():
-                res_free |= {str(s) for s in desc.used_symbols(all_symbols)}
-            # Don't drag in symbols that are genuinely defined inside this
-            # SDFG (e.g., LoopRegion loop variables); keep only the ones
-            # outside ``defined_syms``.
-            res_free -= res_defined
+            read_set, write_set = self.read_and_write_sets()
+            for name in (read_set | write_set) & self.arrays.keys():
+                res_free |= {str(s) for s in self.arrays[name].used_symbols(all_symbols)}
+            res_free -= res_defined  # drop symbols defined inside (e.g. loop vars)
         return res_free, res_defined, res_before
 
     def get_all_toplevel_symbols(self) -> Set[str]:

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -921,16 +921,20 @@ class DataflowGraphView(BlockGraphView, abc.ABC):
                 } if top_source_edge.src.data not in descs else {})
 
             elif isinstance(edge.dst, nd.ExitNode) and isinstance(edge.src, (nd.AccessNode, nd.CodeNode)):
-                # Same case as above, but for outgoing Memlets.
-                # NOTE: We have to use a memlet tree here, because the data could potentially
-                #   go to multiple sources. We have to do it this way, because if we would call
-                #   `memlet_tree()` here, then we would just get the edge back.
+                # Same case as above, but for outgoing Memlets. Resolve the array
+                # from the path's terminal AccessNode, not ``oedge.data.data``: a
+                # source-relative Memlet names the inner transient, not the external
+                # array being written (fall back to the data when the path does not
+                # end at an AccessNode).
                 additional_descs = {}
                 connector_to_look = "OUT_" + edge.dst_conn[3:]
                 for oedge in self.graph.out_edges_by_connector(edge.dst, connector_to_look):
-                    if ((not oedge.data.is_empty()) and (oedge.data.data not in descs)
-                            and (oedge.data.data not in additional_descs)):
-                        additional_descs[oedge.data.data] = sdfg.arrays[oedge.data.data]
+                    if oedge.data.is_empty():
+                        continue
+                    terminal_dst = self.graph.memlet_path(oedge)[-1].dst
+                    dst_name = terminal_dst.data if isinstance(terminal_dst, nd.AccessNode) else oedge.data.data
+                    if dst_name not in descs and dst_name not in additional_descs:
+                        additional_descs[dst_name] = sdfg.arrays[dst_name]
 
             else:
                 # Case is ignored.

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -113,6 +113,16 @@ class LoopToMap(xf.MultiStateTransformation):
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
         for block in in_order_loop_blocks:
+            # A symbol read in the block's own dataflow (e.g. a memlet subset
+            # ``b[im]``) is read before any symbol the block assigns on its
+            # out-edges; if the loop later reassigns it, it is loop-carried. The
+            # per-edge ``read_symbols()`` below only sees interstate-edge reads, so
+            # fold in these in-state reads.
+            try:
+                block_reads = {str(s) for s in block.free_symbols}
+            except Exception:
+                block_reads = set()
+            used_before_assignment |= (block_reads - symbols_that_may_be_used)
             for e in block.parent_graph.out_edges(block):
                 # Collect read-before-assigned symbols (this works because the states are always in order,
                 # see above call to `blockorder_topological_sort`)

--- a/tests/sdfg/free_symbols_test.py
+++ b/tests/sdfg/free_symbols_test.py
@@ -129,6 +129,98 @@ def test_nested_sdfg_free_symbols():
     assert 'k' not in inner_sdfg.free_symbols
 
 
+def _build_with_optional_unused_array(create_unused_transient: bool) -> dace.SDFG:
+    """The issue #2382 reproducer: two used arrays + an optional unused transient
+    ``x`` whose shape uses ``x_shape``.
+
+    :param create_unused_transient: If True, declare the unused ``x`` array.
+    :returns: The constructed SDFG.
+    """
+    sdfg = dace.SDFG('unused_transient')
+    state = sdfg.add_state()
+    sdfg.add_array('a', (10, ), dace.float64, transient=False)
+    sdfg.add_array('b', (10, ), dace.float64, transient=False)
+    sdfg.add_symbol('x_shape', dace.int32)
+    if create_unused_transient:
+        sdfg.add_array('x', ('x_shape', ), dace.float32, transient=True)
+    state.add_mapped_tasklet('map', {'__i': '0:10'}, {'__in': dace.Memlet('a[__i]')},
+                             '__out = __in + 1.90', {'__out': dace.Memlet('b[__i]')},
+                             external_edges=True)
+    return sdfg
+
+
+def test_unused_array_does_not_leak_shape_symbol():
+    """Issue #2382: declaring an unused array must not leak its shape symbol into
+    the signature -- it must not change the arguments needed to invoke the SDFG."""
+    without = _build_with_optional_unused_array(False)
+    with_unused = _build_with_optional_unused_array(True)
+
+    # The unused array's shape symbol must not be treated as a used argument.
+    assert 'x_shape' not in without.used_symbols(all_symbols=False)
+    assert 'x_shape' not in with_unused.used_symbols(all_symbols=False)
+
+    # Declaring the unused array must not perturb the signature at all.
+    assert 'x_shape' not in with_unused.arglist()
+    assert list(without.arglist().keys()) == list(with_unused.arglist().keys())
+    assert without.signature_arglist() == with_unused.signature_arglist()
+    assert without.init_signature() == with_unused.init_signature()
+    assert 'x_shape' not in with_unused.init_signature()
+
+
+def test_used_codeblock_array_keeps_shape_symbol():
+    """A used array's stride symbol must survive even when its only reference is a
+    code block: a guard indexes a 2D array with stride ``S``, so ``S`` must be kept."""
+    from dace.properties import CodeBlock
+    from dace.sdfg.state import ConditionalBlock, ControlFlowRegion, LoopRegion
+
+    sdfg = dace.SDFG('used_codeblock_array')
+    sdfg.add_symbol('S', dace.int32)
+    sdfg.add_array('A', (10, 10), dace.int32, strides=(1, dace.symbol('S')))
+    sdfg.add_scalar('acc', dace.int32, transient=True)
+
+    loop = LoopRegion('loop', condition_expr='k < 5', loop_var='k', initialize_expr='k = 0', update_expr='k = k + 1')
+    sdfg.add_node(loop, is_start_block=True)
+
+    cb = ConditionalBlock('cb')
+    loop.add_node(cb, is_start_block=True)
+    branch = ControlFlowRegion('branch', sdfg=sdfg)
+    cb.add_branch(CodeBlock('A[0, k] == 1'), branch)
+
+    set_one = branch.add_state('set_one', is_start_block=True)
+    t1 = set_one.add_tasklet('t_set', {}, {'o'}, 'o = 1')
+    set_one.add_edge(t1, 'o', set_one.add_write('acc'), None, dace.Memlet('acc[0]'))
+
+    sdfg.validate()
+
+    # ``A`` is referenced only in the conditional guard, but it is genuinely
+    # used; its stride symbol ``S`` must therefore be kept.
+    assert 'S' in sdfg.used_symbols(all_symbols=False)
+    assert 'S' in sdfg.init_signature()
+
+
+def test_used_array_keeps_symbolic_extent():
+    """Guards against the #2382 fix being too aggressive: an array used only through
+    a map memlet (no access node, no code-block ref) must still keep its shape/stride
+    symbols in the signature."""
+    n = dace.symbol('n')
+    s = dace.symbol('s')
+
+    sdfg = dace.SDFG('used_via_map')
+    sdfg.add_array('a', (n, ), dace.float64, strides=(s, ), transient=False)
+    sdfg.add_array('b', (n, ), dace.float64, transient=False)
+    state = sdfg.add_state()
+    state.add_mapped_tasklet('m', {'__i': '0:n'}, {'__in': dace.Memlet('a[__i]')},
+                             '__out = __in + 1.0', {'__out': dace.Memlet('b[__i]')},
+                             external_edges=True)
+    sdfg.validate()
+
+    used = sdfg.used_symbols(all_symbols=False)
+    assert 'n' in used
+    assert 's' in used
+    assert 'n' in sdfg.arglist()
+    assert 's' in sdfg.arglist()
+
+
 if __name__ == '__main__':
     test_single_state()
     test_state_subgraph()
@@ -136,3 +228,6 @@ if __name__ == '__main__':
     test_constants()
     test_interstate_edge_symbols()
     test_nested_sdfg_free_symbols()
+    test_unused_array_does_not_leak_shape_symbol()
+    test_used_codeblock_array_keeps_shape_symbol()
+    test_used_array_keeps_symbolic_extent()

--- a/tests/transformations/interstate/loop_to_map_test.py
+++ b/tests/transformations/interstate/loop_to_map_test.py
@@ -452,7 +452,48 @@ def test_symbol_array_mix_2(parallel):
     body_start.add_edge(t, 'o', body_start.add_write('B'), None, dace.Memlet('B[i]'))
 
     sdfg.apply_transformations_repeated([LoopLifting])
-    assert sdfg.apply_transformations(LoopToMap) == (1 if parallel else 0)
+    # Both variants carry ``sym`` (read in ``B[i]`` before the body edge reassigns it
+    # to ``A[i-1]``), so LoopToMap must refuse: a Map would pin ``sym`` to 0.0 and
+    # compute ``B[i]=0``. The ``parallel`` variant only adds an ``A`` write.
+    assert sdfg.apply_transformations(LoopToMap) == 0
+
+
+_CN = dace.symbol('_CN')
+
+
+@dace.program
+def _carried_symbol_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
+    im = _CN - 1
+    for i in range(_CN):
+        a[i] = b[i] + b[im]
+        im = i
+
+
+@dace.program
+def _peeled_affine_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
+    a[0] = b[0] + b[_CN - 1]  # wrapping first iteration, peeled off
+    for i in range(1, _CN):
+        a[i] = b[i] + b[i - 1]  # induction substituted -> affine
+
+
+def _only_loop(sdfg: dace.SDFG) -> LoopRegion:
+    return next(n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, LoopRegion))
+
+
+def test_loop2map_rejects_unpeeled_carried_symbol():
+    """Wrap-around induction ``im = N-1; a[i] = b[i] + b[im]; im = i`` (TSVC s291):
+    ``im`` is read (in ``b[im]``) before it is reassigned, so it is loop-carried and
+    LoopToMap must refuse -- a Map would pin ``im`` to ``N-1`` and compute
+    ``b[i] + b[N-1]`` everywhere."""
+    sdfg = _carried_symbol_loop.to_sdfg(simplify=True)
+    assert not LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
+
+
+def test_loop2map_accepts_peeled_affine_form():
+    """Once peeled and the induction substituted, ``a[i] = b[i] + b[i-1]`` is affine
+    and LoopToMap accepts it."""
+    sdfg = _peeled_affine_loop.to_sdfg(simplify=True)
+    assert LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
 
 
 @pytest.mark.parametrize('overwrite', (False, True))


### PR DESCRIPTION
This fixes the issue: https://github.com/spcl/dace/issues/2382
And a bug in Loop2Map where loop-carried symbol dependencies were ignored.