### PR TITLE
docs: fix docstring of `SDFG.read_and_write_sets()`

### DIFF
--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1478,9 +1478,10 @@ class SDFG(ControlFlowRegion):
 
     def read_and_write_sets(self) -> Tuple[Set[AnyStr], Set[AnyStr]]:
         """
-        Determines what data containers are read and written in this SDFG. Does
-        not include reads to subsets of containers that have previously been
-        written within the same state.
+        Determines what data containers are read and written in this SDFG.
+
+        Includes all reads including reads to subsets of containers that have
+        previously been written.
 
         :return: A two-tuple of sets of things denoting
                  ({data read}, {data written}).


### PR DESCRIPTION
## Description

Since PR https://github.com/spcl/dace/pull/1678 merged, the docstring of `SDFG.read_and_write_sets()` is outdated because the behavior of `SDFGState._read_and_write_sets()` changed. Read after write situations are no longer considered as explained in the the added NOTE in `SDFGState._read_and_write_sets()`:

https://github.com/spcl/dace/blob/bcb0257f89b0c110330da43eee9e3ed77163b92a/dace/sdfg/state.py#L803-L807

This PR suggests to change the docstring of `SDFG.read_and_write_sets()` to avoid wrong expectations of users.

/cc @philip-paul-mueller 