### PR TITLE
Fuse Maps that bind the same dynamic map range to the same value

### DIFF
--- a/dace/transformation/dataflow/map_fusion_helper.py
+++ b/dace/transformation/dataflow/map_fusion_helper.py
@@ -279,11 +279,18 @@ def relocate_nodes(
             #  inside the Map scope to define a variable. We handle it directly.
             dmr_symbol = edge_to_move.dst_conn
 
-            # TODO(phimuell): Check if the symbol is really unused in the target scope.
             if dmr_symbol in to_node.in_connectors:
-                raise NotImplementedError(f"Tried to move the dynamic map range '{dmr_symbol}' from {from_node}'"
-                                          f" to '{to_node}', but the symbol is already known there, but the"
-                                          " renaming is not implemented.")
+                # Same symbol, same value: the moved binding is redundant, so drop it instead.
+                if not dynamic_map_range_binding_agrees(state, to_node, from_node, dmr_symbol):
+                    raise NotImplementedError(f"Tried to move the dynamic map range '{dmr_symbol}' from {from_node}'"
+                                              f" to '{to_node}', but the symbol is already known there, but the"
+                                              " renaming is not implemented.")
+                source = edge_to_move.src
+                state.remove_edge(edge_to_move)
+                from_node.remove_in_connector(dmr_symbol)
+                if state.degree(source) == 0:
+                    state.remove_node(source)
+                continue
             if not to_node.add_in_connector(dmr_symbol, force=False):
                 raise RuntimeError(  # Might fail because of out connectors.
                     f"Failed to add the dynamic map range symbol '{dmr_symbol}' to '{to_node}'.")
@@ -404,6 +411,47 @@ def is_parallel(
     return True
 
 
+def dynamic_map_range_edge(
+    state: dace.SDFGState,
+    map_entry: nodes.MapEntry,
+    symbol: str,
+) -> graph.MultiConnectorEdge:
+    """The single edge that binds dynamic-map-range `symbol` on `map_entry`."""
+    return next(iter(state.in_edges_by_connector(map_entry, symbol)))
+
+
+def dynamic_map_range_binding_agrees(
+    state: dace.SDFGState,
+    map_entry: nodes.MapEntry,
+    other_map_entry: nodes.MapEntry,
+    symbol: str,
+) -> bool:
+    """`True` if both Maps bind dynamic-map-range `symbol` to provably the same value."""
+    edge = dynamic_map_range_edge(state, map_entry, symbol)
+    other_edge = dynamic_map_range_edge(state, other_map_entry, symbol)
+    data = edge.data.data
+    if (data != other_edge.data.data or edge.src_conn != other_edge.src_conn
+            or edge.data.subset != other_edge.data.subset):
+        return False
+    if edge.src is other_edge.src:
+        return True
+    # Distinct sources agree only if nothing writes that data in this state.
+    return not any(state.in_degree(dn) for dn in state.data_nodes() if dn.data == data)
+
+
+def dynamic_map_ranges_agree(
+    first_map_entry: nodes.MapEntry,
+    second_map_entry: nodes.MapEntry,
+    state: dace.SDFGState,
+) -> bool:
+    """`True` if every dynamic-map-range symbol both Maps bind is bound to the same value."""
+    shared = {c
+              for c in first_map_entry.in_connectors
+              if not c.startswith("IN_")} & {c
+                                             for c in second_map_entry.in_connectors if not c.startswith("IN_")}
+    return all(dynamic_map_range_binding_agrees(state, first_map_entry, second_map_entry, symbol) for symbol in shared)
+
+
 def can_topologically_be_fused(
     first_map_entry: nodes.MapEntry,
     second_map_entry: nodes.MapEntry,
@@ -451,6 +499,10 @@ def can_topologically_be_fused(
     elif only_toplevel_maps:
         if scope[first_map_entry] is not None:
             return None
+
+    # A colliding dynamic map range cannot be renamed, only dropped when both bind the same value.
+    if not dynamic_map_ranges_agree(first_map_entry, second_map_entry, graph):
+        return None
 
     # We will now check if we can rename the Map parameter of the second Map such that they
     #  match the one of the first Map.

--- a/tests/transformations/map_fusion_horizontal_test.py
+++ b/tests/transformations/map_fusion_horizontal_test.py
@@ -1,6 +1,8 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
+import os
 from typing import Tuple
 
+import numpy as np
 import pytest
 
 import dace
@@ -275,6 +277,97 @@ def test_deterministic_label_in_horizontal_map_fusion(first_order: bool):
     assert expected_final_label == final_me.map.label
 
 
+def _make_shared_dynamic_map_range_sdfg(binding: str) -> dace.SDFG:
+    """Two parallel Maps whose ranges are both bounded by a dynamic map range named ``lim``.
+
+    ``binding`` selects how the two bounds are read: ``same_node`` (one AccessNode feeding both),
+    ``same_data`` (two AccessNodes of the same never-written array), ``other_data`` (two different
+    arrays) or ``written_data`` (same array, but a tasklet writes it in this very state).
+    """
+    sdfg = dace.SDFG(unique_name(f"shared_dmr_{binding}"))
+    for name in ("bound", "other_bound"):
+        sdfg.add_array(name, shape=(1, ), dtype=dace.int64, transient=False)
+    for name in ("A", "B"):
+        sdfg.add_array(name, shape=(10, ), dtype=dace.float64, transient=False)
+    state = sdfg.add_state(is_start_block=True)
+
+    first_source = state.add_access("bound")
+    if binding == "same_node":
+        second_source = first_source
+    elif binding == "other_data":
+        second_source = state.add_access("other_bound")
+    else:
+        second_source = state.add_access("bound")
+    if binding == "written_data":
+        writer = state.add_tasklet("set_bound", {}, {"__out"}, "__out = 4")
+        state.add_edge(writer, "__out", state.add_access("bound"), None, dace.Memlet("bound[0]"))
+
+    for name, source, value in (("A", first_source, 1.0), ("B", second_source, 2.0)):
+        _, map_entry, _ = state.add_mapped_tasklet(
+            f"comp_{name}",
+            map_ranges={"__i": "0:lim"},
+            inputs={},
+            code=f"__out = {value}",
+            outputs={"__out": dace.Memlet(f"{name}[__i]")},
+            output_nodes={name: state.add_access(name)},
+            external_edges=True,
+        )
+        map_entry.add_in_connector("lim")
+        state.add_edge(source, None, map_entry, "lim", dace.Memlet(f"{source.data}[0]"))
+    sdfg.validate()
+    return sdfg
+
+
+@pytest.mark.parametrize("binding", ["same_node", "same_data"])
+def test_horizontal_fusion_drops_an_equal_dynamic_map_range(binding: str):
+    """A dynamic map range both Maps bind to the same value is redundant, so it is dropped.
+
+    Relocation cannot rename a colliding symbol; before the fix any collision raised
+    ``NotImplementedError`` from the middle of ``apply()``, leaving the state half-rewired.
+    """
+    sdfg = _make_shared_dynamic_map_range_sdfg(binding)
+    state = sdfg.start_block
+
+    assert sdfg.apply_transformations_repeated(dftrans.MapFusionHorizontal, validate_all=True) == 1
+
+    fused_entry = count_nodes(state, nodes.MapEntry, return_nodes=True)
+    assert len(fused_entry) == 1
+    # The surviving Map still binds `lim` exactly once, through exactly one edge.
+    assert {c for c in fused_entry[0].in_connectors if not c.startswith("IN_")} == {"lim"}
+    assert len(list(state.in_edges_by_connector(fused_entry[0], "lim"))) == 1
+    assert count_nodes(state, nodes.AccessNode) == 3  # bound, A, B -- the duplicate source is gone
+    sdfg.validate()
+
+
+def test_horizontal_fusion_keeps_the_dynamic_map_range_bound():
+    """Dropping the redundant binding must not change the iteration space of the fused Map."""
+    sdfg = _make_shared_dynamic_map_range_sdfg("same_data")
+    assert sdfg.apply_transformations_repeated(dftrans.MapFusionHorizontal, validate_all=True) == 1
+    csdfg = sdfg.compile()
+
+    bound = np.full((1, ), 4, dtype=np.int64)
+    args = {name: np.full((10, ), -1.0, dtype=np.float64) for name in ("A", "B")}
+    expected = {name: np.where(np.arange(10) < 4, value, -1.0) for name, value in (("A", 1.0), ("B", 2.0))}
+
+    csdfg(bound=bound, other_bound=bound.copy(), **args)
+    for name in args:
+        assert np.array_equal(args[name], expected[name]), f"fused Map did not honor the dynamic bound for {name}"
+
+
+@pytest.mark.parametrize("binding", ["other_data", "written_data"])
+def test_horizontal_fusion_rejects_a_disagreeing_dynamic_map_range(binding: str):
+    """Two Maps binding the same symbol to different values cannot fuse -- and must not mutate."""
+    sdfg = _make_shared_dynamic_map_range_sdfg(binding)
+    state = sdfg.start_block
+    before = (state.number_of_nodes(), state.number_of_edges())
+
+    assert sdfg.apply_transformations_repeated(dftrans.MapFusionHorizontal, validate_all=True) == 0
+
+    assert (state.number_of_nodes(), state.number_of_edges()) == before
+    assert count_nodes(state, nodes.MapEntry) == 2
+    sdfg.validate()
+
+
 if __name__ == '__main__':
     test_vertical_map_fusion_common_ancestor_is_required()
     test_vertical_map_fusion_no_common_ancestor_not_required()
@@ -283,3 +376,8 @@ if __name__ == '__main__':
     test_vertical_maps_are_not_fused_horizontally()
     test_deterministic_label_in_horizontal_map_fusion(first_order=True)
     test_deterministic_label_in_horizontal_map_fusion(first_order=False)
+    test_horizontal_fusion_drops_an_equal_dynamic_map_range("same_node")
+    test_horizontal_fusion_drops_an_equal_dynamic_map_range("same_data")
+    test_horizontal_fusion_keeps_the_dynamic_map_range_bound()
+    test_horizontal_fusion_rejects_a_disagreeing_dynamic_map_range("other_data")
+    test_horizontal_fusion_rejects_a_disagreeing_dynamic_map_range("written_data")


### PR DESCRIPTION
A dynamic-map-range collision is now decided in `can_topologically_be_fused` and the redundant binding is dropped, instead of `relocate_nodes` raising `NotImplementedError` after it has already rewired part of the state.