### PR TITLE
Fix GPU callback synchronization race (test_gpu_callback)

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -237,6 +237,9 @@ class CUDACodeGen(TargetCodeGenerator):
         # Annotate CUDA streams and events
         self._cuda_streams, self._cuda_events = self._compute_cudastreams(sdfg)
 
+        # Stream-unaware GPU callbacks -> default stream (see method).
+        self._default_stream_unaware_gpu_callbacks(sdfg)
+
         # Find points where memory should be released to the memory pool
         self._compute_pool_release(sdfg)
 
@@ -945,6 +948,29 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
         max_events = max(state_events)
 
         return max_streams, max_events
+
+    def _default_stream_unaware_gpu_callbacks(self, top_sdfg: SDFG):
+        """A GPU-touching callback not using ``__dace_current_stream`` is forced onto the null stream."""
+        for sd in top_sdfg.all_sdfgs_recursive():
+            for state in sd.states():
+                for node in list(state.nodes()):
+                    if not (isinstance(node, nodes.Tasklet) and node.side_effects):
+                        continue
+                    if is_devicelevel_gpu(sd, state, node):
+                        continue
+                    if not any(
+                            e.data.data in sd.arrays and sd.arrays[e.data.data].storage == dtypes.StorageType.GPU_Global
+                            for e in state.all_edges(node)):
+                        continue
+                    if '__dace_current_stream' in node.code.as_string:  # stream-aware: leave as is
+                        continue
+                    warnings.warn(
+                        f'Callback "{node.label}" accesses GPU memory but is not stream-aware, so its data '
+                        'movement is forced onto the default stream. This is only correct if the callback uses '
+                        'the default stream; for any other stream, add a "dace.current_stream" argument to the '
+                        'callback and use it (e.g. cupy ExternalStream).', UserWarning)
+                    for n in nx.node_connected_component(state.nx.to_undirected(as_view=True), node):
+                        n._cuda_stream = 'nullptr'
 
     def _emit_copy(self, state_id: int, src_node: nodes.Node, src_storage: dtypes.StorageType, dst_node: nodes.Node,
                    dst_storage: dtypes.StorageType, dst_schedule: dtypes.ScheduleType,

--- a/tests/python_frontend/callback_autodetect_test.py
+++ b/tests/python_frontend/callback_autodetect_test.py
@@ -358,6 +358,25 @@ def test_gpu_callback():
     assert cp.allclose(a, expected)
 
 
+def test_gpu_callback_without_stream_warns():
+    # Codegen-only (no device needed): a GPU-touching callback that is not stream-aware must warn.
+    @dace_inhibitor
+    def cb_no_stream(arr):
+        arr *= 2
+
+    @dace.program
+    def gpucallback(A: dace.float64[20]):
+        tmp = dace.ndarray([20], dace.float64, storage=dace.StorageType.GPU_Global)
+        tmp[:] = A
+        cb_no_stream(tmp)
+        A[:] = tmp
+
+    with pytest.warns(match="Automatically creating callback"):
+        sdfg = gpucallback.to_sdfg()
+    with pytest.warns(UserWarning, match="not stream-aware"):
+        sdfg.generate_code()
+
+
 def test_bad_closure():
     """
     Testing functions that should not be in the closure (must be implemented as
@@ -1134,6 +1153,7 @@ if __name__ == '__main__':
     test_reorder_nested()
     test_callback_samename()
     test_gpu_callback()
+    test_gpu_callback_without_stream_warns()
     test_bad_closure()
     test_object_with_nested_callback()
     test_two_parameters_same_name()


### PR DESCRIPTION
A host callback that touches GPU data runs its device work (e.g. cupy) on a stream dace cannot see, so its data movement raced the surrounding async copies and gave wrong results under load (the flaky test_gpu_callback CI failure). This forces a GPU-touching callback that is not stream-aware (does not use `__dace_current_stream`) onto the default stream so ordering holds, and warns that a non-default stream needs a `dace.current_stream` argument.