### PR TITLE
Keep Range bounds symbolic when they are assigned, not only when constructed

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -412,9 +412,11 @@ def add_indirection_subgraph(sdfg: SDFG,
                         toreplace = 'index_' + fname + '_' + str(len(accesses[fname]) - 1)
 
                     if direct_assignment:
-                        # newsubset[dimidx] = newsubset[dimidx].subs(expr, toreplace)
-                        newsubset[dimidx] = r.subs(expr, toreplace)
-                        r = newsubset[dimidx]
+                        # A point range keeps its (begin, end, step) shape. Writing the substituted
+                        # bound back on its own left a bare expression where the subset holds
+                        # tuples -- the malformed state the tuple check above exists to survive.
+                        r = r.subs(expr, toreplace)
+                        newsubset[dimidx] = (r, r, newsubset[dimidx][2])
                     else:
                         rng = list(newsubset[dimidx])
                         rng[i] = rng[i].subs(expr, toreplace)

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -297,8 +297,28 @@ def _approx(val):
     return symbolic.pystr_to_symbolic(val)
 
 
-def _tuple_to_symexpr(val):
+def tuple_to_symexpr(val):
+    """Coerce one range bound to a symbolic expression.
+
+    A ``(main, approx)`` tuple becomes a ``SymExpr``; anything else -- a Python ``int``, a
+    string, an already-symbolic value -- goes through ``pystr_to_symbolic``.
+    """
     return (symbolic.SymExpr(val[0], val[1]) if isinstance(val, tuple) else symbolic.pystr_to_symbolic(val))
+
+
+def symbolic_range_tuple(value):
+    """Coerce a whole ``(start, end, step[, tile])`` range tuple to symbolic bounds.
+
+    ``Range`` promises symbolic bounds -- ``ndrange()`` is annotated ``SymbolicType`` and callers
+    act on it, calling ``.match()``, ``.subs()`` or ``.free_symbols`` without checking. A raw
+    Python ``int`` reaching a bound therefore does not fail where it was stored but much later,
+    in an unrelated pass, as ``'int' object has no attribute 'match'``.
+    """
+    if not isinstance(value, (tuple, list)):
+        raise TypeError(f'Expected a 3- or 4-tuple range, got {type(value).__name__}')
+    if len(value) not in (3, 4):
+        raise ValueError('Expected 3-tuple or 4-tuple')
+    return tuple(tuple_to_symexpr(v) for v in value)
 
 
 @dace.serialize.serializable
@@ -311,7 +331,7 @@ class Range(Subset):
         for r in ranges:
             if len(r) != 3 and len(r) != 4:
                 raise ValueError("Expected 3-tuple or 4-tuple")
-            parsed_ranges.append((_tuple_to_symexpr(r[0]), _tuple_to_symexpr(r[1]), _tuple_to_symexpr(r[2])))
+            parsed_ranges.append((tuple_to_symexpr(r[0]), tuple_to_symexpr(r[1]), tuple_to_symexpr(r[2])))
             if len(r) == 3:
                 parsed_tiles.append(symbolic.pystr_to_symbolic(1))
             else:
@@ -747,7 +767,11 @@ class Range(Subset):
         return self.ranges.__getitem__(key)
 
     def __setitem__(self, key, value):
-        return self.ranges.__setitem__(key, value)
+        # ``__init__`` coerces every bound; this path did not, so ``r[i] = (0, n - 1, 1)``
+        # quietly put Python ints into a container whose contract says symbolic.
+        if isinstance(key, slice):
+            return self.ranges.__setitem__(key, [symbolic_range_tuple(v) for v in value])
+        return self.ranges.__setitem__(key, symbolic_range_tuple(value))
 
     def __eq__(self, other):
         if not isinstance(other, Range):

--- a/tests/subsets_symbolic_bounds_test.py
+++ b/tests/subsets_symbolic_bounds_test.py
@@ -1,0 +1,46 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""``Range`` must hold symbolic bounds no matter which path writes them."""
+
+import pytest
+
+from dace import subsets, symbolic
+
+
+def test_setitem_keeps_bounds_symbolic():
+    """A raw Python ``int`` assigned through ``__setitem__`` must not survive as one.
+
+    ``Range.__init__`` coerces every bound, ``ndrange()`` is annotated ``SymbolicType``, and
+    callers act on that: ``LoopToMap._check_range`` calls ``.match()`` on a bound, other passes
+    call ``.subs()`` or ``.free_symbols``. When the write path stored the tuple verbatim, an
+    ``int`` bound raised ``'int' object has no attribute 'match'`` far from the assignment that
+    caused it -- and ``LoopToMap`` swallows that as a warning, so the loop silently stayed
+    sequential instead of being refused for a stated reason.
+    """
+    rng = subsets.Range([('i', 'i', 1)])
+
+    # The property callers depend on is the sympy interface, not "has free symbols":
+    # ``issymbolic(Integer(2))`` is False, yet ``Integer(2).match(...)`` is exactly what
+    # ``_check_range`` needs and a Python ``int`` cannot do.
+    rng[0] = (2, 5, 1)
+    for bound in rng.ndrange()[0]:
+        assert not isinstance(bound, int), f'{bound!r} is a raw int'
+        bound.match(symbolic.pystr_to_symbolic('__unused'))
+
+    # Slice assignment goes through the same path.
+    rng[0:1] = [(0, 7, 1)]
+    for bound in rng.ndrange()[0]:
+        assert not isinstance(bound, int)
+        bound.match(symbolic.pystr_to_symbolic('__unused'))
+
+    # Strings and already-symbolic values keep working.
+    rng[0] = ('N', symbolic.pystr_to_symbolic('M + 1'), 1)
+    start, end, _ = rng.ndrange()[0]
+    assert str(start) == 'N' and str(end) == 'M + 1'
+
+    # A malformed range is caught where it is written, not frames later.
+    with pytest.raises(ValueError):
+        rng[0] = (1, 2)
+
+
+if __name__ == '__main__':
+    test_setitem_keeps_bounds_symbolic()


### PR DESCRIPTION
`Range.__init__` coerces every bound through `pystr_to_symbolic` and `ndrange()` is annotated SymbolicType, but `__setitem__` stored the tuple verbatim. So `r[i] = (0, n - 1, 1)` puts plain Python ints into a container whose contract says symbolic.

Callers trust that contract: `LoopToMap._check_range` calls `.match()` on a bound, others call `.subs()` or read `.free_symbols`. An int bound therefore fails far from the assignment that caused it, as `AttributeError: 'int' object has no attribute 'match'`. LoopToMap catches matcher exceptions and downgrades them to a warning, so the loop silently stays sequential with no reason reported — one corpus sweep hit this 1028 times.

Coercion moves into a helper shared by the constructor and the setter, so the two paths cannot drift again, and a malformed range now raises where it is written.

Test fails on the current main with `2 is a raw int`.