### PR TITLE
Remove incompatible header

### DIFF
--- a/tests/torch_forward/test_cpp_extension.py
+++ b/tests/torch_forward/test_cpp_extension.py
@@ -18,8 +18,6 @@ op_source = """
 #include <torch/torch.h>
 #include <torch/script.h>
 
-#include <ATen/NamedTensorUtils.h>
-
 using torch::Tensor;
 using torch::DeviceType;
 using torch::autograd::tensor_list;


### PR DESCRIPTION
PyTorch 2.13 removed Named Tensors (https://github.com/pytorch/pytorch/pull/173895)