### PR TITLE
Use int_floor, not `//`, for the symbolic divisions in `view`

### DIFF
--- a/dace/frontend/python/replacements/array_manipulation.py
+++ b/dace/frontend/python/replacements/array_manipulation.py
@@ -335,9 +335,13 @@ def view(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, dtype, type
     # Also, keep in mind that `old_size * (orig_bytes // view_bytes)` is different.
     # E.g., if `orig_bytes == 1 and view_bytes == 2`: `old_size * (1 // 2) == old_size * 0`.
     newshape = list(desc.shape)
-    newstrides = [(s * orig_bytes) // view_bytes if i != contigdim else s for i, s in enumerate(desc.strides)]
+    # int_floor, never `//`: on a symbolic stride `//` builds sympy `floor(expr / d)`, whose argument
+    # sym2cpp prints WITHOUT the floor, leaving each term of the sum to truncate on its own.
+    newstrides = [
+        symbolic.int_floor(s * orig_bytes, view_bytes) if i != contigdim else s for i, s in enumerate(desc.strides)
+    ]
     # don't use `*=`, because it will break the bracket
-    newshape[contigdim] = (newshape[contigdim] * orig_bytes) // view_bytes
+    newshape[contigdim] = symbolic.int_floor(newshape[contigdim] * orig_bytes, view_bytes)
 
     newarr, _ = sdfg.add_view(arr,
                               newshape,
@@ -345,7 +349,7 @@ def view(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, dtype, type
                               storage=desc.storage,
                               strides=newstrides,
                               allow_conflicts=desc.allow_conflicts,
-                              total_size=(desc.total_size * orig_bytes) // view_bytes,
+                              total_size=symbolic.int_floor(desc.total_size * orig_bytes, view_bytes),
                               may_alias=desc.may_alias,
                               alignment=desc.alignment,
                               find_new_name=True)

--- a/tests/numpy/reshape_test.py
+++ b/tests/numpy/reshape_test.py
@@ -195,6 +195,28 @@ def test_reinterpret_invalid():
         reint_invalid(A)
 
 
+def test_reinterpret_symbolic_stride_uses_int_floor():
+    """View descriptors must divide with int_floor, never `//`.
+
+    `//` on a symbolic stride builds sympy `floor(expr / d)`, and sym2cpp prints that argument
+    WITHOUT the floor, leaving each term of the sum to truncate on its own. A non-contiguous
+    symbolic stride is the case where the division does not fold away.
+    """
+
+    @dace.program
+    def reint(A: dace.data.Array(dace.int16, [N, 4], strides=[2 * N + 1, 1], total_size=N * (2 * N + 1))):
+        C = A.view(dace.int32)
+        C[:] += 1
+
+    sdfg = reint.to_sdfg(simplify=False)
+    exprs = [
+        str(e) for d in sdfg.arrays.values() if isinstance(d, dace.data.View)
+        for e in (*d.shape, *d.strides, d.total_size)
+    ]
+    assert any('int_floor' in e for e in exprs), exprs
+    assert not any('floor' in e.replace('int_floor', '') for e in exprs), exprs
+
+
 if __name__ == "__main__":
     test_reshape()
     test_reshape_dst()
@@ -207,3 +229,4 @@ if __name__ == "__main__":
     test_reinterpret_smaller()
     test_reinterpret_larger()
     test_reinterpret_invalid()
+    test_reinterpret_symbolic_stride_uses_int_floor()


### PR DESCRIPTION
`expr // d` on a symbolic stride builds sympy `floor(expr / d)`. sympy distributes the division over the sum inside the floor, and `sym2cpp` prints the argument **without** the floor, so each term is left to truncate on its own.

`view` divided `desc.strides`, `newshape[contigdim]` and `desc.total_size` with `//`. For a contiguous array the divisibility check on the last axis makes the division fold away, so this was latent there. A non-contiguous symbolic stride keeps it: strides `[2 * N + 1, 1]` viewed `int16 -> int32` left `floor(N*(2*N + 1)/2)` as the view's `total_size`.

Three call sites, plus one test that pins the view descriptors to `int_floor`. The test fails on the previous code with that bare `floor(...)` in the expression list.

Note: `tests/numpy/reshape_test.py` has pre-existing compilation failures in my environment on an unmodified `main` checkout (`test_reinterpret_smaller` and others), so I verified the new test in isolation and confirmed the baseline failures are not caused by this change.