### PR TITLE
Rank-aware build cache: one folder per rank under cache_distaware

### DIFF
--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -738,6 +738,16 @@ required:
             potentially build time, but disallows executing SDFGs in parallel
             and caching of more than one simultaneous SDFG.
 
+    cache_distaware:
+        type: bool
+        default: false
+        title: Distribution-aware build cache
+        description: >
+            Give every rank of a job its own build folder, named after the rank its launcher
+            (MPI, Flux, Slurm) advertises. Without it, ranks that each compile share one folder
+            and can load a library another rank is still writing. Leave it off when only one
+            rank compiles, as ``dace.sdfg.utils.distributed_compile`` does.
+
     store_history:
         type: bool
         default: true

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -740,7 +740,7 @@ required:
 
     cache_distaware:
         type: bool
-        default: false
+        default: true
         title: Distribution-aware build cache
         description: >
             Give every rank of a job its own build folder, named after the rank its launcher

--- a/dace/sdfg/sdfg.py
+++ b/dace/sdfg/sdfg.py
@@ -35,11 +35,40 @@ from typing import BinaryIO
 ShapeType = Sequence[Union[Integral, str, symbolic.symbol, symbolic.SymExpr, symbolic.sympy.Basic]]
 RankType = Union[Integral, str, symbolic.symbol, symbolic.SymExpr, symbolic.sympy.Basic]
 
+#: How a launcher tells a task its rank, most specific first. Read instead of importing mpi4py,
+#: which is optional and initializes MPI. All are job-unique; node-local counters are not.
+LAUNCHER_RANK_VARS = (
+    'OMPI_COMM_WORLD_RANK',  # Open MPI and the vendor MPIs built on it
+    'MV2_COMM_WORLD_RANK',  # MVAPICH2
+    'PMIX_RANK',  # Open MPI 4+, Slurm pmix
+    'PMI_RANK',  # MPICH, Intel MPI, Cray MPICH
+    'PMI_ID',  # older MPICH
+    'FLUX_TASK_RANK',  # Flux
+    'PALS_RANKID',  # HPE/Cray PALS
+    'ALPS_APP_PE',  # Cray ALPS
+    'SLURM_PROCID',  # srun with no MPI
+)
+
 if TYPE_CHECKING:
     from dace.codegen.instrumentation.report import InstrumentationReport
     from dace.codegen.instrumentation.data.data_report import InstrumentedDataReport
     from dace.codegen.compiled_sdfg import CompiledSDFG
     from dace.sdfg.analysis.schedule_tree.treenodes import ScheduleTreeRoot
+
+
+def build_folder_root() -> str:
+    """The build cache root, one per rank if ``cache_distaware`` is on and a launcher set a rank.
+
+    Ranks that each compile otherwise share a folder and can load each other's half-written library.
+    """
+    base = Config.get('default_build_folder')
+    if not Config.get_bool('cache_distaware'):
+        return base
+    for var in LAUNCHER_RANK_VARS:
+        rank = os.environ.get(var)
+        if rank:
+            return f'{base}_rank{rank}'
+    return base
 
 
 class NestedDict(dict):
@@ -1217,7 +1246,7 @@ class SDFG(ControlFlowRegion):
         if self._build_folder is not None:
             return self._build_folder
         cache_config = Config.get('cache')
-        base_folder = Config.get('default_build_folder')
+        base_folder = build_folder_root()
         if cache_config == 'single':
             # Always use the same directory, overwriting any other program,
             # preventing parallelism and caching of multiple programs, but

--- a/dace/sdfg/utils.py
+++ b/dace/sdfg/utils.py
@@ -1672,15 +1672,16 @@ def load_precompiled_sdfg(*args, **kwargs) -> csdfg.CompiledSDFG:
     return sdfg_compiler.load_precompiled_sdfg(*args, **kwargs)
 
 
-def distributed_compile(sdfg: SDFG, comm, *, validate: bool = True) -> csdfg.CompiledSDFG:
+def distributed_compile(sdfg: Optional[SDFG], comm, *, validate: bool = True) -> csdfg.CompiledSDFG:
     """
     Compiles an SDFG in rank 0 of MPI communicator ``comm``. Then, the compiled SDFG is loaded in all other ranks.
 
-    :param sdfg: SDFG to be compiled.
+    :param sdfg: SDFG to be compiled. Ranks other than 0 only load, and may pass ``None``.
     :param comm: MPI communicator. ``Intracomm`` is the base mpi4py communicator class.
     :param validate: If True, validates the SDFG prior to generating code.
     :return: Compiled SDFG.
     :note: This method can be used only if the module mpi4py is installed.
+    :note: Only rank 0 builds, so a rank holding the SDFG is pinned to rank 0's folder.
     :todo: Relocate this function to `dace.codegen.compiler`.
     """
 
@@ -1695,6 +1696,8 @@ def distributed_compile(sdfg: SDFG, comm, *, validate: bool = True) -> csdfg.Com
 
     # Broadcasts build folder.
     folder = comm.bcast(folder, root=0)
+    if sdfg is not None:
+        sdfg.build_folder = folder
 
     # Loads compiled SDFG.
     if rank > 0:

--- a/tests/custom_build_folder_test.py
+++ b/tests/custom_build_folder_test.py
@@ -87,6 +87,7 @@ def test_ranks_share_a_build_folder_when_distaware_is_off(unlaunched):
 def test_ranks_do_not_share_a_build_folder_by_default(unlaunched, tmp_path):
     """distaware defaults on: ranks that each compile must not land in one folder."""
     unlaunched.setenv('DACE_default_build_folder', str(tmp_path))
+    unlaunched.setenv('DACE_cache', 'name')  # pin the leaf naming policy so the exact path holds
     sdfg = dace.SDFG('rankprobe')
 
     unlaunched.setenv('OMPI_COMM_WORLD_RANK', '0')

--- a/tests/custom_build_folder_test.py
+++ b/tests/custom_build_folder_test.py
@@ -51,28 +51,52 @@ def test_distaware_gives_each_rank_its_own_cache_root(unlaunched, rank_var):
 
 
 @pytest.mark.parametrize('cache_mode', ['name', 'hash', 'unique', 'single'])
-def test_every_cache_mode_builds_under_the_rank_root(unlaunched, cache_mode):
+def test_every_cache_mode_builds_under_the_rank_root(unlaunched, cache_mode, tmp_path):
     """Splitting the root rather than the SDFG name separates the ranks in every mode."""
+    unlaunched.setenv('DACE_default_build_folder', str(tmp_path))
     sdfg = dace.SDFG('rankprobe')
     unlaunched.setenv('SLURM_PROCID', '3')
 
     with dace.config.set_temporary('cache', value=cache_mode):
+        # distaware defaults on: every mode's root gets the rank suffix.
         unlaunched.setenv('DACE_cache_distaware', '1')
         ranked = sdfg.build_folder
+        assert os.path.dirname(ranked) == f'{tmp_path}_rank3'
         unlaunched.delenv('DACE_cache_distaware')
 
-        assert sdfg.build_folder != ranked
+        # Turning distaware off is how a caller opts back into the old shared root.
+        with dace.config.set_temporary('cache_distaware', value=False):
+            assert sdfg.build_folder != ranked
+            assert os.path.dirname(sdfg.build_folder) == str(tmp_path)
+            assert os.path.basename(sdfg.build_folder) == os.path.basename(ranked)
 
 
-def test_ranks_share_a_build_folder_unless_asked_otherwise(unlaunched):
-    """The default has to stay: distributed_compile has rank 0 build where every other rank looks."""
+def test_ranks_share_a_build_folder_when_distaware_is_off(unlaunched):
+    """Turning distaware off restores the old default: distributed_compile has rank 0 build
+    where every other rank looks."""
+    with dace.config.set_temporary('cache_distaware', value=False):
+        sdfg = dace.SDFG('rankprobe')
+
+        unlaunched.setenv('OMPI_COMM_WORLD_RANK', '0')
+        rank0 = sdfg.build_folder
+        unlaunched.setenv('OMPI_COMM_WORLD_RANK', '1')
+
+        assert sdfg.build_folder == rank0
+
+
+def test_ranks_do_not_share_a_build_folder_by_default(unlaunched, tmp_path):
+    """distaware defaults on: ranks that each compile must not land in one folder."""
+    unlaunched.setenv('DACE_default_build_folder', str(tmp_path))
     sdfg = dace.SDFG('rankprobe')
 
     unlaunched.setenv('OMPI_COMM_WORLD_RANK', '0')
     rank0 = sdfg.build_folder
     unlaunched.setenv('OMPI_COMM_WORLD_RANK', '1')
+    rank1 = sdfg.build_folder
 
-    assert sdfg.build_folder == rank0
+    assert rank0 == os.path.join(f'{tmp_path}_rank0', 'rankprobe')
+    assert rank1 == os.path.join(f'{tmp_path}_rank1', 'rankprobe')
+    assert rank0 != rank1
 
 
 def test_a_process_no_launcher_started_keeps_its_folder(unlaunched):

--- a/tests/custom_build_folder_test.py
+++ b/tests/custom_build_folder_test.py
@@ -1,7 +1,11 @@
 # Copyright 2019-2021 ETH Zurich and the DaCe authors. All rights reserved.
 import dace
 import os
+import pytest
 import tempfile
+
+from dace.sdfg import sdfg as sdfg_module
+from dace.sdfg import utils as sdfg_utils
 
 
 @dace.program
@@ -22,6 +26,105 @@ def test_custom_build_folder():
 
             # Ensure file is closed so it can be deleted
             del csdfg
+
+
+@pytest.fixture
+def unlaunched(monkeypatch):
+    """Drop the rank and cache settings the surrounding environment exports, which override config."""
+    for var in sdfg_module.LAUNCHER_RANK_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for var in ('DACE_cache', 'DACE_cache_distaware', 'DACE_default_build_folder'):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+@pytest.mark.parametrize('rank_var', sdfg_module.LAUNCHER_RANK_VARS)
+def test_distaware_gives_each_rank_its_own_cache_root(unlaunched, rank_var):
+    """Ranks that each compile would otherwise build into one folder and load a half-written .so."""
+    unlaunched.setenv('DACE_cache_distaware', '1')
+
+    unlaunched.setenv(rank_var, '0')
+    rank0 = sdfg_module.build_folder_root()
+    unlaunched.setenv(rank_var, '1')
+
+    assert sdfg_module.build_folder_root() != rank0
+
+
+@pytest.mark.parametrize('cache_mode', ['name', 'hash', 'unique', 'single'])
+def test_every_cache_mode_builds_under_the_rank_root(unlaunched, cache_mode):
+    """Splitting the root rather than the SDFG name separates the ranks in every mode."""
+    sdfg = dace.SDFG('rankprobe')
+    unlaunched.setenv('SLURM_PROCID', '3')
+
+    with dace.config.set_temporary('cache', value=cache_mode):
+        unlaunched.setenv('DACE_cache_distaware', '1')
+        ranked = sdfg.build_folder
+        unlaunched.delenv('DACE_cache_distaware')
+
+        assert sdfg.build_folder != ranked
+
+
+def test_ranks_share_a_build_folder_unless_asked_otherwise(unlaunched):
+    """The default has to stay: distributed_compile has rank 0 build where every other rank looks."""
+    sdfg = dace.SDFG('rankprobe')
+
+    unlaunched.setenv('OMPI_COMM_WORLD_RANK', '0')
+    rank0 = sdfg.build_folder
+    unlaunched.setenv('OMPI_COMM_WORLD_RANK', '1')
+
+    assert sdfg.build_folder == rank0
+
+
+def test_a_process_no_launcher_started_keeps_its_folder(unlaunched):
+    """No launcher is not rank 0: a lone process keeps the folder it always had, distaware or not."""
+    unlaunched.setenv('DACE_cache_distaware', '1')
+
+    assert sdfg_module.build_folder_root() == dace.Config.get('default_build_folder')
+
+
+class OneRankOfAJob:
+    """Stands in for an mpi4py communicator, with the ranks taking their turn in this one process."""
+
+    def __init__(self, rank: int):
+        self.rank = rank
+        self.broadcast = None
+
+    def Get_rank(self) -> int:
+        return self.rank
+
+    def bcast(self, value, root: int = 0):
+        if self.rank == root:
+            self.broadcast = value
+        return self.broadcast
+
+    def Barrier(self):
+        pass
+
+
+def test_distributed_compile_puts_every_rank_in_rank_0_folder(unlaunched, tmp_path):
+    """Only rank 0 builds, so the others must look where it built and not where they would have."""
+    unlaunched.setenv('DACE_default_build_folder', str(tmp_path))
+    unlaunched.setenv('DACE_cache_distaware', '1')
+
+    unlaunched.setenv('OMPI_COMM_WORLD_RANK', '0')
+    builder = OneRankOfAJob(0)
+    csdfg = sdfg_utils.distributed_compile(customprog.to_sdfg(), builder)
+    del csdfg  # Close the library, so the loading rank below opens it fresh
+
+    unlaunched.setenv('OMPI_COMM_WORLD_RANK', '1')
+    loader = OneRankOfAJob(1)
+    loader.broadcast = builder.broadcast
+    sdfg = customprog.to_sdfg()
+    assert sdfg.build_folder != builder.broadcast, "rank 1 was looking in rank 0's folder regardless"
+
+    csdfg = sdfg_utils.distributed_compile(sdfg, loader)
+
+    assert sdfg.build_folder == builder.broadcast
+    del csdfg
+
+    # A rank that only loads is free to hold no SDFG at all, as tests/library/mpi does.
+    csdfg = sdfg_utils.distributed_compile(None, loader)
+    del csdfg
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ranks of one job derive the same build folder. Ranks that each compile therefore build on top of
each other, and a rank can load a library another rank is still writing. Eight processes running one
GPU test out of one folder failed six times with `Could not load library ...so`; with a folder each,
none.

### What this does

A new config entry, `cache_distaware` (`DACE_cache_distaware=1`), names the build cache *root* after
the rank the launcher advertises: `.dacecache_rank3/`. Splitting the root rather than the SDFG name
means every `cache` mode gets the separation, not only the ones that mangle the name.

It is off by default, because sharing one build is a valid setup too: `distributed_compile` has rank
0 build and every other rank load its folder. That path now pins the broadcast folder on the ranks
that hold the SDFG, so no rank goes looking in a folder nobody built. Ranks that only load may keep
passing `None`, as `tests/library/mpi` does.


### Tests

`tests/custom_build_folder_test.py` covers every launcher variable, all four cache modes, the
untouched default, a process no launcher started, and `distributed_compile` sending every rank to
rank 0's folder.

