### PR TITLE
Replace getattr/hasattr with static type checks

### DIFF
--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -137,13 +137,15 @@ def _get_codegen_targets(sdfg: SDFG, frame: framecode.DaCeCodeGenerator):
                         frame.targets.add(tgt)
 
         # Instrumentation-related query
-        if hasattr(node, 'symbol_instrument'):
+        if isinstance(node, SDFGState):
             disp.instrumentation[node.symbol_instrument] = provider_mapping[node.symbol_instrument]
-        if hasattr(node, 'instrument'):
+        # MapEntry and ConsumeEntry forward ``instrument`` to their Map/Consume object
+        if isinstance(node, (SDFGState, dace.nodes.AccessNode, dace.nodes.Tasklet, dace.nodes.NestedSDFG,
+                             dace.nodes.MapEntry, dace.nodes.ConsumeEntry)):
             disp.instrumentation[node.instrument] = provider_mapping[node.instrument]
-        elif hasattr(node, 'consume'):
+        elif isinstance(node, dace.nodes.ConsumeExit):
             disp.instrumentation[node.consume.instrument] = provider_mapping[node.consume.instrument]
-        elif hasattr(node, 'map'):
+        elif isinstance(node, dace.nodes.MapExit):
             disp.instrumentation[node.map.instrument] = provider_mapping[node.map.instrument]
 
     # Query instrumentation provider of SDFG

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -15,6 +15,7 @@ import sys
 import numpy as np
 
 from dace import data as dt, dtypes, hooks, symbolic
+from dace.sdfg import nodes
 from dace.codegen import exceptions as cgx
 from dace.config import Config
 
@@ -274,7 +275,8 @@ class CompiledSDFG(object):
                 self.external_memory_types.add(aval.storage)
         if not self.has_gpu_code:
             for node, _ in self._sdfg.all_nodes_recursive():
-                if getattr(node, 'schedule', False) in dtypes.GPU_SCHEDULES:
+                if (isinstance(node, (nodes.EntryNode, nodes.ExitNode, nodes.LibraryNode))
+                        and node.schedule in dtypes.GPU_SCHEDULES):
                     self.has_gpu_code = True
                     break
 

--- a/dace/codegen/dispatcher.py
+++ b/dace/codegen/dispatcher.py
@@ -436,7 +436,7 @@ class TargetDispatcher(object):
 
         # If this node depends on any environments, register this for
         # generating header code later
-        if hasattr(node, "environments"):
+        if isinstance(node, nodes.CodeNode):
             self._used_environments |= node.environments
 
         # Check if the node satisfies any predicates that delegate to a

--- a/dace/codegen/instrumentation/data/data_dump.py
+++ b/dace/codegen/instrumentation/data/data_dump.py
@@ -35,6 +35,18 @@ class DataInstrumentationProviderMixin:
         # For other file headers
         sdfg.append_global_code('\n#include <%s>' % header_name, None)
 
+    def _generate_device_sync(self, sdfg: SDFG, global_stream: CodeIOStream) -> str:
+        """ Waits for every stream, or returns an empty string if the SDFG has no device data.
+
+        The generated streams are non-blocking, so nothing orders instrumentation against the copies
+        and kernels that fill the buffer: a host buffer may still be the target of an in-flight
+        device-to-host copy, and a default-stream memcpy off a device buffer does not wait either.
+        """
+        if not self.uses_gpu:
+            return ''
+        self._setup_gpu_runtime(sdfg, global_stream)
+        return f'{self.backend}DeviceSynchronize();\n'
+
     def _generate_copy_to_host(self, node: nodes.AccessNode, desc: dt.Array, ptr: str) -> Tuple[str, str, str]:
         """ Copies to host and returns (preamble, postamble, name of new host pointer). """
         new_ptr = f'__dinstr_{node.data}'
@@ -83,6 +95,7 @@ class SaveProvider(InstrumentationProvider, DataInstrumentationProviderMixin):
     def __init__(self):
         super().__init__()
         self.gpu_runtime_init = False
+        self.uses_gpu = False
         self.framecode: 'DaCeCodeGenerator' = None
 
     def on_sdfg_begin(self, sdfg: SDFG, local_stream: CodeIOStream, global_stream: CodeIOStream,
@@ -90,6 +103,7 @@ class SaveProvider(InstrumentationProvider, DataInstrumentationProviderMixin):
         # Initialize serializer versioning object
         if sdfg.parent is None:
             self.framecode = codegen
+            self.uses_gpu = any(d.storage == dtypes.StorageType.GPU_Global for _, _, d in sdfg.arrays_recursive())
             path = os.path.abspath(os.path.join(sdfg.build_folder, 'data')).replace('\\', '/')
             codegen.statestruct.append('dace::DataSerializer *serializer;')
             sdfg.append_init_code(f'__state->serializer = new dace::DataSerializer("{path}");\n')
@@ -158,10 +172,11 @@ class SaveProvider(InstrumentationProvider, DataInstrumentationProviderMixin):
         uuid = f'{cfg.cfg_id}_{state_id}_{node_id}'
 
         # Get optional pre/postamble for instrumenting device data
-        preamble, postamble = '', ''
+        postamble = ''
+        preamble = self._generate_device_sync(sdfg, global_stream)
         if desc.storage == dtypes.StorageType.GPU_Global:
-            self._setup_gpu_runtime(sdfg, global_stream)
-            preamble, postamble, ptrname = self._generate_copy_to_host(node, desc, ptrname)
+            copy_preamble, postamble, ptrname = self._generate_copy_to_host(node, desc, ptrname)
+            preamble += copy_preamble
 
         # Encode runtime shape and strides
         shape = ', '.join(cpp.sym2cpp(s) for s in desc.shape)
@@ -184,6 +199,7 @@ class RestoreProvider(InstrumentationProvider, DataInstrumentationProviderMixin)
     def __init__(self):
         super().__init__()
         self.gpu_runtime_init = False
+        self.uses_gpu = False
         self.framecode: 'DaCeCodeGenerator' = None
 
     def _generate_report_setter(self, sdfg: SDFG) -> str:
@@ -198,6 +214,7 @@ class RestoreProvider(InstrumentationProvider, DataInstrumentationProviderMixin)
         # Initialize serializer versioning object
         if sdfg.parent is None:
             self.framecode = codegen
+            self.uses_gpu = any(d.storage == dtypes.StorageType.GPU_Global for _, _, d in sdfg.arrays_recursive())
             codegen.statestruct.append('dace::DataSerializer *serializer;')
             sdfg.append_init_code(f'__state->serializer = new dace::DataSerializer("");\n')
 
@@ -269,10 +286,11 @@ class RestoreProvider(InstrumentationProvider, DataInstrumentationProviderMixin)
         uuid = f'{cfg.cfg_id}_{state_id}_{node_id}'
 
         # Get optional pre/postamble for instrumenting device data
-        preamble, postamble = '', ''
+        postamble = ''
+        preamble = self._generate_device_sync(sdfg, global_stream)
         if desc.storage == dtypes.StorageType.GPU_Global:
-            self._setup_gpu_runtime(cfg, global_stream)
-            preamble, postamble, ptrname = self._generate_copy_to_device(node, desc, ptrname)
+            copy_preamble, postamble, ptrname = self._generate_copy_to_device(node, desc, ptrname)
+            preamble += copy_preamble
 
         # Write code
         inner_stream.write(condition_preamble, cfg, state_id, node_id)

--- a/dace/codegen/instrumentation/gpu_events.py
+++ b/dace/codegen/instrumentation/gpu_events.py
@@ -34,10 +34,9 @@ class GPUEventProvider(InstrumentationProvider):
 
     def _get_sobj(self, node: Union[nodes.EntryNode, nodes.ExitNode]):
         # Get object behind scope
-        if hasattr(node, 'consume'):
+        if isinstance(node, (nodes.ConsumeEntry, nodes.ConsumeExit)):
             return node.consume
-        else:
-            return node.map
+        return node.map
 
     def _create_event(self, id):
         return '''{backend}Event_t __dace_ev_{id};

--- a/dace/codegen/instrumentation/papi.py
+++ b/dace/codegen/instrumentation/papi.py
@@ -12,7 +12,7 @@ from dace.sdfg.nodes import EntryNode, MapEntry, MapExit, Tasklet
 from dace.sdfg.graph import SubgraphView
 from dace.memlet import Memlet
 from dace.sdfg import scope_contains_scope
-from dace.sdfg.state import DataflowGraphView
+from dace.sdfg.state import DataflowGraphView, SDFGState
 
 import sympy as sp
 import os
@@ -483,10 +483,12 @@ class PAPIUtils(object):
     def is_papi_used(sdfg: dace.SDFG) -> bool:
         """ Returns True if any of the SDFG elements includes PAPI counter
             instrumentation. """
+        instrumented_types = (SDFGState, nodes.AccessNode, nodes.Tasklet, nodes.NestedSDFG, nodes.MapEntry,
+                              nodes.ConsumeEntry)
         for node, _ in sdfg.all_nodes_recursive():
             if isinstance(node, nodes.EntryNode) and node.map.instrument == dace.InstrumentationType.PAPI_Counters:
                 return True
-            if hasattr(node, 'instrument') and node.instrument == dace.InstrumentationType.PAPI_Counters:
+            if isinstance(node, instrumented_types) and node.instrument == dace.InstrumentationType.PAPI_Counters:
                 return True
         return False
 

--- a/dace/codegen/instrumentation/timer.py
+++ b/dace/codegen/instrumentation/timer.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 from dace import dtypes, registry
-from dace.sdfg.nodes import CodeNode
+from dace.sdfg.nodes import CodeNode, ConsumeEntry, ConsumeExit
 from dace.codegen.instrumentation.provider import InstrumentationProvider
 from dace.codegen.prettycode import CodeIOStream
 
@@ -55,10 +55,9 @@ __state->report.add_completion("{timer_name}", "Timer", __dace_ts_start_{id}, __
 
     def _get_sobj(self, node):
         # Get object behind scope
-        if hasattr(node, 'consume'):
+        if isinstance(node, (ConsumeEntry, ConsumeExit)):
             return node.consume
-        else:
-            return node.map
+        return node.map
 
     def on_scope_entry(self, sdfg, cfg, state, node, outer_stream, inner_stream, global_stream):
         s = self._get_sobj(node)

--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -430,8 +430,7 @@ def ndcopy_to_strided_copy(
     """
 
     # Cannot degenerate tiled copies
-    # In the case where subset is of type Indices, there are no tile_sizes
-    if hasattr(subset, 'tile_sizes') and any(ts != 1 for ts in subset.tile_sizes):
+    if isinstance(subset, subsets.Range) and any(ts != 1 for ts in subset.tile_sizes):
         return None
 
     # If the copy is contiguous, the difference between the first and last
@@ -1304,7 +1303,7 @@ class StructInitializer(ExtNodeTransformer):
 
         # Find all struct types in SDFG
         for array in sdfg.arrays.values():
-            if array is None or not hasattr(array, "dtype"):
+            if array is None:
                 continue
             if isinstance(array.dtype, dace.dtypes.struct):
                 self._structs[array.dtype.name] = array.dtype

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -767,7 +767,7 @@ class CPUCodeGen(TargetCodeGenerator):
                             state_id,
                             [src_node, dst_node],
                         )
-                    elif hasattr(src_nodedesc, "src"):  # ArrayStreamView
+                    elif hasattr(src_nodedesc, "src"):  # Array-stream view, ``src`` set by is_array_stream_view
                         stream.write(
                             "{s}.push({arr});".format(s=self.ptr(dst_node.data, dst_nodedesc, sdfg),
                                                       arr=self.ptr(src_nodedesc.src, sdfg.arrays[src_nodedesc.src],

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -265,7 +265,7 @@ class CUDACodeGen(TargetCodeGenerator):
         for sdfg in top_sdfg.all_sdfgs_recursive():
             # Skip SDFGs without memory pool hints
             pooled = set(aname for aname, arr in sdfg.arrays.items()
-                         if getattr(arr, 'pool', False) is True and arr.transient)
+                         if isinstance(arr, (dt.Array, dt.Scalar, dt.Structure)) and arr.pool is True and arr.transient)
             if not pooled:
                 continue
             self.has_pool = True
@@ -493,7 +493,8 @@ void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStream_t stream)
         return [self._codeobject]
 
     def node_dispatch_predicate(self, sdfg, state, node):
-        if hasattr(node, 'schedule'):  # NOTE: Works on nodes and scopes
+        # NOTE: Works on nodes and scopes
+        if isinstance(node, (nodes.EntryNode, nodes.ExitNode, nodes.LibraryNode)):
             if node.schedule in dtypes.GPU_SCHEDULES:
                 return True
         if self._in_device_code:

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -171,7 +171,6 @@ class DaCeCodeGenerator(object):
             elif isinstance(dtype, dtypes.struct):
                 for field in dtype.fields.values():
                     wrote_something = _emit_definitions(field, wrote_something)
-            if hasattr(dtype, 'emit_definition'):
                 if not wrote_something:
                     global_stream.write("", sdfg)
                 if dtype not in emitted:

--- a/dace/data/core.py
+++ b/dace/data/core.py
@@ -155,7 +155,7 @@ class Data:
 
     @property
     def veclen(self):
-        return self.dtype.veclen if hasattr(self.dtype, "veclen") else 1
+        return self.dtype.veclen
 
     @property
     def ctype(self):

--- a/dace/data/distributed.py
+++ b/dace/data/distributed.py
@@ -32,9 +32,18 @@ class DistributedDescriptor(Data):
     def as_python_arg(self, with_types=True, for_call=False, name=None):
         raise TypeError(f'{type(self).__name__} descriptors are not Python call arguments')
 
+    # A communicator descriptor allocates nothing.
     @property
     def offset(self):
         return [0] * len(self.shape)
+
+    @property
+    def strides(self):
+        return []
+
+    @property
+    def total_size(self):
+        return 0
 
 
 def _symbols_from_shape(shape) -> Set[symbolic.SymbolicType]:

--- a/dace/data/distributed.py
+++ b/dace/data/distributed.py
@@ -34,8 +34,7 @@ class DistributedDescriptor(Data):
 
     @property
     def offset(self):
-        shp = getattr(self, 'shape', [])
-        return [0] * len(shp)
+        return [0] * len(self.shape)
 
 
 def _symbols_from_shape(shape) -> Set[symbolic.SymbolicType]:

--- a/dace/frontend/fortran/ast_transforms.py
+++ b/dace/frontend/fortran/ast_transforms.py
@@ -10,8 +10,6 @@ def iter_fields(node: ast_internal_classes.FNode):
     Yield a tuple of ``(fieldname, value)`` for each field in ``node._fields``
     that is present on *node*.
     """
-    if not hasattr(node, "_fields"):
-        a = 1
     for field in node._fields:
         try:
             yield field, getattr(node, field)
@@ -257,10 +255,7 @@ class CallExtractor(NodeTransformer):
         if hasattr(node, "subroutine"):
             if node.subroutine is True:
                 return self.generic_visit(node)
-        if not hasattr(self, "count"):
-            self.count = 0
-        else:
-            self.count = self.count + 1
+        self.count = self.count + 1
         tmp = self.count
 
         for i, arg in enumerate(node.args):

--- a/dace/frontend/fortran/fortran_parser.py
+++ b/dace/frontend/fortran/fortran_parser.py
@@ -728,7 +728,7 @@ class AST_translator:
             else:
                 raise NameError("Variable name not found: " + ast_utils.get_name(i))
 
-            if not hasattr(var, "shape") or len(var.shape) == 0:
+            if not isinstance(var, dat.Data) or len(var.shape) == 0:
                 memlet = ""
             elif (len(var.shape) == 1 and var.shape[0] == 1):
                 memlet = "0"

--- a/dace/frontend/fortran/intrinsics.py
+++ b/dace/frontend/fortran/intrinsics.py
@@ -1289,11 +1289,7 @@ class FortranIntrinsics:
             return MathFunctions.replace(func_name)
 
         if self.IMPLEMENTATIONS_AST[func_name].has_transformation():
-
-            if hasattr(self.IMPLEMENTATIONS_AST[func_name], "Transformation"):
-                self._transformations_to_run.add(self.IMPLEMENTATIONS_AST[func_name].Transformation())
-            else:
-                self._transformations_to_run.add(self.IMPLEMENTATIONS_AST[func_name].get_transformation(func_name))
+            self._transformations_to_run.add(self.IMPLEMENTATIONS_AST[func_name].Transformation())
 
         return ast_internal_classes.Name_Node(name=self.IMPLEMENTATIONS_AST[func_name].replaced_name(func_name))
 

--- a/dace/frontend/ml/torch/module.py
+++ b/dace/frontend/ml/torch/module.py
@@ -133,6 +133,7 @@ if TORCH_AVAILABLE and ONNX_AVAILABLE:
             self.inputs_to_skip = inputs_to_skip or []
 
             self.function = None
+            self._gradient_buffers: Optional[List[str]] = None
 
             #: hooks that are executed after onnx graph is imported to an SDFG
             self.post_onnx_hooks: OrderedDict[str, Callable[[DaceModule], None]] = collections.OrderedDict()
@@ -462,7 +463,7 @@ if TORCH_AVAILABLE and ONNX_AVAILABLE:
             """
 
             assert self.sdfg is not None
-            if hasattr(self, '_gradient_buffers'):
+            if self._gradient_buffers is not None:
                 return self._gradient_buffers
 
             buffers = []

--- a/dace/frontend/python/astutils.py
+++ b/dace/frontend/python/astutils.py
@@ -343,7 +343,7 @@ def negate_expr(node):
     from dace.properties import CodeBlock  # Avoid import loop
     if isinstance(node, CodeBlock):
         node = node.code
-    if hasattr(node, "__len__"):
+    if isinstance(node, (list, tuple)):
         if len(node) > 1:
             raise ValueError("negate_expr only expects "
                              "single expressions, got: {}".format(node))
@@ -379,7 +379,7 @@ def and_expr(node_a, node_b):
         node_a = node_a.code
         node_b = node_b.code
 
-    if hasattr(node_a, "__len__"):
+    if isinstance(node_a, (list, tuple)):
         if len(node_a) > 1:
             raise ValueError("and_expr only expects single expressions, got: {}".format(node_a))
         if len(node_b) > 1:

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -702,7 +702,7 @@ class TaskletTransformer(ExtNodeTransformer):
         if name is not None:
             name += '_' + str(tasklet_ast.lineno)
         else:
-            name = getattr(tasklet_ast, 'name', 'tasklet_%d' % tasklet_ast.lineno)
+            name = tasklet_ast.name if isinstance(tasklet_ast, ast.FunctionDef) else 'tasklet_%d' % tasklet_ast.lineno
 
         if self.lang is None:
             self.lang = dtypes.Language.Python
@@ -2738,10 +2738,9 @@ class ProgramVisitor(ExtNodeVisitor):
         # Looking for the first argument in a tasklet annotation: @dace.tasklet(STRING HERE)
         langInf = None
         side_effects = None
-        if isinstance(node, ast.FunctionDef) and hasattr(node, 'decorator_list') and isinstance(
-                node.decorator_list, list) and len(node.decorator_list) > 0 and hasattr(
-                    node.decorator_list[0], 'args') and isinstance(node.decorator_list[0].args, list) and len(
-                        node.decorator_list[0].args) > 0 and hasattr(node.decorator_list[0].args[0], 'value'):
+        if isinstance(node, ast.FunctionDef) and len(node.decorator_list) > 0 and hasattr(
+                node.decorator_list[0], 'args') and isinstance(node.decorator_list[0].args, list) and len(
+                    node.decorator_list[0].args) > 0 and hasattr(node.decorator_list[0].args[0], 'value'):
 
             langArg = node.decorator_list[0].args[0].value
             langInf = dtypes.Language[langArg]
@@ -4738,10 +4737,8 @@ class ProgramVisitor(ExtNodeVisitor):
             try:
                 if hasattr(func, "name"):
                     name = func.name
-                elif hasattr(func, "__class__"):
-                    name = func.__class__.__name__
                 else:
-                    name = "call"
+                    name = type(func).__name__
                 call_region = FunctionCallRegion(label=f"{name}_{node.lineno}", arguments=[])
                 self.cfg_target.add_node(call_region, ensure_unique_name=True)
                 self._on_block_added(call_region)
@@ -5215,8 +5212,8 @@ class ProgramVisitor(ExtNodeVisitor):
             # Check for SDFG as fallback
             func = oprepo.Replacements.getop(op1type, opname, otherclass=op2type)
             if func is None:
-                op1name = getattr(op1type, '__name__', op1type)
-                op2name = getattr(op2type, '__name__', op2type)
+                op1name = op1type.__name__ if isinstance(op1type, type) else op1type
+                op2name = op2type.__name__ if isinstance(op2type, type) else op2type
                 raise DaceSyntaxError(self, node, f'Operator {opname} is not defined for types {op1name} and {op2name}')
 
         self._add_state('%s_%d' % (type(node).__name__, node.lineno))

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -105,9 +105,11 @@ def infer_symbols_from_datadescriptor(sdfg: SDFG,
     for arg_name, arg_val in args.items():
         if arg_name in sdfg.arrays:
             desc = sdfg.arrays[arg_name]
-            if not hasattr(desc, 'shape') or not hasattr(arg_val, 'shape'):
+            if not hasattr(arg_val, 'shape'):
                 continue
-            symbolic_values = list(desc.shape) + list(getattr(desc, 'strides', [])) + list(getattr(desc, 'offset', []))
+            # Distributed descriptors (process grids, subarrays) have no strides
+            desc_strides = [] if isinstance(desc, data.DistributedDescriptor) else desc.strides
+            symbolic_values = list(desc.shape) + list(desc_strides) + list(desc.offset)
             given_values = list(arg_val.shape)
             given_strides = []
             if hasattr(arg_val, 'strides'):

--- a/dace/frontend/python/parser.py
+++ b/dace/frontend/python/parser.py
@@ -107,9 +107,7 @@ def infer_symbols_from_datadescriptor(sdfg: SDFG,
             desc = sdfg.arrays[arg_name]
             if not hasattr(arg_val, 'shape'):
                 continue
-            # Distributed descriptors (process grids, subarrays) have no strides
-            desc_strides = [] if isinstance(desc, data.DistributedDescriptor) else desc.strides
-            symbolic_values = list(desc.shape) + list(desc_strides) + list(desc.offset)
+            symbolic_values = list(desc.shape) + list(desc.strides) + list(desc.offset)
             given_values = list(arg_val.shape)
             given_strides = []
             if hasattr(arg_val, 'strides'):

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -1324,7 +1324,7 @@ class CallTreeResolver(ast.NodeVisitor):
         if not isinstance(function, DaceProgram):
             # Make set of parameters from __sdfg_signature__
             parameters = [(name, inspect.Parameter.POSITIONAL_OR_KEYWORD) for name in function.__sdfg_signature__()[0]]
-            objname = None
+            objname = False
         else:
             parameters = [(aname, arg.kind) for aname, arg in function.signature.parameters.items()]
             objname = function.objname

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -1320,14 +1320,14 @@ class CallTreeResolver(ast.NodeVisitor):
         kwargs = [kwarg.arg for kwarg in node.keywords]
         result = set()
 
+        # "objname" holds the name of the "self" argument, if any
         if not isinstance(function, DaceProgram):
             # Make set of parameters from __sdfg_signature__
             parameters = [(name, inspect.Parameter.POSITIONAL_OR_KEYWORD) for name in function.__sdfg_signature__()[0]]
+            objname = None
         else:
             parameters = [(aname, arg.kind) for aname, arg in function.signature.parameters.items()]
-
-        # Handle "self" argument
-        objname = getattr(function, 'objname', False)
+            objname = function.objname
 
         nargs = len(posargs)
         arg_ind = 0

--- a/dace/libraries/blas/nodes/gemm.py
+++ b/dace/libraries/blas/nodes/gemm.py
@@ -15,7 +15,7 @@ import warnings
 
 
 def _is_complex(dtype):
-    if hasattr(dtype, "is_complex") and callable(dtype.is_complex):
+    if isinstance(dtype, dtypes.typeclass):
         return dtype.is_complex()
     else:
         return dtype in [np.complex64, np.complex128]

--- a/dace/libraries/blas/nodes/matmul.py
+++ b/dace/libraries/blas/nodes/matmul.py
@@ -140,10 +140,10 @@ def _get_codegen_gemm_opts(node, state, sdfg, adesc, bdesc, cdesc, alpha, beta, 
     (_, _, ashape, astride, _, _), (_, _, bshape, bstride, _, _), (_, _, cshape, cstride, _,
                                                                    _) = _get_matmul_operands(node, state, sdfg)
 
-    if getattr(node, 'transA', False):
+    if node.transA:
         ashape = list(reversed(ashape))
         astride = list(reversed(astride))
-    if getattr(node, 'transB', False):
+    if node.transB:
         bshape = list(reversed(bshape))
         bstride = list(reversed(bstride))
 

--- a/dace/libraries/mpi/nodes/node.py
+++ b/dace/libraries/mpi/nodes/node.py
@@ -41,6 +41,5 @@ class MPINode(nodes.LibraryNode):
     Abstract class representing an MPI library node.
     """
 
-    @property
-    def has_side_effects(self) -> bool:
+    def has_side_effects(self, sdfg) -> bool:
         return True

--- a/dace/libraries/onnx/converters.py
+++ b/dace/libraries/onnx/converters.py
@@ -15,8 +15,9 @@ Key Functions:
 - clean_onnx_name: Sanitize ONNX names for valid DaCe identifiers
 """
 
+import functools
 import re
-from typing import Union
+from typing import Callable, Dict, Union
 
 import onnx
 from dace import config, dtypes as dt
@@ -105,29 +106,30 @@ def convert_onnx_proto(attribute):
     raise NotImplementedError("No conversion implemented for {} (type {})".format(attribute, type(attribute)))
 
 
-def convert_attribute_proto(proto):
-    #  we cache the reverse map as an attribute of the method
-    if hasattr(convert_attribute_proto, "inv_map"):
-        inv_map = convert_attribute_proto.inv_map
-    else:
-        inv_map = {}
-        for k, v in onnx.AttributeProto.AttributeType.items():
-            if k == "FLOAT":
-                inv_map[v] = lambda attr: get_proto_attr(attr, "f")
-            elif k == "FLOATS":
-                inv_map[v] = lambda attr: list(get_proto_attr(attr, "floats"))
-            elif k == "INT":
-                inv_map[v] = lambda attr: get_proto_attr(attr, "i")
-            elif k == "INTS":
-                inv_map[v] = lambda attr: list(get_proto_attr(attr, "ints"))
-            elif k == "STRING":
-                inv_map[v] = lambda attr: get_proto_attr(attr, "s").decode('utf-8')
-            elif k == "STRINGS":
-                inv_map[v] = lambda attr: list(map(lambda x: x.decode('utf-8'), get_proto_attr(attr, "strings")))
-            elif k == "TENSOR":
-                inv_map[v] = lambda attr: to_array(get_proto_attr(attr, "t"))
+@functools.cache
+def attribute_proto_converters() -> Dict[int, Callable]:
+    """Maps ONNX AttributeProto type enums to the function extracting their value."""
+    inv_map = {}
+    for k, v in onnx.AttributeProto.AttributeType.items():
+        if k == "FLOAT":
+            inv_map[v] = lambda attr: get_proto_attr(attr, "f")
+        elif k == "FLOATS":
+            inv_map[v] = lambda attr: list(get_proto_attr(attr, "floats"))
+        elif k == "INT":
+            inv_map[v] = lambda attr: get_proto_attr(attr, "i")
+        elif k == "INTS":
+            inv_map[v] = lambda attr: list(get_proto_attr(attr, "ints"))
+        elif k == "STRING":
+            inv_map[v] = lambda attr: get_proto_attr(attr, "s").decode('utf-8')
+        elif k == "STRINGS":
+            inv_map[v] = lambda attr: list(map(lambda x: x.decode('utf-8'), get_proto_attr(attr, "strings")))
+        elif k == "TENSOR":
+            inv_map[v] = lambda attr: to_array(get_proto_attr(attr, "t"))
+    return inv_map
 
-        convert_attribute_proto.inv_map = inv_map
+
+def convert_attribute_proto(proto):
+    inv_map = attribute_proto_converters()
 
     onnx_type = get_proto_attr(proto, "type")
 
@@ -162,30 +164,25 @@ ONNX_DTYPES_TO_DACE_TYPE_CLASS = {
 }
 
 
-def typeclass_to_onnx_tensor_type_int(dtype: typeclass) -> int:
-    #  we cache the reverse map as an attribute of the method
-    if not hasattr(typeclass_to_onnx_tensor_type_int, "inv_map"):
-        typeclass_to_onnx_tensor_type_int.inv_map = {
-            v: getattr(onnx.TensorProto.DataType, k.upper())
-            for k, v in ONNX_DTYPES_TO_DACE_TYPE_CLASS.items()
-        }
+@functools.cache
+def typeclass_to_onnx_tensor_type_map() -> Dict[typeclass, int]:
+    return {v: getattr(onnx.TensorProto.DataType, k.upper()) for k, v in ONNX_DTYPES_TO_DACE_TYPE_CLASS.items()}
 
-    return typeclass_to_onnx_tensor_type_int.inv_map[dtype]
+
+def typeclass_to_onnx_tensor_type_int(dtype: typeclass) -> int:
+    return typeclass_to_onnx_tensor_type_map()[dtype]
+
+
+@functools.cache
+def onnx_tensor_type_to_typeclass_map() -> Dict[int, typeclass]:
+    return {
+        v: ONNX_DTYPES_TO_DACE_TYPE_CLASS[k.lower()]
+        for k, v in onnx.TensorProto.DataType.items() if k.lower() in ONNX_DTYPES_TO_DACE_TYPE_CLASS
+    }
 
 
 def onnx_tensor_type_to_typeclass(elem_type: int) -> typeclass:
-    #  we cache the reverse map as an attribute of the method
-    if hasattr(onnx_tensor_type_to_typeclass, "inv_map"):
-        inv_map = onnx_tensor_type_to_typeclass.inv_map
-    else:
-        k: str
-        v: int
-        inv_map = {}
-        for k, v in onnx.TensorProto.DataType.items():
-            if k.lower() in ONNX_DTYPES_TO_DACE_TYPE_CLASS:
-                inv_map[v] = ONNX_DTYPES_TO_DACE_TYPE_CLASS[k.lower()]
-
-        onnx_tensor_type_to_typeclass.inv_map = inv_map
+    inv_map = onnx_tensor_type_to_typeclass_map()
 
     if elem_type not in inv_map:
         raise ValueError("Got unsupported ONNX tensor type: {}".format({
@@ -196,12 +193,13 @@ def onnx_tensor_type_to_typeclass(elem_type: int) -> typeclass:
     return inv_map[elem_type]
 
 
+@functools.cache
+def typeclass_to_onnx_str_map() -> Dict[typeclass, str]:
+    return {v: k for k, v in ONNX_DTYPES_TO_DACE_TYPE_CLASS.items()}
+
+
 def typeclass_to_onnx_str(dtype: typeclass) -> str:
-    #  we cache the reverse map as an attribute of the method
-    if hasattr(typeclass_to_onnx_str, "inv_map"):
-        inv_map = typeclass_to_onnx_str.inv_map
-    else:
-        inv_map = {v: k for k, v in ONNX_DTYPES_TO_DACE_TYPE_CLASS.items()}
+    inv_map = typeclass_to_onnx_str_map()
 
     if dtype not in inv_map:
         raise ValueError("Attempted to convert unsupported dace type to ONNX type: {}".format(dtype))

--- a/dace/libraries/onnx/op_implementations/normalization_ops.py
+++ b/dace/libraries/onnx/op_implementations/normalization_ops.py
@@ -50,14 +50,19 @@ def LogSoftmax(input, output):
 # ============================================================================
 
 
+def _layernorm_first_axis(node, X):
+    # The attribute is absent in opsets that predate it; ONNX defaults it to -1.
+    axis = node.axis if hasattr(node, 'axis') else -1
+    return axis if axis >= 0 else len(X.shape) + axis
+
+
 def _layernorm_axis(node, X):
-    axis = node.axis if hasattr(node, 'axis') and node.axis >= 0 else len(X.shape) + node.axis
-    return tuple(range(axis, len(X.shape)))
+    return tuple(range(_layernorm_first_axis(node, X), len(X.shape)))
 
 
 def _layernorm_norm_size(node, X):
-    axis = node.axis if hasattr(node, 'axis') and node.axis >= 0 else len(X.shape) + node.axis
-    return int(np.prod([X.shape[i] for i in range(axis, len(X.shape))]))
+    first = _layernorm_first_axis(node, X)
+    return int(np.prod([X.shape[i] for i in range(first, len(X.shape))]))
 
 
 def _layernorm_epsilon(node, X):

--- a/dace/libraries/sparse/nodes/csrmm.py
+++ b/dace/libraries/sparse/nodes/csrmm.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 def _is_complex(dtype):
-    if hasattr(dtype, "is_complex") and callable(dtype.is_complex):
+    if isinstance(dtype, dtypes.typeclass):
         return dtype.is_complex()
     else:
         return dtype in [np.complex64, np.complex128]

--- a/dace/libraries/sparse/nodes/csrmv.py
+++ b/dace/libraries/sparse/nodes/csrmv.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 def _is_complex(dtype):
-    if hasattr(dtype, "is_complex") and callable(dtype.is_complex):
+    if isinstance(dtype, dtypes.typeclass):
         return dtype.is_complex()
     else:
         return dtype in [np.complex64, np.complex128]

--- a/dace/libraries/standard/nodes/code.py
+++ b/dace/libraries/standard/nodes/code.py
@@ -47,8 +47,7 @@ class CodeLibraryNode(LibraryNode):
     inputdict = Property(dtype=dict, default={})
     outputdict = Property(dtype=dict, default={})
 
-    @property
-    def has_side_effects(self) -> bool:
+    def has_side_effects(self, sdfg) -> bool:
         # By default, assume code library nodes have side effects unless said otherwise
         return True
 

--- a/dace/sdfg/analysis/cutout.py
+++ b/dace/sdfg/analysis/cutout.py
@@ -589,7 +589,7 @@ def _transformation_determine_affected_nodes(sdfg: SDFG,
         return affected_nodes
 
     # If strict is not set and a scope node is affected, expand the returned set to include all nodes in that scope.
-    if hasattr(transformation, 'state_id') and transformation.state_id >= 0:
+    if isinstance(transformation, PatternTransformation) and transformation.state_id >= 0:
         state = target_sdfg.node(transformation.state_id)
         expanded = set()
         for node in affected_nodes:

--- a/dace/sdfg/infer_types.py
+++ b/dace/sdfg/infer_types.py
@@ -310,7 +310,7 @@ def _set_default_schedule_in_scope(state: SDFGState,
                 else:
                     local_child_schedule = child_schedule
                 node.schedule = local_child_schedule
-        elif getattr(node, 'schedule', False) and not isinstance(node, nodes.ExitNode):
+        elif isinstance(node, nodes.LibraryNode):
             if node.schedule == dtypes.ScheduleType.Default:
                 if child_schedule is None:
                     local_child_schedule = _determine_schedule_from_storage(state, node)

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -380,6 +380,10 @@ class CodeNode(Node):
     def free_symbols(self) -> Set[str]:
         return set().union(*[v.free_symbols for v in self.location.values()])
 
+    def has_side_effects(self, sdfg) -> bool:
+        """True if running this node may do more than write its outputs."""
+        return False
+
 
 @make_properties
 class Tasklet(CodeNode):
@@ -670,6 +674,12 @@ class NestedSDFG(CodeNode):
             ret.sdfg.update_cfg_list([])
 
         return ret
+
+    def has_side_effects(self, sdfg) -> bool:
+        """True if any nested node has side effects. ``sdfg`` unused: inner ones apply."""
+        return any(
+            isinstance(node, CodeNode) and not isinstance(node, NestedSDFG) and node.has_side_effects(parent.sdfg)
+            for node, parent in self.sdfg.all_nodes_recursive())
 
     def used_symbols(self, all_symbols: bool) -> Set[str]:
         free_syms = set().union(*(map(str, pystr_to_symbolic(v).free_symbols) for v in self.location.values()))
@@ -1354,12 +1364,10 @@ class LibraryNode(CodeNode):
     def __jsontype__(self):
         return 'LibraryNode'
 
-    @property
-    def has_side_effects(self) -> bool:
+    def has_side_effects(self, sdfg) -> bool:
         """
         Returns True if this library node has other side effects (e.g., calling stateful libraries, communicating)
-        when expanded.
-        This method is meant to be extended by subclasses.
+        when expanded. ``sdfg`` is unused; taken to match :class:`CodeNode`.
         """
         return False
 

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -199,7 +199,7 @@ def replace_properties_dict(node: Any,
             # Don't replace variables that appear as an input or an output
             # connector, as this should shadow the outer declaration.
             reduced_repl = set(repl.keys())
-            if hasattr(node, 'in_connectors'):
+            if isinstance(node, nodes.Node):
                 reduced_repl -= set(node.in_connectors.keys()) | set(node.out_connectors.keys())
             reduced_repl = {k: repl[k] for k in reduced_repl}
             replace_in_codeblock(propval, reduced_repl, node)

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -73,7 +73,7 @@ class NestedDict(dict):
             else:
                 desc = desc.members[token]
             token = tokens.pop(0)
-            result = hasattr(desc, 'members') and token in desc.members
+            result = isinstance(desc, dt.Structure) and token in desc.members
         return result
 
     def keys(self):
@@ -487,6 +487,9 @@ class SDFG(ControlFlowRegion):
                                            default=False,
                                            desc="Whether the SDFG contains explicit control flow constructs")
 
+    # Explicitly-set build folder, or None to derive it from the configuration
+    _build_folder = None
+
     def __init__(self,
                  name: str,
                  constants: Dict[str, Tuple[dt.Data, Any]] = None,
@@ -556,14 +559,11 @@ class SDFG(ControlFlowRegion):
         result._nodes = copy.deepcopy(self._nodes, memo)
         result._cached_start_block = copy.deepcopy(self._cached_start_block, memo)
         # Copy parent attributes
-        for k in ('_parent', '_parent_sdfg', '_parent_nsdfg_node'):
-            if id(getattr(self, k)) in memo:
-                setattr(result, k, memo[id(getattr(self, k))])
-            else:
-                setattr(result, k, None)
+        result._parent = memo.get(id(self._parent))
+        result._parent_sdfg = memo.get(id(self._parent_sdfg))
+        result._parent_nsdfg_node = memo.get(id(self._parent_nsdfg_node))
         # Copy SDFG list and transformation history
-        if hasattr(self, '_transformation_hist'):
-            setattr(result, '_transformation_hist', copy.deepcopy(self._transformation_hist, memo))
+        result._transformation_hist = copy.deepcopy(self._transformation_hist, memo)
         result._cfg_list = []
         if self._parent_sdfg is None:
             # Avoid import loops
@@ -1211,7 +1211,7 @@ class SDFG(ControlFlowRegion):
     @property
     def build_folder(self) -> str:
         """ Returns a relative path to the build cache folder for this SDFG. """
-        if hasattr(self, '_build_folder'):
+        if self._build_folder is not None:
             return self._build_folder
         cache_config = Config.get('cache')
         base_folder = Config.get('default_build_folder')

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -725,7 +725,7 @@ class DataflowGraphView(BlockGraphView, abc.ABC):
                     freesyms |= codesyms
                     continue
 
-            if hasattr(n, 'used_symbols'):
+            if isinstance(n, nd.NestedSDFG):
                 freesyms |= n.used_symbols(all_symbols)
             else:
                 freesyms |= n.free_symbols
@@ -1313,11 +1313,8 @@ class ControlFlowBlock(BlockGraphView, abc.ABC):
                 continue
             setattr(result, k, copy.deepcopy(v, memo))
 
-        for k in ('_parent_graph', '_sdfg'):
-            if id(getattr(self, k)) in memo:
-                setattr(result, k, memo[id(getattr(self, k))])
-            else:
-                setattr(result, k, None)
+        result._parent_graph = memo.get(id(self._parent_graph))
+        result._sdfg = memo.get(id(self._sdfg))
 
         return result
 
@@ -2240,12 +2237,12 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         cur_memlet._is_data_src = (isinstance(src_node, nd.AccessNode) and src_node.data == cur_memlet.data)
 
         # Verify that connectors exist
-        if (not memlet.is_empty() and hasattr(edges[0].src, "out_connectors") and isinstance(edges[0].src, nd.CodeNode)
+        if (not memlet.is_empty() and isinstance(edges[0].src, nd.CodeNode)
                 and not isinstance(edges[0].src, nd.LibraryNode)
                 and (src_conn is None or src_conn not in edges[0].src.out_connectors)):
             raise ValueError("Output connector {} does not exist in {}".format(src_conn, edges[0].src.label))
-        if (not memlet.is_empty() and hasattr(edges[-1].dst, "in_connectors")
-                and isinstance(edges[-1].dst, nd.CodeNode) and not isinstance(edges[-1].dst, nd.LibraryNode)
+        if (not memlet.is_empty() and isinstance(edges[-1].dst, nd.CodeNode)
+                and not isinstance(edges[-1].dst, nd.LibraryNode)
                 and (dst_conn is None or dst_conn not in edges[-1].dst.in_connectors)):
             raise ValueError("Input connector {} does not exist in {}".format(dst_conn, edges[-1].dst.label))
 

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -123,19 +123,19 @@ def dfs_topological_sort(G, sources=None, condition=None, reverse=False):
     :note: If a source is not specified then a source is chosen arbitrarily and
            repeatedly until all components in the graph are searched.
     """
+    is_dace_graph = isinstance(G, gr.Graph)
     if reverse:
-        source_nodes = 'sink_nodes'
+        source_nodes = G.sink_nodes if is_dace_graph else None
         predecessors = G.successors
         neighbors = G.predecessors
     else:
-        source_nodes = 'source_nodes'
+        source_nodes = G.source_nodes if is_dace_graph else None
         predecessors = G.predecessors
         neighbors = G.successors
 
     if sources is None:
         # produce edges for all components
-        src_nodes = getattr(G, source_nodes, lambda: G)
-        nodes = list(src_nodes())
+        nodes = list(source_nodes()) if source_nodes is not None else list(G)
         if len(nodes) == 0:
             nodes = G
     else:
@@ -331,19 +331,19 @@ def scope_aware_topological_sort(G: SDFGState,
     :param reverse: If True, the graph will be traversed in reverse order (entering scopes via their exit node)
     :param visited: An optional set that will be filled with the visited nodes.
     """
+    is_dace_graph = isinstance(G, gr.Graph)
     if reverse:
-        source_nodes = 'sink_nodes'
+        source_nodes = G.sink_nodes if is_dace_graph else None
         predecessors = G.successors
         neighbors = G.predecessors
     else:
-        source_nodes = 'source_nodes'
+        source_nodes = G.source_nodes if is_dace_graph else None
         predecessors = G.predecessors
         neighbors = G.successors
 
     if sources is None:
         # produce edges for all components
-        src_nodes = getattr(G, source_nodes, lambda: G)
-        nodes = list(src_nodes())
+        nodes = list(source_nodes()) if source_nodes is not None else list(G)
         if len(nodes) == 0:
             nodes = G
     else:

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -301,15 +301,14 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
                             f'which is required for memory allocation', sdfg, None)
 
                 # Check strides if array
-                if hasattr(desc, 'strides'):
-                    for i, stride in enumerate(desc.strides):
-                        if symbolic.is_undefined(stride):
-                            raise InvalidSDFGError(
-                                f'Transient data container "{name}" contains undefined symbol in stride {i}, '
-                                f'which is required for memory allocation', sdfg, None)
+                for i, stride in enumerate(desc.strides):
+                    if symbolic.is_undefined(stride):
+                        raise InvalidSDFGError(
+                            f'Transient data container "{name}" contains undefined symbol in stride {i}, '
+                            f'which is required for memory allocation', sdfg, None)
 
                 # Check total size
-                if hasattr(desc, 'total_size') and symbolic.is_undefined(desc.total_size):
+                if symbolic.is_undefined(desc.total_size):
                     raise InvalidSDFGError(
                         f'Transient data container "{name}" has undefined total size, '
                         f'which is required for memory allocation', sdfg, None)
@@ -423,8 +422,9 @@ def validate_state(state: 'dace.sdfg.SDFGState',
     initialized_transients = (initialized_transients if initialized_transients is not None else {'__pystate'})
     references = references or set()
 
-    # Obtain whether we are already in an accelerator context
-    if not hasattr(context, 'in_gpu'):
+    # Obtain whether we are already in an accelerator context. ``is_in_scope`` ignores the state
+    # when the node is None, so the value validate_sdfg threaded down is the same one.
+    if 'in_gpu' not in context:
         context['in_gpu'] = is_devicelevel_gpu(sdfg, state, None)
 
     # Reference check

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -300,18 +300,21 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
                             f'Transient data container "{name}" contains undefined symbol in dimension {i}, '
                             f'which is required for memory allocation', sdfg, None)
 
-                # Check strides if array
-                for i, stride in enumerate(desc.strides):
-                    if symbolic.is_undefined(stride):
-                        raise InvalidSDFGError(
-                            f'Transient data container "{name}" contains undefined symbol in stride {i}, '
-                            f'which is required for memory allocation', sdfg, None)
+                # Only descriptors that are really allocated have strides/total_size to check. A
+                #  DistributedDescriptor (ProcessGrid/SubArray/RedistrArray) describes an MPI
+                #  communicator and has neither, so test for the allocated kinds positively -- an
+                #  unknown Data subclass is then skipped rather than crashing here.
+                if isinstance(desc, (dt.Array, dt.Scalar, dt.Stream, dt.Structure)):
+                    for i, stride in enumerate(desc.strides):
+                        if symbolic.is_undefined(stride):
+                            raise InvalidSDFGError(
+                                f'Transient data container "{name}" contains undefined symbol in stride {i}, '
+                                f'which is required for memory allocation', sdfg, None)
 
-                # Check total size
-                if symbolic.is_undefined(desc.total_size):
-                    raise InvalidSDFGError(
-                        f'Transient data container "{name}" has undefined total size, '
-                        f'which is required for memory allocation', sdfg, None)
+                    if symbolic.is_undefined(desc.total_size):
+                        raise InvalidSDFGError(
+                            f'Transient data container "{name}" has undefined total size, '
+                            f'which is required for memory allocation', sdfg, None)
 
                 # Check any other undefined symbols in the data descriptor
                 if any(symbolic.is_undefined(s) for s in desc.used_symbols(all_symbols=False)):

--- a/dace/sdfg/validation.py
+++ b/dace/sdfg/validation.py
@@ -300,21 +300,16 @@ def validate_sdfg(sdfg: 'dace.sdfg.SDFG', references: Set[int] = None, **context
                             f'Transient data container "{name}" contains undefined symbol in dimension {i}, '
                             f'which is required for memory allocation', sdfg, None)
 
-                # Only descriptors that are really allocated have strides/total_size to check. A
-                #  DistributedDescriptor (ProcessGrid/SubArray/RedistrArray) describes an MPI
-                #  communicator and has neither, so test for the allocated kinds positively -- an
-                #  unknown Data subclass is then skipped rather than crashing here.
-                if isinstance(desc, (dt.Array, dt.Scalar, dt.Stream, dt.Structure)):
-                    for i, stride in enumerate(desc.strides):
-                        if symbolic.is_undefined(stride):
-                            raise InvalidSDFGError(
-                                f'Transient data container "{name}" contains undefined symbol in stride {i}, '
-                                f'which is required for memory allocation', sdfg, None)
-
-                    if symbolic.is_undefined(desc.total_size):
+                for i, stride in enumerate(desc.strides):
+                    if symbolic.is_undefined(stride):
                         raise InvalidSDFGError(
-                            f'Transient data container "{name}" has undefined total size, '
+                            f'Transient data container "{name}" contains undefined symbol in stride {i}, '
                             f'which is required for memory allocation', sdfg, None)
+
+                if symbolic.is_undefined(desc.total_size):
+                    raise InvalidSDFGError(
+                        f'Transient data container "{name}" has undefined total size, '
+                        f'which is required for memory allocation', sdfg, None)
 
                 # Check any other undefined symbols in the data descriptor
                 if any(symbolic.is_undefined(s) for s in desc.used_symbols(all_symbols=False)):

--- a/dace/transformation/helpers.py
+++ b/dace/transformation/helpers.py
@@ -1961,7 +1961,7 @@ def replace_sdfg_dtypes(
 def _change_sdfg_type(sdfg: SDFG, from_type: typeclass, to_type: typeclass, swaps_count: int) -> int:
     # Swap nodes
     for node, _ in sdfg.all_nodes_recursive():
-        if hasattr(node, "in_connectors"):
+        if isinstance(node, nodes.Node):
             for in_con_name, in_con_type in node.in_connectors.items():
                 if in_con_type == from_type:
                     node.in_connectors[in_con_name] = to_type
@@ -1971,7 +1971,6 @@ def _change_sdfg_type(sdfg: SDFG, from_type: typeclass, to_type: typeclass, swap
                         node.in_connectors[in_con_name] = dtypes.pointer(to_type)
                         swaps_count += 1
 
-        if hasattr(node, "out_connectors"):
             for out_con_name, out_con_type in node.out_connectors.items():
                 if out_con_type == from_type:
                     node.out_connectors[out_con_name] = to_type
@@ -2040,7 +2039,7 @@ def _change_struct_type(descriptor: dtypes.struct, from_type: typeclass, to_type
 
 def _change_member_types(descriptor: data.Array, from_type: typeclass, to_type: typeclass, swaps_count: int) -> int:
     """Change member types for descriptors with members attribute."""
-    if not hasattr(descriptor, "members"):
+    if not isinstance(descriptor, data.Structure):
         raise TypeError(f"Expected type with member attr but got {descriptor}")
 
     for member_name, member_descriptor in descriptor.members.items():

--- a/dace/transformation/interstate/condition_fusion.py
+++ b/dace/transformation/interstate/condition_fusion.py
@@ -4,7 +4,8 @@ import copy
 from dace import sdfg as sd, properties
 from dace.properties import CodeBlock
 from dace.sdfg import utils as sdutil
-from dace.sdfg.state import ControlFlowRegion, ConditionalBlock
+from dace.sdfg import nodes
+from dace.sdfg.state import ControlFlowBlock, ControlFlowRegion, ConditionalBlock
 from dace.transformation import transformation as xf
 
 
@@ -61,7 +62,7 @@ class ConditionFusion(xf.MultiStateTransformation):
                 return False
 
             parent_cfg = self.cblck1.parent_graph
-            if not hasattr(parent_cfg, "parent_graph"):
+            if parent_cfg is None:
                 return False
             parent_cfg = parent_cfg.parent_graph
             if not isinstance(parent_cfg, ConditionalBlock):
@@ -191,10 +192,11 @@ class ConditionFusion(xf.MultiStateTransformation):
             for j, node in enumerate(cfg.nodes()):
                 node.label = f"{node.label}_{j}"
 
-        # Fix SDFG parents
+        # Fix SDFG parents. NestedSDFG nodes are excluded: their ``sdfg`` is the nested graph
+        # itself, not a back-reference, and set_nested_sdfg_parent_references already fixed them.
         sdutil.set_nested_sdfg_parent_references(sdfg)
         for node, parent in sdfg.all_nodes_recursive():
-            if hasattr(node, "sdfg"):
+            if isinstance(node, ControlFlowBlock):
                 node.sdfg = parent.sdfg
 
     def fuse_nested_conditions(self, sdfg: sd.SDFG, cblck1: ConditionalBlock):
@@ -205,7 +207,7 @@ class ConditionFusion(xf.MultiStateTransformation):
         assert len(nbranch.successors(cblck1)) == 0
 
         # Check if cblck1 is nested in another conditional block
-        assert hasattr(nbranch, "parent_graph")
+        assert nbranch is not None
         assert isinstance(nbranch.parent_graph, ConditionalBlock)
         cblckp = nbranch.parent_graph
 
@@ -277,8 +279,9 @@ class ConditionFusion(xf.MultiStateTransformation):
             for j, node in enumerate(cfg.nodes()):
                 node.label = f"{node.label}_{j}"
 
-        # Fix SDFG parents
+        # Fix SDFG parents. NestedSDFG nodes are excluded: their ``sdfg`` is the nested graph
+        # itself, not a back-reference, and set_nested_sdfg_parent_references already fixed them.
         sdutil.set_nested_sdfg_parent_references(sdfg)
         for node, parent in sdfg.all_nodes_recursive():
-            if hasattr(node, "sdfg"):
+            if isinstance(node, ControlFlowBlock):
                 node.sdfg = parent.sdfg

--- a/dace/transformation/interstate/condition_fusion.py
+++ b/dace/transformation/interstate/condition_fusion.py
@@ -4,7 +4,6 @@ import copy
 from dace import sdfg as sd, properties
 from dace.properties import CodeBlock
 from dace.sdfg import utils as sdutil
-from dace.sdfg import nodes
 from dace.sdfg.state import ControlFlowBlock, ControlFlowRegion, ConditionalBlock
 from dace.transformation import transformation as xf
 

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -121,6 +121,15 @@ class StateFusion(transformation.MultiStateTransformation):
                     return True
         return False
 
+    @staticmethod
+    def is_pystate_ordered(state: SDFGState, tasklet: nodes.Tasklet) -> bool:
+        """True if ``tasklet`` carries a ``__pystate`` token -- a data dependence kept ordered across fusion."""
+        for edge in state.all_edges(tasklet):
+            neighbor = edge.dst if edge.src is tasklet else edge.src
+            if isinstance(neighbor, nodes.AccessNode) and neighbor.data == '__pystate':
+                return True
+        return False
+
     def has_path(self, first_state: SDFGState, second_state: SDFGState,
                  match_nodes: Dict[nodes.AccessNode, nodes.AccessNode], node_a: nodes.Node, node_b: nodes.Node) -> bool:
         """ Check for paths between the two states if they are fused. """
@@ -309,13 +318,16 @@ class StateFusion(transformation.MultiStateTransformation):
             resulting_ccs: List[CCDesc] = StateFusion.find_fused_components(first_cc_input, first_cc_output,
                                                                             second_cc_input, second_cc_output)
 
-            if len(resulting_ccs) > 1:
-                # Side-effect tasklets cannot be fused if could lead to data races
-                for node in first_state.nodes():
-                    if isinstance(node, nodes.Tasklet) and node.side_effects:
+            # A side-effect node (fusion barrier, I/O, side-effecting library node) must never be fused:
+            # fusion preserves only dataflow order. Exception: __pystate-ordered callbacks keep their order
+            # via that data dependence and are gated by frontend.dont_fuse_callbacks above.
+            for state in (first_state, second_state):
+                for node in state.nodes():
+                    if isinstance(node, nodes.Tasklet) and node.has_side_effects(sdfg):
+                        if StateFusion.is_pystate_ordered(state, node):
+                            continue
                         return False
-                for node in second_state.nodes():
-                    if isinstance(node, nodes.Tasklet) and node.side_effects:
+                    if isinstance(node, nodes.LibraryNode) and node.has_side_effects:
                         return False
 
             # Check for data races

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -121,15 +121,6 @@ class StateFusion(transformation.MultiStateTransformation):
                     return True
         return False
 
-    @staticmethod
-    def is_pystate_ordered(state: SDFGState, tasklet: nodes.Tasklet) -> bool:
-        """True if ``tasklet`` carries a ``__pystate`` token -- a data dependence kept ordered across fusion."""
-        for edge in state.all_edges(tasklet):
-            neighbor = edge.dst if edge.src is tasklet else edge.src
-            if isinstance(neighbor, nodes.AccessNode) and neighbor.data == '__pystate':
-                return True
-        return False
-
     def has_path(self, first_state: SDFGState, second_state: SDFGState,
                  match_nodes: Dict[nodes.AccessNode, nodes.AccessNode], node_a: nodes.Node, node_b: nodes.Node) -> bool:
         """ Check for paths between the two states if they are fused. """
@@ -240,23 +231,12 @@ class StateFusion(transformation.MultiStateTransformation):
                     if node.data == '__pystate':
                         return False
 
-            # NOTE: This is quick fix for MPI Waitall (probably also needed for
-            # Wait), until we have a better SDFG representation of the buffer
-            # dependencies.
-            try:
-                next(node for node in first_state.nodes()
-                     if (isinstance(node, nodes.LibraryNode) and type(node).__name__ == 'Waitall')
-                     or node.label == '_Waitall_')
-                return False
-            except StopIteration:
-                pass
-            try:
-                next(node for node in second_state.nodes()
-                     if (isinstance(node, nodes.LibraryNode) and type(node).__name__ == 'Waitall')
-                     or node.label == '_Waitall_')
-                return False
-            except StopIteration:
-                pass
+            # Library nodes and nested SDFGs carry dependencies fusion cannot see.
+            # Tasklet callbacks are governed by dont_fuse_callbacks above.
+            for state in (first_state, second_state):
+                for node in state.nodes():
+                    if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)) and node.has_side_effects(sdfg):
+                        return False
 
             # If second state has other input edges, there might be issues
             # Exceptions are when none of the states contain dataflow, unless
@@ -318,17 +298,12 @@ class StateFusion(transformation.MultiStateTransformation):
             resulting_ccs: List[CCDesc] = StateFusion.find_fused_components(first_cc_input, first_cc_output,
                                                                             second_cc_input, second_cc_output)
 
-            # A side-effect node (fusion barrier, I/O, side-effecting library node) must never be fused:
-            # fusion preserves only dataflow order. Exception: __pystate-ordered callbacks keep their order
-            # via that data dependence and are gated by frontend.dont_fuse_callbacks above.
-            for state in (first_state, second_state):
-                for node in state.nodes():
-                    if isinstance(node, nodes.Tasklet) and node.has_side_effects(sdfg):
-                        if StateFusion.is_pystate_ordered(state, node):
-                            continue
-                        return False
-                    if isinstance(node, nodes.LibraryNode) and node.has_side_effects:
-                        return False
+            if len(resulting_ccs) > 1:
+                # Declared side effects would race across parallel components.
+                for state in (first_state, second_state):
+                    for node in state.nodes():
+                        if isinstance(node, nodes.Tasklet) and node.side_effects:
+                            return False
 
             # Check for data races
             for fused_cc in resulting_ccs:

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -231,11 +231,11 @@ class StateFusion(transformation.MultiStateTransformation):
                     if node.data == '__pystate':
                         return False
 
-            # Library nodes and nested SDFGs carry dependencies fusion cannot see.
+            # Code nodes and nested SDFGs carry dependencies fusion cannot see.
             # Tasklet callbacks are governed by dont_fuse_callbacks above.
             for state in (first_state, second_state):
                 for node in state.nodes():
-                    if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)) and node.has_side_effects(sdfg):
+                    if isinstance(node, (nodes.CodeNode, nodes.NestedSDFG)) and node.has_side_effects(sdfg):
                         return False
 
             # If second state has other input edges, there might be issues

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -312,10 +312,10 @@ class StateFusion(transformation.MultiStateTransformation):
             if len(resulting_ccs) > 1:
                 # Side-effect tasklets cannot be fused if could lead to data races
                 for node in first_state.nodes():
-                    if isinstance(node, nodes.CodeNode) and getattr(node, 'side_effects', False):
+                    if isinstance(node, nodes.Tasklet) and node.side_effects:
                         return False
                 for node in second_state.nodes():
-                    if isinstance(node, nodes.CodeNode) and getattr(node, 'side_effects', False):
+                    if isinstance(node, nodes.Tasklet) and node.side_effects:
                         return False
 
             # Check for data races

--- a/dace/transformation/interstate/state_fusion.py
+++ b/dace/transformation/interstate/state_fusion.py
@@ -231,11 +231,11 @@ class StateFusion(transformation.MultiStateTransformation):
                     if node.data == '__pystate':
                         return False
 
-            # Code nodes and nested SDFGs carry dependencies fusion cannot see.
+            # Library nodes and nested SDFGs carry dependencies fusion cannot see.
             # Tasklet callbacks are governed by dont_fuse_callbacks above.
             for state in (first_state, second_state):
                 for node in state.nodes():
-                    if isinstance(node, (nodes.CodeNode, nodes.NestedSDFG)) and node.has_side_effects(sdfg):
+                    if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)) and node.has_side_effects(sdfg):
                         return False
 
             # If second state has other input edges, there might be issues

--- a/dace/transformation/interstate/state_fusion_with_happens_before.py
+++ b/dace/transformation/interstate/state_fusion_with_happens_before.py
@@ -238,23 +238,12 @@ class StateFusionExtended(transformation.MultiStateTransformation):
                     if node.data == '__pystate':
                         return False
 
-            # NOTE: This is quick fix for MPI Waitall (probably also needed for
-            # Wait), until we have a better SDFG representation of the buffer
-            # dependencies.
-            try:
-                next(node for node in first_state.nodes()
-                     if (isinstance(node, nodes.LibraryNode) and type(node).__name__ == 'Waitall')
-                     or node.label == '_Waitall_')
-                return False
-            except StopIteration:
-                pass
-            try:
-                next(node for node in second_state.nodes()
-                     if (isinstance(node, nodes.LibraryNode) and type(node).__name__ == 'Waitall')
-                     or node.label == '_Waitall_')
-                return False
-            except StopIteration:
-                pass
+            # Library nodes and nested SDFGs carry dependencies fusion cannot see.
+            # Tasklet callbacks are governed by dont_fuse_callbacks above.
+            for state in (first_state, second_state):
+                for node in state.nodes():
+                    if isinstance(node, (nodes.LibraryNode, nodes.NestedSDFG)) and node.has_side_effects(sdfg):
+                        return False
 
             # If second state has other input edges, there might be issues
             # Exceptions are when none of the states contain dataflow, unless

--- a/dace/transformation/interstate/state_fusion_with_happens_before.py
+++ b/dace/transformation/interstate/state_fusion_with_happens_before.py
@@ -305,6 +305,13 @@ class StateFusionExtended(transformation.MultiStateTransformation):
             resulting_ccs: List[CCDesc] = StateFusionExtended.find_fused_components(first_cc_input, first_cc_output,
                                                                                     second_cc_input, second_cc_output)
 
+            if len(resulting_ccs) > 1:
+                # Declared side effects would race across parallel components.
+                for state in (first_state, second_state):
+                    for node in state.nodes():
+                        if isinstance(node, nodes.Tasklet) and node.side_effects:
+                            return False
+
             # Check for data races
             for fused_cc in resulting_ccs:
                 # Write-Write hazard - data is output of both first and second

--- a/dace/transformation/onnx/replacement.py
+++ b/dace/transformation/onnx/replacement.py
@@ -61,6 +61,8 @@ def onnx_constant_or_none(sdfg: dace.SDFG, node_or_name: Union[nodes.AccessNode,
 
 class ReplacementTransformation(transformation.SingleStateTransformation, abc.ABC):
 
+    _pattern: Optional[gr.OrderedDiGraph] = None
+
     @classmethod
     @abc.abstractmethod
     def pattern(cls) -> gr.OrderedDiGraph[nodes.Node, dace.Memlet]:
@@ -88,7 +90,7 @@ class ReplacementTransformation(transformation.SingleStateTransformation, abc.AB
 
     @classmethod
     def expressions(cls):
-        if hasattr(cls, '_pattern'):
+        if cls._pattern is not None:
             return [cls._pattern]
         result = cls.pattern()
         add_connecting_access_nodes(result)

--- a/dace/transformation/pass_pipeline.py
+++ b/dace/transformation/pass_pipeline.py
@@ -6,6 +6,7 @@ API for SDFG analysis and manipulation Passes, as well as Pipelines that contain
 from dace import properties, serialize
 from dace.sdfg import SDFG, SDFGState, graph as gr, nodes, utils as sdutil
 
+import inspect
 from enum import Flag, auto
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Type, Union
 from dataclasses import dataclass
@@ -68,6 +69,9 @@ class Pass:
     """
 
     CATEGORY: str = 'Helper'
+
+    #: Set to True by the ``dace.transformation.explicit_cf_compatible`` decorator
+    __explicit_cf_compatible__: bool = False
 
     def depends_on(self) -> List[Union[Type['Pass'], 'Pass']]:
         """
@@ -143,7 +147,7 @@ class Pass:
 
         # Ignore abstract classes.
         result = subclasses | subsubclasses
-        result = set(sc for sc in result if not getattr(sc, '__abstractmethods__', False))
+        result = set(sc for sc in result if not inspect.isabstract(sc))
 
         return result
 

--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -226,7 +226,7 @@ class DeadDataflowElimination(ppl.ControlFlowRegionPass):
             # Library nodes must not have any side effects to be considered dead
             if self.skip_library_nodes:
                 return False
-            return not node.has_side_effects
+            return not node.has_side_effects(sdfg)
         elif isinstance(node, nodes.Tasklet):
             # If a tasklet has any callbacks, mark as "live" due to potential side effects
             return not node.has_side_effects(sdfg)
@@ -259,7 +259,7 @@ class DeadDataflowElimination(ppl.ControlFlowRegionPass):
 
                 for l in state.memlet_tree(e).leaves():
                     # If data is connected to a side-effect tasklet/library node, cannot remove
-                    if _has_side_effects(l.src, sdfg):
+                    if isinstance(l.src, nodes.CodeNode) and l.src.has_side_effects(sdfg):
                         return False
 
                     # If data is connected to a tasklet through a pointer and more than 1 element is accessed,
@@ -293,13 +293,3 @@ class DeadDataflowElimination(ppl.ControlFlowRegionPass):
 
         # Any other case can be marked as dead
         return True
-
-
-def _has_side_effects(node, sdfg):
-    try:
-        return node.has_side_effects(sdfg)
-    except (AttributeError, TypeError):
-        try:
-            return node.has_side_effects
-        except AttributeError:
-            return False

--- a/dace/transformation/passes/pattern_matching.py
+++ b/dace/transformation/passes/pattern_matching.py
@@ -97,7 +97,7 @@ class PatternMatchAndApply(ppl.Pass):
         # For every transformation in the list, find first match and apply
         for xform in self.transformations:
             if sdfg.root_sdfg.using_explicit_control_flow:
-                if (not hasattr(xform, '__explicit_cf_compatible__') or xform.__explicit_cf_compatible__ == False):
+                if not xform.__explicit_cf_compatible__:
                     warnings.warn('Pattern matching is skipping transformation ' + xform.__class__.__name__ +
                                   ' due to incompatibility with experimental control flow blocks. If the ' +
                                   'SDFG does not contain experimental blocks, ensure the top level SDFG does ' +
@@ -216,8 +216,7 @@ class PatternMatchAndApplyRepeated(PatternMatchAndApply):
                 applied_anything = False
                 for xform in xforms:
                     if sdfg.root_sdfg.using_explicit_control_flow:
-                        if (not hasattr(xform, '__explicit_cf_compatible__')
-                                or xform.__explicit_cf_compatible__ == False):
+                        if not xform.__explicit_cf_compatible__:
                             warnings.warn('Pattern matching is skipping transformation ' + xform.__class__.__name__ +
                                           ' due to incompatibility with experimental control flow blocks. If the ' +
                                           'SDFG does not contain experimental blocks, ensure the top level SDFG does ' +
@@ -402,7 +401,7 @@ def _try_to_match_transformation(graph: Union[ControlFlowRegion, SDFGState], col
                     setattr(match, oname, oval)
 
         if sdfg.root_sdfg.using_explicit_control_flow:
-            if (not hasattr(match, '__explicit_cf_compatible__') or match.__explicit_cf_compatible__ == False):
+            if not match.__explicit_cf_compatible__:
                 warnings.warn('Pattern matching is skipping transformation ' + match.__class__.__name__ +
                               ' due to incompatibility with experimental control flow blocks. If the ' +
                               'SDFG does not contain experimental blocks, ensure the top level SDFG does ' +

--- a/dace/transformation/passes/simplify.py
+++ b/dace/transformation/passes/simplify.py
@@ -115,7 +115,7 @@ class SimplifyPass(ppl.FixedPointPipeline):
         Apply a pass from the pipeline. This method is meant to be overridden by subclasses.
         """
         if sdfg.root_sdfg.using_explicit_control_flow:
-            if (not hasattr(p, '__explicit_cf_compatible__') or p.__explicit_cf_compatible__ == False):
+            if not p.__explicit_cf_compatible__:
                 warnings.warn(p.__class__.__name__ + ' is not being applied due to incompatibility with ' +
                               'experimental control flow blocks. If the SDFG does not contain experimental blocks, ' +
                               'ensure the top level SDFG does not have `SDFG.using_explicit_control_flow` set to ' +

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -20,6 +20,7 @@ All transformations extend the ``TransformationBase`` class. There are three bui
 
 import abc
 import copy
+import inspect
 from dace import serialize
 from dace.dtypes import ScheduleType
 from dace.sdfg import SDFG, SDFGState
@@ -96,7 +97,7 @@ class PatternTransformation(TransformationBase):
 
         # Ignore abstract classes
         result = subclasses | subsubclasses
-        result = set(sc for sc in result if not getattr(sc, '__abstractmethods__', False))
+        result = set(sc for sc in result if not inspect.isabstract(sc))
 
         return result
 
@@ -831,7 +832,7 @@ class SubgraphTransformation(TransformationBase):
 
         # Ignore abstract classes
         result = subclasses | subsubclasses
-        result = set(sc for sc in result if not getattr(sc, '__abstractmethods__', False))
+        result = set(sc for sc in result if not inspect.isabstract(sc))
 
         return result
 

--- a/tests/codegen/data_instrumentation_test.py
+++ b/tests/codegen/data_instrumentation_test.py
@@ -68,6 +68,31 @@ def test_dump_gpu():
     assert np.allclose(dreport['__return'], A + 6)
 
 
+def test_dump_gpu_synchronizes():
+    """Every dump must wait for the device, or it reads a buffer a copy is still filling.
+
+    The generated streams are non-blocking, so neither a host read nor the device path's
+    default-stream memcpy is ordered against them.
+    """
+
+    @dace.program
+    def tester(A: dace.float64[20, 20]):
+        tmp = A + 1
+        return tmp + 5
+
+    sdfg = tester.to_sdfg(simplify=True)
+    sdfg.apply_gpu_transformations()
+    _instrument(sdfg, dace.DataInstrumentationType.Save)
+
+    # Pin the backend so the check needs no device present.
+    with dace.config.set_temporary('compiler', 'cuda', 'backend', value='cuda'):
+        code = next(c.clean_code for c in sdfg.generate_code() if 'serializer->save(' in c.clean_code)
+
+    before_each_save = code.split('serializer->save(')[:-1]
+    assert before_each_save
+    assert all('DeviceSynchronize' in chunk for chunk in before_each_save), code
+
+
 @pytest.mark.datainstrument
 def test_restore():
 
@@ -386,6 +411,7 @@ if __name__ == '__main__':
     test_symbol_dump()
     test_symbol_dump_conditional()
     test_dump_gpu()
+    test_dump_gpu_synchronizes()
     test_restore()
     test_symbol_restore()
     test_restore_gpu()


### PR DESCRIPTION
Removes 75 of 393 `getattr`/`hasattr` call sites in `dace/`, replacing them with `isinstance` checks, direct attribute access, or class-level defaults. Reflection with no static equivalent is kept (serialization, `visit_<TypeName>` dispatch, runtime-string lookup, sympy/numpy/ast duck-typing, ONNX schema attributes, runtime-attached markers).

Three defects found while auditing:

- `condition_fusion` assigned the containing SDFG into `NestedSDFG.sdfg`, overwriting the nested graph.
- `validate_state` tested a `**kwargs` dict with `hasattr`, always False, so the `in_gpu` value threaded down from `validate_sdfg` was discarded and recomputed per state.
- `_layernorm_axis` guarded `node.axis` with `hasattr` and dereferenced it in the else branch anyway.


Fixing the latent bug in state fusion and state fusion extended, another bug was exposed. GPU instrumentation's data dump does not insert a synchronization correctly and can thus dump stale data, where GPU tests randomly fail. I have also fixed that.