### PR TITLE
Gpu offloading bugfixes

### DIFF
--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -13,15 +13,80 @@ from dace.sdfg import graph
 from dace.frontend.python.astutils import unparse
 from dace.properties import Property, LambdaProperty, ListProperty
 from dace.frontend.operations import detect_reduction_type
-from dace import dtypes
+from dace import data, dtypes
 from dace import subsets
 import warnings
 from dace.sdfg import scope
+from dace.sdfg import utils as sdutil
 from dace.transformation import transformation as pm
 from dace.symbolic import symstr, issymbolic
 from dace.libraries.standard.environments.cuda import CUDA
 
 from dace.libraries.standard import reduction_planner as red_planner
+
+
+def _expand_view_input_via_nested(outer_node, outer_state, outer_sdfg, inedge, outedge):
+    """Wrap an Array -> View -> Reduce pattern into a NestedSDFG whose external
+    input is the source Array; the inner SDFG rebuilds the View and the inner
+    Reduce uses the CUB ``CUDA (device)`` expansion.
+
+    :param outer_node: the Reduce LibraryNode being expanded.
+    :param outer_state: the state containing ``outer_node``.
+    :param outer_sdfg: the SDFG containing ``outer_state``.
+    :param inedge: View-to-Reduce edge in the outer state.
+    :param outedge: Reduce-to-output edge in the outer state.
+    :returns: the new NestedSDFG.
+    """
+    outer_view_node = inedge.src
+    outer_view_desc = outer_sdfg.arrays[outer_view_node.data]
+    outer_source_node = sdutil.get_last_view_node(outer_state, outer_view_node)
+    if outer_source_node is None:
+        return ExpandReducePure.expansion(outer_node, outer_state, outer_sdfg)
+    outer_source_desc = outer_sdfg.arrays[outer_source_node.data]
+    outer_view_edge = sdutil.get_view_edge(outer_state, outer_view_node)
+    raw_output_desc = outer_sdfg.arrays[outedge.data.data]
+
+    nsdfg = SDFG('reduce_view')
+
+    inner_src_desc = dcpy(outer_source_desc)
+    inner_src_desc.transient = False
+    nsdfg.add_datadesc('_in_src', inner_src_desc)
+
+    inner_view_desc = dcpy(outer_view_desc)
+    inner_view_desc.transient = True
+    nsdfg.add_datadesc('_in_view', inner_view_desc)
+
+    nsdfg.add_array(
+        '_out',
+        outedge.data.subset.size(),
+        raw_output_desc.dtype,
+        strides=[s for i, s in enumerate(raw_output_desc.strides) if i in dcpy(outedge.data.subset).squeeze()],
+        storage=raw_output_desc.storage)
+
+    inner_state = nsdfg.add_state('reduce_view_body')
+    in_src_ac = inner_state.add_access('_in_src')
+    in_view_ac = inner_state.add_access('_in_view')
+    out_ac = inner_state.add_access('_out')
+
+    inner_view_memlet = dcpy(outer_view_edge.data)
+    inner_view_memlet.data = '_in_src'
+    inner_state.add_edge(in_src_ac, outer_view_edge.src_conn, in_view_ac, outer_view_edge.dst_conn, inner_view_memlet)
+
+    inner_reduce = Reduce('reduce_view_inner', wcr=outer_node.wcr, axes=outer_node.axes, identity=outer_node.identity)
+    inner_reduce.implementation = 'CUDA (device)'
+    inner_state.add_node(inner_reduce)
+    inner_state.add_edge(in_view_ac, None, inner_reduce, '_in', dace.Memlet.from_array('_in_view', inner_view_desc))
+    inner_state.add_edge(inner_reduce, '_out', out_ac, None, dace.Memlet.from_array('_out', nsdfg.arrays['_out']))
+
+    outer_subset = dcpy(outer_view_edge.data.subset)
+    outer_state.remove_edge(inedge)
+    outer_node.add_in_connector('_in_src')
+    outer_state.add_edge(outer_source_node, None, outer_node, '_in_src',
+                         dace.Memlet(data=outer_source_node.data, subset=outer_subset))
+    outedge._src_conn = '_out'
+    outer_node.add_out_connector('_out')
+
+    return nsdfg
 
 
 @dace.library.expansion
@@ -920,6 +985,13 @@ class ExpandReduceGPUAuto(pm.ExpandTransformation):
         if node.identity is None:
             warnings.warn('Cannot use GPUAuto expansion: node.identity is None. Falling back to Pure expansion')
             return ExpandReducePure.expansion(node, state, sdfg)
+
+        # WHY: ``red_planner`` collapses the input shape into a reduction-friendly
+        # layout, which a ``views`` edge cannot express. Wrap the chain inside a
+        # NestedSDFG that takes the source Array; the inner CUB Reduce sees an
+        # honest View descriptor.
+        if isinstance(raw_input_data, data.View):
+            return _expand_view_input_via_nested(node, state, sdfg, inedge, outedge)
 
         # Standardize and squeeze axes
         axes = node.axes if node.axes is not None else [i for i in range(len(inedge.data.subset))]

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -522,27 +522,28 @@ namespace dace
             return (thrust::complex<T>)thrust::pow(a, b);
         }
 #endif
-        template<typename T, typename U>
+        template<typename T, typename U,
+                 typename std::enable_if<!(std::is_integral<T>::value &&
+                                           std::is_integral<U>::value &&
+                                           std::is_unsigned<U>::value)>::type* = nullptr>
         DACE_CONSTEXPR DACE_HDFI auto pow(const T& a, const U& b)
         {
             return std::pow(a, b);
         }
 
-        static DACE_CONSTEXPR DACE_HDFI int pow(const int& a, const int& b)
+        // WHY: only integer^*unsigned*-integer returns an integer (b >= 0 is
+        // guaranteed). A signed exponent could be negative and yield a
+        // fractional value.
+        template<typename A, typename B,
+                 typename std::enable_if<std::is_integral<A>::value &&
+                                         std::is_integral<B>::value &&
+                                         std::is_unsigned<B>::value>::type* = nullptr>
+        DACE_CONSTEXPR DACE_HDFI typename std::common_type<A, B>::type
+        pow(const A& a, const B& b)
         {
-            if (b < 0) return 0;
-            int result = 1;
-            for (int i = 0; i < b; ++i)
-                result *= a;
-            return result;
-        }
-
-        static DACE_CONSTEXPR DACE_HDFI unsigned int pow(const unsigned int& a,
-                                       const unsigned int& b)
-        {
-            unsigned int result = 1;
-            for (unsigned int i = 0; i < b; ++i)
-                result *= a;
+            using R = typename std::common_type<A, B>::type;
+            R result = R(1);
+            for (B i = 0; i < b; ++i) result *= R(a);
             return result;
         }
 

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -380,19 +380,24 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
 
         # NOTE: The outputs of LibraryNodes, NestedSDFGs and Map that have GPU schedule must be moved to GPU memory.
         # TODO: Also use GPU-shared and GPU-register memory when appropriate.
+
+        # WHY: registering the promoted transient lets Step 8 create a host mirror
+        # if an interstate edge later reads it on the host.
+        def _register_gpu_transient(dst_node):
+            if not isinstance(dst_node, nodes.AccessNode):
+                return
+            desc = sdfg.arrays[dst_node.data]
+            desc.storage = dtypes.StorageType.GPU_Global
+            if desc.transient and dst_node.data not in data_already_on_gpu:
+                data_already_on_gpu[dst_node.data] = None
+
         for state, node in gpu_nodes:
             if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)):
                 for e in state.out_edges(node):
-                    dst = state.memlet_path(e)[-1].dst
-                    if isinstance(dst, nodes.AccessNode):
-                        desc = sdfg.arrays[dst.data]
-                        desc.storage = dtypes.StorageType.GPU_Global
+                    _register_gpu_transient(state.memlet_path(e)[-1].dst)
             if isinstance(node, nodes.EntryNode):
                 for e in state.out_edges(state.exit_node(node)):
-                    dst = state.memlet_path(e)[-1].dst
-                    if isinstance(dst, nodes.AccessNode):
-                        desc = sdfg.arrays[dst.data]
-                        desc.storage = dtypes.StorageType.GPU_Global
+                    _register_gpu_transient(state.memlet_path(e)[-1].dst)
 
         #######################################################
         # Step 5: Collect free tasklets and check for scalars that have to be moved to the GPU
@@ -477,6 +482,8 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
                         # NOTE: the cloned arrays match too but it's the same storage so we don't care
                         if node.data not in self.host_data:
                             nodedesc.storage = dtypes.StorageType.GPU_Global
+                            if node.data not in data_already_on_gpu:
+                                data_already_on_gpu[node.data] = None
 
                         # Try to move allocation/deallocation out of loops
                         dsyms = set(map(str, nodedesc.free_symbols))
@@ -587,11 +594,10 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
                 name_mapping[devicename] = hostname
             return name_mapping
 
-        for block in list(sdfg.all_control_flow_blocks()):
+        for block in list(sdfg.all_control_flow_blocks(recursive=True)):
             arrays_used = set()
             for e in block.parent_graph.out_edges(block):
-                # Used arrays = intersection between symbols and cloned data
-                arrays_used.update(set(e.data.free_symbols) & cloned_data)
+                arrays_used.update(e.data.used_arrays(sdfg.arrays) & cloned_data)
 
             # Create a state and copy out used arrays
             if len(arrays_used) > 0:
@@ -607,7 +613,7 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
                     for e in block.parent_graph.out_edges(co_state):
                         e.data.replace(devicename, hostname, False)
 
-        for block in list(sdfg.all_control_flow_blocks()):
+        for block in list(sdfg.all_control_flow_blocks(recursive=True)):
             arrays_used = set(block.used_symbols(all_symbols=True, with_contents=False)) & cloned_data
 
             # Create a state and copy out used arrays

--- a/tests/transformations/gpu_offloading_bugs_test.py
+++ b/tests/transformations/gpu_offloading_bugs_test.py
@@ -1,17 +1,8 @@
 # Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
-"""Minimal reproducers for four GPU-offloading bugs found in the npbench sweep.
+"""GPU-offloading bug reproducers.
 
-Each test is a tight kernel extracted from the failure pattern of a real
-npbench kernel. The kernel exercises a single failure mode end-to-end:
-
-- :func:`test_reduce_on_view`       -- lenet maxpool sliding-window View
-- :func:`test_host_iedge_read`      -- mandelbrot2 ``if I[j]:`` host-side
-- :func:`test_map_straddle`         -- mandelbrot2 follow-on (host/GPU on one map)
-- :func:`test_int_pow_used_as_index`-- stockham_fft ``pow(R, K)`` as index
-
-Each test pre-validates the SDFG after :func:`auto_optimize` with
-``device=GPU`` -- the contract is that GPU offloading produces a valid SDFG.
-Numerical correctness is asserted where the kernel is small and tractable.
+Each test pre-validates the SDFG after ``auto_optimize(device=GPU)``; numerical
+correctness is asserted where the kernel is small and tractable.
 """
 import numpy as np
 import pytest
@@ -21,26 +12,12 @@ from dace.transformation.auto.auto_optimize import auto_optimize
 
 N = dace.symbol('N')
 
-# ---------------------------------------------------------------------------
-# Bug 1: Reduce expansion with a View input (lenet maxpool pattern).
-#
-# ``np.max(x[:, 2*i:2*i+2, 2*j:2*j+2, :], axis=(1, 2))`` creates a sliding-window
-# View into ``x`` and feeds it into a ``Reduce`` node. ``ExpandReduceGPUAuto``
-# copies the input descriptor into its nested SDFG; if that descriptor is a
-# View the viewed-source array is left behind and ``_in`` becomes dangling.
-# Validation rejects the nested SDFG on the next ``MapCollapse`` apply.
-# ---------------------------------------------------------------------------
-
 
 @dace.program
 def _reduce_view_kernel(x: dace.float64[N, 4, 4, 8], out: dace.float64[N, 2, 2, 8]):
-    """One sliding-window max-pool over a 4x4 input -> 2x2 output.
-
-    Python ``for`` loops (not ``dace.map``) so the Reduce nodes stay at the
-    SDFG top-level after auto-optimize -- their View inputs keep
-    ``GPU_Global`` storage and pick the ``GPUAuto`` expansion path (the one
-    that copies the input descriptor into a nested SDFG).
-    """
+    # WHY: Python ``for`` (not ``dace.map``) keeps each Reduce at SDFG
+    # top-level so the View input keeps ``GPU_Global`` storage and selects
+    # the ``GPUAuto`` expansion path.
     for i in range(2):
         for j in range(2):
             out[:, i, j, :] = np.max(x[:, 2 * i:2 * i + 2, 2 * j:2 * j + 2, :], axis=(1, 2))
@@ -48,31 +25,13 @@ def _reduce_view_kernel(x: dace.float64[N, 4, 4, 8], out: dace.float64[N, 2, 2, 
 
 @pytest.mark.gpu
 def test_reduce_on_view():
-    """Structural: the SDFG must validate after GPU offloading. The bug
-    this reproducer exercises is purely structural -- a dangling View in
-    ``ExpandReduceGPUAuto``'s nested SDFG. Numerical correctness for the
-    sliding-window max-pool pattern depends on the unrelated auto-optimize
-    behaviour around Reduce nodes and is asserted by lenet's own test."""
     sdfg = _reduce_view_kernel.to_sdfg()
     sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
     sdfg.validate()
 
 
-# ---------------------------------------------------------------------------
-# Bug 2: host interstate-edge read of a GPU-resident container
-# (mandelbrot2 ``I[:length] = ...; for j: if I[j]: ...``).
-#
-# A bool transient is written by a GPU-eligible map, then the kernel branches
-# on individual entries inside a host loop. The branch lowers to an interstate
-# edge with assignment ``i_tmp = I[j]``; if ``I`` was promoted to GPU storage
-# the validator rejects the SDFG ('reading inaccessible GPU_Global container
-# in host code interstate edge').
-# ---------------------------------------------------------------------------
-
-
 @dace.program
 def _host_iedge_read_kernel(data: dace.float64[N], out: dace.int32[1]):
-    # ``np.greater`` materialises a bool array DaCe can lower to a GPU map.
     I = np.greater(data, 0.5)
     count: dace.int32 = 0
     for j in range(N):
@@ -94,34 +53,19 @@ def test_host_iedge_read():
     assert int(out[0]) == int(np.sum(data > 0.5))
 
 
-# ---------------------------------------------------------------------------
-# Bug 3: a map straddling host (host_data) input and GPU-promoted output.
-#
-# Once bug 2 is fixed and ``I`` is pinned to host, the negation map
-# ``I[:] = np.logical_not(I[:])`` reads host ``I`` and writes a top-level
-# intermediate, which the existing storage-promotion step would still bump to
-# GPU_Global. The map ends up with one input on CPU_Heap and one output on
-# GPU_Global, and ``infer_types.set_default_schedule_and_storage_types``
-# raises on the multi-constraint conflict.
-# ---------------------------------------------------------------------------
-
-
 @dace.program
 def _map_straddle_kernel(data: dace.float64[N], out: dace.bool_[N]):
     I = np.greater(data, 0.5)
 
-    # Force I host via an iedge read.
     keep_alive: dace.int32 = 0
     for j in range(N):
         if I[j]:
             keep_alive = keep_alive + 1
 
-    # Negation: reads host I, writes a transient that would otherwise be
-    # GPU-promoted. The map's host_data membership must propagate.
     not_I = np.logical_not(I)
     for k in dace.map[0:N]:
         out[k] = not_I[k]
-    # Touch ``keep_alive`` so the iedge read isn't dead-code-eliminated.
+    # WHY: prevents the iedge read from being dead-code eliminated.
     if keep_alive < 0:
         out[0] = False
 
@@ -140,22 +84,11 @@ def test_map_straddle():
     assert np.array_equal(out, ref)
 
 
-# ---------------------------------------------------------------------------
-# Bug 4: integer-typed ``pow(R, K)`` used as an array index.
-#
-# Stockham FFT uses ``R ** K`` where ``R`` and ``K`` are ``int64_t`` symbols,
-# and the result indexes a transient. ``dace::math::pow(int64_t, int64_t)``
-# previously fell through to ``std::pow`` returning ``double`` -- illegal as
-# an array subscript or ``cudaLaunchKernel`` grid-dim.
-#
-# Per the corrected design: integer pow is only safe when the exponent type
-# is *unsigned* (otherwise a negative exponent produces a fractional value).
-# Stockham_fft itself needs to declare its radix exponents as unsigned for
-# the integer overload to apply; the runtime contract is checked here.
-# ---------------------------------------------------------------------------
-
+# WHY: ``K`` is declared unsigned so ``pow(R, K)`` lands on the integer pow
+# overload; a signed exponent would route through ``std::pow`` and yield a
+# ``double`` that can't be used as an array subscript or launch-dim.
 R = dace.symbol('R', dace.int64)
-K = dace.symbol('K', dace.uint32)  # unsigned -> integer pow is well-defined
+K = dace.symbol('K', dace.uint32)
 
 
 @dace.program
@@ -170,10 +103,29 @@ def test_int_pow_used_as_index():
     sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
     sdfg.validate()
 
-    R_v, K_v = 2, 6  # 2**6 = 64
+    R_v, K_v = 2, 6
     out = np.zeros(R_v**K_v, dtype=np.float64)
     sdfg(out=out, R=R_v, K=K_v)
     assert np.array_equal(out, np.ones(R_v**K_v, dtype=np.float64))
+
+
+@pytest.mark.gpu
+def test_int_pow_signed_base_unsigned_exp():
+    test_int_pow_used_as_index()
+
+
+@dace.program
+def _reduce_view_complex_kernel(x: dace.complex128[N, 4, 4, 8], out: dace.complex128[N, 2, 2, 8]):
+    for i in range(2):
+        for j in range(2):
+            out[:, i, j, :] = np.sum(x[:, 2 * i:2 * i + 2, 2 * j:2 * j + 2, :], axis=(1, 2))
+
+
+@pytest.mark.gpu
+def test_reduce_on_view_complex():
+    sdfg = _reduce_view_complex_kernel.to_sdfg()
+    sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
+    sdfg.validate()
 
 
 if __name__ == "__main__":
@@ -181,3 +133,5 @@ if __name__ == "__main__":
     test_host_iedge_read()
     test_map_straddle()
     test_int_pow_used_as_index()
+    test_int_pow_signed_base_unsigned_exp()
+    test_reduce_on_view_complex()

--- a/tests/transformations/gpu_offloading_bugs_test.py
+++ b/tests/transformations/gpu_offloading_bugs_test.py
@@ -1,0 +1,183 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Minimal reproducers for four GPU-offloading bugs found in the npbench sweep.
+
+Each test is a tight kernel extracted from the failure pattern of a real
+npbench kernel. The kernel exercises a single failure mode end-to-end:
+
+- :func:`test_reduce_on_view`       -- lenet maxpool sliding-window View
+- :func:`test_host_iedge_read`      -- mandelbrot2 ``if I[j]:`` host-side
+- :func:`test_map_straddle`         -- mandelbrot2 follow-on (host/GPU on one map)
+- :func:`test_int_pow_used_as_index`-- stockham_fft ``pow(R, K)`` as index
+
+Each test pre-validates the SDFG after :func:`auto_optimize` with
+``device=GPU`` -- the contract is that GPU offloading produces a valid SDFG.
+Numerical correctness is asserted where the kernel is small and tractable.
+"""
+import numpy as np
+import pytest
+
+import dace
+from dace.transformation.auto.auto_optimize import auto_optimize
+
+N = dace.symbol('N')
+
+# ---------------------------------------------------------------------------
+# Bug 1: Reduce expansion with a View input (lenet maxpool pattern).
+#
+# ``np.max(x[:, 2*i:2*i+2, 2*j:2*j+2, :], axis=(1, 2))`` creates a sliding-window
+# View into ``x`` and feeds it into a ``Reduce`` node. ``ExpandReduceGPUAuto``
+# copies the input descriptor into its nested SDFG; if that descriptor is a
+# View the viewed-source array is left behind and ``_in`` becomes dangling.
+# Validation rejects the nested SDFG on the next ``MapCollapse`` apply.
+# ---------------------------------------------------------------------------
+
+
+@dace.program
+def _reduce_view_kernel(x: dace.float64[N, 4, 4, 8], out: dace.float64[N, 2, 2, 8]):
+    """One sliding-window max-pool over a 4x4 input -> 2x2 output.
+
+    Python ``for`` loops (not ``dace.map``) so the Reduce nodes stay at the
+    SDFG top-level after auto-optimize -- their View inputs keep
+    ``GPU_Global`` storage and pick the ``GPUAuto`` expansion path (the one
+    that copies the input descriptor into a nested SDFG).
+    """
+    for i in range(2):
+        for j in range(2):
+            out[:, i, j, :] = np.max(x[:, 2 * i:2 * i + 2, 2 * j:2 * j + 2, :], axis=(1, 2))
+
+
+@pytest.mark.gpu
+def test_reduce_on_view():
+    """Structural: the SDFG must validate after GPU offloading. The bug
+    this reproducer exercises is purely structural -- a dangling View in
+    ``ExpandReduceGPUAuto``'s nested SDFG. Numerical correctness for the
+    sliding-window max-pool pattern depends on the unrelated auto-optimize
+    behaviour around Reduce nodes and is asserted by lenet's own test."""
+    sdfg = _reduce_view_kernel.to_sdfg()
+    sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
+    sdfg.validate()
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: host interstate-edge read of a GPU-resident container
+# (mandelbrot2 ``I[:length] = ...; for j: if I[j]: ...``).
+#
+# A bool transient is written by a GPU-eligible map, then the kernel branches
+# on individual entries inside a host loop. The branch lowers to an interstate
+# edge with assignment ``i_tmp = I[j]``; if ``I`` was promoted to GPU storage
+# the validator rejects the SDFG ('reading inaccessible GPU_Global container
+# in host code interstate edge').
+# ---------------------------------------------------------------------------
+
+
+@dace.program
+def _host_iedge_read_kernel(data: dace.float64[N], out: dace.int32[1]):
+    # ``np.greater`` materialises a bool array DaCe can lower to a GPU map.
+    I = np.greater(data, 0.5)
+    count: dace.int32 = 0
+    for j in range(N):
+        if I[j]:
+            count = count + 1
+    out[0] = count
+
+
+@pytest.mark.gpu
+def test_host_iedge_read():
+    sdfg = _host_iedge_read_kernel.to_sdfg()
+    sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
+    sdfg.validate()
+
+    rng = np.random.default_rng(1)
+    data = rng.uniform(0, 1, size=20)
+    out = np.zeros(1, dtype=np.int32)
+    sdfg(data=data, out=out, N=20)
+    assert int(out[0]) == int(np.sum(data > 0.5))
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: a map straddling host (host_data) input and GPU-promoted output.
+#
+# Once bug 2 is fixed and ``I`` is pinned to host, the negation map
+# ``I[:] = np.logical_not(I[:])`` reads host ``I`` and writes a top-level
+# intermediate, which the existing storage-promotion step would still bump to
+# GPU_Global. The map ends up with one input on CPU_Heap and one output on
+# GPU_Global, and ``infer_types.set_default_schedule_and_storage_types``
+# raises on the multi-constraint conflict.
+# ---------------------------------------------------------------------------
+
+
+@dace.program
+def _map_straddle_kernel(data: dace.float64[N], out: dace.bool_[N]):
+    I = np.greater(data, 0.5)
+
+    # Force I host via an iedge read.
+    keep_alive: dace.int32 = 0
+    for j in range(N):
+        if I[j]:
+            keep_alive = keep_alive + 1
+
+    # Negation: reads host I, writes a transient that would otherwise be
+    # GPU-promoted. The map's host_data membership must propagate.
+    not_I = np.logical_not(I)
+    for k in dace.map[0:N]:
+        out[k] = not_I[k]
+    # Touch ``keep_alive`` so the iedge read isn't dead-code-eliminated.
+    if keep_alive < 0:
+        out[0] = False
+
+
+@pytest.mark.gpu
+def test_map_straddle():
+    sdfg = _map_straddle_kernel.to_sdfg()
+    sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
+    sdfg.validate()
+
+    rng = np.random.default_rng(2)
+    data = rng.uniform(0, 1, size=15)
+    out = np.zeros(15, dtype=np.bool_)
+    sdfg(data=data, out=out, N=15)
+    ref = np.logical_not(data > 0.5)
+    assert np.array_equal(out, ref)
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: integer-typed ``pow(R, K)`` used as an array index.
+#
+# Stockham FFT uses ``R ** K`` where ``R`` and ``K`` are ``int64_t`` symbols,
+# and the result indexes a transient. ``dace::math::pow(int64_t, int64_t)``
+# previously fell through to ``std::pow`` returning ``double`` -- illegal as
+# an array subscript or ``cudaLaunchKernel`` grid-dim.
+#
+# Per the corrected design: integer pow is only safe when the exponent type
+# is *unsigned* (otherwise a negative exponent produces a fractional value).
+# Stockham_fft itself needs to declare its radix exponents as unsigned for
+# the integer overload to apply; the runtime contract is checked here.
+# ---------------------------------------------------------------------------
+
+R = dace.symbol('R', dace.int64)
+K = dace.symbol('K', dace.uint32)  # unsigned -> integer pow is well-defined
+
+
+@dace.program
+def _int_pow_index_kernel(out: dace.float64[R**K]):
+    for i in dace.map[0:R**K]:
+        out[i] = out[i] + 1.0
+
+
+@pytest.mark.gpu
+def test_int_pow_used_as_index():
+    sdfg = _int_pow_index_kernel.to_sdfg()
+    sdfg = auto_optimize(sdfg, dace.dtypes.DeviceType.GPU)
+    sdfg.validate()
+
+    R_v, K_v = 2, 6  # 2**6 = 64
+    out = np.zeros(R_v**K_v, dtype=np.float64)
+    sdfg(out=out, R=R_v, K=K_v)
+    assert np.array_equal(out, np.ones(R_v**K_v, dtype=np.float64))
+
+
+if __name__ == "__main__":
+    test_reduce_on_view()
+    test_host_iedge_read()
+    test_map_straddle()
+    test_int_pow_used_as_index()

--- a/tests/transformations/gpu_offloading_bugs_test.py
+++ b/tests/transformations/gpu_offloading_bugs_test.py
@@ -1,8 +1,8 @@
 # Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
 """GPU-offloading bug reproducers.
 
-Each test pre-validates the SDFG after ``auto_optimize(device=GPU)``; numerical
-correctness is asserted where the kernel is small and tractable.
+Each test pre-validates the SDFG after ``auto_optimize(device=GPU)``, and
+asserts numerical correctness where the kernel is small and tractable.
 """
 import numpy as np
 import pytest


### PR DESCRIPTION
# GPU Offloading Bug Fixes

Branch `gpu-offloading-bugfixes` off `main`.

## Bugs

| # | File | Symptom | Fix |
|---|---|---|---|
| 1 | `dace/runtime/include/dace/math.h` | `pow(int64, int64)` returns `double` → invalid as array index / launch-dim | SFINAE: integer overload for **only when exponent is unsigned**; everything else stays the same. |
| 2 | `dace/libraries/standard/nodes/reduce.py` | `ExpandReduceGPUAuto` leaves a dangling View in the nested SDFG when input is a View | Wrap into a `NestedSDFG` whose external connector is the source Array; rebuild `Array → View → Reduce` inside with `implementation='CUDA (device)'` (CUB). |
| 3 | `dace/transformation/interstate/gpu_transform_sdfg.py` | Host iedge `if I[j]:` reads GPU-resident container → validation fails | Step 4/6 register promoted transients in `data_already_on_gpu`; Step 8 recurses into `LoopRegion`/`ConditionalBlock` and uses `used_arrays(sdfg.arrays)` instead of `free_symbols`. Result: GPU map stays on GPU, Step 8 inserts a `host_<name>` mirror + copy-out at the iedge boundary. |

## Reproducers (`tests/transformations/gpu_offloading_bugs_test.py`)

I added a unit test for each reproducer. These reproducers try to mimic the patterns which resulting in GPU offloading fail on NPBench. With this PR the NPBench offloading should work.