### PR TITLE
[stree] stree to SDFG fixes

### DIFF
--- a/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
+++ b/dace/sdfg/analysis/schedule_tree/sdfg_to_tree.py
@@ -146,7 +146,7 @@ def _dealias_sdfg(sdfg: SDFG) -> None:
                 for e in nsdfg.all_interstate_edges():
                     repl_dict = dict()
                     syms = e.data.read_symbols()
-                    for memlet in e.data.get_read_memlets(nsdfg.arrays):
+                    for memlet in e.data.get_read_memlets(nsdfg.arrays, include_scalars=True):
                         if memlet.data in child_names:
                             repl_dict[str(memlet)] = unsqueeze_memlet(memlet, parent_edges_inputs[memlet.data].data)
                             if memlet.data in syms:
@@ -279,7 +279,7 @@ def _replace_memlets(sdfg: SDFG, input_mapping: Dict[str, Memlet], output_mappin
     for e in sdfg.all_interstate_edges():
         repl_dict = dict()
         syms = e.data.read_symbols()
-        for memlet in e.data.get_read_memlets(sdfg.arrays):
+        for memlet in e.data.get_read_memlets(sdfg.arrays, include_scalars=True):
             if memlet.data in input_mapping or memlet.data in output_mapping:
                 # If array name is both in the input connectors and output connectors with different
                 # memlets, this is undefined behavior. Prefer output

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -253,7 +253,7 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
         memlets = loop_region.get_meta_read_memlets(self._ctx.root.containers, include_scalars=True)
         self._ensure_data_descriptors(memlets, sdfg)
 
-        cf_region.add_node(loop_region)
+        cf_region.add_node(loop_region, ensure_unique_name=True)
         prefix = self._loop_state_name_prefix(node)
         loop_state = loop_region.add_state(f"{prefix}_loop_state_{id(node)}", is_start_block=True)
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -23,7 +23,6 @@ class StateBoundaryBehavior(Enum):
 
 PREFIX_PASSTHROUGH_IN: Final[str] = "IN_"
 PREFIX_PASSTHROUGH_OUT: Final[str] = "OUT_"
-PREFIX_SINK_TASKLET: Final[str] = "__stree_sink_tasklet"
 
 
 @dataclass
@@ -578,11 +577,10 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
         # connect writes to map_exit node
         for name in to_connect:
-            # Special case:
-            # This tasklet is a sink node and just needs an (empty) memlet connection to the MapExit node.
-            if name.startswith(PREFIX_SINK_TASKLET):
-                tasklet_to_connect, empty_memlet = to_connect[name]
-                self._current_state.add_nedge(tasklet_to_connect, map_exit, empty_memlet)
+            access_node, memlet = to_connect[name]
+            # Special case: connect tasklets without outputs via an empty Memlet to the MapExit node.
+            if isinstance(memlet, Memlet) and memlet.is_empty():
+                self._current_state.add_nedge(access_node, map_exit, memlet)
                 continue
 
             in_connector_name = f"{PREFIX_PASSTHROUGH_IN}{name}"
@@ -592,7 +590,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
             assert new_in_connector == new_out_connector
 
             # connect "inside the map"
-            access_node, memlet = to_connect[name]
             if isinstance(access_node, nodes.NestedSDFG):
                 self._current_state.add_edge(access_node, name, map_exit, in_connector_name, memlet)
             else:
@@ -764,7 +761,7 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
         # Add empty memlet if this tasklet is a sink node
         if isinstance(scope_node, nodes.MapEntry) and not node.out_memlets:
-            to_connect[f"{PREFIX_SINK_TASKLET}_{id(tasklet)}"] = (tasklet, Memlet())
+            to_connect[f"tasklet_{id(tasklet)}"] = (tasklet, Memlet())
 
     def visit_LibraryCall(self, node: tn.LibraryCall, sdfg: SDFG) -> None:
         raise NotImplementedError(f"Support for {type(node)} not yet implemented.")

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -526,8 +526,13 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     assert new_in_connector == True
                     assert new_in_connector == new_out_connector
 
+                if memlet_data in sdfg.arrays:
+                    data_descriptor = sdfg.arrays[memlet_data]
+                else:
+                    _sdfg = self._parent_sdfg_with_array(memlet_data, sdfg)
+                    data_descriptor = _sdfg.arrays[memlet_data]
                 self._current_state.add_edge(outer_map_entry, connector_name, map_entry, connector,
-                                             Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]))
+                                             Memlet.from_array(memlet_data, data_descriptor))
             else:
                 if isinstance(outer_map_entry, SDFG):
                     # Copy data descriptor from parent SDFG and add input connector
@@ -624,13 +629,18 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                 access_cache[name] = write_access_node
 
             access_node = access_cache[name]
+            if name in sdfg.arrays:
+                data_descriptor = sdfg.arrays[name]
+            else:
+                _sdfg = self._parent_sdfg_with_array(name, sdfg)
+                data_descriptor = _sdfg.arrays[name]
             self._current_state.add_memlet_path(map_exit,
                                                 access_node,
                                                 src_conn=out_connector_name,
-                                                memlet=Memlet.from_array(name, sdfg.arrays[name]))
+                                                memlet=Memlet.from_array(name, data_descriptor))
 
             if isinstance(outer_map_entry, nodes.EntryNode):
-                outer_to_connect[name] = (access_node, Memlet.from_array(name, sdfg.arrays[name]))
+                outer_to_connect[name] = (access_node, Memlet.from_array(name, data_descriptor))
             else:
                 assert isinstance(outer_map_entry, SDFG) or outer_map_entry is None
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -776,13 +776,23 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
             self._ctx.access_cache[cache_key] = {}
         access_cache = self._ctx.access_cache[cache_key]
 
-        # assumption source access may or may not yet exist (in this state)
+        # both, source and target nodes, may or may not exist (in this state)
         src_name = node.memlet.data
-        source = access_cache[src_name] if src_name in access_cache else self._current_state.add_read(src_name)
+        if src_name not in access_cache:
+            # cache new read access
+            source_access_node = self._current_state.add_read(src_name)
+            access_cache[src_name] = source_access_node
+        source = access_cache[src_name]
 
-        # assumption: target access node doesn't exist yet
-        assert node.target not in access_cache
-        target = self._current_state.add_write(node.target)
+        target_name = node.target
+        # only re-use cached write-only nodes, e.g. don't create a cycle for
+        # field[5, 0, 0:73] = copy field[0, 0, 0:73]
+        if target_name not in access_cache or self._current_state.out_degree(
+                access_cache[target_name]) > 0 or src_name == target_name:
+            # cache new write access node
+            target_access_node = self._current_state.add_write(node.target)
+            access_cache[node.target] = target_access_node
+        target = access_cache[node.target]
 
         self._current_state.add_memlet_path(source, target, memlet=node.memlet)
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
 from types import TracebackType
-from typing import Final
+from typing import Final, Sequence
 
 from dace import symbolic
 from dace.memlet import Memlet
@@ -223,51 +223,79 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
             if memlet.data not in sdfg.arrays:
                 raise ValueError(f"Parsing AssignNode {node} failed. Can't find {memlet.data} in {sdfg}.")
 
-    def visit_ForScope(self, node: tn.ForScope, sdfg: SDFG) -> None:
+    def _loop_state_name_prefix(self, node: tn.ForScope | tn.WhileScope) -> str:
+        if isinstance(node, tn.ForScope):
+            return "for"
+
+        if isinstance(node, tn.WhileScope):
+            return "while"
+
+        raise NotImplementedError(f"Loop state name prefix not implemented for loop of type {type(node)}.")
+
+    def _add_loop_region(self, node: tn.ForScope | tn.WhileScope, sdfg: SDFG) -> None:
         current_state = self._current_state
-        assert current_state is not None
+        assert current_state is not None  # just to keep pyright happy
         cf_region = current_state.parent_graph
 
-        loop_region = LoopRegion(label=node.loop.label,
-                                 condition_expr=node.loop.loop_condition,
-                                 loop_var=node.loop.loop_variable,
-                                 initialize_expr=node.loop.init_statement,
-                                 update_expr=node.loop.update_statement,
-                                 unroll=node.loop.unroll,
-                                 unroll_factor=node.loop.unroll_factor)
+        loop_region = LoopRegion(
+            label=node.loop.label,
+            condition_expr=node.loop.loop_condition,
+            loop_var=node.loop.loop_variable,
+            initialize_expr=node.loop.init_statement,
+            update_expr=node.loop.update_statement,
+            unroll=node.loop.unroll,
+            unroll_factor=node.loop.unroll_factor,
+            inverted=node.loop.inverted,
+            update_before_condition=node.loop.update_before_condition,
+        )
+
+        memlets = loop_region.get_meta_read_memlets(self._ctx.root.containers, include_scalars=True)
+        self._ensure_data_descriptors(memlets, sdfg)
+
         cf_region.add_node(loop_region)
-        loop_state = loop_region.add_state(f"for_loop_state_{id(node)}", is_start_block=True)
+        prefix = self._loop_state_name_prefix(node)
+        loop_state = loop_region.add_state(f"{prefix}_loop_state_{id(node)}", is_start_block=True)
 
         _insert_and_split_assignments(current_state, loop_region)
 
         self._current_state = loop_state
         self.visit(node.children, sdfg=sdfg)
 
-        after_state = _insert_and_split_assignments(loop_region, label="loop_after")
+        after_state = _insert_and_split_assignments(loop_region, label=f"{prefix}_loop_after")
         self._current_state = after_state
+
+    def visit_ForScope(self, node: tn.ForScope, sdfg: SDFG) -> None:
+        self._add_loop_region(node, sdfg)
 
     def visit_WhileScope(self, node: tn.WhileScope, sdfg: SDFG) -> None:
-        current_state = self._current_state
-        assert current_state is not None
-        cf_region = current_state.parent_graph
-
-        loop_region = node.loop
-        cf_region.add_node(loop_region)
-        loop_state = loop_region.add_state(f"while_loop_state_{id(node)}", is_start_block=True)
-
-        _insert_and_split_assignments(current_state, loop_region)
-
-        self._current_state = loop_state
-        self.visit(node.children, sdfg=sdfg)
-
-        after_state = _insert_and_split_assignments(loop_region, label="loop_after")
-        self._current_state = after_state
+        self._add_loop_region(node, sdfg)
 
     def visit_DoWhileScope(self, node: tn.DoWhileScope, sdfg: SDFG) -> None:
         raise NotImplementedError(f"Support for {type(node)} not yet implemented.")
 
     def visit_LoopScope(self, node: tn.LoopScope, sdfg: SDFG) -> None:
         raise NotImplementedError(f"Support for {type(node)} not yet implemented.")
+
+    def _ensure_data_descriptors(self, memlets: Sequence[Memlet], sdfg: SDFG) -> None:
+        scope_node, to_connect = self._dataflow_stack[-1] if self._dataflow_stack else (None, None)
+        if isinstance(scope_node, SDFG):
+            for memlet in memlets:
+                # Copy data descriptor from parent SDFG and add input connector
+                if memlet.data not in sdfg.arrays:
+                    parent_sdfg = self._parent_sdfg_with_array(memlet.data, sdfg)
+
+                    # Support for  NView nodes
+                    use_nview = self._apply_nview_array_override(memlet.data, sdfg)
+                    if not use_nview:
+                        sdfg.add_datadesc(memlet.data, parent_sdfg.arrays[memlet.data].clone())
+
+                        # Transients passed into a nested SDFG become non-transient inside that nested SDFG
+                        if parent_sdfg.arrays[memlet.data].transient:
+                            sdfg.arrays[memlet.data].transient = False
+
+                    # Dev note: memlet.data and nview.target are identical
+                    assert memlet.data not in to_connect["inputs"]
+                    to_connect["inputs"].add(memlet.data)
 
     def visit_IfScope(self, node: tn.IfScope, sdfg: SDFG) -> None:
         before_state = self._current_state
@@ -284,6 +312,9 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
         if_body = ControlFlowRegion("if_body", sdfg=sdfg)
         conditional_block.add_branch(node.condition, if_body)
+
+        memlets = conditional_block.get_meta_read_memlets(self._ctx.root.containers, include_scalars=True)
+        self._ensure_data_descriptors(memlets, sdfg)
 
         if_state = if_body.add_state("if_state", is_start_block=True)
         self._current_state = if_state

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -23,6 +23,7 @@ class StateBoundaryBehavior(Enum):
 
 PREFIX_PASSTHROUGH_IN: Final[str] = "IN_"
 PREFIX_PASSTHROUGH_OUT: Final[str] = "OUT_"
+PREFIX_SINK_TASKLET: Final[str] = "__stree_sink_tasklet"
 
 
 @dataclass
@@ -510,10 +511,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
             # connect to local access node (if available)
             if memlet_data in access_cache:
                 cached_access = access_cache[memlet_data]
-                self._current_state.add_memlet_path(cached_access,
-                                                    map_entry,
-                                                    dst_conn=connector,
-                                                    memlet=Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]))
+                self._current_state.add_memlet_path(
+                    cached_access,
+                    map_entry,
+                    dst_conn=connector,
+                    memlet=Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]),
+                )
                 continue
 
             if isinstance(outer_map_entry, nodes.EntryNode):
@@ -558,10 +561,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                 assert memlet_data not in access_cache
                 access_cache[memlet_data] = self._current_state.add_read(memlet_data)
                 cached_access = access_cache[memlet_data]
-                self._current_state.add_memlet_path(cached_access,
-                                                    map_entry,
-                                                    dst_conn=connector,
-                                                    memlet=Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]))
+                self._current_state.add_memlet_path(
+                    cached_access,
+                    map_entry,
+                    dst_conn=connector,
+                    memlet=Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]),
+                )
 
         if isinstance(outer_map_entry, nodes.EntryNode) and self._current_state.out_degree(outer_map_entry) < 1:
             self._current_state.add_nedge(outer_map_entry, map_entry, Memlet())
@@ -573,6 +578,13 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
         # connect writes to map_exit node
         for name in to_connect:
+            # Special case:
+            # This tasklet is a sink node and just needs an (empty) memlet connection to the MapExit node.
+            if name.startswith(PREFIX_SINK_TASKLET):
+                tasklet_to_connect, empty_memlet = to_connect[name]
+                self._current_state.add_nedge(tasklet_to_connect, map_exit, empty_memlet)
+                continue
+
             in_connector_name = f"{PREFIX_PASSTHROUGH_IN}{name}"
             out_connector_name = f"{PREFIX_PASSTHROUGH_OUT}{name}"
             new_in_connector = map_exit.add_in_connector(in_connector_name)
@@ -709,8 +721,8 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
             cached_access = cache[memlet.data]
             self._current_state.add_memlet_path(cached_access, tasklet, dst_conn=name, memlet=memlet)
 
-        # Add empty memlet if map_entry has no out_connectors to connect to
-        if isinstance(scope_node, nodes.MapEntry) and self._current_state.out_degree(scope_node) < 1:
+        # Add empty memlet if this tasklet is a source node
+        if isinstance(scope_node, nodes.MapEntry) and not node.in_memlets:
             self._current_state.add_nedge(scope_node, tasklet, Memlet())
 
         # Connect output memlets
@@ -749,6 +761,10 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
             else:
                 assert scope_node is None
+
+        # Add empty memlet if this tasklet is a sink node
+        if isinstance(scope_node, nodes.MapEntry) and not node.out_memlets:
+            to_connect[f"{PREFIX_SINK_TASKLET}_{id(tasklet)}"] = (tasklet, Memlet())
 
     def visit_LibraryCall(self, node: tn.LibraryCall, sdfg: SDFG) -> None:
         raise NotImplementedError(f"Support for {type(node)} not yet implemented.")

--- a/dace/sdfg/analysis/schedule_tree/treenodes.py
+++ b/dace/sdfg/analysis/schedule_tree/treenodes.py
@@ -350,7 +350,7 @@ class AssignNode(ScheduleTreeNode):
 
     def input_memlets(self, root: ScheduleTreeRoot | None = None, **kwargs) -> MemletSet:
         root = root if root is not None else self.get_root()
-        return MemletSet(self.edge.get_read_memlets(root.containers))
+        return MemletSet(self.edge.get_read_memlets(root.containers, include_scalars=True))
 
     def output_memlets(self, root: ScheduleTreeRoot | None = None, **kwargs) -> MemletSet:
         return MemletSet()
@@ -540,7 +540,7 @@ class IfScope(ControlFlowScope):
                       **kwargs) -> MemletSet:
         root = root if root is not None else self.get_root()
         result = MemletSet()
-        result.update(memlets_in_ast(self.condition.code[0], root.containers))
+        result.update(memlets_in_ast(self.condition.code[0], root.containers, include_scalars=True))
         result.update(super().input_memlets(root, **kwargs))
         return result
 
@@ -623,7 +623,7 @@ class ElifScope(ControlFlowScope):
                       **kwargs) -> MemletSet:
         root = root if root is not None else self.get_root()
         result = MemletSet()
-        result.update(memlets_in_ast(self.condition.code[0], root.containers))
+        result.update(memlets_in_ast(self.condition.code[0], root.containers, include_scalars=True))
         result.update(super().input_memlets(root, **kwargs))
         return result
 

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1572,9 +1572,6 @@ def propagate_memlet(dfg_state,
                                   neighboring internal memlets within the same
                                   scope into account.
     """
-    if memlet.is_empty():
-        return Memlet()
-
     use_dst = False
     if isinstance(scope_node, nodes.EntryNode):
         use_dst = False
@@ -1590,8 +1587,9 @@ def propagate_memlet(dfg_state,
             neighboring_edges = [e for e in neighboring_edges if e.dst_conn and e.dst_conn[3:] == connector]
     else:
         raise TypeError('Trying to propagate through a non-scope node')
+    if memlet.is_empty():
+        return Memlet()
 
-    assert entry_node is not None
     sdfg = dfg_state.parent
     scope_node_symbols = set(conn for conn in entry_node.in_connectors if not conn.startswith('IN_'))
     defined_vars = [

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1572,6 +1572,9 @@ def propagate_memlet(dfg_state,
                                   neighboring internal memlets within the same
                                   scope into account.
     """
+    if memlet.is_empty():
+        return Memlet()
+
     use_dst = False
     if isinstance(scope_node, nodes.EntryNode):
         use_dst = False
@@ -1587,9 +1590,8 @@ def propagate_memlet(dfg_state,
             neighboring_edges = [e for e in neighboring_edges if e.dst_conn and e.dst_conn[3:] == connector]
     else:
         raise TypeError('Trying to propagate through a non-scope node')
-    if memlet.is_empty():
-        return Memlet()
 
+    assert entry_node is not None
     sdfg = dfg_state.parent
     scope_node_symbols = set(conn for conn in entry_node.in_connectors if not conn.startswith('IN_'))
     defined_vars = [

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -119,13 +119,14 @@ def _replace_dict_values(d, old, new):
             d[k] = new
 
 
-def memlets_in_ast(node: ast.AST, arrays: Dict[str, dt.Data]) -> List[mm.Memlet]:
+def memlets_in_ast(node: ast.AST, arrays: Dict[str, dt.Data], *, include_scalars: bool = False) -> List[mm.Memlet]:
     """
     Generates a list of memlets from each of the subscripts that appear in the Python AST.
     Assumes the subscript slice can be coerced to a symbolic expression (e.g., no indirect access).
 
     :param node: The AST node to find memlets in.
     :param arrays: A dictionary mapping array names to their data descriptors (a-la ``sdfg.arrays``)
+    :param include_scalars: If True, include Memlets for scalar accesses. Defaults to False to be backwards compatible.
     :return: A list of Memlet objects in the order they appear in the AST.
     """
     result: List[mm.Memlet] = []
@@ -136,6 +137,10 @@ def memlets_in_ast(node: ast.AST, arrays: Dict[str, dt.Data]) -> List[mm.Memlet]
             data, slc = astutils.subscript_to_slice(subnode, arrays)
             subset = sbs.Range(slc)
             result.append(mm.Memlet(data=data, subset=subset))
+        elif include_scalars and isinstance(subnode, ast.Name):
+            data = astutils.rname(subnode)
+            if data in arrays and isinstance(arrays[data], dace.data.Scalar):
+                result.append(mm.Memlet.from_array(data, arrays[data]))
 
     return result
 
@@ -393,19 +398,20 @@ class InterstateEdge(object):
 
         return {k: v for k, v in inferred_lhs_symbols.items() if k in lhs_symbols}
 
-    def get_read_memlets(self, arrays: Dict[str, dt.Data]) -> List[mm.Memlet]:
+    def get_read_memlets(self, arrays: Dict[str, dt.Data], include_scalars: bool = False) -> List[mm.Memlet]:
         """
         Returns a list of memlets (with data descriptors and subsets) used in this edge. This includes
         both reads in the condition and in every assignment.
 
         :param arrays: A dictionary mapping names to their corresponding data descriptors (a-la ``sdfg.arrays``)
+        :param include_scalars: If True, include Memlets for scalar accesses. Defaults to False to be backwards compatible.
         :return: A list of Memlet objects for each read.
         """
         result: List[mm.Memlet] = []
-        result.extend(memlets_in_ast(self.condition.code[0], arrays))
+        result.extend(memlets_in_ast(self.condition.code[0], arrays, include_scalars=include_scalars))
         for assign in self.assignments.values():
             vast = ast.parse(assign)
-            result.extend(memlets_in_ast(vast, arrays))
+            result.extend(memlets_in_ast(vast, arrays, include_scalars=include_scalars))
 
         return result
 

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -161,7 +161,7 @@ class BlockGraphView(object):
     @abc.abstractmethod
     def exit_node(self, entry_node: nd.EntryNode) -> Optional[nd.ExitNode]:
         """ Returns the exit node leaving the context opened by the given entry node. """
-        raise None
+        return None
 
     ###################################################################
     # Memlet-tracking methods

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -3581,23 +3581,26 @@ class LoopRegion(ControlFlowRegion):
             codes.append(self.update_statement)
         return codes
 
-    def get_meta_read_memlets(self, arrays: Optional[Dict[str, dt.Data]] = None) -> List[mm.Memlet]:
+    def get_meta_read_memlets(self,
+                              arrays: Optional[Dict[str, dt.Data]] = None,
+                              include_scalars: bool = False) -> List[mm.Memlet]:
         """
         Get a list of all (read) memlets in meta codeblocks.
 
         :param arrays: An optional dictionary mapping array names to their data descriptors.
             If not not given defaults to ``self.sdfg.arrays``.
+        :param include_scalars: If True, include Memlets for scalar accesses. Defaults to False to be backwards compatible.
         """
         # Avoid cyclic imports.
         from dace.sdfg.sdfg import memlets_in_ast
 
         arrays = arrays if arrays is not None else self.sdfg.arrays
 
-        read_memlets = memlets_in_ast(self.loop_condition.code[0], arrays)
+        read_memlets = memlets_in_ast(self.loop_condition.code[0], arrays, include_scalars=include_scalars)
         if self.init_statement:
-            read_memlets.extend(memlets_in_ast(self.init_statement.code[0], arrays))
+            read_memlets.extend(memlets_in_ast(self.init_statement.code[0], arrays, include_scalars=include_scalars))
         if self.update_statement:
-            read_memlets.extend(memlets_in_ast(self.update_statement.code[0], arrays))
+            read_memlets.extend(memlets_in_ast(self.update_statement.code[0], arrays, include_scalars=include_scalars))
         return read_memlets
 
     def replace_meta_accesses(self, replacements):
@@ -3855,13 +3858,25 @@ class ConditionalBlock(AbstractControlFlowRegion):
                 codes.append(c)
         return codes
 
-    def get_meta_read_memlets(self) -> List[mm.Memlet]:
+    def get_meta_read_memlets(self,
+                              arrays: Optional[Dict[str, dt.Data]] = None,
+                              include_scalars: bool = False) -> List[mm.Memlet]:
+        """
+        Get a list of all (read) memlets in meta codeblocks.
+
+        :param arrays: An optional dictionary mapping array names to their data descriptors.
+            If not not given defaults to ``self.sdfg.arrays``.
+        :param include_scalars: If True, include Memlets for scalar accesses. Defaults to False to be backwards compatible.
+        """
         # Avoid cyclic imports.
         from dace.sdfg.sdfg import memlets_in_ast
+
+        arrays = arrays if arrays is not None else self.sdfg.arrays
+
         read_memlets = []
         for c, _ in self.branches:
             if c is not None:
-                read_memlets.extend(memlets_in_ast(c.code[0], self.sdfg.arrays))
+                read_memlets.extend(memlets_in_ast(c.code[0], arrays, include_scalars=include_scalars))
         return read_memlets
 
     def propagate_memlets(self, border_memlets: Dict[str, Dict[str, Optional[mm.Memlet]]]) -> None:

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -161,7 +161,7 @@ class BlockGraphView(object):
     @abc.abstractmethod
     def exit_node(self, entry_node: nd.EntryNode) -> Optional[nd.ExitNode]:
         """ Returns the exit node leaving the context opened by the given entry node. """
-        return None
+        raise None
 
     ###################################################################
     # Memlet-tracking methods

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -350,6 +350,36 @@ def test_create_loop_for():
     assert tasklet_2.label == "assign_2"
 
 
+def test_create_loop_for_same_name() -> None:
+    loop_1 = tn.ForScope(
+        loop=LoopRegion(label="same_label",
+                        loop_var="i",
+                        initialize_expr=CodeBlock("i = 0 "),
+                        condition_expr=CodeBlock("i < 3"),
+                        update_expr=CodeBlock("i = i+1")),
+        children=[
+            tn.TaskletNode(nodes.Tasklet('assign_1', {}, {'out'}, 'out = 1'), {}, {'out': dace.Memlet('A[1]')}),
+        ],
+    )
+    loop_2 = tn.ForScope(
+        loop=LoopRegion(label="same_label",
+                        loop_var="i",
+                        initialize_expr=CodeBlock("i = 0 "),
+                        condition_expr=CodeBlock("i < 3"),
+                        update_expr=CodeBlock("i = i+1")),
+        children=[
+            tn.TaskletNode(nodes.Tasklet('assign_2', {}, {'out'}, 'out = 2'), {}, {'out': dace.Memlet('A[1]')}),
+        ],
+    )
+    stree = tn.ScheduleTreeRoot(
+        name='tester',
+        containers={'A': data.Array(dace.float64, [20])},
+        children=[loop_1, loop_2],
+    )
+    sdfg = stree.as_sdfg(validate=False, simplify=False)
+    assert sdfg.is_valid()
+
+
 def test_create_loop_while():
     while_scope = tn.WhileScope(
         children=[
@@ -1031,6 +1061,7 @@ if __name__ == '__main__':
     test_create_tasklet_waw()
     test_create_tasklet_war()
     test_create_loop_for()
+    test_create_loop_for_same_name()
     test_create_loop_while()
     test_create_if_else()
     test_create_if_elif_else()

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -501,6 +501,41 @@ def test_create_map_scope_write():
     sdfg.validate()
 
 
+def test_create_map_scope_read():
+    stree = tn.ScheduleTreeRoot(
+        name="tester",
+        containers={'A': data.Array(dace.float64, [20])},
+        children=[
+            tn.MapScope(
+                node=nodes.MapEntry(nodes.Map("bla", "i", sbs.Range.from_string("0:20"))),
+                children=[
+                    tn.TaskletNode(nodes.Tasklet("print_i", {"read"}, {}, "print(read)"), {"read": dace.Memlet("A[i]")},
+                                   {})
+                ],
+            )
+        ],
+    )
+
+    sdfg = stree.as_sdfg(simplify=False)
+    sdfg.validate()
+
+
+def test_create_map_scope_hello_world():
+    stree = tn.ScheduleTreeRoot(
+        name="tester",
+        containers={},
+        children=[
+            tn.MapScope(
+                node=nodes.MapEntry(nodes.Map("bla", "i", sbs.Range.from_string("0:2"))),
+                children=[tn.TaskletNode(nodes.Tasklet("print_hi", {}, {}, "print('Hello world!')"), {}, {})],
+            )
+        ],
+    )
+
+    sdfg = stree.as_sdfg(simplify=False)
+    sdfg.validate()
+
+
 def test_create_map_scope_read_after_write():
     stree = tn.ScheduleTreeRoot(
         name="tester",
@@ -581,6 +616,28 @@ def test_create_map_scope_double_memlet():
                             }, {"out": dace.Memlet("B[i]")})
                         ])
         ])
+
+    sdfg = stree.as_sdfg()
+    sdfg.validate()
+
+
+def test_create_map_scope_write_in_two_tasklets():
+    stree = tn.ScheduleTreeRoot(
+        name="tester",
+        containers={
+            'A': data.Array(dace.float64, [20]),
+            'B': data.Array(dace.float32, [20]),
+        },
+        children=[
+            tn.MapScope(
+                node=nodes.MapEntry(nodes.Map("bla", "i", sbs.Range.from_string("0:20"))),
+                children=[
+                    tn.TaskletNode(nodes.Tasklet("assign_i", {}, {"out"}, "out = i"), {}, {"out": dace.Memlet("A[i]")}),
+                    tn.TaskletNode(nodes.Tasklet("assign_i", {}, {"out"}, "out = i"), {}, {"out": dace.Memlet("B[i]")}),
+                ],
+            )
+        ],
+    )
 
     sdfg = stree.as_sdfg()
     sdfg.validate()
@@ -954,10 +1011,13 @@ if __name__ == '__main__':
     test_create_if_elif_else()
     test_create_if_without_else()
     test_create_map_scope_write()
+    test_create_map_scope_read()
+    test_create_map_scope_hello_world()
     test_create_map_scope_read_after_write()
     test_create_map_scope_write_after_read()
     test_create_map_scope_copy()
     test_create_map_scope_double_memlet()
+    test_create_map_scope_write_in_two_tasklets()
     test_create_nested_map_scope()
     test_double_map_with_for_loop()
     test_triple_map_flat_if()

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -987,6 +987,31 @@ def test_assign_nodes_avoid_duplicate_boundaries():
     assert [type(child) for child in stree.children] == [tn.AssignNode, tn.StateBoundaryNode, tn.TaskletNode]
 
 
+def test_multiple_copy_nodes() -> None:
+    stree = tn.ScheduleTreeRoot(
+        name='tester',
+        containers={
+            'A': data.Array(dace.float64, [20]),
+        },
+        children=[
+            tn.CopyNode('A', dace.Memlet("A[0] -> [10]")),
+            tn.CopyNode('A', dace.Memlet("A[1] -> [11]")),
+            tn.CopyNode('A', dace.Memlet("A[2] -> [12]")),
+        ],
+    )
+
+    sdfg = stree.as_sdfg()
+
+    states = sdfg.states()
+    assert len(states) == 1, "expect one state"
+
+    nodes = states[0].nodes()
+    assert len(nodes) == 4, "expect four access nodes"
+    for node in nodes:
+        assert isinstance(node, dace.nodes.AccessNode)
+        assert node.data == "A"
+
+
 if __name__ == '__main__':
     test_state_boundaries_none()
     test_state_boundaries_waw()
@@ -1029,3 +1054,4 @@ if __name__ == '__main__':
     test_assign_nodes_force_state_transition()
     test_assign_nodes_multiple_force_one_transition()
     test_assign_nodes_avoid_duplicate_boundaries()
+    test_multiple_copy_nodes()

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -730,6 +730,50 @@ def test_triple_map_nested_if():
     sdfg.validate()
 
 
+def test_triple_map_if_condition_outside():
+    stree = tn.ScheduleTreeRoot(
+        name="tester",
+        containers={
+            'A': data.Array(dace.float64, [60]),
+            'tmp': data.Scalar(dace.float64, transient=True),
+        },
+        children=[
+            tn.TaskletNode(nodes.Tasklet('assign', {'read'}, {'out'}, 'out = read'), {'read': dace.Memlet('A[1]')},
+                           {'out': dace.Memlet("tmp[0]")}),
+            tn.MapScope(
+                node=nodes.MapEntry(nodes.Map("map_i", "i", sbs.Range.from_string("0:4"))),
+                children=[
+                    tn.MapScope(
+                        node=nodes.MapEntry(nodes.Map("map_j", "j", sbs.Range.from_string("0:5"))),
+                        children=[
+                            tn.MapScope(
+                                node=nodes.MapEntry(nodes.Map("map_k", "k", sbs.Range.from_string("0:3"))),
+                                children=[
+                                    tn.IfScope(
+                                        condition=CodeBlock("tmp + 1 > 0"),
+                                        children=[
+                                            tn.TaskletNode(nodes.Tasklet("assign", {}, {"out"}, "out = 1"), {},
+                                                           {"out": dace.Memlet("A[i*15+j*3+k]")})
+                                        ],
+                                    ),
+                                    tn.ElseScope(children=[
+                                        tn.TaskletNode(nodes.Tasklet("assign", {}, {"out"}, "out = 2"), {},
+                                                       {"out": dace.Memlet("A[i*15+j*3+k]")})
+                                    ], ),
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    sdfg = stree.as_sdfg(simplify=False)
+    sdfg.validate()
+    sdfg.compile()
+
+
 def test_create_nested_map_scope_multi_read():
     stree = tn.ScheduleTreeRoot(
         name="tester",
@@ -903,14 +947,25 @@ if __name__ == '__main__':
     # test_create_state_boundary_empty_memlet()
     test_create_tasklet_raw()
     test_create_tasklet_waw()
+    test_create_tasklet_war()
     test_create_loop_for()
     test_create_loop_while()
     test_create_if_else()
+    test_create_if_elif_else()
     test_create_if_without_else()
     test_create_map_scope_write()
+    test_create_map_scope_read_after_write()
+    test_create_map_scope_write_after_read()
     test_create_map_scope_copy()
     test_create_map_scope_double_memlet()
     test_create_nested_map_scope()
+    test_double_map_with_for_loop()
+    test_triple_map_flat_if()
+    test_triple_map_if_condition_outside()
     test_create_nested_map_scope_multi_read()
     test_map_with_state_boundary_inside()
+    test_map_calculate_temporary_in_two_loops()
     test_edge_assignment_read_after_write()
+    test_assign_nodes_force_state_transition()
+    test_assign_nodes_multiple_force_one_transition()
+    test_assign_nodes_avoid_duplicate_boundaries()


### PR DESCRIPTION
## Description

This PR brings back a couple of stree -> SDFG fixes from the NASA working branch https://github.com/spcl/dace/pull/2364, which accumulated a bunch of changes last month. In particular, this PR contains

1. consider scalar memlets e.g. when collecting memlets of conditions. our use-case is a conditional inside a triple-nested loop where the conditional depends on a scalar condition that is calculated outside the loop (see test case).
2. connect all source / sink nodes inside a map with empty memlets to the corresponding entry / exit node of the containing map (e.g. see image below of what was wrong before)
3. proper support for (self-assigning) copy nodes
4. ensure unique names of added loop regions (this is enforced by validation)

Support for collecting scalar memlets bleeds out into `sdfg.py` and `state.py`. All changes there (outside the schedule tree world) are fully backwards compatible.

---

problematic stree -> sdfg transformation before fix number 2

<img width="1920" height="1001" alt="image" src="https://github.com/user-attachments/assets/bc798341-bd84-4951-b80f-eed77fbaa653" />
