### PR TITLE
Fixed Copy Node

### DIFF
--- a/dace/codegen/common.py
+++ b/dace/codegen/common.py
@@ -7,8 +7,8 @@ from dace.sdfg import SDFG
 from dace.properties import CodeBlock
 from dace.codegen import cppunparse
 from dace.codegen.tools import gpu_runtime
-from functools import lru_cache
 from io import StringIO
+import functools
 import os
 import subprocess
 from typing import List, Optional, Set, Union
@@ -37,7 +37,7 @@ def find_outgoing_edges(node, dfg):
         return list(dfg.out_edges(node))
 
 
-@lru_cache(maxsize=16384)
+@functools.lru_cache(maxsize=16384)
 def _sym2cpp(s, arrayexprs):
     return cppunparse.pyexpr2cpp(symbolic.symstr(s, arrayexprs, cpp_mode=True))
 
@@ -100,18 +100,26 @@ def unparse_interstate_edge(code_ast: Union[ast.AST, str], sdfg: SDFG, symbols=N
     return strio.getvalue().strip()
 
 
-@lru_cache()
 def get_gpu_backend() -> str:
-    """
-    Returns the currently-selected GPU backend. If automatic,
-    will perform a series of checks to see if an NVIDIA device exists,
-    then if an AMD device exists, or fail.
-    Otherwise, chooses the configured backend in ``compiler.cuda.backend``.
+    """Returns the currently-selected GPU backend in ``compiler.cuda.backend``.
+
+    If automatic, will perform a series of checks to see if an NVIDIA device exists,
+    then if an AMD device exists, or fail. Note that the automatically detected case
+    will never be revisited.
     """
     backend: str = config.Config.get('compiler', 'cuda', 'backend')
     if backend and backend != 'auto':
         return backend
 
+    return _probing_for_gpu_backend()
+
+
+@functools.cache
+def _probing_for_gpu_backend() -> str:
+    # Inspects the system to figuring out which GPU backend to be used.
+    #  This function should not be called directly by the user, instead it is called
+    #  by `get_gpu_backend()` is the backend is not set. Note that the return value
+    #  of this function is cached and will never change.
     def _try_execute(cmd: str) -> bool:
         process = subprocess.Popen(cmd.split(' '), stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
         errcode = process.wait()
@@ -147,12 +155,20 @@ def get_gpu_backend() -> str:
                        'to either "cuda" or "hip".')
 
 
-@lru_cache()
 def get_gpu_runtime() -> gpu_runtime.GPURuntime:
     """
     Returns the GPU runtime library (CUDA / HIP) if exists. The result is cached for performance.
     """
     backend = get_gpu_backend()
+    return _look_for_runtime_file(backend)
+
+
+@functools.cache
+def _look_for_runtime_file(backend: str) -> gpu_runtime.GPURuntime:
+    # Look for the runtime information of a GPU backend.
+    #  The user should never call this function directly, instead it is called
+    #  indirectly by ``get_gpu_runtime()``.
+
     if backend == 'cuda':
         libpath = ctypes.util.find_library('cudart')
         if os.name == 'nt' and not libpath:  # Windows-based search

--- a/dace/libraries/standard/nodes/copy_node.py
+++ b/dace/libraries/standard/nodes/copy_node.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import dace
 from dace import data, library, nodes, dtypes, symbolic
-from dace.codegen.common import sym2cpp
+from dace.codegen.common import sym2cpp, get_gpu_backend
 from dace.libraries.standard.helper import CURRENT_STREAM_NAME, auto_dispatch, collapse_shape_and_strides
 from dace.sdfg.scope import is_devicelevel_gpu, is_in_scope
 from dace.transformation.transformation import ExpandTransformation
@@ -384,7 +384,8 @@ def _memcpy_kind(inp: data.Data, out: data.Data) -> str:
     """``cudaMemcpy<src>To<dst>`` from endpoint storages."""
     src_loc = "Device" if inp.storage == dace.dtypes.StorageType.GPU_Global else "Host"
     dst_loc = "Device" if out.storage == dace.dtypes.StorageType.GPU_Global else "Host"
-    return f"cudaMemcpy{src_loc}To{dst_loc}"
+    backend = get_gpu_backend()
+    return f"{backend}Memcpy{src_loc}To{dst_loc}"
 
 
 def _make_memcpy_tasklet(node: "CopyLibraryNode", parent_state: dace.SDFGState, *, cuda: bool) -> nodes.Tasklet:
@@ -414,7 +415,8 @@ def _make_memcpy_tasklet(node: "CopyLibraryNode", parent_state: dace.SDFGState, 
     out_conn = CopyLibraryNode.OUTPUT_CONNECTOR_NAME
     nbytes = f"{sym2cpp(in_subset.num_elements_exact())} * sizeof({inp.dtype.ctype})"
     if cuda:
-        code = f"cudaMemcpyAsync({out_conn}, {in_conn}, {nbytes}, {_memcpy_kind(inp, out)}, {CURRENT_STREAM_NAME});"
+        backend = get_gpu_backend()
+        code = f"{backend}MemcpyAsync({out_conn}, {in_conn}, {nbytes}, {_memcpy_kind(inp, out)}, {CURRENT_STREAM_NAME});"
     else:
         code = f"memcpy({out_conn}, {in_conn}, {nbytes});"
 
@@ -567,6 +569,7 @@ class ExpandMemcpyCUDA2D(ExpandTransformation):
         src_strides = in_strides_2d
         dst_strides = out_strides_2d
         ctype = inp.dtype.ctype
+        backend = get_gpu_backend()
 
         if src_strides[1] == 1 and dst_strides[1] == 1:
             dpitch = f"{sym2cpp(dst_strides[0])} * sizeof({ctype})"
@@ -589,7 +592,7 @@ class ExpandMemcpyCUDA2D(ExpandTransformation):
                                       f"src_strides={src_strides}, dst_strides={dst_strides}.")
 
         code = (
-            f"cudaMemcpy2DAsync({CopyLibraryNode.OUTPUT_CONNECTOR_NAME}, {dpitch}, {CopyLibraryNode.INPUT_CONNECTOR_NAME}, {spitch}, "
+            f"{backend}Memcpy2DAsync({CopyLibraryNode.OUTPUT_CONNECTOR_NAME}, {dpitch}, {CopyLibraryNode.INPUT_CONNECTOR_NAME}, {spitch}, "
             f"{width}, {height}, {kind}, {CURRENT_STREAM_NAME});")
 
         in_conns = {CopyLibraryNode.INPUT_CONNECTOR_NAME: dace.dtypes.pointer(inp.dtype)}
@@ -644,12 +647,13 @@ class ExpandMemcpyCUDANDStrided(ExpandTransformation):
         ctype = inp.dtype.ctype
         chunk = sym2cpp(in_shape_collapsed[chunk_dim])
         kind = _memcpy_kind(inp, out)
+        backend = get_gpu_backend()
 
         if ndims == 1:
             # Degenerate case: a single contiguous run. Emit a flat Tasklet
             # with the libnode's connector naming directly -- no wrapper SDFG.
             code = (
-                f"DACE_GPU_CHECK(cudaMemcpyAsync({CopyLibraryNode.OUTPUT_CONNECTOR_NAME}, {CopyLibraryNode.INPUT_CONNECTOR_NAME}, "
+                f"DACE_GPU_CHECK({backend}MemcpyAsync({CopyLibraryNode.OUTPUT_CONNECTOR_NAME}, {CopyLibraryNode.INPUT_CONNECTOR_NAME}, "
                 f"{chunk} * sizeof({ctype}), {kind}, {CURRENT_STREAM_NAME}));")
             in_conns = {CopyLibraryNode.INPUT_CONNECTOR_NAME: dace.dtypes.pointer(inp.dtype)}
             return nodes.Tasklet(node.name,
@@ -684,7 +688,8 @@ class ExpandMemcpyCUDANDStrided(ExpandTransformation):
         # Inner-tasklet connectors. Must not collide with the wrapper SDFG's
         # parameter arrays, which are named after the libnode's outer connectors.
         inner_in, inner_out = "_in", "_out"
-        code = (f"DACE_GPU_CHECK(cudaMemcpyAsync({inner_out}, {inner_in}, "
+        backend = get_gpu_backend()
+        code = (f"DACE_GPU_CHECK({backend}MemcpyAsync({inner_out}, {inner_in}, "
                 f"{chunk} * sizeof({ctype}), {kind}, {CURRENT_STREAM_NAME}));")
 
         inner_tasklet, map_entry, _map_exit = ctx.state.add_mapped_tasklet(name=f"{node.label}_tasklet",


### PR DESCRIPTION
The expansion of the copy node always assumed the CUDA backend.

Updated how get_gpu_{backend, runtime}() worked:
- It was not possible to change the backend, which only affect systems that have an Nvidia _and_ AMD GPU.
- `lru_cache` is not needed `cache` is fully adequate.