### PR TITLE
fix: new `dace.math.atan2` requires two arguments

### DIFF
--- a/dace/runtime/include/dace/math.h
+++ b/dace/runtime/include/dace/math.h
@@ -627,9 +627,9 @@ namespace dace
             return std::atan(a);
         }
         template<typename T>
-        DACE_CONSTEXPR DACE_HDFI T atan2(const T& a)
+        DACE_CONSTEXPR DACE_HDFI T atan2(const T& a, const T& b)
         {
-            return std::atan2(a);
+            return std::atan2(a, b);
         }
         template<typename T>
         DACE_CONSTEXPR DACE_HDFI T tanh(const T& a)


### PR DESCRIPTION
## Description

Quick follow-up from https://github.com/spcl/dace/pull/2418. `std::atan2` exposed as `dace.math.atan2` computes the arc tangent of `y / x` and thus requires two arguments.