### PR TITLE
fix: gpu transform node selection

### DIFF
--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -361,10 +361,9 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
             sdict = state.scope_dict()
             for node in state.nodes():
                 if sdict[node] is None:
-                    if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)):
-                        if node.guid:
-                            if isinstance(node, nodes.LibraryNode):
-                                node.schedule = dtypes.ScheduleType.GPU_Device
+                    if isinstance(node, (nodes.LibraryNode)):
+                        if not self._output_or_input_is_marked_host(state, node):
+                            node.schedule = dtypes.ScheduleType.GPU_Device
                             gpu_nodes.add((state, node))
                     elif isinstance(node, nodes.EntryNode):
                         if node.guid not in self.host_maps and not self._output_or_input_is_marked_host(state, node):

--- a/dace/transformation/interstate/gpu_transform_sdfg.py
+++ b/dace/transformation/interstate/gpu_transform_sdfg.py
@@ -377,21 +377,24 @@ class GPUTransformSDFG(transformation.MultiStateTransformation):
                             if isinstance(nnode, (nodes.EntryNode, nodes.LibraryNode)):
                                 nnode.schedule = dtypes.ScheduleType.Sequential
 
-        # NOTE: The outputs of LibraryNodes, NestedSDFGs and Map that have GPU schedule must be moved to GPU memory.
+        # NOTE: The outputs of LibraryNodes and Maps that have GPU schedule must be moved to GPU memory.
         # TODO: Also use GPU-shared and GPU-register memory when appropriate.
         for state, node in gpu_nodes:
-            if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)):
+            if isinstance(node, (nodes.LibraryNode)):
                 for e in state.out_edges(node):
                     dst = state.memlet_path(e)[-1].dst
                     if isinstance(dst, nodes.AccessNode):
                         desc = sdfg.arrays[dst.data]
                         desc.storage = dtypes.StorageType.GPU_Global
-            if isinstance(node, nodes.EntryNode):
+            elif isinstance(node, nodes.EntryNode):
                 for e in state.out_edges(state.exit_node(node)):
                     dst = state.memlet_path(e)[-1].dst
                     if isinstance(dst, nodes.AccessNode):
                         desc = sdfg.arrays[dst.data]
                         desc.storage = dtypes.StorageType.GPU_Global
+            else:
+                raise RuntimeError(
+                    f"GPU node of unexpected type. Expected `LibraryNode` or `EntryNode`, found {type(node)}.")
 
         #######################################################
         # Step 5: Collect free tasklets and check for scalars that have to be moved to the GPU


### PR DESCRIPTION
## Description

This part of the gpu transforms decides which nodes should move to the GPU. The original selection was enhanced/changed with the following two PRs

- https://github.com/spcl/dace/pull/1701
- https://github.com/spcl/dace/pull/2272

In combination, I think we ended in an inconsistent state where any `NestedSDFG` node would end up in the list of "gpu nodes". This in turn would force all inputs/outputs of that nested SDFG to GPU-bound memory.

The other issue that I could see is the following: in the current version, if a library node has an input/output that is marked to be forced on the host, the library node will anyway be exectured on the device (and the input/output data will be moved to the device).