### PR TITLE
`lru_cache` Type Aware

### DIFF
--- a/dace/codegen/common.py
+++ b/dace/codegen/common.py
@@ -37,7 +37,7 @@ def find_outgoing_edges(node, dfg):
         return list(dfg.out_edges(node))
 
 
-@lru_cache(maxsize=16384)
+@lru_cache(maxsize=16384, typed=True)
 def _sym2cpp(s, arrayexprs):
     return cppunparse.pyexpr2cpp(symbolic.symstr(s, arrayexprs, cpp_mode=True))
 

--- a/dace/codegen/cppunparse.py
+++ b/dace/codegen/cppunparse.py
@@ -1162,6 +1162,6 @@ def py2cpp(code, expr_semicolon=True, defined_symbols=None):
         raise NotImplementedError('Unsupported type for py2cpp')
 
 
-@lru_cache(maxsize=16384)
+@lru_cache(maxsize=16384, typed=True)
 def pyexpr2cpp(expr):
     return py2cpp(expr, expr_semicolon=False)

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -776,7 +776,7 @@ def overapproximate(expr):
     return _overapproximate(expr)
 
 
-@lru_cache(maxsize=2048)
+@lru_cache(maxsize=2048, typed=True)
 def _overapproximate(expr):
     if isinstance(expr, SymExpr):
         if expr.expr != expr.approx:
@@ -2125,7 +2125,7 @@ def serialize_symbolic(expr):
     return _serialize_symbolic_uncached(expr)
 
 
-@lru_cache(maxsize=16384)
+@lru_cache(maxsize=16384, typed=True)
 def deserialize_symbolic(expr) -> SymbolicType:
     """Deserialize a string produced by :func:`serialize_symbolic`."""
     if isinstance(expr, (SymExpr, sympy.Basic)):
@@ -2235,7 +2235,7 @@ def pystr_to_symbolic(expr, symbol_map=None, simplify=None) -> sympy.Basic:
     return _pystr_to_symbolic_uncached(expr, symbol_map, simplify)
 
 
-@lru_cache(maxsize=16384)
+@lru_cache(maxsize=16384, typed=True)
 def _pystr_to_symbolic_cached(expr, simplify=None) -> sympy.Basic:
     return _pystr_to_symbolic_uncached(expr, None, simplify)
 
@@ -2422,7 +2422,7 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
                 return f'({self._print(expr.args[0])}) ** ({self._print(expr.args[1])})'
 
 
-@lru_cache(maxsize=16384)
+@lru_cache(maxsize=16384, typed=True)
 def symstr(sym, arrayexprs: Optional[FrozenSet[str]] = None, cpp_mode=False) -> str:
     """
     Convert a symbolic expression to a compilable expression.
@@ -2520,7 +2520,7 @@ def safe_replace(mapping: Dict[Union[SymbolicType, str], Union[SymbolicType, str
     replace_callback(invrepl)
 
 
-@lru_cache(16384)
+@lru_cache(maxsize=16384, typed=True)
 def _spickle(obj):
     return str(obj)
 


### PR DESCRIPTION
This PR is similar to [PR#2404](https://github.com/spcl/dace/pull/2404) but adds `typed=True` to all `lru_cache`s (except the ones that do not take an argument.