### PR TITLE
[opt] guard expensive pattern matching in simplify_ext(expr)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,5 +37,6 @@ Yihang Luo
 Alexandru Calotoiu
 Phillip Lane
 Samuel Martin
+Roman Cattaneo
 
 and other contributors listed in https://github.com/spcl/dace/graphs/contributors

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1474,13 +1474,15 @@ def simplify_ext(expr):
 
     # Push expressions into both sides of min/max.
     # Example: Min(N, 4) + 1 => Min(N + 1, 5)
-    min_ab_plus_c, max_ab_plus_c, a, b, c = _cached_sympy_pattern()
-    matches = expr.match(min_ab_plus_c)
-    if matches is not None:
-        return sympy.Min(matches[a] + matches[c], matches[b] + matches[c])
-    matches = expr.match(max_ab_plus_c)
-    if matches is not None:
-        return sympy.Max(matches[a] + matches[c], matches[b] + matches[c])
+    # Guarded by a quick check if `expr` is an addition because matching is an expensive operation.
+    if expr.is_Add:
+        min_ab_plus_c, max_ab_plus_c, a, b, c = _cached_sympy_pattern()
+        matches = expr.match(min_ab_plus_c)
+        if matches is not None:
+            return sympy.Min(matches[a] + matches[c], matches[b] + matches[c])
+        matches = expr.match(max_ab_plus_c)
+        if matches is not None:
+            return sympy.Max(matches[a] + matches[c], matches[b] + matches[c])
     return expr
 
 

--- a/tests/symbolic_test.py
+++ b/tests/symbolic_test.py
@@ -1,0 +1,19 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+
+from sympy import Min, Max
+
+from dace.symbolic import simplify_ext, symbol
+
+
+def test_simplify_ext_min() -> None:
+    N = symbol("N")
+
+    assert simplify_ext(Min(N, 4) + 1) == Min(N + 1, 5)
+    assert simplify_ext(Max(N, 4) + 1) == Max(N + 1, 5)
+
+    untouched = Min(N, 4)
+    assert simplify_ext(untouched) == untouched
+
+
+if __name__ == "__main__":
+    test_simplify_ext_min()


### PR DESCRIPTION
## Description

`dace/symbolic.py` exposes a function `simplify_ext(expr)` that matches expressions like `min(a, b) + c` and `max(a, b) + c`. This function is known to be slow and previous attempts (e.g. PR https://github.com/spcl/dace/pull/2093) have been made to avoid the function at all cost.

This PR builds on PR https://github.com/spcl/dace/pull/2494 and not only caches the pattern to be matched, but guards pattern matching with a much simpler check. This - again - speeds up repeated calls to the function were we can't match (e.g. single symbols).

#### Motivation

See #2494 for the full story. Basically we start from a profile where we spend 1:18 min in `covers()` mostly due to matching `{Min,Max}(a, b) + c` 


<img width="3196" height="1610" alt="image" src="https://github.com/user-attachments/assets/f65748ed-0ccf-4360-a65c-11d2c3de04cf" />

_profile before this PR_

With this PR, we can reduce the time spent in `covers()` to 5 seconds!

<img width="3195" height="1610" alt="image" src="https://github.com/user-attachments/assets/0cc40786-0457-4a0a-8cf1-3d5fe5333b2a" />

_profile after this PR_

bringing down the whole test case to something just over a minute.
