### PR TITLE
Add a `@dace.always_inline` decorator

### DIFF
--- a/dace/frontend/python/interface.py
+++ b/dace/frontend/python/interface.py
@@ -373,6 +373,60 @@ def inline(expression):
     return expression
 
 
+#: Attribute set by :func:`always_inline` on the callables it marks.
+ALWAYS_INLINE_ATTRIBUTE = '__dace_always_inline__'
+
+
+def always_inline(func: F) -> F:
+    """
+    Marks a callable as compile-time evaluable, so that every call to it from within a ``@dace.program`` is
+    evaluated during parsing and replaced by its result.
+
+    This is the callee-side counterpart of :func:`inline`: instead of annotating every call site with
+    ``dace.inline(...)``, the callable itself is annotated once. It is also narrower than the
+    ``constant_functions=True`` argument of :func:`program`, which folds *every* external call in a program.
+
+    Example::
+
+        class TracerRegistry:
+            @dace.always_inline
+            def index(self, name: str) -> int:
+                return self._mapping[name]
+
+        tracers = TracerRegistry(...)
+
+        @dace.program
+        def prog(A: dace.float64[10]):
+            A[tracers.index('liquid')] = 1.0  # Parsed as ``A[1] = 1.0``
+
+    The callable keeps its normal Python behavior outside of ``@dace.program`` parsing.
+
+    :param func: The callable to mark.
+    :return: The same callable, marked for compile-time evaluation.
+    :note: Only use with stateless functions whose arguments are compile-time evaluable! A call whose arguments
+           cannot be evaluated at parse time is a parsing error rather than a fallback to a Python callback.
+    """
+    setattr(func, ALWAYS_INLINE_ATTRIBUTE, True)
+    return func
+
+
+def is_always_inline(value: Any) -> bool:
+    """
+    Tests whether a value is a callable marked with :func:`always_inline`.
+
+    :param value: The value to test.
+    :return: True if the value (or, for callable objects, its ``__call__`` method) is marked.
+    """
+    # ``value`` may be an arbitrary object with a custom ``__getattr__``, so attribute access can fail in any
+    # way. Compare against True explicitly as well: proxies may return arbitrary truthy values.
+    try:
+        if getattr(value, ALWAYS_INLINE_ATTRIBUTE, False) is True:
+            return True
+    except Exception:
+        pass
+    return getattr(getattr(type(value), '__call__', None), ALWAYS_INLINE_ATTRIBUTE, False) is True
+
+
 def in_program() -> bool:
     """
     Returns True if in a DaCe program parsing context. This function can be used to test whether the current

--- a/dace/frontend/python/preprocessing.py
+++ b/dace/frontend/python/preprocessing.py
@@ -751,12 +751,14 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
         return self._visit_potential_constant(node, True)
 
     def visit_Call(self, node: ast.Call) -> Any:
-        from dace.frontend.python.interface import in_program, inline  # Avoid import loop
+        from dace.frontend.python.interface import in_program, inline, is_always_inline  # Avoid import loop
 
         if hasattr(node.func, 'value') and isinstance(node.func.value, SDFGConvertible):
             # Skip already-parsed calls
             return self.generic_visit(node)
 
+        # Callees marked with ``@dace.always_inline`` are folded regardless of the ``resolve_functions`` setting
+        always_inline = False
         try:
             global_func = astutils.evalnode(node.func, self.globals)
 
@@ -767,15 +769,21 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
             if global_func is inline:
                 return node
 
-            if self.resolve_functions:
+            always_inline = is_always_inline(global_func)
+            if self.resolve_functions or always_inline:
                 global_val = astutils.evalnode(node, self.globals)
             else:
                 global_val = node
         except SyntaxError:
+            if always_inline:
+                raise DaceSyntaxError(
+                    None, node, f'Cannot evaluate the call to "{astutils.unparse(node.func)}" at compile time, '
+                    'even though it is annotated with @dace.always_inline. Make sure all of its arguments are '
+                    'compile-time constants.')
             return self.generic_visit(node)
 
         newnode = None
-        if self.resolve_functions and global_val is not node:
+        if global_val is not node:
             # Without this check, casts don't generate code
             if not isinstance(global_val, dtypes.typeclass):
                 newnode = self.global_value_to_node(global_val,
@@ -784,6 +792,11 @@ class GlobalResolver(astutils.ExtNodeTransformer, astutils.ASTHelperMixin):
                                                     recurse=True)
                 if newnode is not None:
                     return newnode
+                if always_inline:
+                    raise DaceSyntaxError(
+                        None, node, f'The result of "{astutils.unparse(node.func)}" (of type '
+                        f'{type(global_val).__name__}) cannot be inlined into the program, even though the '
+                        'function is annotated with @dace.always_inline.')
         elif not isinstance(global_func, dtypes.typeclass):
             callables = not self.do_not_detect_callables
             newnode = self.global_value_to_node(global_func,

--- a/tests/python_frontend/inline_preprocessing_test.py
+++ b/tests/python_frontend/inline_preprocessing_test.py
@@ -127,9 +127,76 @@ def test_inlinepp_in_unroll():
     assert np.allclose(a, np.array([12, 14, 16]))
 
 
+class _TracerRegistry:
+    """An object whose methods are meant to be resolved at parse time."""
+
+    def __init__(self, *names: str):
+        self._mapping = {name: index for index, name in enumerate(names)}
+
+    @dace.always_inline
+    def index(self, name: str) -> int:
+        return self._mapping[name]
+
+    def __len__(self) -> int:
+        return len(self._mapping)
+
+
+_tracers = _TracerRegistry('vapor', 'liquid', 'ice')
+
+
+@dace.always_inline
+def _tracer_count() -> int:
+    return len(_tracers)
+
+
+def test_always_inline_method():
+    # Regular Python semantics are unaffected by the decorator
+    assert _tracers.index('ice') == 2
+
+    @dace.program
+    def tester(a: dace.float64[10]):
+        a[_tracers.index('liquid')] = 1.0
+
+    sdfg = tester.to_sdfg()
+    assert _find_in_memlet(sdfg, '1')
+
+    a = np.zeros(10)
+    sdfg(a)
+    expected = np.zeros(10)
+    expected[1] = 1.0
+    assert np.allclose(a, expected)
+
+
+def test_always_inline_function():
+
+    @dace.program
+    def tester(a: dace.float64[10]):
+        a[_tracer_count()] = 2.0
+
+    a = np.zeros(10)
+    tester(a)
+    expected = np.zeros(10)
+    expected[3] = 2.0
+    assert np.allclose(a, expected)
+
+
+def test_always_inline_fail():
+    """A non-constant argument is an error, not a silent fallback to a callback."""
+
+    @dace.program
+    def tester(a: dace.float64[10], i: dace.int64):
+        a[_tracers.index(i)] = 1.0
+
+    with pytest.raises(DaceSyntaxError):
+        tester(np.zeros(10), 1)
+
+
 if __name__ == '__main__':
     test_inlinepp_simple()
     test_inlinepp_fail()
     test_inlinepp_tuple_retval()
     test_inlinepp_stateful()
     test_inlinepp_in_unroll()
+    test_always_inline_method()
+    test_always_inline_function()
+    test_always_inline_fail()


### PR DESCRIPTION
With a robust Python frontend, some functions cannot be trusted to be side-effect free. This decorator can be placed on functions to ensure that dace understands that they will in fact be side-effect free. Avoids the need to wrap the function with `dace.inline(func_call(...))` and setting the global dace.program `constant_functions` kwarg, which would be dangerously assuming all callbacks are inlineable.