### PR TITLE
Forward replace_keys when replace_dict recurses into a nested control flow region

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1212,8 +1212,13 @@ class ControlGraphView(BlockGraphView, abc.ABC):
                 edge.data.replace_dict(repl, replace_keys=replace_keys)
 
             # Replace in states
-            for state in self.nodes():
-                state.replace_dict(repl, symrepl)
+            for block in self.nodes():
+                # A nested region owns interstate edges of its own, so ``replace_keys`` must reach it:
+                # dropping it renames an assignment's uses but not its target, splitting one symbol in two.
+                if isinstance(block, AbstractControlFlowRegion):
+                    block.replace_dict(repl, symrepl, replace_in_graph, replace_keys)
+                else:
+                    block.replace_dict(repl, symrepl)
 
 
 @make_properties
@@ -3774,7 +3779,7 @@ class LoopRegion(ControlFlowRegion):
         from dace.sdfg.replace import replace_properties_dict
         replace_properties_dict(self, repl, symrepl)
 
-        super().replace_dict(repl, symrepl, replace_in_graph)
+        super().replace_dict(repl, symrepl, replace_in_graph, replace_keys)
 
     def add_break(self, label=None) -> BreakBlock:
         label = self._ensure_unique_block_name(label)
@@ -3951,7 +3956,7 @@ class ConditionalBlock(AbstractControlFlowRegion):
             replace_properties_dict(self, repl, symrepl)
 
         for cond, region in self._branches:
-            region.replace_dict(repl, symrepl, replace_in_graph)
+            region.replace_dict(repl, symrepl, replace_in_graph, replace_keys)
             if cond is not None:
                 replace_in_codeblock(cond, repl)
 

--- a/tests/sdfg/replace_keys_test.py
+++ b/tests/sdfg/replace_keys_test.py
@@ -1,0 +1,30 @@
+# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests that ``replace_keys`` reaches interstate edges inside nested control flow regions. """
+
+import dace
+from dace.sdfg.state import ControlFlowRegion
+
+
+def test_replace_keys_reaches_nested_region():
+    sdfg = dace.SDFG('replace_keys_nested')
+    sdfg.add_symbol('cur', dace.int64)
+
+    region = ControlFlowRegion('region', sdfg=sdfg)
+    sdfg.add_node(region)
+    inner_a = region.add_state('inner_a', is_start_block=True)
+    inner_b = region.add_state('inner_b')
+    region.add_edge(inner_a, inner_b, dace.InterstateEdge(assignments={'cur': 'cur + 1'}))
+
+    start = sdfg.add_state('start', is_start_block=True)
+    sdfg.add_edge(start, region, dace.InterstateEdge(assignments={'cur': '0'}))
+
+    sdfg.replace_dict({'cur': 'cur_new'}, replace_keys=True)
+
+    # The nested assignment's target must be renamed alongside its uses, or the symbol splits in two.
+    assert 'cur_new' in list(sdfg.edges())[0].data.assignments
+    assert 'cur_new' in list(region.edges())[0].data.assignments
+    assert 'cur' not in list(region.edges())[0].data.assignments
+
+
+if __name__ == '__main__':
+    test_replace_keys_reaches_nested_region()

--- a/tests/sdfg/replace_keys_test.py
+++ b/tests/sdfg/replace_keys_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
 """ Tests that ``replace_keys`` reaches interstate edges inside nested control flow regions. """
 
 import dace


### PR DESCRIPTION
`ControlGraphView.replace_dict` dropped `replace_keys` when recursing into child blocks and `LoopRegion`/`ConditionalBlock` dropped it again, so each fell back to its own conflicting default and a rename could rewrite an assignment's uses without its target, silently splitting one symbol into two.
