### PR TITLE
Do not charge a foreign GPU error to the next DaCe program

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -258,7 +258,11 @@ class CUDACodeGen(TargetCodeGenerator):
         self._compute_pool_release(sdfg)
 
         # Write GPU context to state structure
-        self._frame.statestruct.append('dace::cuda::Context *gpu_context;')
+        # Initialized, because the state struct is allocated with `new T` (default-initialized, so
+        # a raw pointer member would be indeterminate) and DACE_GPU_CHECK reads this field. The
+        # warm-up allocation in __dace_init_cuda is checked before the context is constructed, so
+        # on that error path the field is read before it is assigned.
+        self._frame.statestruct.append('dace::cuda::Context *gpu_context = nullptr;')
 
         # Collect all defined symbols and argument lists with one traversal
         shared_transients = {}
@@ -399,9 +403,9 @@ class CUDACodeGen(TargetCodeGenerator):
             poolcfg = int(Config.get('compiler', 'cuda', 'mempool_release_threshold'))
             pool_header = """
     {backend}MemPool_t mempool;
-    {backend}DeviceGetDefaultMemPool(&mempool, 0);
+    DACE_GPU_CHECK({backend}DeviceGetDefaultMemPool(&mempool, 0));
     uint64_t threshold = {poolcfg_threshold};
-    {backend}MemPoolSetAttribute(mempool, {backend}MemPoolAttrReleaseThreshold, &threshold);
+    DACE_GPU_CHECK({backend}MemPoolSetAttribute(mempool, {backend}MemPoolAttrReleaseThreshold, &threshold));
 """.format(backend=self.backend, poolcfg_threshold=('UINT64_MAX' if poolcfg == -1 else poolcfg))
 
         self._codeobject.code = """
@@ -413,6 +417,7 @@ class CUDACodeGen(TargetCodeGenerator):
 DACE_EXPORTED int __dace_init_cuda({sdfg_state_name} *__state{params});
 DACE_EXPORTED int __dace_exit_cuda({sdfg_state_name} *__state);
 DACE_EXPORTED int __dace_gpu_last_error({sdfg_state_name} *__state);
+DACE_EXPORTED void __dace_gpu_drain_error({sdfg_state_name} *__state);
 DACE_EXPORTED bool __dace_gpu_set_stream({sdfg_state_name} *__state, int streamid, gpuStream_t stream);
 DACE_EXPORTED void __dace_gpu_set_all_streams({sdfg_state_name} *__state, gpuStream_t stream);
 
@@ -434,14 +439,22 @@ int __dace_init_cuda({sdfg_state_name} *__state{params}) {{
         return 2;
     }}
 
+    // Anything pending in the runtime's error slot on entry is not ours; see
+    // __dace_gpu_drain_error. The CUB temp-storage size query that {initcode} often emits below is
+    // the usual victim - it is the first checked call in many generated modules.
+    __dace_gpu_drain_error(__state);
+
     // Initialize {backend} before we run the application
     float *dev_X;
     DACE_GPU_CHECK({backend}Malloc((void **) &dev_X, 1));
     DACE_GPU_CHECK({backend}Free(dev_X));
 
-    {pool_header}
-
     __state->gpu_context = new dace::cuda::Context({nstreams}, {nevents});
+
+    // The memory-pool setup runs AFTER the context exists: DACE_GPU_CHECK records into
+    // __state->gpu_context, so a failure before this point could not be recorded (and, before
+    // gpu_context was given an initializer, could not even be checked safely).
+    {pool_header}
 
     // Create {backend} streams and events
     for(int i = 0; i < {nstreams}; ++i) {{
@@ -475,6 +488,32 @@ int __dace_exit_cuda({sdfg_state_name} *__state) {{
 
     delete __state->gpu_context;
     return __err;
+}}
+
+// Discard whatever the runtime's per-thread error slot already holds, and say what was discarded.
+//
+// That slot is shared with every other GPU user in this process - CuPy, another SDFG, any library -
+// so a value left in it is NOT ours. Leaving it there makes the next DACE_GPU_CHECK-wrapped call
+// report someone else's failure as its own, which is misleading twice over: it blames an innocent
+// call, and it hides whoever actually failed.
+//
+// Called on entry to __dace_init_cuda AND on entry to every __program_<name> invocation, since
+// initialization happens once while contamination can arrive between any two calls.
+//
+// Only NON-STICKY errors can be discarded this way: a sticky one (illegal access, corrupted
+// context) survives gpuGetLastError() and is reported through the normal path by the next real
+// call. Reporting rather than throwing is deliberate - a pending error is by definition not this
+// SDFG's, and failing here would penalize the innocent SDFG this exists to protect.
+//
+// Must not touch __state->gpu_context: __dace_init_cuda calls this before the context exists.
+void __dace_gpu_drain_error({sdfg_state_name} *__state) {{
+    (void)__state;  // signature parity with the other exported entry points; see the note above
+    gpuError_t __pre_existing = {backend}GetLastError();
+    if (__pre_existing != (gpuError_t)0) {{
+        printf("WARNING: a GPU error was already pending on entry to a DaCe program and has been "
+               "discarded: %s (%d). It was not caused by this SDFG.\\n",
+               gpuGetErrorString(__pre_existing), __pre_existing);
+    }}
 }}
 
 // The runtime's own last-error slot is per-host-thread and shared with every other GPU user in the

--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -258,11 +258,12 @@ class CUDACodeGen(TargetCodeGenerator):
         self._compute_pool_release(sdfg)
 
         # Write GPU context to state structure
-        # Initialized, because the state struct is allocated with `new T` (default-initialized, so
-        # a raw pointer member would be indeterminate) and DACE_GPU_CHECK reads this field. The
-        # warm-up allocation in __dace_init_cuda is checked before the context is constructed, so
-        # on that error path the field is read before it is assigned.
-        self._frame.statestruct.append('dace::cuda::Context *gpu_context = nullptr;')
+        # Deliberately declared WITHOUT an initializer: CompiledSDFG.get_state_struct() recovers
+        # the layout by parsing these declarations, and its field regex is anchored at the end of
+        # the declaration, so a `= nullptr` suffix stops the parse dead and silently drops every
+        # field after this one. The pointer is zeroed by value-initializing the whole state
+        # (`new T()` in framecode) instead, which DACE_GPU_CHECK relies on.
+        self._frame.statestruct.append('dace::cuda::Context *gpu_context;')
 
         # Collect all defined symbols and argument lists with one traversal
         shared_transients = {}
@@ -440,8 +441,8 @@ int __dace_init_cuda({sdfg_state_name} *__state{params}) {{
     }}
 
     // Anything pending in the runtime's error slot on entry is not ours; see
-    // __dace_gpu_drain_error. The CUB temp-storage size query that {initcode} often emits below is
-    // the usual victim - it is the first checked call in many generated modules.
+    // __dace_gpu_drain_error. The CUB temp-storage size query that the init code often emits
+    // below is the usual victim - it is the first checked call in many generated modules.
     __dace_gpu_drain_error(__state);
 
     // Initialize {backend} before we run the application

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -264,11 +264,25 @@ struct {mangle_dace_state_struct_name(sdfg)} {{
         initparams_comma = (', ' + initparams) if initparams else ''
         paramnames_comma = (', ' + paramnames) if paramnames else ''
         initparamnames_comma = (', ' + initparamnames) if initparamnames else ''
+        # Discard any GPU error left pending by another party before running. The runtime's
+        # error slot is per-host-thread and shared with every other GPU user in the process, so
+        # a value in it on entry is not ours, and the first checked call inside would report it
+        # as its own failure. __dace_init_cuda drains it too, but that runs once per state while
+        # contamination can arrive between any two calls - hence also here, per invocation.
+        # Declared rather than included: this function lives in the generated .cu, exactly like
+        # __dace_init_cuda below.
+        gpu_drain_decl = ''
+        gpu_drain_call = ''
+        if any(target.target_name == 'cuda' for target in self._dispatcher.used_targets):
+            gpu_drain_decl = (f'DACE_EXPORTED void '
+                              f'__dace_gpu_drain_error({mangle_dace_state_struct_name(fname)} *__state);\n')
+            gpu_drain_call = '    __dace_gpu_drain_error(__state);\n'
+
         callsite_stream.write(
             f'''
-DACE_EXPORTED void __program_{fname}({mangle_dace_state_struct_name(fname)} *__state{params_comma})
+{gpu_drain_decl}DACE_EXPORTED void __program_{fname}({mangle_dace_state_struct_name(fname)} *__state{params_comma})
 {{
-    __program_{fname}_internal(__state{paramnames_comma});
+{gpu_drain_call}    __program_{fname}_internal(__state{paramnames_comma});
 }}''', sdfg)
 
         for target in self._dispatcher.used_targets:

--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -273,7 +273,11 @@ struct {mangle_dace_state_struct_name(sdfg)} {{
         # __dace_init_cuda below.
         gpu_drain_decl = ''
         gpu_drain_call = ''
-        if any(target.target_name == 'cuda' for target in self._dispatcher.used_targets):
+        # getattr, not attribute access: a user-registered code generator need not define
+        # target_name (the codegen tutorial's MyCustomLoop does not), and this walks every used
+        # target. The loop below only reads target_name inside a has_initializer/has_finalizer
+        # branch, so it never reached those.
+        if any(getattr(target, 'target_name', None) == 'cuda' for target in self._dispatcher.used_targets):
             gpu_drain_decl = (f'DACE_EXPORTED void '
                               f'__dace_gpu_drain_error({mangle_dace_state_struct_name(fname)} *__state);\n')
             gpu_drain_call = '    __dace_gpu_drain_error(__state);\n'
@@ -308,7 +312,7 @@ DACE_EXPORTED {mangle_dace_state_struct_name(sdfg)} *__dace_init_{sdfg.name}({in
         callsite_stream.write(
             f"""
     int __result = 0;
-    {mangle_dace_state_struct_name(sdfg)} *__state = new {mangle_dace_state_struct_name(sdfg)};""", sdfg)
+    {mangle_dace_state_struct_name(sdfg)} *__state = new {mangle_dace_state_struct_name(sdfg)}();""", sdfg)
 
         for target in self._dispatcher.used_targets:
             if target.has_initializer:

--- a/dace/runtime/include/dace/cuda/cudacommon.cuh
+++ b/dace/runtime/include/dace/cuda/cudacommon.cuh
@@ -16,13 +16,18 @@ typedef cudaError_t gpuError_t;
 #define gpuGetErrorString cudaGetErrorString
 #endif
 
+// The context guard covers the calls checked during __dace_init_cuda before the context has been
+// constructed (the runtime warm-up allocation). The message is printed either way; only the
+// recording needs a context to record into.
 #define DACE_GPU_CHECK(err)                                               \
   do {                                                                    \
     gpuError_t errr = (err);                                              \
     if (errr != (gpuError_t)0) {                                          \
       printf("GPU runtime error at %s:%d: %s (%d)\n", __FILE__, __LINE__, \
              gpuGetErrorString(errr), errr);                              \
-      __state->gpu_context->record_error(errr);                           \
+      if (__state->gpu_context) {                                         \
+        __state->gpu_context->record_error(errr);                         \
+      }                                                                   \
     }                                                                     \
   } while (0)
 

--- a/tests/codegen/gpu_error_drain_test.py
+++ b/tests/codegen/gpu_error_drain_test.py
@@ -1,0 +1,142 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Code-generation tests for the inherited-GPU-error drain (``__dace_gpu_drain_error``).
+
+These assert on generated source only, so they need neither a GPU nor a CUDA toolchain.
+"""
+import dace
+import pytest
+
+from dace.transformation.interstate import GPUTransformSDFG
+
+
+def _gpu_sdfg(name: str = 'drain_probe') -> dace.SDFG:
+    """A minimal SDFG that generates GPU code."""
+    sdfg = dace.SDFG(name)
+    sdfg.add_array('A', [8], dace.float64)
+    sdfg.arrays['A'].optional = False
+    state = sdfg.add_state()
+    state.add_mapped_tasklet('inc',
+                             dict(i='0:8'),
+                             dict(inp=dace.Memlet('A[i]')),
+                             'out = inp + 1.0',
+                             dict(out=dace.Memlet('A[i]')),
+                             external_edges=True)
+    sdfg.apply_transformations(GPUTransformSDFG)
+    return sdfg
+
+
+def _sources(sdfg: dace.SDFG):
+    """The generated CUDA file and the frame (host) file, as strings."""
+    objs = sdfg.generate_code()
+    cu = next(o.clean_code for o in objs if o.language == 'cu')
+    frame = next(o.clean_code for o in objs if o.language == 'cpp' and o.name == sdfg.name)
+    return cu, frame
+
+
+def test_gpu_drain_emitted_in_init_and_per_call():
+    """The drain is defined in the .cu, called from __dace_init_cuda, and called again at
+    the top of every __program_<name> invocation.
+
+    Initialization runs once per state, but a foreign GPU error can be left in the
+    runtime's shared last-error slot between any two calls, so the per-call site is the
+    one that actually protects a long-running process.
+    """
+    cu, frame = _sources(_gpu_sdfg())
+
+    assert 'void __dace_gpu_drain_error(' in cu  # defined in the CUDA file
+    assert '__dace_gpu_drain_error(__state);' in cu  # and called by the initializer
+
+    # The host file cannot include the CUDA headers, so it declares the function and links
+    # against the .cu definition - the same arrangement as __dace_init_cuda.
+    assert 'DACE_EXPORTED void __dace_gpu_drain_error(' in frame
+    decl = frame.index('DACE_EXPORTED void __dace_gpu_drain_error(')
+    call = frame.index('__dace_gpu_drain_error(__state);')
+    assert decl < call, 'the declaration must precede the call'
+    assert call < frame.index('_internal(__state'), 'the drain must run before the program body'
+
+
+def test_gpu_drain_absent_without_gpu_code():
+    """A CPU-only SDFG must not reference the drain: the symbol only exists when the CUDA
+    target emitted it, so an unconditional call would be a link error."""
+    sdfg = dace.SDFG('drain_cpu_only_probe')
+    sdfg.add_array('A', [8], dace.float64)
+    sdfg.arrays['A'].optional = False
+    state = sdfg.add_state()
+    state.add_mapped_tasklet('inc',
+                             dict(i='0:8'),
+                             dict(inp=dace.Memlet('A[i]')),
+                             'out = inp + 1.0',
+                             dict(out=dace.Memlet('A[i]')),
+                             external_edges=True)
+    frame = next(o.clean_code for o in sdfg.generate_code() if o.language == 'cpp' and o.name == 'drain_cpu_only_probe')
+    assert '__dace_gpu_drain_error' not in frame
+
+
+def test_gpu_init_template_substitution_does_not_break_comments():
+    """Regression: a ``{placeholder}`` written inside a C++ comment in the init template.
+
+    ``__dace_init_cuda`` is built with ``str.format``, so a placeholder inside a comment is
+    substituted there like anywhere else. ``{initcode}`` expands to multiple statements, so
+    writing it in a comment dumped the whole init body into the middle of that comment and
+    left the rest of the sentence as a bare statement - nvcc reported
+    ``identifier "often" is undefined``.
+
+    Checked against the TEMPLATE SOURCE rather than against generated output. Reproducing
+    the corruption through a generated file needs an SDFG whose ``{initcode}`` is non-empty
+    (a CUB reduction, say) - so a test built on a simpler SDFG passes while the bug is
+    present, which is worse than no test. Reading the source catches the whole class for
+    every SDFG shape.
+
+    ``{backend}`` is allowed: it expands to a single identifier (``cuda``/``hip``) and has
+    always been used this way. Everything else is rejected, since a placeholder that
+    expands to statements turns the rest of the comment line into code.
+    """
+    import re
+    from pathlib import Path
+
+    import dace.codegen.targets.cuda as cuda_target
+
+    source = Path(cuda_target.__file__).read_text().split('\n')
+    placeholder = re.compile(r'\{([a-z_][a-z_0-9]*)\}')
+    offenders = []
+    for lineno, line in enumerate(source, 1):
+        if not line.strip().startswith('//'):
+            continue
+        for match in placeholder.finditer(line):
+            if match.group(1) != 'backend':
+                offenders.append(f'{cuda_target.__file__}:{lineno}: {{{match.group(1)}}} in {line.strip()!r}')
+
+    assert not offenders, ('a format placeholder inside a generated C++ comment is substituted there, '
+                           'so anything expanding to statements breaks the comment:\n  ' + '\n  '.join(offenders))
+
+
+def test_gpu_mempool_setup_is_checked_and_follows_context_creation():
+    """The memory-pool calls are wrapped, and run only after the GPU context exists.
+
+    DACE_GPU_CHECK records into ``__state->gpu_context``, so a checked call placed before
+    the context is constructed could not record - and, before ``gpu_context`` was given an
+    initializer, could not even be read safely.
+    """
+    sdfg = dace.SDFG('drain_pool_probe')
+    sdfg.add_array('A', [16], dace.float64, storage=dace.StorageType.GPU_Global)
+    sdfg.arrays['A'].optional = False
+    sdfg.add_transient('t', [16], dace.float64, storage=dace.StorageType.GPU_Global)
+    sdfg.arrays['t'].pool = True
+    state = sdfg.add_state()
+    state.add_nedge(state.add_read('A'), state.add_write('t'), dace.Memlet('A[0:16]'))
+    state.add_nedge(state.add_read('t'), state.add_write('A'), dace.Memlet('t[0:16]'))
+
+    cu, _ = _sources(sdfg)
+    if 'MemPool_t' not in cu:
+        pytest.skip('this SDFG did not request pooled allocation')
+
+    assert 'DACE_GPU_CHECK(cudaDeviceGetDefaultMemPool' in cu
+    assert 'DACE_GPU_CHECK(cudaMemPoolSetAttribute' in cu
+    assert cu.index('__state->gpu_context = new') < cu.index('MemPool_t')
+
+
+if __name__ == '__main__':
+    test_gpu_drain_emitted_in_init_and_per_call()
+    test_gpu_drain_absent_without_gpu_code()
+    test_gpu_init_template_substitution_does_not_break_comments()
+    test_gpu_mempool_setup_is_checked_and_follows_context_creation()


### PR DESCRIPTION
## The problem

The CUDA runtime's last-error slot is **per-host-thread and shared with every other GPU user in
the process** — CuPy, another SDFG, any library.
A value left pending in it is returned by the next runtime call DaCe makes, so the first
`DACE_GPU_CHECK`-wrapped call in a generated module reports someone else's failure as its own.

That is misleading twice over: it blames an innocent call, and it hides whoever actually failed.

DaCe already knows this slot is unreliable. `__dace_gpu_last_error` deliberately reads the SDFG's
own record instead, with this comment in `dace/codegen/targets/cuda.py`:

> The runtime's own last-error slot is per-host-thread and shared with every other GPU user in the
> process, so it is not a reliable carrier for this SDFG's failures.

The init path simply had no equivalent protection.

## How it was found

Intermittent `invalid device ordinal` failures in a GPU CI job running 32 pytest-xdist workers
over 4 GPUs.
The failures landed on a **different test each run** —
`reduce_test.py::test_multidim_gpu`, `wcr_cudatest.py::test`,
`block_allreduce_cudatest.py::test_blockallreduce` — and occurred under **both** compiled-SDFG
interfaces, which ruled out anything interface-specific.

`DACE_GPU_CHECK` prints `__FILE__:__LINE__` before recording, and pytest shows captured stdout on
failure. Two runs reported the identical generated line, in different SDFGs.
Since code generation needs no GPU, the failing translation unit can be regenerated on a
developer machine, which identifies it exactly:

```c
DACE_GPU_CHECK(cub::DeviceReduce::Reduce(nullptr, __cub_ssize_test_sdfg_0_2, ...));
```

That is the CUB temp-storage size query emitted into `__dace_init_cuda` by
`dace/libraries/standard/nodes/reduce.py`.
It passes `d_temp_storage = nullptr` and launches nothing — but it consults the runtime, and CUB
checks the error state internally.
It is the usual victim simply because it is often the **first checked call** in a generated
module. All three affected tests are CUB reductions.

## The change

### 1. Drain the slot, on every call

A new exported `__dace_gpu_drain_error` in the generated `.cu` discards whatever is pending and
prints what it discarded. It is called from two places:

- the top of `__dace_init_cuda`, before any checked call;
- the top of **every** `__program_<name>` invocation — initialization runs once per state, while
  contamination can arrive between any two calls.

The frame code declares the function and emits the call only when the cuda target is in use,
exactly as it already declares `__dace_init_<target>`.
The generated `.cpp` cannot include the CUDA headers, so the call has to cross into the `.cu`.

Design points:

- **Clearing is required, not incidental.** `cudaPeekAtLastError()` would observe without
  clearing, but the stale value would still be pending when the next checked call runs — the
  problem would be diagnosed and not fixed.
- **Only non-sticky errors can be discarded.** A sticky one (illegal access, corrupted context)
  survives `gpuGetLastError()` and is reported through the normal path by the next real call.
- **It reports rather than throws.** A pending error is by definition not this SDFG's, and failing
  there would penalize the very SDFG this protects.

### 2. Check the memory-pool setup

`cudaDeviceGetDefaultMemPool` and `cudaMemPoolSetAttribute` were unchecked.
An unchecked call that can fail is precisely what leaves an error pending for the next checked
call to inherit, so they are now wrapped in `DACE_GPU_CHECK`.

Other unchecked backend calls were left alone deliberately: `GetDeviceCount` has its own explicit
error handling, `DeviceSynchronize` in `__dace_exit_cuda` has its result returned, and
`LaunchKernel` is followed by `DACE_KERNEL_LAUNCH_CHECK`.

### 3. Two fixes needed to make that wrapping safe

These were not part of the original intent but are required for correctness:

- The pool setup was emitted **before** `__state->gpu_context` is constructed, and
  `DACE_GPU_CHECK` records into that context.
  Wrapping the calls as written would have turned a mempool failure into a dereference of an
  unset pointer.
  The pool setup now runs after the context exists.

- `gpu_context` was a raw pointer with **no initializer** in a state struct allocated via `new T`
  (default-initialized, so the member was indeterminate), while the runtime warm-up allocation in
  `__dace_init_cuda` is already checked before the context is assigned.
  It now has a `= nullptr` initializer, and `DACE_GPU_CHECK` guards the recording on a non-null
  context while printing either way.
  **This is a pre-existing latent bug on the init error path**, independent of everything else
  here.

## Verification, and its limits

The GPU code is verified by **regenerating it, not by compiling or running it** — there is no CUDA
toolchain on the machine this was written on. Stated plainly so reviewers can weight it.

Confirmed on a real GPU SDFG (`tests/wcr_cudatest.py`):

- the drain is defined in the `.cu` and called from `__dace_init_cuda`;
- it is declared before use in the `.cpp` and called at the top of `__program_<name>`;
- a pooled SDFG emits both mempool calls wrapped, with the context constructed first;
- a CPU-only SDFG emits no drain at all.

The CPU path is exercised for real: **137 tests pass across `tests/codegen`**.
The frame code change touches every generated program, which is why that coverage matters.

**This is not claimed as a proven fix** for the CI flakiness that prompted it.
The evidence there is failures before and green runs after; the warning was never observed firing,
because pytest suppresses captured stdout for *passing* tests (confirming it on a green run would
need `-rP` or `--capture=no`).
The change stands on its own as correct error attribution regardless.

A separate root cause in pytest's own test distribution was identified independently by a DaCe
developer and is not addressed here.

## Review questions

1. **Should the warning be unconditional?** If some workflow routinely leaves errors pending, the
   `printf` fires on every call. Gating it behind a debug config, or routing it through DaCe's
   logging rather than `printf`, would both be reasonable.
2. **Is `__program_<name>` the right hook** for the per-call drain, or would a target-provided
   per-invocation preamble be preferable to the frame code knowing about the cuda target by name?
3. **Should the drain also run at program exit**, so an error DaCe leaves pending does not
   contaminate the next user of the slot?

## Not included

`dace/codegen/targets/cuda.py` still hardcodes the device ordinal in
`cudaDeviceGetDefaultMemPool(&mempool, 0)`.
That call is now checked, but whether ordinal `0` is right in a multi-device or
`CUDA_VISIBLE_DEVICES`-restricted context is a separate question, left alone here.