### PR TITLE
Relax non-negative-integer Pow to ipow (fix symbolic-exponent codegen)

### DIFF
--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -131,7 +131,8 @@ def infer_symbols_from_datadescriptor(sdfg: SDFG,
                     sym_dim = sym_dim.subs(repldict)
 
                 if symbolic.issymbolic(sym_dim - real_dim):
-                    equations.append(sym_dim - real_dim)
+                    # ipow is semantically Pow; restore it so the solver can invert the shape.
+                    equations.append((sym_dim - real_dim).replace(symbolic.ipow, lambda b, e: b**e))
 
     if len(symbols) == 0:
         return {}

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -911,8 +911,8 @@ def swalk(expr, enter_functions=False):
 
 
 _builtin_userfunctions = {
-    'int_floor', 'int_ceil', 'abs', 'Abs', 'min', 'Min', 'max', 'Max', 'not', 'Not', 'Eq', 'NotEq', 'Ne', 'AND', 'OR',
-    'pow', 'round'
+    'int_floor', 'int_ceil', 'ipow', 'abs', 'Abs', 'min', 'Min', 'max', 'Max', 'not', 'Not', 'Eq', 'NotEq', 'Ne',
+    'AND', 'OR', 'pow', 'round'
 }
 
 
@@ -1091,6 +1091,28 @@ class int_ceil(sympy.Function):
 
     def _eval_is_integer(self):
         return True
+
+
+class ipow(sympy.Function):
+    """Integer power ``base ** exp`` with a non-negative integer exponent, lowered
+    to ``dace::math::ipow`` (repeated multiply, exact integer) -- valid where
+    ``dace::math::pow`` (libm ``double``) is not: an array size, subscript or loop
+    bound.  ``RelaxIntegerPowers`` mints these from ``Pow``."""
+
+    @classmethod
+    def eval(cls, base, exp):
+        if base.is_Number and exp.is_Number and exp.is_integer and exp.is_nonnegative:
+            return base**exp
+
+    def _eval_is_integer(self):
+        base, exp = self.args
+        if base.is_integer and exp.is_integer:
+            return True
+
+    def _eval_is_positive(self):
+        base, _exp = self.args
+        if base.is_positive:
+            return True
 
 
 class OR(sympy.Function):
@@ -2203,6 +2225,7 @@ _PYSTR2SYM_locals = {
     'int_floor': int_floor,
     '__int_floor': __int_floor,
     'int_ceil': int_ceil,
+    'ipow': ipow,
     'IfExpr': IfExpr,
     'Mod': sympy.Mod,
     'Attr': Attr,
@@ -2348,6 +2371,8 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
         if base == 'int_floor' and as_operator:
             op = '/' if self.cpp_mode else '//'
             return '((%s) %s (%s))' % (self._print(expr.args[0]), op, self._print(expr.args[1]))
+        if str(expr.func) == 'ipow' and self.cpp_mode:
+            return 'dace::math::ipow(%s, %s)' % (self._print(expr.args[0]), self._print(expr.args[1]))
         if str(expr.func) == 'IfExpr':
             cond, tval, fval = (self._print(a) for a in expr.args)
             if self.cpp_mode:

--- a/dace/transformation/passes/relax_integer_powers.py
+++ b/dace/transformation/passes/relax_integer_powers.py
@@ -1,0 +1,267 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""``RelaxIntegerPowers`` -- lower ``base ** exp`` to ``ipow`` where the exponent
+is a non-negative integer.
+
+DaCe's symbolic C++ printer emits ``dace::math::pow`` (libm, ``double``) for a
+non-constant exponent, which is illegal where an integer is required -- an array
+size, a subscript, or a loop bound.  ``dace::math::ipow`` (repeated multiply,
+exact integer) is correct there iff the exponent is a non-negative integer (its
+C++ exponent is ``unsigned``, so a negative one is catastrophic).
+
+This pass rewrites ``Pow(base, exp) -> ipow(base, exp)`` whenever ``exp`` is
+provably a non-negative integer:
+
+* a non-negative integer constant (``3``) or an integer-valued float constant
+  (``2.0``, ``3.0``); or
+* a symbolic integer expression proven ``>= 0`` by interval analysis over the
+  enclosing loop / map iterator ranges -- e.g. ``K - i - 1`` with the loop
+  ``for i in range(K)`` giving ``i in [0, K-1]``, so the exponent bottoms out at
+  ``0``.
+
+A provably-negative exponent (a genuine reciprocal) is left on the ``pow`` path.
+See :class:`dace.symbolic.ipow`.
+"""
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+import sympy
+
+from dace import SDFG, data, subsets, symbolic
+from dace.sdfg import nodes
+from dace.sdfg.state import LoopRegion
+from dace.symbolic import ipow
+from dace.transformation import pass_pipeline as ppl, transformation
+from dace.transformation.passes.analysis import loop_analysis
+
+#: A per-symbol inclusive iteration range ``name -> (low, high)``.  Keyed by
+#: symbol *name* (not object) so a mismatch in SymPy assumptions between the
+#: iterator declaration and its use in an exponent cannot hide the range.
+_RangeMap = Dict[str, Tuple[symbolic.SymbolicType, symbolic.SymbolicType]]
+
+
+def _iterator_ranges(sdfg: SDFG) -> _RangeMap:
+    """Collect inclusive ``[low, high]`` ranges of every loop / map iterator.
+
+    A symbol seen with two different ranges (e.g. the map parameter ``__i0``
+    reused by unrelated maps) is dropped -- an ambiguous bound is no bound.
+    """
+    ranges: _RangeMap = {}
+    dropped = set()
+
+    def add(name, low, high):
+        key = str(name)
+        if key in dropped:
+            return
+        val = (low, high)
+        if key in ranges and ranges[key] != val:
+            del ranges[key]
+            dropped.add(key)
+            return
+        ranges[key] = val
+
+    for sd in sdfg.all_sdfgs_recursive():
+        for state in sd.all_states():
+            for node in state.nodes():
+                if isinstance(node, nodes.MapEntry):
+                    for param, (low, high, _step) in zip(node.map.params, node.map.range.ranges):
+                        add(param, low, high)  # DaCe map ranges are inclusive
+        for region in sd.all_control_flow_regions():
+            if not isinstance(region, LoopRegion) or not region.loop_variable:
+                continue
+            start = loop_analysis.get_init_assignment(region)
+            end = loop_analysis.get_loop_end(region)  # inclusive
+            if start is None or end is None:
+                continue
+            step = loop_analysis.get_loop_stride(region)
+            if step is not None and step.is_negative:
+                add(region.loop_variable, end, start)
+            else:
+                add(region.loop_variable, start, end)
+    return ranges
+
+
+def _proven_nonnegative(exp: sympy.Expr, ranges: _RangeMap) -> bool:
+    """Is ``exp`` provably ``>= 0``?
+
+    First trust SymPy's own assumptions (covers ``R**K`` / ``R**(K-1)`` when the
+    base symbols are positive).  Otherwise minimise ``exp`` over the iterator
+    box: for an exponent affine in each iterator, its minimum sits at a corner
+    -- the iterator's high end where its coefficient is negative, its low end
+    otherwise -- so substitute those corners and test the residual's sign.
+    """
+    if exp.is_nonnegative:
+        return True
+    if exp.is_negative:
+        return False
+
+    # The exponent's symbols carry the SDFG's real assumptions; a range bound
+    # parsed out of a loop condition (via ``loop_analysis``) may spell the same
+    # symbol with different assumptions, so ``K_exp - K_loop`` would not cancel.
+    # Rebind range-bound symbols onto the exponent's like-named symbols first.
+    canonical = {s.name: s for s in exp.free_symbols}
+
+    def rebind(bound):
+        if not symbolic.issymbolic(bound):
+            return bound
+        return bound.subs({s: canonical[s.name] for s in bound.free_symbols if s.name in canonical})
+
+    corners = {}
+    for sym in exp.free_symbols:
+        if sym.name not in ranges:
+            continue  # a free symbol we cannot bound stays in the residual
+        coeff = sympy.diff(exp, sym)
+        if not coeff.is_number:
+            return False  # non-affine in an iterator -> no simple corner minimum
+        low, high = ranges[sym.name]
+        corners[sym] = rebind(high) if coeff.is_negative else rebind(low)
+    if not corners:
+        return False  # not provable by assumptions and no iterator to bound
+    return exp.subs(corners).is_nonnegative is True
+
+
+def _authoritative_symbols(sdfg: SDFG) -> Dict[str, sympy.Symbol]:
+    """Map each symbol name to its strongest sign assumption seen anywhere in the
+    SDFG.
+
+    DaCe loses a symbol's assumptions across some copies -- the same ``K``
+    declared ``positive`` on an array shape can reappear sign-less on a map
+    range, so ``R**K`` would relax in one place and not the other.  A symbol
+    declared positive/nonnegative *anywhere* holds that everywhere (it is one
+    logical symbol), so this rebinds every occurrence to the strongest witness.
+    """
+    auth: Dict[str, sympy.Symbol] = {}
+    for expr in _size_expressions(sdfg):
+        for sym in expr.free_symbols:
+            if not isinstance(sym, sympy.Symbol):
+                continue
+            current = auth.get(sym.name)
+            if current is None:
+                auth[sym.name] = sym
+            elif sym.is_positive and not current.is_positive:
+                auth[sym.name] = sym
+            elif sym.is_nonnegative and not current.is_nonnegative and not current.is_positive:
+                auth[sym.name] = sym
+    return auth
+
+
+def _relaxed_exponent(exp: sympy.Expr, ranges: _RangeMap, auth: Dict[str, sympy.Symbol]) -> Optional[sympy.Expr]:
+    """Return the integer exponent to feed ``ipow``, or ``None`` to keep ``pow``."""
+    if exp.is_Number:
+        if exp.is_integer:
+            value = int(exp)
+        elif exp.is_real and float(exp) == int(float(exp)):
+            value = int(float(exp))  # integer-valued float literal (2.0 -> 2)
+        else:
+            return None  # genuinely fractional (0.5 -> sqrt) -> not an integer power
+        return sympy.Integer(value) if value >= 0 else None  # negative -> reciprocal
+    # Prove on the assumption-canonicalized exponent, but emit ``ipow`` with the
+    # original symbols so it matches its surrounding expression.
+    canon = exp.xreplace({s: auth[s.name] for s in exp.free_symbols if s.name in auth})
+    if canon.is_integer and _proven_nonnegative(canon, ranges):
+        return exp
+    return None
+
+
+def _subset_exprs(sub) -> Iterator[sympy.Expr]:
+    """Yield the symbolic components of a memlet subset."""
+    if isinstance(sub, subsets.Range):
+        for rng in sub.ranges:
+            yield from rng
+    elif isinstance(sub, subsets.Indices):
+        yield from sub.indices
+
+
+def _size_expressions(sdfg: SDFG) -> Iterator[sympy.Expr]:
+    """Yield every symbolic size / subscript / bound expression (read-only)."""
+    for sd in sdfg.all_sdfgs_recursive():
+        for desc in sd.arrays.values():
+            for seq in (desc.shape, desc.strides, desc.offset):
+                for item in seq:
+                    if symbolic.issymbolic(item):
+                        yield item
+            if symbolic.issymbolic(desc.total_size):
+                yield desc.total_size
+        for state in sd.all_states():
+            for node in state.nodes():
+                if isinstance(node, nodes.MapEntry):
+                    for item in _subset_exprs(node.map.range):
+                        if symbolic.issymbolic(item):
+                            yield item
+            for edge in state.edges():
+                if edge.data is None:
+                    continue
+                for sub in (edge.data.subset, edge.data.other_subset):
+                    if sub is not None:
+                        for item in _subset_exprs(sub):
+                            if symbolic.issymbolic(item):
+                                yield item
+
+
+def _relax_subset(sub, relax) -> None:
+    """Rewrite a memlet subset's components in place with ``relax`` (expr -> expr)."""
+    if isinstance(sub, subsets.Range):
+        sub.ranges = [tuple(relax(component) for component in rng) for rng in sub.ranges]
+    elif isinstance(sub, subsets.Indices):
+        sub.indices = [relax(idx) for idx in sub.indices]
+
+
+@transformation.explicit_cf_compatible
+class RelaxIntegerPowers(ppl.Pass):
+    """Lower non-negative-integer ``Pow`` to ``ipow`` across the SDFG's size,
+    subscript and bound expressions."""
+
+    CATEGORY: str = 'Simplification'
+
+    def modifies(self) -> ppl.Modifies:
+        return ppl.Modifies.Descriptors | ppl.Modifies.Memlets | ppl.Modifies.Nodes
+
+    def should_reapply(self, _modified: ppl.Modifies) -> bool:
+        # Idempotent: an ``ipow`` is never re-relaxed.
+        return False
+
+    def depends_on(self):
+        return set()
+
+    def apply_pass(self, sdfg: SDFG, _pipeline_results: Dict[str, Any]) -> Optional[int]:
+        # Fast out (this pass runs on every SimplifyPass iteration): nothing to do
+        # without a power to relax.
+        if not any(expr.has(sympy.Pow) for expr in _size_expressions(sdfg)):
+            return None
+        ranges = _iterator_ranges(sdfg)
+        auth = _authoritative_symbols(sdfg)
+        relaxed = [0]
+
+        def relax(expr):
+            """Rewrite each provable ``Pow`` in ``expr`` to ``ipow`` (SymPy-native)."""
+            if not symbolic.issymbolic(expr):
+                return expr
+
+            def to_ipow(base, exp):
+                new_exp = _relaxed_exponent(exp, ranges, auth)
+                if new_exp is None:
+                    return base**exp
+                relaxed[0] += 1
+                return ipow(base, new_exp)
+
+            return expr.replace(sympy.Pow, to_ipow)
+
+        for sd in sdfg.all_sdfgs_recursive():
+            for desc in sd.arrays.values():
+                if not isinstance(desc, data.Array):
+                    continue  # Scalar / Stream have no settable shape / strides / offset
+                desc.shape = tuple(relax(item) for item in desc.shape)
+                desc.strides = tuple(relax(item) for item in desc.strides)
+                desc.offset = tuple(relax(item) for item in desc.offset)
+                desc.total_size = relax(desc.total_size)
+            for state in sd.all_states():
+                for node in state.nodes():
+                    if isinstance(node, nodes.MapEntry):
+                        _relax_subset(node.map.range, relax)
+                for edge in state.edges():
+                    if edge.data is not None:
+                        for sub in (edge.data.subset, edge.data.other_subset):
+                            if sub is not None:
+                                _relax_subset(sub, relax)
+        return relaxed[0] or None
+
+
+__all__ = ['RelaxIntegerPowers']

--- a/dace/transformation/passes/simplify.py
+++ b/dace/transformation/passes/simplify.py
@@ -21,6 +21,7 @@ from dace.transformation.passes.simplification.control_flow_raising import Contr
 from dace.transformation.passes.simplification.prune_empty_conditional_branches import PruneEmptyConditionalBranches
 from dace.transformation.passes.simplification.continue_to_condition import ContinueToCondition
 from dace.transformation.passes.empty_loop_elimination import EmptyLoopElimination
+from dace.transformation.passes.relax_integer_powers import RelaxIntegerPowers
 
 SIMPLIFY_PASSES = [
     InlineSDFGs,
@@ -40,6 +41,7 @@ SIMPLIFY_PASSES = [
     ConsolidateEdges,
     ContinueToCondition,
     EmptyLoopElimination,
+    RelaxIntegerPowers,
 ]
 
 _nonrecursive_passes = [

--- a/tests/npbench/misc/stockham_fft_test.py
+++ b/tests/npbench/misc/stockham_fft_test.py
@@ -140,12 +140,10 @@ def run_stockham_fft(device_type: dace.dtypes.DeviceType):
     return sdfg
 
 
-@pytest.mark.skip(reason="Assertion error in read_and_write_sets")
 def test_cpu():
     run_stockham_fft(dace.dtypes.DeviceType.CPU)
 
 
-@pytest.mark.skip(reason="Assertion error in read_and_write_sets")
 @pytest.mark.gpu
 def test_gpu():
     run_stockham_fft(dace.dtypes.DeviceType.GPU)

--- a/tests/passes/relax_integer_powers_test.py
+++ b/tests/passes/relax_integer_powers_test.py
@@ -1,0 +1,123 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests for the ``ipow`` symbolic Function and the ``RelaxIntegerPowers`` pass."""
+import numpy as np
+import sympy
+
+import dace
+from dace import symbolic
+from dace.symbolic import ipow, pystr_to_symbolic, symstr
+from dace.transformation.passes.relax_integer_powers import (RelaxIntegerPowers, _proven_nonnegative, _relaxed_exponent)
+
+
+# --------------------------------------------------------------------------- #
+# ipow symbolic Function
+# --------------------------------------------------------------------------- #
+def test_ipow_lowers_to_cpp_ipow():
+    R, K = (symbolic.symbol(s, positive=True, integer=True) for s in ('R', 'K'))
+    assert 'dace::math::ipow(R, K)' in symstr(ipow(R, K), cpp_mode=True)
+
+
+def test_ipow_roundtrips_through_serialization():
+    R, K, i = (symbolic.symbol(s) for s in ('R', 'K', 'i'))
+    e = R * ipow(R, K - i - 1) + ipow(R, K - i - 1)
+    back = pystr_to_symbolic(str(e))
+    # Structural (assumption-free) identity: the C++ rendering must match.
+    assert symstr(e, cpp_mode=True) == symstr(back, cpp_mode=True)
+    assert any(type(a).__name__ == 'ipow' for a in sympy.preorder_traversal(back))
+
+
+def test_ipow_is_integer_and_positive():
+    R, K = (symbolic.symbol(s, positive=True, integer=True) for s in ('R', 'K'))
+    assert ipow(R, K).is_integer is True
+    assert ipow(R, K).is_positive is True
+
+
+def test_ipow_folds_constant_power():
+    assert ipow(sympy.Integer(2), sympy.Integer(10)) == 1024
+
+
+# --------------------------------------------------------------------------- #
+# Interval analysis (the soundness crux)
+# --------------------------------------------------------------------------- #
+def test_interval_proves_radix_decomposition():
+    K = symbolic.symbol('K', positive=True, integer=True)
+    i = symbolic.symbol('i', integer=True)
+    ranges = {'i': (0, K - 1)}  # loop ``for i in range(K)``
+    # K - i - 1 bottoms out at 0 when i = K-1; i bottoms out at 0.
+    assert _proven_nonnegative(K - i - 1, ranges) is True
+    assert _proven_nonnegative(i, ranges) is True
+    assert _proven_nonnegative(K, ranges) is True  # positive symbol, no iterator
+
+
+def test_interval_refuses_unbounded_iterator():
+    K = symbolic.symbol('K', positive=True, integer=True)
+    i = symbolic.symbol('i', integer=True)
+    # Without a range for i, K - i - 1 could be negative -> must not relax.
+    assert _proven_nonnegative(K - i - 1, {}) is False
+
+
+def test_interval_refuses_provably_negative():
+    i = symbolic.symbol('i', positive=True, integer=True)
+    assert _proven_nonnegative(-i, {}) is False
+
+
+def test_interval_canonicalizes_mismatched_assumptions():
+    # The exponent's K is positive but the range bound's K (as if parsed from a
+    # loop condition) is assumption-less; they must still cancel to 0.
+    K_pos = symbolic.symbol('K', positive=True, integer=True)
+    K_bare = sympy.Symbol('K')
+    i = symbolic.symbol('i', integer=True)
+    assert _proven_nonnegative(K_pos - i - 1, {'i': (0, K_bare - 1)}) is True
+
+
+# --------------------------------------------------------------------------- #
+# Exponent classification
+# --------------------------------------------------------------------------- #
+def test_relaxes_symbolic_and_constant_exponents():
+    K = symbolic.symbol('K', positive=True, integer=True)
+    i = symbolic.symbol('i', integer=True)
+    ranges, auth = {'i': (0, K - 1)}, {'K': K, 'i': i}
+    assert _relaxed_exponent(K - i - 1, ranges, auth) == K - i - 1  # symbolic, proven
+    assert _relaxed_exponent(sympy.Integer(3), ranges, auth) == 3  # integer constant
+    assert _relaxed_exponent(sympy.Float(2.0), ranges, auth) == 2  # integer-valued float
+
+
+def test_refuses_fractional_and_negative_exponents():
+    assert _relaxed_exponent(sympy.Rational(1, 2), {}, {}) is None  # sqrt -> keep pow
+    assert _relaxed_exponent(sympy.Integer(-2), {}, {}) is None  # reciprocal -> keep pow
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: stockham-like complex array with a symbolic-power shape
+# --------------------------------------------------------------------------- #
+def test_end_to_end_complex_power_shape_compiles():
+    """A ``complex128`` array whose shape ``R**K`` is a symbolic power -- the
+    stockham-fft shape.
+
+    Both the array size and the ``0:R**K`` map bound are that symbolic power.
+    ``dace::math::pow`` would render them as ``double`` (an illegal C++ array
+    size / loop predicate), so the pass must relax them to ``ipow`` for the
+    kernel to compile at all -- and it must stay bit-exact with NumPy.
+    """
+    R = dace.symbol('R', positive=True, integer=True)
+    K = dace.symbol('K', positive=True, integer=True)
+
+    sdfg = dace.SDFG('power_shape')
+    sdfg.add_array('x', [R**K], dace.complex128)
+    state = sdfg.add_state()
+    state.add_mapped_tasklet('scale',
+                             dict(j=f'0:{R**K}'), {'a': dace.Memlet('x[j]')},
+                             'b = a * 2.0', {'b': dace.Memlet('x[j]')},
+                             external_edges=True)
+
+    assert RelaxIntegerPowers().apply_pass(sdfg, {}) is not None
+    # Both the descriptor size and the map bound became ``ipow`` (not double pow).
+    assert any(
+        isinstance(e, sympy.Basic) and e.atoms(ipow) for d in sdfg.arrays.values()
+        for e in (*d.shape, d.total_size)), "expected a relaxed ipow array size"
+
+    Rv, Kv = 2, 4  # N = R**K = 16
+    x = (np.arange(1, Rv**Kv + 1) + 1j * np.arange(1, Rv**Kv + 1)).astype(np.complex128)
+    ref = x * 2.0
+    sdfg(x=x, R=Rv, K=Kv)
+    assert np.allclose(x, ref)


### PR DESCRIPTION
## Problem

DaCe's symbolic C++ printer emits `dace::math::pow` (libm, `double`) for a non-constant exponent. That `double` is illegal where C++ requires an integer -- an array size, a subscript, or a loop bound. A radix decomposition such as `R**(K-i-1)` used as a stride (stockham_fft) therefore fails to compile:

```
error: invalid types 'dace::complex128*[double]' for array subscript
```

`dace::math::ipow` (repeated multiply, exact integer) is the correct lowering, but only when the exponent is a non-negative integer (its C++ exponent is `unsigned`).

## Change

- **`ipow` SymPy Function** (`dace/symbolic.py`): lowers to `dace::math::ipow`, registered so it round-trips through parsing and serialization.
- **`RelaxIntegerPowers` pass**: rewrites `Pow(b, e) -> ipow(b, e)` when `e` is a non-negative integer -- a constant, an integer-valued float literal (`2.0`), or a symbolic exponent proven `>= 0` by interval analysis over the enclosing loop / map iterator ranges (`K-i-1` with `i in [0, K-1]` bottoms out at 0). Wired last in `SIMPLIFY_PASSES` with a Pow-free fast out. A provably-negative exponent (a reciprocal) stays on the `pow` path.
- **`infer_symbols_from_datadescriptor`**: reads `ipow` as `Pow` when solving a shape for its symbols (the opaque `ipow` is otherwise not invertible by `sympy.solve`).
- Unskip the `stockham_fft` CPU test; add `tests/passes/relax_integer_powers_test.py`.

## Testing

- `stockham_fft` now compiles and is bit-exact against the NumPy reference.
- `tests/passes/relax_integer_powers_test.py` (11 tests): ipow lowering / round-trip, interval analysis, exponent classification, and an end-to-end complex power-shape kernel.
- No regressions: the polybench + npbench canonicalize corpus shows zero PASS->FAIL when run with vs. without the pass; the core symbolic / inference / simplify suites stay green.

## Note for reviewers

Because the pass also relaxes *constant* integer exponents, every symbolic multi-dimensional array's `total_size` (e.g. `N**2`) now lowers to `ipow(N, 2)` rather than `(N)*(N)`. This is value-identical and caused no regressions, but it is a broad change in generated size expressions -- flagging it as an intentional design choice worth a conscious ack.
