### PR TITLE
stree: consider read-after-write when calculating input_memlets of tree nodes

### DIFF
--- a/dace/sdfg/analysis/schedule_tree/treenodes.py
+++ b/dace/sdfg/analysis/schedule_tree/treenodes.py
@@ -108,7 +108,25 @@ class ScheduleTreeScope(ScheduleTreeNode):
 
         # Fast path, no propagation necessary
         if keep_locals:
-            return MemletSet().union(*(gather(c, root) for c in self.children))
+            if not inputs:
+                # for outputs we don't need to care about read after write
+                return MemletSet().union(*(gather(c, root) for c in self.children))
+
+            # for inputs, make sure read-after-write doesn't show up in inputs
+            result = MemletSet()
+            previously_written = MemletSet()
+
+            for child in self.children:
+                c_reads = child.input_memlets(root, **kwargs)
+                for read in c_reads:
+                    if read not in previously_written:
+                        result.add(read)
+
+                # register writes
+                for c_write in child.output_memlets(root, **kwargs):
+                    previously_written.add(c_write)
+
+            return result
 
         root = root if root is not None else self.get_root()
 
@@ -120,6 +138,7 @@ class ScheduleTreeScope(ScheduleTreeNode):
         current_locals = set()
         current_locals |= disallow_propagation
         result = MemletSet()
+        previously_written = MemletSet()
 
         # Loop over children in order, if any new symbol is defined within this scope (e.g., symbol assignment,
         # dynamic map range), consider it as a new local
@@ -133,6 +152,8 @@ class ScheduleTreeScope(ScheduleTreeNode):
             internal_memlets: MemletSet = gather(c, root)
             if propagate:
                 for memlet in internal_memlets:
+                    if memlet in previously_written:
+                        continue
                     result.add(
                         propagate_subset([memlet],
                                          root.containers[memlet.data],
@@ -140,6 +161,11 @@ class ScheduleTreeScope(ScheduleTreeNode):
                                          propagate_values,
                                          undefined_variables=current_locals,
                                          use_dst=not inputs))
+
+            if inputs:
+                # register writes to keep track of read-after-write
+                for c_write in c.output_memlets(root, **kwargs):
+                    previously_written.add(c_write)
 
         return result
 

--- a/tests/schedule_tree/treenodes_test.py
+++ b/tests/schedule_tree/treenodes_test.py
@@ -9,7 +9,7 @@ import pytest
 
 
 @pytest.fixture
-def tasklet() -> nodes.Tasklet:
+def tasklet() -> tn.TaskletNode:
     return tn.TaskletNode(nodes.Tasklet("noop", {}, {}, code="pass"), {}, {})
 
 
@@ -19,7 +19,7 @@ def tasklet() -> nodes.Tasklet:
     tn.GBlock,
     tn.ElseScope,
 ))
-def test_schedule_tree_scope_children(ScopeClass: type[tn.ScheduleTreeScope], tasklet: nodes.Tasklet) -> None:
+def test_schedule_tree_scope_children(ScopeClass: type[tn.ScheduleTreeScope], tasklet: tn.TaskletNode) -> None:
     scope = ScopeClass(children=[tasklet])
 
     for child in scope.children:
@@ -44,7 +44,7 @@ def test_schedule_tree_scope_children(ScopeClass: type[tn.ScheduleTreeScope], ta
     tn.WhileScope,
     tn.DoWhileScope,
 ))
-def test_loop_scope_children(LoopScope: type[tn.LoopScope], tasklet: nodes.Tasklet) -> None:
+def test_loop_scope_children(LoopScope: type[tn.LoopScope], tasklet: tn.TaskletNode) -> None:
     scope = LoopScope(loop=None, children=[tasklet])
 
     for child in scope.children:
@@ -68,7 +68,7 @@ def test_loop_scope_children(LoopScope: type[tn.LoopScope], tasklet: nodes.Taskl
     tn.StateIfScope,
     tn.ElifScope,
 ))
-def test_if_scope_children(IfScope: type[tn.IfScope], tasklet: nodes.Tasklet) -> None:
+def test_if_scope_children(IfScope: type[tn.IfScope | tn.ElifScope], tasklet: tn.TaskletNode) -> None:
     scope = IfScope(condition=None, children=[tasklet])
 
     for child in scope.children:
@@ -92,7 +92,7 @@ def test_if_scope_children(IfScope: type[tn.IfScope], tasklet: nodes.Tasklet) ->
     tn.MapScope,
     tn.ConsumeScope,
 ))
-def test_dataflow_scope_children(DataflowScope: type[tn.DataflowScope], tasklet: nodes.Tasklet) -> None:
+def test_dataflow_scope_children(DataflowScope: type[tn.DataflowScope], tasklet: tn.TaskletNode) -> None:
     scope = DataflowScope(node=None, children=[tasklet])
 
     for child in scope.children:
@@ -136,6 +136,7 @@ def test_scope_inputs_outputs() -> None:
         children=[map_scope],
     )
 
+    assert stree
     assert len(map_scope.input_memlets()) == 0
     assert len(map_scope.output_memlets()) == 2
 
@@ -155,3 +156,4 @@ if __name__ == '__main__':
     test_dataflow_scope_children(tn.DataflowScope, tasklet)
     test_dataflow_scope_children(tn.MapScope, tasklet)
     test_dataflow_scope_children(tn.ConsumeScope, tasklet)
+    test_scope_inputs_outputs()

--- a/tests/schedule_tree/treenodes_test.py
+++ b/tests/schedule_tree/treenodes_test.py
@@ -1,8 +1,10 @@
 # Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
 
 from dace.sdfg.analysis.schedule_tree import treenodes as tn
-from dace import nodes
+from dace import nodes, data, subsets
+from dace import Memlet
 
+import dace
 import pytest
 
 
@@ -107,6 +109,35 @@ def test_dataflow_scope_children(DataflowScope: type[tn.DataflowScope], tasklet:
 
     for child in scope.children:
         assert child.parent == scope
+
+
+def test_scope_inputs_outputs() -> None:
+    write_scalar = tn.TaskletNode(
+        nodes.Tasklet('bla', {}, {'out'}, 'out = 1'),
+        {},
+        {'out': Memlet('scalar[0]')},
+    )
+    read_scalar = tn.TaskletNode(
+        nodes.Tasklet('bla2', {'inp'}, {'out'}, 'out = inp + 1'),
+        {'inp': Memlet('scalar[0]')},
+        {'out': Memlet('A[1]')},
+    )
+    map_scope = tn.MapScope(
+        node=nodes.MapEntry(nodes.Map('map', ['i'], subsets.Range.from_string("0:20"))),
+        children=[write_scalar, read_scalar],
+    )
+
+    stree = tn.ScheduleTreeRoot(
+        name='tester',
+        containers={
+            'A': data.Array(dace.float64, [20]),
+            'scalar': data.Scalar(dace.float64)
+        },
+        children=[map_scope],
+    )
+
+    assert len(map_scope.input_memlets()) == 0
+    assert len(map_scope.output_memlets()) == 2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Every tree node has functions to calculate input and output memlets of that node. Tree scopes have a default implementation to gather all inputs/outputs of their children. That default implementation for scopes didn't consider read after write (within the same scope). This caused "too many inputs" to be returned, which - in turn - caused the dependency analysis of the state boundary inserter to generate wrong results, which - in the end - generated wrong SDFGs from a given schedule tree.

This PR changes the default implementation of `_gather_memlets_in_scope()` to account for read-after-write memlets and adds a test.

This PR is part of a series of commits to bring back the fixes from the June push (i.e. https://github.com/spcl/dace/pull/2364) into `main` as clean commits with test cases.