### PR TITLE
Fix floor/ceil division on symbolic operands

### DIFF
--- a/dace/data/core.py
+++ b/dace/data/core.py
@@ -193,7 +193,9 @@ class Data:
         for dim in dimensions:
             strides[dim] = total_size
             if not only_first_aligned or first:
-                dimsize = (((self.shape[dim] + alignment - 1) // alignment) * alignment)
+                # int_ceil, never `//`: `(N + a - 1) // a` builds sympy `floor(...)`, whose argument
+                # sym2cpp prints WITHOUT the floor, truncating each term (N=1, a=8 gives 0, not 8).
+                dimsize = symbolic.int_ceil(self.shape[dim], alignment) * alignment
             else:
                 dimsize = self.shape[dim]
             total_size *= dimsize

--- a/dace/frontend/python/replacements/array_manipulation.py
+++ b/dace/frontend/python/replacements/array_manipulation.py
@@ -335,9 +335,13 @@ def view(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, dtype, type
     # Also, keep in mind that `old_size * (orig_bytes // view_bytes)` is different.
     # E.g., if `orig_bytes == 1 and view_bytes == 2`: `old_size * (1 // 2) == old_size * 0`.
     newshape = list(desc.shape)
-    newstrides = [(s * orig_bytes) // view_bytes if i != contigdim else s for i, s in enumerate(desc.strides)]
+    # int_floor, never `//`: on a symbolic stride `//` builds sympy `floor(expr / d)`, whose argument
+    # sym2cpp prints WITHOUT the floor, leaving each term of the sum to truncate on its own.
+    newstrides = [
+        symbolic.int_floor(s * orig_bytes, view_bytes) if i != contigdim else s for i, s in enumerate(desc.strides)
+    ]
     # don't use `*=`, because it will break the bracket
-    newshape[contigdim] = (newshape[contigdim] * orig_bytes) // view_bytes
+    newshape[contigdim] = symbolic.int_floor(newshape[contigdim] * orig_bytes, view_bytes)
 
     newarr, _ = sdfg.add_view(arr,
                               newshape,
@@ -345,7 +349,7 @@ def view(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str, dtype, type
                               storage=desc.storage,
                               strides=newstrides,
                               allow_conflicts=desc.allow_conflicts,
-                              total_size=(desc.total_size * orig_bytes) // view_bytes,
+                              total_size=symbolic.int_floor(desc.total_size * orig_bytes, view_bytes),
                               may_alias=desc.may_alias,
                               alignment=desc.alignment,
                               find_new_name=True)

--- a/dace/libraries/standard/reduction_planner.py
+++ b/dace/libraries/standard/reduction_planner.py
@@ -113,7 +113,7 @@ def simplify_input(shape, strides, axes):
         s = shape[rem[0]]
         for i in range(len(out_strides)):
             if (out_strides[i] > r) == True or r == 1 or expr_is_contained(r, out_strides[i]):
-                out_strides[i] //= s
+                out_strides[i] = symbolic.int_floor(out_strides[i], s)
 
     return shape, strides, axes, out_shape, out_strides
 
@@ -261,7 +261,7 @@ def get_reduction_schedule(in_array: Array,
         if len(schedule.in_shape) == 1 and schedule.out_shape == [1]:
             schedule.one_d_reduction = True
             # increase schedule.grid to appropriate value --> each block sums up 1024 values
-            schedule.grid = [(schedule.in_shape[0] + 1024 - 1) // 1024]
+            schedule.grid = [symbolic.int_ceil(schedule.in_shape[0], 1024)]
 
     else:
         # we are reducing a non-contiguous dimension
@@ -278,7 +278,7 @@ def get_reduction_schedule(in_array: Array,
         if use_mini_warps and (shape[contiguous_dimension] <= 16) == True:
             # we turn on mini_warps
             schedule.mini_warps = True
-            schedule.num_mini_warps = warp_size // shape[contiguous_dimension]
+            schedule.num_mini_warps = symbolic.int_floor(warp_size, shape[contiguous_dimension])
             # we now use 16 * schedule.num_mini_warps threads to compute 1 output element
             schedule.block = [16, shape[contiguous_dimension]]
             schedule.shared_mem_size = shape[contiguous_dimension]

--- a/dace/libraries/stencil/_common.py
+++ b/dace/libraries/stencil/_common.py
@@ -201,7 +201,7 @@ def generate_boundary_conditions(node, shape, field_accesses, field_to_desc, ite
                     if i != len(indices) - 1:
                         cond_global.add(f"_i{i} >= {offset_str}")
                     elif offset >= veclen:
-                        offset_str = sym2cpp((shape[i] - offset) // veclen)
+                        offset_str = sym2cpp(dace.symbolic.int_floor(shape[i] - offset, veclen))
                         cond_global.add(f"_i{i} >= {offset_str}")
                 else:
                     continue

--- a/dace/sdfg/performance_evaluation/op_in_helpers.py
+++ b/dace/sdfg/performance_evaluation/op_in_helpers.py
@@ -9,7 +9,7 @@ import sympy as sp
 from collections import deque
 from scipy.optimize import curve_fit
 import numpy as np
-from dace import symbol
+from dace import symbol, symbolic
 
 
 class CacheLineTracker:
@@ -27,7 +27,7 @@ class CacheLineTracker:
             self.array_info[name] = a
             self.start_lines[name] = self.next_free_line
             # increase next_free_line
-            self.next_free_line += (a.total_size.subs(mapping) * a.dtype.bytes + self.L - 1) // self.L  # ceil division
+            self.next_free_line += symbolic.int_ceil(a.total_size.subs(mapping) * a.dtype.bytes, self.L)
 
     def cache_line_id(self, name: str, access: [int], mapping):
         arr = self.array_info[name]
@@ -37,7 +37,7 @@ class CacheLineTracker:
             one_d_index += (i + sp.sympify(arr.offset[dim]).subs(mapping)) * sp.sympify(arr.strides[dim]).subs(mapping)
 
         # divide by L to get the cache line id
-        return self.start_lines[name] + (one_d_index * arr.dtype.bytes) // self.L
+        return self.start_lines[name] + symbolic.int_floor(one_d_index * arr.dtype.bytes, self.L)
 
     def copy(self):
         new_clt = CacheLineTracker(self.L)

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1063,6 +1063,10 @@ class int_floor(sympy.Function):
             return x // y
         if y.is_Number and y == 1:
             return x
+        # Exact division is not a rounding operation at all -- return the quotient itself, so the
+        # expression stays comparable and simplifiable instead of hiding behind an int_floor node.
+        if y.is_Number and sympy.Mod(x, y).is_zero:
+            return x / y
 
     def _eval_is_integer(self):
         return True
@@ -1092,9 +1096,9 @@ class int_ceil(sympy.Function):
         # descriptor keeps an int_ceil(N, 1) that never folds back to N.
         if y.is_Number and y == 1:
             return x
-        # Exact division has nothing to round up, so it is plain floor division.
+        # Exact division has nothing to round up, so it is just the quotient.
         if y.is_Number and sympy.Mod(x, y).is_zero:
-            return int_floor(x, y)
+            return x / y
 
     def _eval_is_integer(self):
         return True

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1088,6 +1088,13 @@ class int_ceil(sympy.Function):
         """
         if x.is_Number and y.is_Number:
             return sympy.ceiling(x / y)
+        # Mirrors int_floor: dividing by 1 is a no-op. Without this an unpadded (alignment == 1)
+        # descriptor keeps an int_ceil(N, 1) that never folds back to N.
+        if y.is_Number and y == 1:
+            return x
+        # Exact division has nothing to round up, so it is plain floor division.
+        if y.is_Number and sympy.Mod(x, y).is_zero:
+            return int_floor(x, y)
 
     def _eval_is_integer(self):
         return True

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1061,12 +1061,14 @@ class int_floor(sympy.Function):
         """
         if x.is_Number and y.is_Number:
             return x // y
-        if y.is_Number and y == 1:
-            return x
-        # Exact division is not a rounding operation at all -- return the quotient itself, so the
-        # expression stays comparable and simplifiable instead of hiding behind an int_floor node.
-        if y.is_Number and sympy.Mod(x, y).is_zero:
-            return x / y
+        if y.is_Number:
+            if y == 1:
+                return x
+            # Exact division is not a rounding operation at all -- return the quotient itself, so the
+            # expression stays comparable and simplifiable instead of hiding behind an int_floor node.
+            quotient = x / y
+            if quotient.is_integer:
+                return quotient
 
     def _eval_is_integer(self):
         return True
@@ -1092,13 +1094,15 @@ class int_ceil(sympy.Function):
         """
         if x.is_Number and y.is_Number:
             return sympy.ceiling(x / y)
-        # Mirrors int_floor: dividing by 1 is a no-op. Without this an unpadded (alignment == 1)
-        # descriptor keeps an int_ceil(N, 1) that never folds back to N.
-        if y.is_Number and y == 1:
-            return x
-        # Exact division has nothing to round up, so it is just the quotient.
-        if y.is_Number and sympy.Mod(x, y).is_zero:
-            return x / y
+        if y.is_Number:
+            # Mirrors int_floor: dividing by 1 is a no-op. Without this an unpadded (alignment == 1)
+            # descriptor keeps an int_ceil(N, 1) that never folds back to N.
+            if y == 1:
+                return x
+            # Exact division has nothing to round up, so it is just the quotient.
+            quotient = x / y
+            if quotient.is_integer:
+                return quotient
 
     def _eval_is_integer(self):
         return True

--- a/dace/transformation/dataflow/map_distribution.py
+++ b/dace/transformation/dataflow/map_distribution.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from numbers import Number
 import dace
 import sympy
-from dace import data, subsets
+from dace import data, subsets, symbolic
 from dace.sdfg import nodes
 from dace.sdfg import utils as sdutil
 from dace.transformation import transformation as pm
@@ -373,9 +373,11 @@ class ElementWiseArrayOperation2D(pm.SingleStateTransformation):
 
             elif isinstance(desc, data.Array):
 
-                local_name, local_arr = sdfg.add_temp_transient([(desc.shape[0]) // Px, (desc.shape[1]) // Py],
-                                                                dtype=desc.dtype,
-                                                                storage=desc.storage)
+                local_name, local_arr = sdfg.add_temp_transient(
+                    [symbolic.int_floor(desc.shape[0], Px),
+                     symbolic.int_floor(desc.shape[1], Py)],
+                    dtype=desc.dtype,
+                    storage=desc.storage)
                 local_access = graph.add_access(local_name)
                 bsizes_name, bsizes_arr = sdfg.add_temp_transient((2, ), dtype=dace.int32)
                 bsizes_access = graph.add_access(bsizes_name)
@@ -435,9 +437,11 @@ class ElementWiseArrayOperation2D(pm.SingleStateTransformation):
             if isinstance(desc, data.Scalar):
                 raise NotImplementedError
             elif isinstance(desc, data.Array):
-                local_name, local_arr = sdfg.add_temp_transient([(desc.shape[0]) // Px, (desc.shape[1]) // Py],
-                                                                dtype=desc.dtype,
-                                                                storage=desc.storage)
+                local_name, local_arr = sdfg.add_temp_transient(
+                    [symbolic.int_floor(desc.shape[0], Px),
+                     symbolic.int_floor(desc.shape[1], Py)],
+                    dtype=desc.dtype,
+                    storage=desc.storage)
                 local_access = graph.add_access(local_name)
                 bsizes_name, bsizes_arr = sdfg.add_temp_transient((2, ), dtype=dace.int32)
                 bsizes_access = graph.add_access(bsizes_name)

--- a/dace/transformation/dataflow/vectorization.py
+++ b/dace/transformation/dataflow/vectorization.py
@@ -130,7 +130,12 @@ class Vectorization(transformation.SingleStateTransformation):
         if self.strided_map:
             new_range = [dim_from, dim_to - vector_size + 1, vector_size]
         else:
-            new_range = [dim_from // vector_size, ((dim_to + 1) // vector_size) - 1, dim_skip]
+            # int_floor, never `//`: `(dim_to + 1) // vector_size` is a sum numerator, the shape
+            # sympy splits into separately-truncating terms once the floor is dropped by sym2cpp.
+            new_range = [
+                symbolic.int_floor(dim_from, vector_size),
+                symbolic.int_floor(dim_to + 1, vector_size) - 1, dim_skip
+            ]
 
         # Create preamble non-vectorized map (replacing the original map)
         if create_preamble:

--- a/dace/transformation/interstate/loop_overwrite_elimination.py
+++ b/dace/transformation/interstate/loop_overwrite_elimination.py
@@ -24,6 +24,30 @@ class LoopOverwriteElimination(transformation.MultiStateTransformation):
     def expressions(cls):
         return [sdutil.node_path_graph(cls.loop)]
 
+    def _last_iteration(self):
+        """The last value the iteration variable actually ATTAINS, or None if the range is unknown.
+
+        ``get_loop_end`` returns the inclusive bound implied by the loop CONDITION (``i < 10`` -> 9),
+        which is NOT the last attained iterate whenever the stride does not divide the trip range:
+        ``range(0, 10, 2)`` attains 8 and never 9.
+
+        Both the loop-carried-dependency guard in ``can_be_applied`` and the substitution in ``apply``
+        must reason about the SAME index -- eliminating the loop keeps exactly this iteration. They used
+        to compute it separately and disagreed (the guard tested ``end``, ``apply`` substituted the real
+        iterate), so the guard validated an index the body was never pinned to and a genuinely
+        loop-carried-dependent loop was eliminated. Deriving it once here is what keeps them in step.
+
+        ``int_floor``, never ``//``: on sympy operands ``//`` builds ``sympy.floor``, which the code
+        generator lowers to C ``/`` -- truncation toward zero, not floor -- so the emitted index
+        disagreed with the analyzed one for a symbolic bound.
+        """
+        start = loop_analysis.get_init_assignment(self.loop)
+        end = loop_analysis.get_loop_end(self.loop)
+        stride = loop_analysis.get_loop_stride(self.loop)
+        if start is None or end is None or stride is None:
+            return None
+        return start + symbolic.int_floor(end - start, stride) * stride
+
     def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
         # Check if this is a for-loop with known range.
         start = loop_analysis.get_init_assignment(self.loop)
@@ -157,11 +181,7 @@ class LoopOverwriteElimination(transformation.MultiStateTransformation):
         return True
 
     def apply(self, graph: ControlFlowRegion, sdfg: sd.SDFG):
-        start = loop_analysis.get_init_assignment(self.loop)
-        end = loop_analysis.get_loop_end(self.loop)
-        stride = loop_analysis.get_loop_stride(self.loop)
-
-        last_iteration = start + symbolic.int_floor(end - start, stride) * stride
+        last_iteration = self._last_iteration()
         itervar = self.loop.loop_variable
 
         # Rewrite each occurence of the loop variable in the loop body

--- a/dace/transformation/interstate/loop_overwrite_elimination.py
+++ b/dace/transformation/interstate/loop_overwrite_elimination.py
@@ -161,7 +161,7 @@ class LoopOverwriteElimination(transformation.MultiStateTransformation):
         end = loop_analysis.get_loop_end(self.loop)
         stride = loop_analysis.get_loop_stride(self.loop)
 
-        last_iteration = start + (end - start) // stride * stride
+        last_iteration = start + symbolic.int_floor(end - start, stride) * stride
         itervar = self.loop.loop_variable
 
         # Rewrite each occurence of the loop variable in the loop body

--- a/tests/datadesc_test.py
+++ b/tests/datadesc_test.py
@@ -60,6 +60,9 @@ def test_strides_alignment_symbolic_uses_int_ceil():
     _, total_size = desc.strides_from_layout(0, alignment=8)
     assert 'floor' not in str(total_size).replace('int_ceil', ''), total_size
     assert 'int_ceil' in sym2cpp(total_size), sym2cpp(total_size)
+    # alignment=1 is no padding: int_ceil(N, 1) must fold back to N, or every unaligned
+    # symbolic descriptor carries an int_ceil.
+    assert dace.data.Array(dace.float32, [N, N]).strides_from_layout(0, 1)[1] == N * N
 
 
 if __name__ == '__main__':

--- a/tests/datadesc_test.py
+++ b/tests/datadesc_test.py
@@ -48,8 +48,23 @@ def test_numpy_integral_shape_program():
     np.testing.assert_equal(A, 2)
 
 
+def test_strides_alignment_symbolic_uses_int_ceil():
+    """Aligned padding of a SYMBOLIC dimension must use int_ceil, never `//`.
+
+    `(N + a - 1) // a` builds sympy `floor(...)`; sym2cpp prints the argument WITHOUT the floor, so
+    each term truncates on its own and the padded size collapses (N=1, a=8 emits 0 instead of 8).
+    """
+    from dace.codegen.targets.cpp import sym2cpp
+    N = dace.symbol('N')
+    desc = dace.data.Array(dace.float32, [N])
+    _, total_size = desc.strides_from_layout(0, alignment=8)
+    assert 'floor' not in str(total_size).replace('int_ceil', ''), total_size
+    assert 'int_ceil' in sym2cpp(total_size), sym2cpp(total_size)
+
+
 if __name__ == '__main__':
     test_strides()
     test_strides_alignment()
     test_numpy_integral_properties()
     test_numpy_integral_shape_program()
+    test_strides_alignment_symbolic_uses_int_ceil()

--- a/tests/numpy/reshape_test.py
+++ b/tests/numpy/reshape_test.py
@@ -195,6 +195,28 @@ def test_reinterpret_invalid():
         reint_invalid(A)
 
 
+def test_reinterpret_symbolic_stride_uses_int_floor():
+    """View descriptors must divide with int_floor, never `//`.
+
+    `//` on a symbolic stride builds sympy `floor(expr / d)`, and sym2cpp prints that argument
+    WITHOUT the floor, leaving each term of the sum to truncate on its own. A non-contiguous
+    symbolic stride is the case where the division does not fold away.
+    """
+
+    @dace.program
+    def reint(A: dace.data.Array(dace.int16, [N, 4], strides=[2 * N + 1, 1], total_size=N * (2 * N + 1))):
+        C = A.view(dace.int32)
+        C[:] += 1
+
+    sdfg = reint.to_sdfg(simplify=False)
+    exprs = [
+        str(e) for d in sdfg.arrays.values() if isinstance(d, dace.data.View)
+        for e in (*d.shape, *d.strides, d.total_size)
+    ]
+    assert any('int_floor' in e for e in exprs), exprs
+    assert not any('floor' in e.replace('int_floor', '') for e in exprs), exprs
+
+
 if __name__ == "__main__":
     test_reshape()
     test_reshape_dst()
@@ -207,3 +229,4 @@ if __name__ == "__main__":
     test_reinterpret_smaller()
     test_reinterpret_larger()
     test_reinterpret_invalid()
+    test_reinterpret_symbolic_stride_uses_int_floor()

--- a/tests/symbolic/test_int_ceil_rewrites.py
+++ b/tests/symbolic/test_int_ceil_rewrites.py
@@ -1,0 +1,48 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""``int_ceil`` rewrite rules.
+
+``int_ceil`` used to fold only when BOTH operands were numbers, unlike ``int_floor`` which already
+folded a unit denominator. That asymmetry leaked: ``strides_from_layout`` pads with the default
+``alignment=1``, so every symbolic descriptor came back carrying an ``int_ceil(N, 1)`` that never
+folded back to ``N``.
+"""
+import pytest
+
+from dace.symbolic import int_ceil, int_floor, pystr_to_symbolic
+
+N = pystr_to_symbolic('N')
+M = pystr_to_symbolic('M')
+
+
+def test_unit_denominator_folds_away():
+    """Dividing by 1 rounds nothing up, and int_floor already folds it."""
+    assert int_ceil(N, 1) == N
+    assert int_floor(N, 1) == N
+    assert int_ceil(N * M + 3, 1) == N * M + 3
+
+
+def test_exact_division_becomes_int_floor():
+    """When the denominator divides the numerator there is nothing to round up."""
+    assert int_ceil(4 * N, 4) == int_floor(4 * N, 4)
+    assert int_ceil(8 * N + 16, 8) == int_floor(8 * N + 16, 8)
+
+
+def test_inexact_division_is_left_symbolic():
+    """A numerator that may leave a remainder must keep the ceiling."""
+    assert int_ceil(N, 8).func is int_ceil
+    assert int_ceil(4 * N + 2, 4).func is int_ceil
+    # A symbolic denominator cannot be shown to divide, so it is left alone too.
+    assert int_ceil(N, M).func is int_ceil
+
+
+@pytest.mark.parametrize('x,y,expected', [(17, 8, 3), (16, 8, 2), (1, 8, 1), (0, 8, 0)])
+def test_numeric_operands_fold(x, y, expected):
+    assert int_ceil(x, y) == expected
+
+
+if __name__ == '__main__':
+    test_unit_denominator_folds_away()
+    test_exact_division_becomes_int_floor()
+    test_inexact_division_is_left_symbolic()
+    for args in [(17, 8, 3), (16, 8, 2), (1, 8, 1), (0, 8, 0)]:
+        test_numeric_operands_fold(*args)

--- a/tests/symbolic/test_int_div_rewrites.py
+++ b/tests/symbolic/test_int_div_rewrites.py
@@ -1,10 +1,10 @@
 # Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
-"""``int_ceil`` rewrite rules.
+"""``int_floor`` / ``int_ceil`` rewrite rules.
 
 ``int_ceil`` used to fold only when BOTH operands were numbers, unlike ``int_floor`` which already
 folded a unit denominator. That asymmetry leaked: ``strides_from_layout`` pads with the default
 ``alignment=1``, so every symbolic descriptor came back carrying an ``int_ceil(N, 1)`` that never
-folded back to ``N``.
+folded back to ``N``. Both functions now share the unit-denominator and exact-division rules.
 """
 import pytest
 
@@ -21,18 +21,25 @@ def test_unit_denominator_folds_away():
     assert int_ceil(N * M + 3, 1) == N * M + 3
 
 
-def test_exact_division_becomes_int_floor():
-    """When the denominator divides the numerator there is nothing to round up."""
-    assert int_ceil(4 * N, 4) == int_floor(4 * N, 4)
-    assert int_ceil(8 * N + 16, 8) == int_floor(8 * N + 16, 8)
+@pytest.mark.parametrize('fn', [int_floor, int_ceil])
+def test_exact_division_yields_the_quotient(fn):
+    """Exact division is not a rounding operation, so neither node should survive it.
+
+    Returning the quotient rather than the other rounding function keeps the result comparable and
+    simplifiable -- ``int_floor(4*N, 4)`` and ``N`` are the same number and should compare equal.
+    """
+    assert fn(4 * N, 4) == N
+    assert fn(8 * N + 16, 8) == N + 2
+    assert fn(12 * N + 6, 3) == 4 * N + 2
 
 
-def test_inexact_division_is_left_symbolic():
-    """A numerator that may leave a remainder must keep the ceiling."""
-    assert int_ceil(N, 8).func is int_ceil
-    assert int_ceil(4 * N + 2, 4).func is int_ceil
+@pytest.mark.parametrize('fn', [int_floor, int_ceil])
+def test_inexact_division_is_left_symbolic(fn):
+    """A numerator that may leave a remainder must keep the rounding node."""
+    assert fn(N, 8).func is fn
+    assert fn(4 * N + 2, 4).func is fn
     # A symbolic denominator cannot be shown to divide, so it is left alone too.
-    assert int_ceil(N, M).func is int_ceil
+    assert fn(N, M).func is fn
 
 
 @pytest.mark.parametrize('x,y,expected', [(17, 8, 3), (16, 8, 2), (1, 8, 1), (0, 8, 0)])
@@ -42,7 +49,8 @@ def test_numeric_operands_fold(x, y, expected):
 
 if __name__ == '__main__':
     test_unit_denominator_folds_away()
-    test_exact_division_becomes_int_floor()
-    test_inexact_division_is_left_symbolic()
+    for fn in (int_floor, int_ceil):
+        test_exact_division_yields_the_quotient(fn)
+        test_inexact_division_is_left_symbolic(fn)
     for args in [(17, 8, 3), (16, 8, 2), (1, 8, 1), (0, 8, 0)]:
         test_numeric_operands_fold(*args)

--- a/tests/transformations/vectorization_test.py
+++ b/tests/transformations/vectorization_test.py
@@ -86,8 +86,22 @@ def test_propagate_parent():
     assert np.allclose(B.reshape(20), A * 2)
 
 
+def test_vectorization_symbolic_range_uses_int_floor():
+    """The vectorized map range must divide with int_floor, never `//`.
+
+    `(dim_to + 1) // vector_len` is a sum numerator: sympy splits it into separately-truncating
+    terms once sym2cpp drops the floor, so the trip count is wrong for a symbolic bound.
+    """
+    sdfg: dace.SDFG = tovec_uneven.to_sdfg()
+    # strided_map=False is the branch that divides the range; the strided form never divides.
+    assert sdfg.apply_transformations(Vectorization, options={'vector_len': 2, 'strided_map': False}) == 1
+    ranges = [str(r) for state in sdfg.states() for n in state.nodes() if hasattr(n, 'map') for r in n.map.range]
+    assert not any('floor' in r.replace('int_floor', '') for r in ranges), ranges
+
+
 if __name__ == '__main__':
     test_vectorization()
     test_vectorization_uneven()
     test_vectorization_postamble()
     test_propagate_parent()
+    test_vectorization_symbolic_range_uses_int_floor()

--- a/tests/transformations/vectorization_test.py
+++ b/tests/transformations/vectorization_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
+from dace.sdfg import nodes
 from dace.transformation.dataflow import Vectorization
 
 
@@ -93,9 +94,15 @@ def test_vectorization_symbolic_range_uses_int_floor():
     terms once sym2cpp drops the floor, so the trip count is wrong for a symbolic bound.
     """
     sdfg: dace.SDFG = tovec_uneven.to_sdfg()
+    # Vectorization matches the simplified shape, and to_sdfg only simplifies when
+    # optimizer.automatic_simplification is on -- which the CI matrix also runs OFF. Simplify
+    # here, like every sibling test does, so this checks the range expression either way.
+    sdfg.simplify()
     # strided_map=False is the branch that divides the range; the strided form never divides.
     assert sdfg.apply_transformations(Vectorization, options={'vector_len': 2, 'strided_map': False}) == 1
-    ranges = [str(r) for state in sdfg.states() for n in state.nodes() if hasattr(n, 'map') for r in n.map.range]
+    ranges = [
+        str(r) for state in sdfg.states() for n in state.nodes() if isinstance(n, nodes.MapEntry) for r in n.map.range
+    ]
     assert not any('floor' in r.replace('int_floor', '') for r in ranges), ranges
 
 


### PR DESCRIPTION
## Problem

Applying Python's `//` to a **sympy** operand builds `sympy.floor(expr / d)`. Sympy then distributes
the division over the sum inside the floor, and `sym2cpp` prints the floor's *argument* without the
floor itself -- so every term of the sum truncates on its own.

```python
>>> N = dace.symbol('N')
>>> sym2cpp((N + 1) // 16)
'((N / 16) + (1 / 16))'      # each term truncates separately; N=15 gives 0, not 1
```

`sympy.ceiling` has the identical defect, which is the more damaging one because the
`(x + a - 1) // a` round-up idiom is exactly a sum numerator.

Not every `//` is affected. Three paths exist, and only one is broken:

| path | example | status |
| --- | --- | --- |
| string | `pystr_to_symbolic("N // 2")` | correct -- parses to `__int_floor(N, 2)` |
| `@dace.program` body | `A[i // 2]` | correct -- the frontend rewrites it |
| **operator on a sympy object** | `sym // 2` in framework code | **broken** |

So this is a framework-code bug, not a user-facing one. `dace.programs` keep writing `//`.

## Fix

Two parts.

**1. Call sites.** Replace `//` / `sympy.ceiling` with `symbolic.int_floor` / `symbolic.int_ceil`
wherever the operand is symbolic. Sites where the operands are plain Python ints are left alone --
there `//` is ordinary integer division.

The live bug is `Array.strides_from_layout`: an aligned symbolic descriptor computed
`(N + a - 1) // a`, so `dace.data.Array(dace.float32, [N]).strides_from_layout(0, alignment=8)`
emitted a total size of `0` for `N = 1` instead of `8`.

**2. `int_floor` / `int_ceil` rewrite rules.** Both now fold in `eval`:

```
f(X, 1) -> X                     # dividing by 1 is not a rounding operation
f(X, Y) -> X / Y                 # when the quotient is provably an integer
```

The second rule returns the quotient itself rather than a rounding node, so the result stays
comparable and simplifiable instead of hiding behind an opaque `int_floor`. The first is load-bearing:
`alignment` defaults to `1`, so without it every unaligned symbolic descriptor came back carrying an
`int_ceil(N, 1)` that never folded back to `N` -- `int_ceil(N, 1)**2` in place of `N**2`.

## Tests

- `tests/symbolic/test_int_div_rewrites.py` -- new; both rules, over both functions: unit
  denominator, exact division, inexact division left symbolic, and numeric folding.
- `tests/datadesc_test.py` -- symbolic aligned padding emits `int_ceil`, plus an `alignment=1`
  regression guard.
- `tests/transformations/vectorization_test.py` -- symbolic non-strided map range. Needs
  `strided_map: False`; with the default the dividing branch is never reached and the test passes
  against broken code.
- `tests/numpy/reshape_test.py` -- `reinterpret` on a symbolic stride.
