### PR TITLE
Register a control-flow region in the CFG list when it is added

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -2914,7 +2914,12 @@ class AbstractControlFlowRegion(OrderedDiGraph[ControlFlowBlock, 'dace.sdfg.Inte
         node.sdfg = sdfg
         if isinstance(node, AbstractControlFlowRegion):
             for n in node.all_control_flow_blocks():
-                n.sdfg = self.sdfg
+                n.sdfg = sdfg
+            # ``cfg_id`` is a position in ``cfg_list``, so a region that is not in the list
+            # reports 0 -- the same id as the root and as every other unregistered region.
+            # Appending instead would assign positions in insertion order while this assigns
+            # them in tree order, so the next reset would silently renumber.
+            self.reset_cfg_list()
         start_block = is_start_block
         if is_start_state is not None:
             warnings.warn('is_start_state is deprecated, use is_start_block instead', DeprecationWarning)
@@ -3851,6 +3856,12 @@ class ConditionalBlock(AbstractControlFlowRegion):
         self._branches.append([condition, branch])
         branch.parent_graph = self
         branch.sdfg = self.sdfg
+        # A branch is reached only through this list, never through ``nodes()``, so the generic
+        # ``add_node`` bookkeeping never runs for it: propagate the SDFG into the branch and
+        # invalidate here instead. Without this the branch's blocks keep ``sdfg is None``.
+        for n in branch.all_control_flow_blocks():
+            n.sdfg = self.sdfg
+        self.reset_cfg_list()
 
     def remove_branch(self, branch: ControlFlowRegion):
         self._branches = [(c, b) for c, b in self._branches if b is not branch]

--- a/tests/sdfg/cfg_list_registration_test.py
+++ b/tests/sdfg/cfg_list_registration_test.py
@@ -1,0 +1,84 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Every control-flow region must be registered in its SDFG's ``cfg_list`` as soon as it is added."""
+
+import dace
+from dace.properties import CodeBlock
+from dace.sdfg.state import ConditionalBlock, ControlFlowRegion, LoopRegion
+
+
+def assert_all_registered(sdfg: dace.SDFG) -> None:
+    """Every reachable region is in ``cfg_list`` and owns a distinct ``cfg_id``.
+
+    ``cfg_id`` is a position in ``cfg_list`` and each region starts out holding a list containing
+    only itself, so an unregistered region does not raise -- it reports 0, the same id as the root
+    and as every other unregistered region. Callers that key results by ``cfg_id`` (for instance
+    ``ControlFlowRegionPass.apply_pass``) then overwrite each other's entries silently.
+    """
+    reachable = list(sdfg.all_control_flow_regions(recursive=True))
+    registered = {id(cfg) for cfg in sdfg.cfg_list}
+    unregistered = [cfg.label for cfg in reachable if id(cfg) not in registered]
+    assert not unregistered, f'regions missing from cfg_list: {unregistered}'
+
+    ids = [cfg.cfg_id for cfg in reachable]
+    assert len(set(ids)) == len(ids), f'cfg_id collision: {ids}'
+
+    detached = [b.label for b in sdfg.all_control_flow_blocks() if b.sdfg is None]
+    assert not detached, f'blocks left without an SDFG: {detached}'
+
+
+def test_regions_are_registered_when_added():
+    """The four construction paths that build a fresh, never-serialized SDFG."""
+    sdfg = dace.SDFG('fresh')
+    sdfg.add_array('a', [10], dace.float64)
+
+    loop = LoopRegion('myloop', 'i < 10', 'i', 'i = 0', 'i = i + 1')
+    sdfg.add_node(loop)
+    loop.add_state('body', is_start_block=True)
+    assert_all_registered(sdfg)
+
+    inner = ControlFlowRegion('inner')
+    loop.add_node(inner)
+    inner.add_state('istate', is_start_block=True)
+    assert_all_registered(sdfg)
+
+    cond = ConditionalBlock('cond')
+    sdfg.add_node(cond)
+    branch = ControlFlowRegion('br')
+    branch.add_state('bstate', is_start_block=True)
+    cond.add_branch(CodeBlock('i < 5'), branch)
+    assert_all_registered(sdfg)
+
+    # A region carrying a subtree registers that subtree too, not just its own root.
+    subtree = ControlFlowRegion('subtree')
+    nested = LoopRegion('nested', 'k < 3', 'k', 'k = 0', 'k = k + 1')
+    subtree.add_node(nested, is_start_block=True)
+    nested.add_state('nstate', is_start_block=True)
+    sdfg.add_node(subtree)
+    assert_all_registered(sdfg)
+
+    # Registering eagerly must agree with a full recompute, or ids would shift underneath
+    # anything that cached one.
+    before = [cfg.label for cfg in sdfg.cfg_list]
+    sdfg.reset_cfg_list()
+    assert [cfg.label for cfg in sdfg.cfg_list] == before
+
+
+def test_registration_survives_serialization_round_trip():
+    sdfg = dace.SDFG('roundtrip')
+    sdfg.add_array('a', [10], dace.float64)
+    loop = LoopRegion('loop', 'i < 10', 'i', 'i = 0', 'i = i + 1')
+    sdfg.add_node(loop)
+    loop.add_state('body', is_start_block=True)
+    cond = ConditionalBlock('cond')
+    loop.add_node(cond)
+    branch = ControlFlowRegion('br')
+    branch.add_state('bstate', is_start_block=True)
+    cond.add_branch(CodeBlock('i < 5'), branch)
+
+    assert_all_registered(sdfg)
+    assert_all_registered(dace.SDFG.from_json(sdfg.to_json()))
+
+
+if __name__ == '__main__':
+    test_regions_are_registered_when_added()
+    test_registration_survives_serialization_round_trip()


### PR DESCRIPTION
An unregistered region does not fail loudly. `cfg_id` is `cfg_list.index(self)`, and every region is constructed holding a list containing only itself, so a region that was never registered answers **0** — the same id as the root SDFG and as every other unregistered region. Then things break.

### Also fixed

`add_branch` never propagated the SDFG into the branch it was given. A branch is reached only through `branches`, never through `nodes()`, so the bookkeeping in `add_node` never runs for it; its blocks kept `sdfg is None` and `to_json` failed on a fresh conditional with `AttributeError: 'NoneType' object has no attribute 'symbols'`.

### Tests

`tests/sdfg/cfg_list_registration_test.py` covers the four construction paths, a region carrying a subtree, and a serialization round trip. Both tests fail on current main (`regions missing from cfg_list: ['myloop']` / `['loop', 'cond', 'br']`).

### Note

Reset cfg list is not too slow, but we could update lazily by setting an "invalid cfg list" flag and resetting only an API call needs to latest one.