### PR TITLE
Expose additional math functions in `dace/math.h`

### DIFF
--- a/dace/config.py
+++ b/dace/config.py
@@ -402,7 +402,7 @@ class Config(object):
     @staticmethod
     def get_default(*key_hierarchy):
         """ Returns the default value of a given configuration entry.
-            Takes into accound current operating system.
+            Takes into account current operating system.
 
             :param key_hierarchy: A tuple of strings leading to the
                                   configuration entry.

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -514,6 +514,16 @@ namespace dace
         {
             return (T)std::exp(a);
         }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T exp2(const T& a)
+        {
+            return (T)std::exp2(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T expm1(const T& a)
+        {
+            return (T)std::expm1(a);
+        }
 
 #ifdef __CUDACC__
         template<typename T>
@@ -617,6 +627,11 @@ namespace dace
             return std::atan(a);
         }
         template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T atan2(const T& a)
+        {
+            return std::atan2(a);
+        }
+        template<typename T>
         DACE_CONSTEXPR DACE_HDFI T tanh(const T& a)
         {
             return std::tanh(a);
@@ -647,9 +662,24 @@ namespace dace
           return std::log10(a);
         }
         template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T log1p(const T& a)
+        {
+            return std::log1p(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T log2(const T& a)
+        {
+            return std::log2(a);
+        }
+        template<typename T>
         DACE_CONSTEXPR DACE_HDFI T fmod(const T& a)
         {
             return std::fmod(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T lgamma(const T& a)
+        {
+            return std::lgamma(a);
         }
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T tgamma(const T& a)
@@ -685,6 +715,11 @@ namespace dace
         DACE_CONSTEXPR DACE_HDFI T round(const T& a)
         {
             return std::round(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T hypot(const T& a)
+        {
+            return std::hypot(a);
         }
     }
 

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -717,9 +717,9 @@ namespace dace
             return std::round(a);
         }
         template<typename T>
-        DACE_CONSTEXPR DACE_HDFI T hypot(const T& a)
+        DACE_CONSTEXPR DACE_HDFI T hypot(const T& a, const T& b)
         {
-            return std::hypot(a);
+            return std::hypot(a, b);
         }
     }
 

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -86,7 +86,7 @@ static DACE_CONSTEXPR DACE_HDFI T Modulo_float(const T& value, const T& modulus)
     return value - floor(value / modulus) * modulus;
 }
 
-// Implement to support a match wtih Fortran's intrinsic EXPONENT
+// Implement to support a match with Fortran's intrinsic EXPONENT
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
 static DACE_CONSTEXPR DACE_HDFI int frexp(const T& a) {
   int exponent = 0;
@@ -254,7 +254,7 @@ static DACE_CONSTEXPR DACE_HDFI std::complex<double> np_float_pow(const std::com
 // Computes Python modulus (also NumPy remainder)
 // Formula: num - (num // den) * den
 // NOTE: This is different than Python math.remainder and C remainder,
-// which are equaivalent to the IEEE remainder: num - round(num / den) * den
+// which are equivalent to the IEEE remainder: num - round(num / den) * den
 template<typename T>
 static DACE_CONSTEXPR DACE_HDFI T py_mod(const T& numerator, const T& denominator) {
     T quotient = py_floor(numerator, denominator);
@@ -392,7 +392,7 @@ static DACE_CONSTEXPR DACE_HDFI std::complex<T> reciprocal(const std::complex<T>
 
 #if __cplusplus < 201703L
 
-// Compute the greates common divisor of two integers
+// Compute the greatest common divisor of two integers
 template<typename T>
 static DACE_CONSTEXPR DACE_HDFI T gcd(T a, T b) {
     // Modern Euclidian algorithm
@@ -417,7 +417,7 @@ static DACE_CONSTEXPR DACE_HDFI T lcm(T a, T b) {
 
 #else
 
-// Compute the greates common divisor of two integers
+// Compute the greatest common divisor of two integers
 template<typename T>
 static DACE_CONSTEXPR DACE_HDFI T gcd(const T& a, const T& b) {
     return std::gcd(a, b);
@@ -572,9 +572,19 @@ namespace dace
             return std::sin(a);
         }
         template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T asin(const T& a)
+        {
+            return std::asin(a);
+        }
+        template<typename T>
         DACE_CONSTEXPR DACE_HDFI T sinh(const T& a)
         {
             return std::sinh(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T asinh(const T& a)
+        {
+            return std::asinh(a);
         }
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T cos(const T& a)
@@ -582,9 +592,19 @@ namespace dace
             return std::cos(a);
         }
         template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T acos(const T& a)
+        {
+            return std::acos(a);
+        }
+        template<typename T>
         DACE_CONSTEXPR DACE_HDFI T cosh(const T& a)
         {
             return std::cosh(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T acosh(const T& a)
+        {
+            return std::acosh(a);
         }
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T tan(const T& a)
@@ -592,14 +612,29 @@ namespace dace
             return std::tan(a);
         }
         template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T atan(const T& a)
+        {
+            return std::atan(a);
+        }
+        template<typename T>
         DACE_CONSTEXPR DACE_HDFI T tanh(const T& a)
         {
             return std::tanh(a);
         }
         template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T atanh(const T& a)
+        {
+            return std::atanh(a);
+        }
+        template<typename T>
         DACE_CONSTEXPR DACE_HDFI T sqrt(const T& a)
         {
             return std::sqrt(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T cbrt(const T& a)
+        {
+            return std::cbrt(a);
         }
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T log(const T& a)
@@ -610,6 +645,46 @@ namespace dace
         DACE_CONSTEXPR DACE_HDFI T log10(const T& a)
         {
           return std::log10(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T fmod(const T& a)
+        {
+            return std::fmod(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T tgamma(const T& a)
+        {
+            return std::tgamma(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T ceil(const T& a)
+        {
+            return std::ceil(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T trunc(const T& a)
+        {
+            return std::trunc(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T erf(const T& a)
+        {
+            return std::erf(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T erfc(const T& a)
+        {
+            return std::erfc(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T nearbyint(const T& a)
+        {
+            return std::nearbyint(a);
+        }
+        template<typename T>
+        DACE_CONSTEXPR DACE_HDFI T round(const T& a)
+        {
+            return std::round(a);
         }
     }
 

--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -672,9 +672,9 @@ namespace dace
             return std::log2(a);
         }
         template<typename T>
-        DACE_CONSTEXPR DACE_HDFI T fmod(const T& a)
+        DACE_CONSTEXPR DACE_HDFI T fmod(const T& a, const T& b)
         {
-            return std::fmod(a);
+            return std::fmod(a, b);
         }
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T lgamma(const T& a)

--- a/tests/numpy/common.py
+++ b/tests/numpy/common.py
@@ -26,7 +26,7 @@ def compare_numpy_output(device=dace.dtypes.DeviceType.CPU,
         (including errors).
 
         `func` will be run once as a dace program, and once using python.
-        The inputs to the function will be randomly intialized arrays with
+        The inputs to the function will be randomly initialized arrays with
         shapes and dtypes according to the argument annotations.
 
         Note that this should be used *instead* of the `@dace.program`

--- a/tests/runtime_math_test.py
+++ b/tests/runtime_math_test.py
@@ -1,0 +1,82 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+import dace
+
+
+@dace.program
+def cpp_float(A: dace.float32[1], B: dace.float32[2]):
+
+    @dace.tasklet('CPP')
+    def asin():
+        a << A[0]
+        b0 >> B[0]
+        b1 >> B[1]
+        """
+        b0 = asin(a);       // from <math.h> (only double precision)
+        b1 = std::asin(a);  // from <cmath>
+        """
+
+
+@dace.program
+def cpp_double(A: dace.float64[1], B: dace.float64[2]):
+
+    @dace.tasklet('CPP')
+    def asin():
+        a << A[0]
+        b0 >> B[0]
+        b1 >> B[1]
+        """
+        b0 = asin(a);       // from <math.h> (only double precision)
+        b1 = std::asin(a);  // from <cmath>
+        """
+
+
+@dace.program
+def dace_32(A: dace.float32[1], B: dace.float32[2]):
+
+    @dace.tasklet
+    def asin():
+        a << A[0]
+        b0 = asin(a)
+        b1 = dace.math.asin(a)
+        b0 >> B[0]
+        b1 >> B[1]
+
+
+@dace.program
+def dace_64(A: dace.float64[1], B: dace.float64[2]):
+
+    @dace.tasklet
+    def asin():
+        a << A[0]
+        b0 = asin(a)
+        b1 = dace.math.asin(a)
+        b0 >> B[0]
+        b1 >> B[1]
+
+
+def test_math_precision():
+    in_32 = dace.ndarray((1, ), dace.float32)
+    in_64 = dace.ndarray((1, ), dace.float64)
+    in_32[:] = [0.5]
+    in_64[:] = [0.5]
+
+    cpp_out_32 = dace.ndarray((2, ), dace.float32)
+    cpp_out_64 = dace.ndarray((2, ), dace.float64)
+    cpp_float(in_32, cpp_out_32)
+    cpp_double(in_64, cpp_out_64)
+
+    dace_out_32 = dace.ndarray((2, ), dace.float32)
+    dace_out_64 = dace.ndarray((2, ), dace.float64)
+    dace_32(in_32, dace_out_32)
+    dace_64(in_64, dace_out_64)
+
+    # Assert single & double precision version don't return the same response.
+    assert (dace_out_32 != dace_out_64).all()
+
+    # Assert single & double precision versions match the cpp baseline.
+    assert (cpp_out_32 == dace_out_32).all()
+    assert (cpp_out_64 == dace_out_64).all()
+
+
+if __name__ == "__main__":
+    test_math_precision()


### PR DESCRIPTION
## Description

`dace/math.h` re-exposes a couple of math functions from `cmath`, e.g. `std::sin(x)`, which has overloads for e.g. `float` and `double`. Some functions, e.g. `asin(x)`, were not exposed in this way. This leads to precision issues when `asin(x)` is called with a `float` because in the generated code, `asin` will be mapped to [the C version](https://en.cppreference.com/c/numeric/math/asin), which is only defined for doubles. There is thus an implicit cast happening of the argument and the computation is done in double precision. Worse, the return type is always a `double`, which will force the rest of the calculation to be up-casted to double precision if `asin()` is used in an expression.

This is a re-hash (including the missing test) of https://github.com/spcl/dace/pull/2364, which grew way too big and is now plucked apart into smaller, more meaningful PRs.

@alexnick83 would you mind giving this another look? I've added a simple test for `asin()` as you asked in https://github.com/spcl/dace/pull/2364#pullrequestreview-4264812947.