### PR TITLE
Report GPU errors from the SDFG's own record, and stop segfaulting after reporting one

### DIFF
--- a/dace/codegen/compiled_sdfg.py
+++ b/dace/codegen/compiled_sdfg.py
@@ -235,6 +235,9 @@ class CompiledSDFG(object):
         self._exit = lib.get_symbol('__dace_exit_{}'.format(sdfg.name))
         self._exit.restype = ctypes.c_int
         self._cfunc = lib.get_symbol('__program_{}'.format(sdfg.name))
+        # Present exactly when a GPU target emitted its init/exit pair, which is a sharper test than
+        # the ``has_gpu_code`` heuristic below.
+        self._gpu_last_error = self.get_exported_function('__dace_gpu_last_error', restype=ctypes.c_int)
 
         # Cache SDFG return values
         self._return_syms: Dict[str, Any] = None
@@ -438,7 +441,9 @@ class CompiledSDFG(object):
         return self._libhandle
 
     def finalize(self):
-        if self._exit is not None:
+        # ``fast_call`` unloads the library when a call fails, which leaves every cached function
+        # pointer dangling, so an uninitialized handle must never be called through.
+        if self._exit is not None and self._initialized is True:
             res: int = self._exit(self._libhandle)
             self._initialized = False
             if res != 0:
@@ -573,21 +578,17 @@ with open(r"{temp_path}", "wb") as f:
                 if self.do_not_execute is False:
                     self._cfunc(self._libhandle, *callargs)
 
-            # Optionally get errors from call
-            if do_gpu_check and self.has_gpu_code:
-                from dace.codegen import common  # Circular import; Must be here to avoid import in hot path.
-                try:
-                    lasterror = common.get_gpu_runtime().get_last_error_string()
-                except RuntimeError as ex:
-                    warnings.warn(f'Could not get last error from GPU runtime: {ex}')
-                    lasterror = None
-
-                if lasterror is not None:
+            # Optionally get errors from call. Read what this SDFG's generated code recorded rather than
+            # the GPU runtime's last-error slot, which is per-host-thread and shared process-wide.
+            if do_gpu_check and self._gpu_last_error is not None:
+                lasterror: int = self._gpu_last_error(self._libhandle)
+                if lasterror != 0:
                     raise RuntimeError(
                         f'An error was detected when calling "{self._sdfg.name}": {self._get_error_text(lasterror)}')
             return
         except (RuntimeError, TypeError, UnboundLocalError, KeyError, cgx.DuplicateDLLError, ReferenceError):
             self._lib.unload()
+            self._initialized = False
             raise
 
     def __del__(self):

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -398,6 +398,7 @@ class CUDACodeGen(TargetCodeGenerator):
 
 DACE_EXPORTED int __dace_init_cuda({sdfg_state_name} *__state{params});
 DACE_EXPORTED int __dace_exit_cuda({sdfg_state_name} *__state);
+DACE_EXPORTED int __dace_gpu_last_error({sdfg_state_name} *__state);
 DACE_EXPORTED bool __dace_gpu_set_stream({sdfg_state_name} *__state, int streamid, gpuStream_t stream);
 DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStream_t stream);
 
@@ -459,6 +460,15 @@ int __dace_exit_cuda({sdfg_state_name} *__state) {{
     }}
 
     delete __state->gpu_context;
+    return __err;
+}}
+
+// The runtime's own last-error slot is per-host-thread and shared with every other GPU user in the
+// process, so it is not a reliable carrier for this SDFG's failures. Hand back what the generated
+// code recorded instead, and clear it so a failure is delivered exactly once.
+int __dace_gpu_last_error({sdfg_state_name} *__state) {{
+    int __err = static_cast<int>(__state->gpu_context->lasterror);
+    __state->gpu_context->lasterror = (gpuError_t)0;
     return __err;
 }}
 

--- a/tests/codegen/gpu_error_reporting_test.py
+++ b/tests/codegen/gpu_error_reporting_test.py
@@ -1,0 +1,109 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests that a GPU failure inside a compiled SDFG reaches the caller, and reaches the right caller."""
+import numpy as np
+import pytest
+
+import dace
+from dace.codegen import common
+
+N = dace.symbol('N')
+M = dace.symbol('M')
+
+GRID_Y_LIMIT = 65535
+
+# An M above the grid y limit makes the launch itself invalid, which the driver reports without
+# poisoning the context, so the remaining tests can keep using the GPU.
+FAILING_M = GRID_Y_LIMIT + 1
+WORKING_M = 8
+
+
+@dace.program
+def gpu_error_doubler(A: dace.float64[M, N], B: dace.float64[M, N]):
+    for i, j in dace.map[0:M, 0:N]:
+        B[i, j] = A[i, j] * 2.0
+
+
+def build_doubler():
+    """Compiles the doubler with block y == 1, so the map's M range lands directly on the grid y dimension."""
+    sdfg = gpu_error_doubler.to_sdfg(simplify=True)
+    sdfg.apply_gpu_transformations()
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, dace.sdfg.nodes.MapEntry) and node.map.schedule == dace.ScheduleType.GPU_Device:
+                node.map.gpu_block_size = [64, 1, 1]
+    return sdfg.compile()
+
+
+def arguments(m):
+    return {
+        'A': np.ones((m, 2), dtype=np.float64),
+        'B': np.zeros((m, 2), dtype=np.float64),
+        'N': 2,
+        'M': m,
+    }
+
+
+@pytest.mark.gpu
+def test_failed_launch_reaches_caller():
+    csdfg = build_doubler()
+    with pytest.raises(RuntimeError, match='gpu_error_doubler'):
+        csdfg(**arguments(FAILING_M))
+
+    # Reporting the failure consumed it, so tearing down finds nothing left to complain about.
+    csdfg.finalize()
+
+
+@pytest.mark.gpu
+def test_failure_is_not_charged_to_an_innocent_sdfg():
+    failing = build_doubler()
+    innocent = build_doubler()
+
+    # ``do_gpu_check=False`` is the documented default, so nothing here consumes the runtime's slot.
+    callargs, initargs = failing.construct_arguments(**arguments(FAILING_M))
+    failing.fast_call(callargs, initargs, do_gpu_check=False)
+
+    innocent(**arguments(WORKING_M))
+    innocent.finalize()
+
+    # The failure is still charged to the SDFG that actually caused it.
+    with pytest.raises(RuntimeError, match='gpu_error_doubler'):
+        failing.finalize()
+
+
+@pytest.mark.gpu
+def test_failure_survives_a_drained_runtime_slot():
+    csdfg = build_doubler()
+
+    callargs, initargs = csdfg.construct_arguments(**arguments(FAILING_M))
+    csdfg.fast_call(callargs, initargs, do_gpu_check=False)
+
+    # Stands in for any other GPU user in the process reading the runtime's shared last-error slot.
+    common.get_gpu_runtime().get_last_error()
+
+    # This launch is valid, so only the record the generated code kept can still report the failure.
+    callargs, initargs = csdfg.construct_arguments(**arguments(WORKING_M))
+    with pytest.raises(RuntimeError, match='gpu_error_doubler'):
+        csdfg.fast_call(callargs, initargs, do_gpu_check=True)
+
+    csdfg.finalize()
+
+
+@pytest.mark.gpu
+def test_reported_failure_is_not_reported_again():
+    csdfg = build_doubler()
+
+    callargs, initargs = csdfg.construct_arguments(**arguments(FAILING_M))
+    with pytest.raises(RuntimeError, match='gpu_error_doubler'):
+        csdfg.fast_call(callargs, initargs, do_gpu_check=True)
+
+    callargs, initargs = csdfg.construct_arguments(**arguments(WORKING_M))
+    csdfg.fast_call(callargs, initargs, do_gpu_check=True)
+
+    csdfg.finalize()
+
+
+if __name__ == '__main__':
+    test_failed_launch_reaches_caller()
+    test_failure_is_not_charged_to_an_innocent_sdfg()
+    test_failure_survives_a_drained_runtime_slot()
+    test_reported_failure_is_not_reported_again()


### PR DESCRIPTION
`fast_call`'s `do_gpu_check` read `cudaGetLastError()`. That slot is per-host-thread and shared with every GPU user in the process, so an error left by one SDFG is charged to whichever SDFG is checked next (any call using the default `do_gpu_check=False`, or any PyTorch/CuPy activity in the same process, will do it), and because reading it also clears it, DaCe goes blind whenever another consumer reads first — even though the generated code's own `lasterror` still holds the failure. The same failure also gets reported twice, once from `fast_call` and again from `finalize()`, the second time inside `__del__` as an unraisable exception.

This exports `__dace_gpu_last_error` from the CUDA target and has `fast_call` read that instead, gated on the symbol being present rather than on the `has_gpu_code` heuristic. The accessor clears `lasterror` on read, so a failure is delivered exactly once.

Second, coupled defect: `fast_call`'s error handler `dlclose`s the library but left `_initialized = True`, so the later `finalize()`/`__del__` called through dangling function pointers and segfaulted. That is why a reported GPU error currently does not reach the user — the process dies first, and it kills whatever test runs next on the same worker. `finalize()` is now guarded on `_initialized`, which is cleared on unload.

Tests fail on `main` (4 failed, one of them by crashing the worker) and pass with the fix. The provoked error is a grid-Y-over-65535 launch, chosen because it is non-sticky and so does not poison the context for later tests.