### PR TITLE
Fix symbol-promotion and squeezing behavior in Frontend

### DIFF
--- a/dace/frontend/python/replacements/array_manipulation.py
+++ b/dace/frontend/python/replacements/array_manipulation.py
@@ -210,6 +210,25 @@ def _transpose(pv: ProgramVisitor,
 
     restype = arr1.dtype
     new_shape = [arr1.shape[i] for i in axes]
+    # Strict numpy: a 2D array with a unit dim (``(N, 1)`` / ``(1, N)``) transposes to the swapped
+    # shape. With one axis of length 1 the transpose is a straight positional copy of the N elements
+    # (no permutation) -- squeeze the unit axis on both sides and copy. This is stride-safe (the unit
+    # axis is dropped as a view, unlike a reshape that reinterprets strides), and it sidesteps the
+    # Transpose library node, which squeezes the subset to a vector and then rejects it as "not a matrix".
+    if len(arr1.shape) == 2 and 1 in arr1.shape:
+        if outname is None:
+            outname = pv.get_target_name()
+        outname, arr2 = sdfg.add_transient(outname, new_shape, restype, arr1.storage, find_new_name=True)
+        vec = arr1.shape[0] if arr1.shape[1] == 1 else arr1.shape[1]
+        in_idx = "__i, 0" if arr1.shape[1] == 1 else "0, __i"
+        out_idx = "0, __i" if new_shape[0] == 1 else "__i, 0"
+        state.add_mapped_tasklet("transpose_unit_dim",
+                                 map_ranges={"__i": "0:%s" % vec},
+                                 inputs={"__inp": Memlet("%s[%s]" % (inpname, in_idx))},
+                                 code="__out = __inp",
+                                 outputs={"__out": Memlet("%s[%s]" % (outname, out_idx))},
+                                 external_edges=True)
+        return outname
     if outname is None:
         outname = pv.get_target_name()
     outname, arr2 = sdfg.add_transient(outname, new_shape, restype, arr1.storage, find_new_name=True)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -2217,11 +2217,37 @@ class SDFG(ControlFlowRegion):
                 if sym.name not in sdfg.symbols and sym.name not in sdfg.arg_names:
                     sdfg.add_symbol(sym.name, sym.dtype)
 
+        # A shape symbol of the incoming descriptor may already be a data descriptor: a size the frontend
+        # materialized as a scalar (e.g. ``Nt+1`` -> scalar ``Nt_plus_1``) then used symbolically. Promote
+        # that size scalar to a symbol first, so it does not collide with add_symbol below.
+        for sym in datadesc.free_symbols:
+            existing = self._arrays.get(sym.name)
+            if existing is not None and sym.name not in self.symbols and existing.total_size == 1:
+                self._promote_size_scalar_to_symbol(sym.name)
+
         # Add the data descriptor to the SDFG and all symbols that are not yet known.
         self._arrays[name] = datadesc
         _add_symbols(self, datadesc)
 
         return name
+
+    def _promote_size_scalar_to_symbol(self, name: str) -> None:
+        """Promote a size-1 data descriptor used as a shape symbol -- a size the frontend materialized as a
+        scalar (e.g. ``Nt+1`` -> ``Nt_plus_1``) then used symbolically -- into an SDFG symbol, so it can serve
+        as a shape without colliding with :func:`add_symbol`. A length-1 array is reduced to a scalar first.
+        Restricts ScalarToSymbolPromotion to ``name`` (which handles any size-1 descriptor, scalar or len-1
+        array); raises if it is not a promotable size scalar."""
+        # scalar_to_symbol lives under transformation; import lazily to avoid a core<-transformation cycle
+        from dace.transformation.passes.scalar_to_symbol import ScalarToSymbolPromotion, find_promotable_scalars
+        props = dict(transients_only=False, readonly_inputs=True, unwrap_integer_casts=True)
+        promotable = find_promotable_scalars(self, **props)
+        if name not in promotable:
+            raise FileExistsError(f'Cannot create symbol "{name}": the like-named data descriptor is not a '
+                                  f'promotable size scalar.')
+        promo = ScalarToSymbolPromotion()
+        promo.transients_only, promo.readonly_inputs, promo.unwrap_integer_casts = False, True, True
+        promo.ignore = promotable - {name}  # promote ONLY this size scalar
+        promo.apply_pass(self, {})
 
     def add_datadesc_view(self, name: str, datadesc: dt.Data, find_new_name=False) -> str:
         """ Adds a view of a given data descriptor to the SDFG array store.

--- a/tests/size_scalar_shape_promotion_test.py
+++ b/tests/size_scalar_shape_promotion_test.py
@@ -1,0 +1,28 @@
+"""A size the numpy frontend materializes as a data descriptor (``np.empty(Nt+1)`` -> ``Nt_plus_1``) and
+then uses as that array's SHAPE must be promoted to a symbol when the next descriptor is added, not collide
+with ``add_symbol`` (which raised ``FileExistsError: ... used by a data descriptor``)."""
+import numpy as np
+
+import dace
+
+N = dace.symbol("N")
+
+
+@dace.program
+def size_scalar_shape_prog(a: dace.float64[N], Nt: dace.int64):
+    b = np.empty(Nt + 1, dace.float64)
+    for i in range(N):
+        b[i] = a[i] * 2.0
+    return b
+
+
+def test_size_scalar_used_as_shape_is_promoted_to_symbol():
+    sdfg = size_scalar_shape_prog.to_sdfg(simplify=True)  # pre-fix: FileExistsError on Nt_plus_1
+    assert "Nt_plus_1" in sdfg.symbols, "the size scalar must become a symbol"
+    assert "Nt_plus_1" not in sdfg.arrays, "the colliding data descriptor must be gone after promotion"
+    sdfg.validate()
+
+
+if __name__ == "__main__":
+    test_size_scalar_used_as_shape_is_promoted_to_symbol()
+    print("OK")

--- a/tests/transpose_unit_dim_squeeze_test.py
+++ b/tests/transpose_unit_dim_squeeze_test.py
@@ -1,0 +1,78 @@
+"""Strict numpy slice/transpose semantics for unit dims: ``X[:, 0:1]`` keeps the axis (``(N, 1)``)
+while ``X[:, 0]`` squeezes it (``(N,)``), and a ``(N, 1)`` array transposes to ``(1, N)`` -- the
+DaCe frontend used to squeeze the unit dim and reject ``(N, 1).T`` as "not a matrix"."""
+import numpy as np
+
+import dace
+
+N = dace.symbol("N")
+M = dace.symbol("M")
+
+
+@dace.program
+def col_transpose_matmul(x: dace.float64[N, 1], a: dace.float64[N, M]):
+    return x.T @ a  # (1, N) @ (N, M) -> (1, M)
+
+
+def test_column_vector_transpose_matmul():
+    n, m = 5, 4
+    rng = np.random.default_rng(0)
+    x, a = rng.random((n, 1)), rng.random((n, m))
+    got = np.asarray(col_transpose_matmul(x.copy(), a.copy()))
+    ref = x.T @ a
+    assert got.shape == ref.shape == (1, m)
+    assert np.allclose(got.reshape(ref.shape), ref)
+
+
+@dace.program
+def slice_keeps_axis(x: dace.float64[N, 3]):
+    col = x[:, 1:2]  # a length-1 slice keeps the axis: (N, 1)
+    return col.T @ x  # (1, N) @ (N, 3) -> (1, 3); only valid if col stayed 2D
+
+
+def test_length_one_slice_keeps_axis():
+    n = 6
+    rng = np.random.default_rng(1)
+    x = rng.random((n, 3))
+    got = np.asarray(slice_keeps_axis(x.copy()))
+    ref = x[:, 1:2].T @ x
+    assert got.shape == ref.shape == (1, 3)
+    assert np.allclose(got.reshape(ref.shape), ref)
+
+
+@dace.program
+def slice_outer_product(x: dace.float64[N, 3]):
+    col = x[:, 1:2]  # (N, 1)
+    return col @ col.T  # (N, 1) @ (1, N) -> (N, N) outer product
+
+
+def test_length_one_slice_outer_product():
+    n = 6
+    rng = np.random.default_rng(3)
+    x = rng.random((n, 3))
+    got = np.asarray(slice_outer_product(x.copy()))
+    ref = x[:, 1:2] @ x[:, 1:2].T
+    assert got.shape == ref.shape == (n, n)
+    assert np.allclose(got, ref)
+
+
+@dace.program
+def index_squeezes_axis(x: dace.float64[N, 3]):
+    col = x[:, 1]  # an integer index squeezes the axis: (N,)
+    return np.sum(col)
+
+
+def test_integer_index_squeezes_axis():
+    n = 6
+    rng = np.random.default_rng(2)
+    x = rng.random((n, 3))
+    got = np.asarray(index_squeezes_axis(x.copy()))
+    assert np.allclose(got, np.sum(x[:, 1]))
+
+
+if __name__ == "__main__":
+    test_column_vector_transpose_matmul()
+    test_length_one_slice_keeps_axis()
+    test_length_one_slice_outer_product()
+    test_integer_index_squeezes_axis()
+    print("OK")


### PR DESCRIPTION
This branch isolates the two DaCe Python-frontend fixes — promoting a size scalar used as an array shape to a symbol (`add_datadesc`) and correctly squeezing unit dims for a `(N,1)`/`(1,N)` transpose (`_transpose`) — from unrelated work, carrying only the frontend edits plus the two regression tests that expose those bugs. It is a single focused commit intended for review.

Note: the symbol-promotion half is already on `extended` (f8fc64462), so the net diff against this base is the squeezing fix + its test; the commit itself bundles both for a standalone record.