### PR TITLE
Fixed Instrumentation

### DIFF
--- a/dace/codegen/compiler.py
+++ b/dace/codegen/compiler.py
@@ -152,8 +152,18 @@ def generate_program_folder(
 
     # Generate the parts of the folder that are exclusive to the development folder mode.
     if folder_mode in ["development"]:
-        # Copy a full snapshot of configuration script
+        # NOTE: There is a bug here, as this only saves they keys inside the configuration
+        #   `dict`. It ignores the configuration values set through environment variables.
+        #   instead it will store the ones in the `dict`.
         Config.save(os.path.join(out_path, "dace.conf"), all=True)
+
+    # The runtime's `report.save()` uses `std::ofstream` to open `<folder>/perf/report-*.json`.
+    #  If `perf/` does not exist it will fail, thus we have to create it if it is needed.
+    #  Technically we only need to create it if the SDFG is instrumented. But we will also
+    #  create it in development mode. Furthermore, if there is no SDFG given, we also create
+    #  it to be on the safe side.
+    if (folder_mode in ["development"]) or (sdfg is None) or sdfg.is_instrumented():
+        os.makedirs(os.path.join(out_path, 'perf'), exist_ok=True)
 
     # The folder mode file is always generated. In case it is missing we assume the old version.
     with open(os.path.join(out_path, "FOLDER_MODE"), "w") as version_file:
@@ -194,9 +204,10 @@ def configure_and_compile(
     build_folder = os.path.join(program_folder, "build")
     os.makedirs(build_folder, exist_ok=True)
 
-    # Prepare performance report folder if requested.
-    if folder_mode == "development":
-        os.makedirs(os.path.join(program_folder, "perf"), exist_ok=True)
+    # NOTE: We do not create the instrumentation-report folder (`perf/`) here.
+    #   The reason is that this folder is only needed when the SDFG is instrumented,
+    #   and to determine this we need the SDFG and we do not have that. Thus the
+    #   folder is generated (if needed) by `generate_program_folder()`.
 
     # Read list of DaCe files to compile.
     # We do this instead of iterating over source files in the directory to

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -1047,8 +1047,11 @@ class SDFG(ControlFlowRegion):
         if self.instrument != dtypes.InstrumentationType.No_Instrumentation:
             return True
         try:
+            # There are two different `instrument` attributes one in `SDFGState`, with type
+            #  `InstrumentationType` and one in `AccessNode`, with type `DataInstrumentationType`.
+            #  The check bellow works for both cases.
             next(n for n, _ in self.all_nodes_recursive()
-                 if hasattr(n, 'instrument') and n.instrument != dtypes.InstrumentationType.No_Instrumentation)
+                 if hasattr(n, 'instrument') and n.instrument != type(n.instrument).No_Instrumentation)
             return True
         except StopIteration:
             return False

--- a/tests/sdfg/instrumentation_report_folder_test.py
+++ b/tests/sdfg/instrumentation_report_folder_test.py
@@ -69,8 +69,9 @@ def test_perf_folder_created_exactly_when_instrumented(tmp_path):
                 sdfg.instrument = dtypes.InstrumentationType.Timer
             objects = codegen.generate_code(sdfg)
             out = str(tmp_path / sdfg.name)
+            should_folder_exists = instrumented or folder_mode == "development"
             compiler.generate_program_folder(sdfg, objects, out, folder_mode=folder_mode)
-            assert os.path.isdir(os.path.join(out, 'perf')) == instrumented, \
+            assert os.path.isdir(os.path.join(out, 'perf')) == should_folder_exists, \
                 f'perf/ existence mismatch for folder_mode={folder_mode}, instrumented={instrumented}'
 
 

--- a/tests/sdfg/instrumentation_report_folder_test.py
+++ b/tests/sdfg/instrumentation_report_folder_test.py
@@ -1,0 +1,80 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""``SDFG.is_instrumented()`` correctness and creation of the ``perf/``
+report folder.
+
+The runtime's ``report.save()`` opens ``<build_folder>/perf/report-*.json``
+with a bare ``std::ofstream``, which neither creates directories nor reports a
+failed open - if ``perf/`` is missing, every instrumentation report is dropped
+silently. It therefore must be created for every instrumented SDFG, in BOTH
+folder modes ('production' used to skip it entirely), and only for
+instrumented SDFGs (uninstrumented folders stay lean).
+"""
+
+import os
+
+import dace
+from dace import dtypes
+
+
+def _make_sdfg(name: str) -> dace.SDFG:
+    sdfg = dace.SDFG(name)
+    sdfg.add_array('A', [16], dace.float64)
+    state = sdfg.add_state()
+    state.add_mapped_tasklet(
+        'work',
+        map_ranges={'i': '0:16'},
+        inputs={'__in': dace.Memlet('A[i]')},
+        outputs={'__out': dace.Memlet('A[i]')},
+        code='__out = __in + 1.0',
+        external_edges=True,
+    )
+    return sdfg
+
+
+def test_is_instrumented_distinguishes_enum_kinds():
+    # AccessNodes carry a DataInstrumentationType whose No_Instrumentation is
+    # a DIFFERENT enum member than InstrumentationType's: a cross-enum
+    # comparison made every SDFG with an access node count as instrumented.
+    sdfg = _make_sdfg('instr_probe')
+    assert not sdfg.is_instrumented()
+
+    sdfg.instrument = dtypes.InstrumentationType.Timer
+    assert sdfg.is_instrumented()
+    sdfg.instrument = dtypes.InstrumentationType.No_Instrumentation
+    assert not sdfg.is_instrumented()
+
+    state = next(iter(sdfg.states()))
+    state.instrument = dtypes.InstrumentationType.Timer
+    assert sdfg.is_instrumented()
+    state.instrument = dtypes.InstrumentationType.No_Instrumentation
+    assert not sdfg.is_instrumented()
+
+    # Data instrumentation counts as well - against its OWN enum.
+    an = next(n for n in state.nodes() if isinstance(n, dace.nodes.AccessNode))
+    an.instrument = dtypes.DataInstrumentationType.Save
+    assert sdfg.is_instrumented()
+    an.instrument = dtypes.DataInstrumentationType.No_Instrumentation
+    assert not sdfg.is_instrumented()
+
+
+def test_perf_folder_created_exactly_when_instrumented(tmp_path):
+    # Codegen-only (no compiler involved): generate_program_folder is the
+    # function that owns the decision.
+    from dace.codegen import codegen, compiler
+
+    for folder_mode in ('development', 'production'):
+        for instrumented in (False, True):
+            sdfg = _make_sdfg(f'perfdir_{folder_mode}_{int(instrumented)}')
+            if instrumented:
+                sdfg.instrument = dtypes.InstrumentationType.Timer
+            objects = codegen.generate_code(sdfg)
+            out = str(tmp_path / sdfg.name)
+            compiler.generate_program_folder(sdfg, objects, out, folder_mode=folder_mode)
+            assert os.path.isdir(os.path.join(out, 'perf')) == instrumented, \
+                f'perf/ existence mismatch for folder_mode={folder_mode}, instrumented={instrumented}'
+
+
+if __name__ == '__main__':
+    test_is_instrumented_distinguishes_enum_kinds()
+    import tempfile, pathlib
+    test_perf_folder_created_exactly_when_instrumented(pathlib.Path(tempfile.mkdtemp()))


### PR DESCRIPTION
This PR fixes two small and related bugs.
The first is `SDFG.is_instrumented()`, which uses a very clever way to check if `SDFGState`s and `AccessNode`s are instrumented. However, these two entities uses different enumeration types to and so a simple `node.instrument != {Data}InstrumentationType.No_Instrumentation` is not enough.

The second one is related to the `perf/` folder, in which the instrumentation reports are stored. If the folder is not created it will fail (because the runtime uses a bare `std::ofstream`). Before the folder was only generated in `development` mode. Now it is generated also if it is needed.

