### PR TITLE
External Memory Types not Correctly Detected

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -265,20 +265,20 @@ class CompiledSDFG(object):
             warnings.warn('You passed `None` as `argnames` to `CompiledSDFG`, but the SDFG you passed has positional'
                           ' arguments. This is allowed but deprecated.')
 
-        self.has_gpu_code = False
-        self.external_memory_types = set()
-        for _, _, aval in self._sdfg.arrays_recursive():
-            if aval.storage in dtypes.GPU_STORAGES:
-                self.has_gpu_code = True
-                break
-            if aval.lifetime == dtypes.AllocationLifetime.External:
-                self.external_memory_types.add(aval.storage)
-        if not self.has_gpu_code:
-            for node, _ in self._sdfg.all_nodes_recursive():
-                if (isinstance(node, (nodes.EntryNode, nodes.ExitNode, nodes.LibraryNode))
-                        and node.schedule in dtypes.GPU_SCHEDULES):
-                    self.has_gpu_code = True
-                    break
+        if any(aval.storage in dtypes.GPU_STORAGES for _, _, aval in self._sdfg.arrays_recursive()):
+            self.has_gpu_code = True
+        elif any(
+                isinstance(node, (nodes.EntryNode, nodes.ExitNode,
+                                  nodes.LibraryNode)) and node.schedule in dtypes.GPU_SCHEDULES
+                for node, _ in self._sdfg.all_nodes_recursive()):
+            self.has_gpu_code = True
+        else:
+            self.has_gpu_code = False
+
+        self.external_memory_types = {
+            aval.storage
+            for _, _, aval in self._sdfg.arrays_recursive() if aval.lifetime == dtypes.AllocationLifetime.External
+        }
 
     def get_exported_function(self, name: str, restype=None) -> Optional[Callable[..., Any]]:
         """

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -265,7 +265,7 @@ class CompiledSDFG(object):
             warnings.warn('You passed `None` as `argnames` to `CompiledSDFG`, but the SDFG you passed has positional'
                           ' arguments. This is allowed but deprecated.')
 
-        if any(aval.storage in dtypes.GPU_STORAGES for _, _, aval in self._sdfg.arrays_recursive()):
+        if any(aval.storage == dtypes.GPU_Global for _, _, aval in self._sdfg.arrays_recursive()):
             self.has_gpu_code = True
         elif any(
                 isinstance(node, (nodes.EntryNode, nodes.ExitNode,

--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -265,7 +265,7 @@ class CompiledSDFG(object):
             warnings.warn('You passed `None` as `argnames` to `CompiledSDFG`, but the SDFG you passed has positional'
                           ' arguments. This is allowed but deprecated.')
 
-        if any(aval.storage == dtypes.GPU_Global for _, _, aval in self._sdfg.arrays_recursive()):
+        if any(aval.storage == dtypes.StorageType.GPU_Global for _, _, aval in self._sdfg.arrays_recursive()):
             self.has_gpu_code = True
         elif any(
                 isinstance(node, (nodes.EntryNode, nodes.ExitNode,

--- a/tests/codegen/external_memory_test.py
+++ b/tests/codegen/external_memory_test.py
@@ -94,7 +94,61 @@ def test_external_twobuffers():
     assert np.allclose(wsp[-1], m)
 
 
+def test_external_memory_detection_with_gpu_arrays():
+    """Regression test for [PR#2461](https://github.com/spcl/dace/pull/2461)"""
+    from dace.codegen import compiler
+    from dace.codegen.compiled_sdfg import CompiledSDFG, ReloadableDLL
+
+    @dace.program
+    def tester(a: dace.float64[20]):
+        workspace = dace.ndarray([20], dace.float64, lifetime=dace.AllocationLifetime.External)
+        workspace[:] = a
+        workspace += 1
+        a[:] = workspace
+
+    sdfg = tester.to_sdfg()
+    csdfg = sdfg.compile()
+    assert csdfg.has_gpu_code == False
+    binary_name = str(compiler.get_binary_name(sdfg.build_folder, sdfg.name))
+
+    def make_probe(gpu_storage: dace.StorageType) -> CompiledSDFG:
+        # ``arrays_recursive()`` yields in insertion order: the GPU array
+        #  comes FIRST, before the external-lifetime arrays - the order the
+        #  broken scan dropped.
+        crafted = dace.SDFG(sdfg.name)
+        crafted.add_array('gpu_scratch', [2], dace.float64, storage=gpu_storage, transient=True)
+        crafted.add_array('ws_heap', [2],
+                          dace.float64,
+                          storage=dace.StorageType.CPU_Heap,
+                          transient=True,
+                          lifetime=dace.AllocationLifetime.External)
+        crafted.add_array('ws_pinned', [2],
+                          dace.float64,
+                          storage=dace.StorageType.CPU_Pinned,
+                          transient=True,
+                          lifetime=dace.AllocationLifetime.External)
+        crafted.add_state()
+        # A separate DLL handle over the same binary keeps the probes'
+        #  unloading independent (dlopen reference-counts the library).
+        return CompiledSDFG(crafted, ReloadableDLL(binary_name))
+
+    external = {dace.StorageType.CPU_Heap, dace.StorageType.CPU_Pinned}
+
+    # Defect 1: a GPU_Global array must be detected as GPU code.
+    probe = make_probe(dace.StorageType.GPU_Global)
+    assert probe.has_gpu_code
+    assert probe.external_memory_types == external
+
+    # Defect 2: a leading GPU-storage array (GPU_Shared was the ONLY member
+    #  of GPU_STORAGES, i.e. the storage that took the old ``break``) must
+    #  not swallow the external arrays behind it.
+    probe = make_probe(dace.StorageType.GPU_Shared)
+    assert probe.external_memory_types == external
+    assert not probe.has_gpu_code  # No GPU_Global array, no GPU-scheduled node.
+
+
 if __name__ == '__main__':
     test_external_mem(False)
     test_external_mem(True)
     test_external_twobuffers()
+    test_external_memory_detection_with_gpu_arrays()


### PR DESCRIPTION
The storage types of the external memory is computed in the same loop that scans the data descriptor for GPU memory, which is needed to set `CompiledSDFG.has_gpu_code`, once such a descriptor is found, the loop exits.
This means if a GPU data descriptor is found before any data descriptor with external memory external memory is not found.
This PR moves the computation of the external memory storage types into its separate loops.
Furthermore, it makes the computation of the `has_gpu_code` property a bit more elegant by using `any()` and a less nested `if` construct. 





