### PR TITLE
Fix miscompiling connector/array element-type mismatches

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1109,6 +1109,9 @@ class CPUCodeGen(TargetCodeGenerator):
         :return: String of C++ performing the write.
         """
         codegen = codegen or self
+        # Scalar-to-scalar with differing types: convert the value with a cast.
+        if src_dtype != dst_dtype and src_dtype.veclen == 1 and dst_dtype.veclen == 1:
+            return f"{dst_expr} = static_cast<{dst_dtype.ctype}>({src_expr});"
         # If there is a type mismatch, cast pointer
         dst_expr = codegen.make_ptr_vector_cast(dst_expr, dst_dtype, src_dtype, True, DefinedType.Pointer)
         return f"{dst_expr} = {src_expr};"

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -758,6 +758,28 @@ class NestedSDFG(CodeNode):
                 raise ValueError(f"Inout connector {conn} is connected to different input ({inputs}) and "
                                  f"output ({outputs}) arrays")
 
+        # Reject inner/outer array base-type mismatches across connectors.
+        if self.sdfg:
+            for conn in self.in_connectors.keys() | self.out_connectors.keys():
+                if conn not in self.sdfg.arrays:
+                    continue
+                inner_dtype = self.sdfg.arrays[conn].dtype
+                outer_arrays = set()
+                for edge in state.in_edges_by_connector(self, conn):
+                    src = utils.get_global_memlet_path_src(sdfg, state, edge)
+                    if isinstance(src, AccessNode):
+                        outer_arrays.add(src.data)
+                for edge in state.out_edges_by_connector(self, conn):
+                    dst = utils.get_global_memlet_path_dst(sdfg, state, edge)
+                    if isinstance(dst, AccessNode):
+                        outer_arrays.add(dst.data)
+                for outer_name in outer_arrays:
+                    outer_dtype = sdfg.arrays[outer_name].dtype
+                    if inner_dtype.base_type != outer_dtype.base_type:
+                        raise ValueError(
+                            f'Element type mismatch on nested SDFG connector "{conn}": inner array '
+                            f'is {inner_dtype} but outer array "{outer_name}" is {outer_dtype}. ')
+
         # Validate undefined symbols
         if self.sdfg:
             symbols = set(k for k in self.sdfg.free_symbols if k not in connectors)

--- a/tests/codegen/scalar_dtype_mismatch_cast_test.py
+++ b/tests/codegen/scalar_dtype_mismatch_cast_test.py
@@ -1,0 +1,43 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests that a scalar tasklet output connector whose dtype differs from its
+    destination array is cast on assignment (``B[i] = (float)y``) rather than
+    stored by reinterpreting the destination pointer. """
+import numpy as np
+import dace
+
+
+def _build(out_conn_dtype: dace.dtypes.typeclass) -> dace.SDFG:
+    N = 8
+    sdfg = dace.SDFG("scalar_dtype_mismatch_cast")
+    sdfg.add_array("A", [N], dace.float64)  # input
+    sdfg.add_array("B", [N], dace.float32)  # output: narrower than the computation
+
+    st = sdfg.add_state()
+    me, mx = st.add_map("m", {"i": f"0:{N}"})
+    t = st.add_tasklet("t", {"x"}, {"y"}, "y = x * 2.0;", language=dace.Language.CPP)
+    me.add_in_connector("IN_A")
+    me.add_out_connector("OUT_A")
+    mx.add_in_connector("IN_B")
+    mx.add_out_connector("OUT_B")
+    st.add_edge(st.add_read("A"), None, me, "IN_A", dace.Memlet(f"A[0:{N}]"))
+    st.add_edge(me, "OUT_A", t, "x", dace.Memlet("A[i]"))
+    st.add_edge(t, "y", mx, "IN_B", dace.Memlet("B[i]"))
+    st.add_edge(mx, "OUT_B", st.add_write("B"), None, dace.Memlet(f"B[0:{N}]"))
+
+    # Compute in double, store into the f32 array -- the shape a precision-lowering
+    # transformation produces (output connector wider than its destination array).
+    t.in_connectors["x"] = dace.float64
+    t.out_connectors["y"] = out_conn_dtype
+    return sdfg
+
+
+def test_scalar_output_connector_wider_than_array_narrows():
+    sdfg = _build(dace.float64)
+    A = np.arange(1, 9, dtype=np.float64)
+    B = np.zeros(8, dtype=np.float32)
+    sdfg(A=A, B=B)
+    np.testing.assert_allclose(B, (A * 2.0).astype(np.float32))
+
+
+if __name__ == "__main__":
+    test_scalar_output_connector_wider_than_array_narrows()

--- a/tests/nested_sdfg_dtype_validation_test.py
+++ b/tests/nested_sdfg_dtype_validation_test.py
@@ -1,0 +1,48 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests that validate() rejects inner/outer array base-type mismatches across
+    nested SDFG connectors, while allowing differences that share a base type
+    (e.g. a vector view of a scalar). """
+import pytest
+import dace
+from dace.sdfg.validation import InvalidSDFGError
+
+
+def _build(inner_a_dtype: dace.dtypes.typeclass,
+           outer_a_dtype: dace.dtypes.typeclass) -> dace.SDFG:
+    N = 8
+    inner = dace.SDFG("nsdfg_dtype_inner")
+    inner.add_array("A", [N], inner_a_dtype)
+    inner.add_array("B", [N], dace.float64)
+    ist = inner.add_state()
+    ist.add_mapped_tasklet("m",
+                           dict(i=f"0:{N}"),
+                           dict(x=dace.Memlet("A[i]")),
+                           "y = x * 2.0",
+                           dict(y=dace.Memlet("B[i]")),
+                           external_edges=True)
+
+    outer = dace.SDFG("nsdfg_dtype_outer")
+    outer.add_array("outside_A", [N], outer_a_dtype)
+    outer.add_array("outside_B", [N], dace.float64)
+    ost = outer.add_state()
+    nsdfg = ost.add_nested_sdfg(inner, {"A"}, {"B"})
+    ost.add_edge(ost.add_read("outside_A"), None, nsdfg, "A", dace.Memlet(f"outside_A[0:{N}]"))
+    ost.add_edge(nsdfg, "B", ost.add_write("outside_B"), None, dace.Memlet(f"outside_B[0:{N}]"))
+    return outer
+
+
+def test_nested_sdfg_base_type_mismatch_rejected():
+    # inner A is f32, outer outside_A is f64 -> reinterpret of the buffer -> reject.
+    sdfg = _build(dace.float32, dace.float64)
+    with pytest.raises(InvalidSDFGError):
+        sdfg.validate()
+
+
+def test_nested_sdfg_matching_base_type_ok():
+    sdfg = _build(dace.float64, dace.float64)
+    sdfg.validate()  # must not raise
+
+
+if __name__ == "__main__":
+    test_nested_sdfg_base_type_mismatch_rejected()
+    test_nested_sdfg_matching_base_type_ok()


### PR DESCRIPTION
## Problem

A data boundary whose connector dtype differs from its connected array is silently miscompiled instead of being converted or rejected — and `sdfg.validate()` reports the SDFG as valid in both cases. This shows up wherever a transformation produces a connector dtype that doesn't match its array (e.g. mixed/lowered precision), in two ways:

1. **Scalar tasklet store → pointer reinterpret.**
A tasklet output connector of one scalar type written into an array of another (e.g. an `float64` result stored into a `float32` array) is lowered by reinterpreting the destination pointer:
   ```cpp
   double y;
   y = x * 2.0;
   *(double *)(&B[i]) = y;   // B is float* — 8-byte store into a 4-byte slot
   ```
   This type-puns the value: it corrupts neighbouring elements, writes past the end of the buffer when narrowing, and produces a **misaligned store that faults on GPUs** (`cudaErrorMisalignedAddress`). On CPU it silently returns wrong values.

2. **Nested-SDFG buffer → whole-buffer reinterpret.**
A nested SDFG accesses the outer array's memory using its own (inner) array's element type. If the base types differ (inner `float32` vs outer `float64`), the entire buffer is reinterpreted with no per-element conversion, silently producing garbage. Nothing rejects it.

## Fix

- **codegen** (`CPUCodeGen.make_ptr_assignment`): when a scalar connector and its destination array have different element types, narrow the value on assignment (`B[i] = static_cast<float>(y)`) instead of reinterpreting the pointer.
- **validation** (`NestedSDFG.validate`): reject a nested-SDFG connector whose inner array base type differs from the connected outer array.

## Tests

- `tests/codegen/scalar_dtype_mismatch_cast_test.py` — a scalar `f64`-connector store into an `f32` array now matches NumPy (`(A*2).astype(float32)`) instead of producing garbage.
- `tests/nested_sdfg_dtype_validation_test.py` — a base-type mismatch across a nested-SDFG connector raises `InvalidSDFGError`; a matching boundary still validates.
