### PR TITLE
[stree] Fix propagation of memlets with undefined symbols

### DIFF
--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -1686,10 +1686,8 @@ def propagate_subset(memlets: List[Memlet],
     else:
         defined_variables = set(defined_variables)
 
-    if undefined_variables is not None:
-        defined_variables = defined_variables - set(symbolic.pystr_to_symbolic(p) for p in undefined_variables)
-    else:
-        undefined_variables = set()
+    undefined_variables = set(symbolic.pystr_to_symbolic(p) for p in undefined_variables or set())
+    defined_variables -= undefined_variables
 
     # Propagate subset
     variable_context = [defined_variables, [symbolic.pystr_to_symbolic(p) for p in params]]
@@ -1714,7 +1712,10 @@ def propagate_subset(memlets: List[Memlet],
         else:
             subset = md.subset
 
-        for pclass in MemletPattern.extensions():
+        subset_free_symbols = set(symbolic.pystr_to_symbolic(s) for s in subset.free_symbols)
+        # Local symbols are opaque outside their defining scope, so use the conservative fallback.
+        applicable_patterns = [] if subset_free_symbols & undefined_variables else MemletPattern.extensions()
+        for pclass in applicable_patterns:
             pattern = pclass()
             if pattern.can_be_applied([subset], variable_context, rng, [md]):
                 tmp_subset = pattern.propagate(arr, [subset], rng)

--- a/tests/memlet_propagation_test.py
+++ b/tests/memlet_propagation_test.py
@@ -1,7 +1,7 @@
 # Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import numpy as np
-from dace.sdfg.propagation import propagate_memlets_sdfg
+from dace.sdfg import propagation
 
 
 def test_conditional():
@@ -74,7 +74,7 @@ def test_nsdfg_memlet_propagation_with_one_sparse_dimension():
             A[i, ind[i, j]] += 1
 
     sdfg = sparse.to_sdfg(simplify=False)
-    propagate_memlets_sdfg(sdfg)
+    propagation.propagate_memlets_sdfg(sdfg)
 
     # Verify all memlet subsets and volumes in the main state of the program, i.e. around the NSDFG.
     map_state = sdfg.states()[1]
@@ -106,8 +106,27 @@ def test_nsdfg_memlet_propagation_with_one_sparse_dimension():
         raise RuntimeError('Expected subset of outer out memlet to be [0:M, 0:N], found ' + str(outer_out.subset))
 
 
+def test_undefined_symbol_propagation():
+    N = dace.symbol('N')
+    k = dace.symbol('k')
+    array = dace.data.Array(dace.float64, [20])
+    map_range = dace.subsets.Range([(0, N - 1, 1)])
+    expected_memlet = dace.Memlet('A[0:20]', volume=N)
+
+    for undefined_variables in ({'k'}, {k}):
+        propagated_memlet = propagation.propagate_subset([dace.Memlet('A[i + k]')],
+                                                         array, ['i'],
+                                                         map_range,
+                                                         undefined_variables=undefined_variables)
+        assert propagated_memlet == expected_memlet
+
+    propagated_memlet = propagation.propagate_subset([dace.Memlet('A[i + k]')], array, ['i'], map_range)
+    assert propagated_memlet == dace.Memlet('A[k:N + k]', volume=N)
+
+
 if __name__ == '__main__':
     test_conditional()
     test_conditional_nested()
     test_runtime_conditional()
     test_nsdfg_memlet_propagation_with_one_sparse_dimension()
+    test_undefined_symbol_propagation()

--- a/tests/schedule_tree/propagation_test.py
+++ b/tests/schedule_tree/propagation_test.py
@@ -8,7 +8,6 @@ from dace.sdfg.analysis.schedule_tree import tree_to_sdfg as t2s, treenodes as t
 from dace.properties import CodeBlock
 
 import numpy as np
-import pytest
 
 
 def test_stree_propagation_forloop():
@@ -30,7 +29,6 @@ def test_stree_propagation_forloop():
     assert list(node_types[2].output_memlets()) == [memlet]
 
 
-@pytest.mark.skip("Suboptimal memlet propagation: https://github.com/spcl/dace/issues/2293")
 def test_stree_propagation_symassign():
     # Manually create a schedule tree
     N = dace.symbol('N')
@@ -58,7 +56,6 @@ def test_stree_propagation_symassign():
     assert list(stree.children[0].input_memlets()) == [dace.Memlet('A[0:20]', volume=N - 1)]
 
 
-@pytest.mark.skip("Suboptimal memlet propagation: https://github.com/spcl/dace/issues/2293")
 def test_stree_propagation_dynset():
     H = dace.symbol('H')
     nnz = dace.symbol('nnz')


### PR DESCRIPTION
## Description

Normalize explicitly undefined symbols before memlet propagation and route subsets containing them through the conservative fallback. This prevents scope-local symbols from leaking into outer schedule-tree memlet summaries while preserving precise propagation for symbols that remain defined.

This also re-enables the symbol-assignment and dynamic-range schedule-tree regression tests, and adds coverage for affine expressions with string- and symbol-valued undefined-variable sets.

Closes #2293.

## Testing

- `pre-commit run --all-files`
- Relevant memlet propagation and schedule-tree suite: 118 passed, 2 xfailed
- Focused regressions: 4 passed