### PR TITLE
Rewrite a dot to an arrow only between names, not inside an index expression

### DIFF
--- a/dace/codegen/targets/cpp.py
+++ b/dace/codegen/targets/cpp.py
@@ -9,6 +9,7 @@ import functools
 import itertools
 import math
 import numbers
+import re
 import warnings
 
 import sympy as sp
@@ -369,9 +370,11 @@ def emit_memlet_reference(dispatcher: 'TargetDispatcher',
     # Register defined variable
     dispatcher.defined_vars.add(pointer_name, defined_type, typedef, allow_shadowing=True)
 
-    # NOTE: `expr` may only be a name or a sequence of names and dots. The latter indicates nested data and structures.
-    # NOTE: Since structures are implemented as pointers, we replace dots with arrows.
-    expr = expr.replace('.', '->')
+    # NOTE: A dot separating names indicates nested data and structures, and structures are
+    # implemented as pointers, so it becomes an arrow. Only a dot BETWEEN NAMES qualifies: `expr`
+    # ends in an index expression, so a decimal literal there was rewritten too, e.g.
+    # `&A[(0.5 * j)]` -> `&A[(0->5 * j)]`, which does not compile.
+    expr = re.sub(r'\.(?=[A-Za-z_])', '->', expr)
 
     return (typedef + ref, pointer_name, expr)
 

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -478,10 +478,10 @@ class Range(Subset):
         coord = self.coord_at(i)
 
         # Return i0 + i1*size0 + i2*size1*size0 + ....
-        # Cancel out stride since we determine the initial offset only here
-        return sum(
-            _expr(s) * _expr(astr) / _expr(rs)
-            for s, (_, _, rs), astr in zip(coord, self.ranges, self.absolute_strides(strides)))
+        # The array stride directly, rather than `absolute_strides` divided back down by the range
+        # step: those are `rs * strides[i]` and `rs`, so the division only undoes the multiplication,
+        # and it cancels only because `/` is modeled over the rationals.
+        return sum(_expr(s) * _expr(stride) for s, _, stride in zip(coord, self.ranges, strides))
 
     def data_dims(self):
         return (sum(1 if (re - rb + 1) != 1 else 0 for rb, re, _ in self.ranges) + sum(1 if ts != 1 else 0

--- a/tests/codegen/cpp_test.py
+++ b/tests/codegen/cpp_test.py
@@ -4,7 +4,7 @@ from functools import reduce
 from operator import mul
 import warnings
 
-from dace import SDFG, Memlet, dtypes
+from dace import SDFG, Memlet, dtypes, symbol
 from dace.codegen import codegen
 from dace.codegen.targets import cpp
 from dace.codegen.targets.cpu import _use_aligned_operator_new
@@ -184,6 +184,35 @@ def test_arrays_bigger_than_max_stack_size_get_deallocated():
             assert "delete[] A" in code, "A is deallocated from the heap."
 
 
+def test_at_multiplies_the_coordinate_by_the_array_stride():
+    # A strided range: the offset is coordinate * array stride, with no rational division to cancel.
+    assert Range([(0, 19, 2)]).at([1], [4]) == 8
+
+
+def test_pointer_argument_keeps_a_decimal_literal():
+    # The dot-to-arrow rewrite for struct members must not reach a decimal literal in the index
+    # expression a pointer argument carries: `&A[(0.5 * j)]` became `&A[(0->5 * j)]`.
+    N = symbol('N')
+    nsdfg = SDFG('inner')
+    nsdfg.add_array('a', [N], dtypes.float64)
+    nstate = nsdfg.add_state()
+    tasklet = nstate.add_tasklet('z', {}, {'o'}, 'o = 1.0')
+    nstate.add_edge(tasklet, 'o', nstate.add_write('a'), None, Memlet('a[0]'))
+
+    sdfg = SDFG('pointer_decimal')
+    sdfg.add_symbol('N', dtypes.int64)
+    sdfg.add_array('A', [N], dtypes.float64)
+    state = sdfg.add_state()
+    entry, exit = state.add_map('m', dict(j='0:N'))
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {}, {'a'}, symbol_mapping=dict(N='N', j='j'))
+    state.add_nedge(entry, nsdfg_node, Memlet())
+    state.add_memlet_path(nsdfg_node, exit, state.add_write('A'), src_conn='a', memlet=Memlet('A[0.5*j]'))
+
+    code = codegen.generate_code(sdfg)[0].clean_code
+    assert '&A[(0.5 * j)]' in code
+    assert '0->5' not in code
+
+
 if __name__ == '__main__':
     test_reshape_strides_multidim_array_all_dims_unit()
     test_reshape_strides_multidim_array_some_dims_unit()
@@ -192,3 +221,6 @@ if __name__ == '__main__':
     test_reshape_strides_from_strided_and_offset_range()
 
     test_arrays_bigger_than_max_stack_size_get_deallocated()
+
+    test_at_multiplies_the_coordinate_by_the_array_stride()
+    test_pointer_argument_keeps_a_decimal_literal()


### PR DESCRIPTION
The struct-member dot-to-arrow rewrite in `emit_memlet_reference` ran over the whole pointer expression, so a decimal literal in an index offset became `0->5` and the generated C++ did not compile.

Reproducer (`tests/codegen/cpp_test.py::test_pointer_argument_keeps_a_decimal_literal`, fails before this change): a nested SDFG whose pointer argument carries a subset with a decimal coefficient emits

```
nested_0_0_3(__state, &A[(0->5 * j)], M, N);
```

A blanket `replace('.', '->')` cannot serve both cases: `&s.f[(0.5 * i)]` needs the first dot converted and the second left alone. A dot between names is the struct access; a dot followed by a digit is part of a literal.
