### PR TITLE
frontend: drop the redundant process-grid merge from ProgramVisitor.defined

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1372,11 +1372,11 @@ class ProgramVisitor(ExtNodeVisitor):
         # Add SDFG arrays, in case a replacement added a new output
         result.update(self.sdfg.arrays)
 
-        # MPI-related stuff
-        result.update({
-            v: self.sdfg.process_grids[v]
-            for k, v in self.variables.items() if v in self.sdfg.process_grids
-        })
+        # MPI-related stuff. ``process_grids`` is a PROPERTY that rebuilds a dict by scanning every
+        # descriptor in the SDFG, so reading it inside the comprehension re-scanned once per variable:
+        # |variables| x |arrays| per access, and this property is read while parsing every statement.
+        process_grids = self.sdfg.process_grids
+        result.update({v: process_grids[v] for k, v in self.variables.items() if v in process_grids})
         # Installed is not usable: an mpi4py with no libmpi to dlopen raises RuntimeError, not
         # ImportError, so the availability question belongs in one place (see the helper's docstring).
         if preprocessing.mpi4py_is_usable():

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1369,14 +1369,10 @@ class ProgramVisitor(ExtNodeVisitor):
         # TODO: Is there a case of a variable-symbol?
         result.update({k: self.sdfg.symbols[v] for k, v in self.variables.items() if v in self.sdfg.symbols})
 
-        # Add SDFG arrays, in case a replacement added a new output
+        # Add SDFG arrays, in case a replacement added a new output. Process grids are data
+        # descriptors, so this carries them as well.
         result.update(self.sdfg.arrays)
 
-        # MPI-related stuff. ``process_grids`` is a PROPERTY that rebuilds a dict by scanning every
-        # descriptor in the SDFG, so reading it inside the comprehension re-scanned once per variable:
-        # |variables| x |arrays| per access, and this property is read while parsing every statement.
-        process_grids = self.sdfg.process_grids
-        result.update({v: process_grids[v] for k, v in self.variables.items() if v in process_grids})
         # Installed is not usable: an mpi4py with no libmpi to dlopen raises RuntimeError, not
         # ImportError, so the availability question belongs in one place (see the helper's docstring).
         if preprocessing.mpi4py_is_usable():

--- a/tests/python_frontend/program_visitor_defined_test.py
+++ b/tests/python_frontend/program_visitor_defined_test.py
@@ -1,0 +1,56 @@
+# Copyright 2019-2022 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests the name resolution table ``ProgramVisitor.defined`` hands to memlet and symbol parsing. """
+import dace
+from dace import data
+from dace.frontend.python.newast import ProgramVisitor
+
+
+def _visitor(name: str) -> ProgramVisitor:
+    return ProgramVisitor(name=name,
+                          filename=__file__,
+                          line_offset=0,
+                          col_offset=0,
+                          global_vars={},
+                          constants={},
+                          scope_arrays={},
+                          scope_vars={})
+
+
+def test_defined_resolves_arrays_symbols_and_process_grids():
+    pv = _visitor('defined_table')
+    sdfg = pv.sdfg
+    sdfg.add_array('A', (20, ), dace.float64)
+    sdfg.add_symbol('N', dace.int32)
+    pgrid = sdfg.add_pgrid(shape=[2, 2])
+
+    # The visitor's own variable names, as an assignment in the parsed program would bind them.
+    pv.variables['a'] = 'A'
+    pv.variables['n'] = 'N'
+    pv.variables['grid'] = pgrid
+
+    defined = pv.defined
+
+    assert defined['a'] is sdfg.arrays['A']
+    assert defined['n'] is sdfg.symbols['N']
+    # Keyed by the DESCRIPTOR name, not the program-side name: that is what the process-grid entry
+    # has always promised its consumers, and it is the entry a lookup of the grid resolves through.
+    assert defined[pgrid] is sdfg.process_grids[pgrid]
+    assert isinstance(defined[pgrid], data.distributed.ProcessGrid)
+
+
+def test_defined_resolves_a_process_grid_under_every_name_bound_to_it():
+    pv = _visitor('defined_two_names_one_grid')
+    pgrid = pv.sdfg.add_pgrid(shape=[2, 2])
+    pv.variables['grid'] = pgrid
+    pv.variables['alias'] = pgrid
+
+    # Every binding resolves to the SAME descriptor, and the descriptor name resolves whether or not
+    # a variable is bound to it (`add_pgrid` files the grid in the SDFG's descriptor repository).
+    defined = pv.defined
+    assert defined[pgrid] is pv.sdfg.process_grids[pgrid]
+    assert isinstance(defined[pgrid], data.distributed.ProcessGrid)
+
+
+if __name__ == '__main__':
+    test_defined_resolves_arrays_symbols_and_process_grids()
+    test_defined_resolves_a_process_grid_under_every_name_bound_to_it()


### PR DESCRIPTION
### What

`ProgramVisitor.defined` is read while parsing every statement. Its MPI block read
`self.sdfg.process_grids` **inside** a dict comprehension over `self.variables`:

```python
result.update({
    v: self.sdfg.process_grids[v]
    for k, v in self.variables.items() if v in self.sdfg.process_grids
})
```

`process_grids` is a property that builds a fresh dict by scanning every descriptor in
`SDFG._arrays`, so the membership test re-scanned the whole descriptor repository once per
variable — `|variables| x |arrays|` work per access, on a property read once per parsed
statement.
