### PR TITLE
[opt] cache sympy pattern for matching in `simplify_ext(expr)`

### DIFF
--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -135,7 +135,7 @@ class Subset(object):
     def ndrange(self) -> list[tuple[symbolic.SymbolicType, symbolic.SymbolicType, symbolic.SymbolicType]]:
         """
         Implements an iterator over strided N-dimensional rectangular regions of the subset.
-        Note that this may be an overapproximation of the actual subset, based on the subclass.
+        Note that this may be an over-approximation of the actual subset, based on the subclass.
 
         :return: An iterator over N-dimensional ranges.
         """
@@ -153,8 +153,7 @@ class Subset(object):
 
         if Config.get('optimizer', 'symbolic_positive'):
             return bounding_box_symbolic_positive(self, other, approximation=True)
-        else:
-            return bounding_box_cover_exact(self, other, approximation=True)
+        return bounding_box_cover_exact(self, other, approximation=True)
 
     def covers_precise(self, other):
         """ Returns True if self contains all the elements in other. """
@@ -169,7 +168,7 @@ class Subset(object):
         symbolic_positive = Config.get('optimizer', 'symbolic_positive')
         if symbolic_positive and (not bounding_box_cover_exact(self, other)):
             return False
-        elif not bounding_box_symbolic_positive(self, other):
+        if not bounding_box_symbolic_positive(self, other):
             return False
 
         # NOTE: The original implementation always called ``nng()``. However, it was decided that

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -2,7 +2,7 @@
 import ast
 import contextlib
 from collections import Counter
-from functools import lru_cache
+from functools import lru_cache, cache
 import sympy
 import threading
 import pickle
@@ -1445,6 +1445,23 @@ def sympy_divide_fix(expr):
     return nexpr
 
 
+@cache
+def _cached_sympy_pattern():
+    """
+    Cache sympy pattern for `min(a, b) + c`  and `max(a, b) + c`.
+
+    Those patterns are (surprisingly) costly to create. Since they are pattern (similar to a regex),
+    they can be constructed once and then re-used in subsequent calls. Greatly reduces the overhead
+    of `simplify_ext()`  (see below).
+    """
+    a = sympy.Wild('a')
+    b = sympy.Wild('b')
+    c = sympy.Wild('c')
+    min_pattern = sympy.Min(a, b) + c
+    max_pattern = sympy.Max(a, b) + c
+    return min_pattern, max_pattern, a, b, c
+
+
 def simplify_ext(expr):
     """
     An extended version of simplification with expression fixes for sympy.
@@ -1454,18 +1471,16 @@ def simplify_ext(expr):
     """
     if not isinstance(expr, sympy.Basic):
         return expr
-    a = sympy.Wild('a')
-    b = sympy.Wild('b')
-    c = sympy.Wild('c')
 
     # Push expressions into both sides of min/max.
     # Example: Min(N, 4) + 1 => Min(N + 1, 5)
-    dic = expr.match(sympy.Min(a, b) + c)
-    if dic:
-        return sympy.Min(dic[a] + dic[c], dic[b] + dic[c])
-    dic = expr.match(sympy.Max(a, b) + c)
-    if dic:
-        return sympy.Max(dic[a] + dic[c], dic[b] + dic[c])
+    min_ab_plus_c, max_ab_plus_c, a, b, c = _cached_sympy_pattern()
+    matches = expr.match(min_ab_plus_c)
+    if matches is not None:
+        return sympy.Min(matches[a] + matches[c], matches[b] + matches[c])
+    matches = expr.match(max_ab_plus_c)
+    if matches is not None:
+        return sympy.Max(matches[a] + matches[c], matches[b] + matches[c])
     return expr
 
 


### PR DESCRIPTION
## Description

`dace/symbolic.py` exposes a function `simplify_ext(expr)` that matches expressions like `min(a, b) + c` and `max(a, b) + c`. This function is known to be slow and previous attempts (e.g. PR https://github.com/spcl/dace/pull/2093) have been made to avoid the function at all cost.

In this PR, we are looking into the function, optimizing a crucial part. To find the min/max expressions, the function uses sympy pattern-matching. The patterns are re-built for every call. This is unnecessary because patterns (similar to regex) can be re-used once created. It turns out, pattern creation is a (surprisingly) expensive operation. By simply caching the patterns, we can get significant speedup for codes calling the function often (e.g. subset covers).

#### Motivation

This PR is motivated by SDFG -> schedule tree -> SDFG roundtrips. While it's fast to go from an SDFG to a schedule tree, the reverse transformation (from schedule tree to SDFG) takes a long time. This is mostly due to the fact that (re-)building an SDFG from the schedule tree, we have to make a ton of calls to figure out if one subset overlaps with another or if ti's covered.

For our testcase, we spend 6:40 in `covers()` before the optimization where 4:47 min is spent creating sympy patterns as shown from the profile below.

<img width="3196" height="1610" alt="image" src="https://github.com/user-attachments/assets/cac2b0fc-0503-47fc-86ca-8fd141a89ae6" />

_profile before_

with the pattern caching proposed in this PR, we can remove this time entirely, reducing the runtime of `covers()` to 1:18 min and the total runtime from 7+ minutes to 2+ minutes.

<img width="3196" height="1610" alt="image" src="https://github.com/user-attachments/assets/f65748ed-0ccf-4360-a65c-11d2c3de04cf" />

_profile after_