### PR TITLE
LoopToMap Fixes

### DIFF
--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -41,9 +41,8 @@ def _check_range(subset, a, itersym, b, step):
 
 
 def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
-    """Whether every write to ``conn`` inside ``nsdfg_node`` is ``a*i+b``-indexed. The connector
-    memlet is the union over the loop, so look at the inner subsets through ``symbol_mapping``.
-    """
+    """Every write to ``conn`` inside ``nsdfg_node`` is ``a*i+b``-indexed; the connector memlet is
+    the union over the loop, so read the inner subsets through ``symbol_mapping``."""
     repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
     found = False
     for state in nsdfg_node.sdfg.all_states():
@@ -70,9 +69,8 @@ def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
 
 
 def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
-    """Whether every read of ``conn`` inside ``nsdfg_node`` matches the writes' ``a*i+b`` or is
-    loop-invariant; write uniqueness alone lets ``a[i] = a[i+1]`` race.
-    """
+    """Every read of ``conn`` inside ``nsdfg_node`` matches the writes' ``a*i+b`` or is
+    loop-invariant; write uniqueness alone lets ``a[i] = a[i+1]`` race."""
     repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
     for state in nsdfg_node.sdfg.all_states():
         for dn in state.data_nodes():
@@ -82,7 +80,6 @@ def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
                 if e.data is None:
                     continue
                 if isinstance(e.dst, nodes.NestedSDFG):
-                    # The read enters another nested SDFG; descend.
                     if not _nested_reads_match_writes(e.dst, e.dst_conn, itersym, a, b, step):
                         return False
                     continue
@@ -91,7 +88,6 @@ def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
                     return False
                 outer = copy.deepcopy(src_subset)
                 outer.replace(repl)
-                # Loop-invariant read (no itersym) -- safe, same value every iteration.
                 free = OrderedSet()
                 for rb, re, _ in outer.ndrange():
                     for expr in (rb, re):
@@ -99,7 +95,6 @@ def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
                             free |= set(expr.free_symbols)
                 if itersym not in free:
                     continue
-                # itersym-dependent read: must match the writes' a*i+b, else it's a carried read.
                 if not _check_range(outer, a, itersym, b, step):
                     return False
     return True
@@ -123,10 +118,11 @@ def _sanitize_by_index(indices: Set[int], subset: subsets.Subset) -> subsets.Ran
 
 
 def _affine_coeffs(expr, itersym):
-    """Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if not affine in ``itersym``.
+    """Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if not affine.
 
-        The derivative is ``a`` (still mentioning ``itersym`` above degree one, which is the
-        degree test) and the value at zero is ``b``; ``expand`` + ``coeff`` hung on tiled indices.
+        The derivative is ``a`` (still naming ``itersym`` above degree one, which is the
+        degree test) and the value at zero is ``b``; ``expand`` + ``coeff`` hung on tiled
+        indices.
     """
     e = symbolic.pystr_to_symbolic(expr)
     if not e.is_polynomial(itersym):
@@ -149,8 +145,9 @@ def _same_injective_index(idx1, idx2, itersym) -> bool:
 def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
     """True iff ``idx1`` at any iteration can never equal ``idx2`` at any iteration.
 
-        Over the counter ``t`` (``i == start + step*t``), ``A1*t1 + B1 == A2*t2 + B2`` is solvable
-        iff ``gcd(A1, A2)`` divides ``B2 - B1``. All-integer ``t`` is conservative, hence sound.
+        Over the counter ``t`` (``i == start + step*t``), ``A1*t1 + B1 == A2*t2 + B2`` is
+        solvable iff ``gcd(A1, A2)`` divides ``B2 - B1``; ranging over all integers is
+        conservative, hence sound.
     """
     f1 = _affine_coeffs(idx1, itersym)
     f2 = _affine_coeffs(idx2, itersym)
@@ -162,8 +159,7 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
         return False
     step_s = symbolic.pystr_to_symbolic(step)
     start_s = symbolic.pystr_to_symbolic(start)
-    # ``expand``, not ``sp.simplify``: only the difference needs cancelling, and only across a
-    # product ``Add`` will not flatten. ``simplify`` looked like a hang on tiled write sets.
+    # ``expand``, not ``simplify``: the latter looked like a hang on tiled write sets.
     A1 = a1 * step_s
     A2 = a2 * step_s
     B1 = a1 * start_s + b1
@@ -171,8 +167,7 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
     diff = sp.expand(B2 - B1)
     if A1 == 0 and A2 == 0:
         return diff.is_number and diff != 0
-    # A strided or offset loop yields symbolic ``A_k`` only when the step/start
-    # are symbolic; the gcd criterion then cannot be evaluated -- stay safe.
+    # A symbolic step or start leaves ``A_k`` symbolic, and the gcd criterion undecidable.
     if not (A1.is_Integer and A2.is_Integer):
         return False
     g = sp.igcd(int(A1), int(A2))
@@ -186,9 +181,8 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
 
 
 def loop_varying_symbols(loop: LoopRegion) -> OrderedSet[str]:
-    """Symbols that can change while ``loop`` runs: nested loop and map iterators, and what its
-    interstate edges assign. Every other symbol holds one value, which the tests below rely on.
-    """
+    """Symbols that can change while ``loop`` runs: nested iterators and interstate assignments.
+    Every other symbol holds one value, which the tests below rely on."""
     varying: OrderedSet[str] = OrderedSet()
     for cfr in loop.all_control_flow_regions(recursive=True):
         if isinstance(cfr, LoopRegion) and cfr is not loop and cfr.loop_variable:
@@ -204,10 +198,8 @@ def loop_varying_symbols(loop: LoopRegion) -> OrderedSet[str]:
 
 def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, itersym, step, start,
                               varying: OrderedSet[str]) -> bool:
-    """True iff some dimension's read/write point-indices are provably disjoint across every pair of
-    in-domain iterations. Unlike propagate+intersect this keeps constant disproving dimensions
-        (``aa[0, i]`` vs ``aa[1, i-1]``).
-    """
+    """Some dimension's read/write indices are disjoint for every pair of iterations, keeping the
+    constant dimensions propagate+intersect drops."""
     rnd = list(read.ndrange())
     wnd = list(write.ndrange())
     if len(rnd) != len(wnd) or len(rnd) == 0:
@@ -228,9 +220,7 @@ def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, iters
 
 
 def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, itersym) -> bool:
-    """True iff a point dimension indexes read and write by the same injective function of
-    ``itersym``: any overlap is then within one iteration, where program order holds.
-    """
+    """A point dimension indexing read and write alike confines any overlap to one iteration."""
     rnd = list(read.ndrange())
     wnd = list(write.ndrange())
     if len(rnd) != len(wnd) or len(rnd) == 0:
@@ -247,9 +237,9 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
                                      varying: OrderedSet[str]) -> bool:
     """Prove two point subsets of one container collide only when their iterations coincide.
 
-        With ``itersym`` replaced by ``p`` in ``sub1`` and ``q`` in ``sub2``, rationals ``lam_d``
-        with ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` certify it for every parameter
-        value. Catches transposes (``cov[i,j]`` vs ``cov[j,i]``); without one, may-alias stands.
+        With ``itersym`` replaced by ``p`` and ``q``, rationals ``lam_d`` with
+        ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` certify it for every parameter
+        value; this is what catches transposes (``cov[i,j]`` vs ``cov[j,i]``).
     """
     nd1 = list(sub1.ndrange())
     nd2 = list(sub2.ndrange())
@@ -263,20 +253,19 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
             return False
         x1 = symbolic.pystr_to_symbolic(b1)
         x2 = symbolic.pystr_to_symbolic(b2)
-        # SOUNDNESS: sharing a body-varying symbol certifies ``p == q`` for aliasing accesses.
+        # SOUNDNESS: a body-varying symbol would certify ``p == q`` for aliasing accesses.
         if any(str(s) in varying for s in x1.free_symbols) or any(str(s) in varying for s in x2.free_symbols):
             return False
         eqs.append(sp.expand(x1.subs(itersym, p) - x2.subs(itersym, q)))
         params |= {s for s in (set(x1.free_symbols) | set(x2.free_symbols)) if str(s) != str(itersym)}
     monomials = [p, q] + list(params)
-    # Every equation must be affine in {p, q, params}: on ``A[i*i]`` a linear certificate lies.
+    # Affine only: on ``A[i*i]`` a linear certificate lies.
     for eq in eqs:
         try:
             if sp.Poly(eq, *monomials).total_degree() > 1:
                 return False
         except sp.PolynomialError:
             return False
-    # Matching monomial coefficients of ``sum_d lam_d * eq_d == p - q`` gives a linear system.
     lambdas = list(sp.symbols(f'_l2m_lam0:{len(eqs)}'))
     diff = sp.expand(sum(l * e for l, e in zip(lambdas, eqs)) - (p - q))
     lin_eqs = [diff.coeff(mono) for mono in monomials]
@@ -288,11 +277,7 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
 
 
 def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, start, varying: OrderedSet[str]) -> bool:
-    """Whether two writes to the same container may hit one element from different iterations.
-
-        Per dimension first (same injective index, or provably disjoint), then the collision
-        system.
-    """
+    """Whether two writes to one container may hit the same element from different iterations."""
     nd1 = list(m1.subset.ndrange())
     nd2 = list(m2.subset.ndrange())
     if len(nd1) != len(nd2):
@@ -300,8 +285,7 @@ def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, sta
     for (b1, e1, _), (b2, e2, _) in zip(nd1, nd2):
         if b1 != e1 or b2 != e2:  # non-point range dimension: cannot decide here
             continue
-        # Same injective index: a collision forces the iterations equal, so the overlap is
-        # inside one iteration, where the map body keeps program order.
+        # A collision then forces the two iterations equal, so order inside one holds.
         if _same_injective_index(b1, b2, itersym):
             return False
         if _dim_provably_disjoint(b1, b2, itersym, step, start):
@@ -340,7 +324,6 @@ class LoopToMap(xf.MultiStateTransformation):
         sset.update(sdfg.symbols)
         sset.update(sdfg.arrays)
         t = dtypes.result_type_of(infer_expr_type(start, sset), infer_expr_type(step, sset), infer_expr_type(end, sset))
-        # Bounds must be integer-derived: non-sequential map schedules are otherwise invalid.
         if not t in dtypes.INTEGER_TYPES:
             return False
 
@@ -355,8 +338,7 @@ class LoopToMap(xf.MultiStateTransformation):
             if symbolic.contains_sympy_functions(expr):
                 return False
 
-        # A range symbol the body assigns moves into the loop_body NSDFG, the range does not:
-        # ``Missing symbols on nested SDFG`` downstream.
+        # A range symbol the body assigns moves into the NSDFG while the range does not.
         range_syms: OrderedSet[str] = OrderedSet()
         for expr in (start, end, step):
             try:
@@ -377,8 +359,7 @@ class LoopToMap(xf.MultiStateTransformation):
             if [n for n in loop_state.data_nodes() if isinstance(n.desc(sdfg), dt.StructureView)]:
                 return False
 
-        # At most one iteration cannot carry a dependence, and a clamped bound only confuses
-        # the analysis below.
+        # At most one iteration cannot carry a dependence; a clamped bound only confuses.
         if loop_analysis.loop_provably_at_most_one_iteration(self.loop):
             return True
 
@@ -390,8 +371,7 @@ class LoopToMap(xf.MultiStateTransformation):
             in_order_loop_blocks = list(
                 cfg_analysis.blockorder_topological_sort(self.loop, recursive=True, ignore_nonstate_blocks=False))
             for block in in_order_loop_blocks:
-                # The sort emits a ConditionalBlock before its branches though its out-edges
-                # run after them: what every branch of an exhaustive one assigns is defined.
+                # The sort emits a ConditionalBlock before the branches its out-edges follow.
                 if isinstance(block, ConditionalBlock) and any(c is None for c, _ in block.branches):
                     per_branch = []
                     for _cond, body in block.branches:
@@ -403,16 +383,13 @@ class LoopToMap(xf.MultiStateTransformation):
                     if per_branch:
                         symbols_that_may_be_used |= set.intersection(*per_branch)
 
-                # ``read_symbols()`` below misses reads in the block's own dataflow (``b[im]``),
-                # which happen before its out-edges assign.
+                # ``read_symbols()`` misses the block's own dataflow reads, which come first.
                 try:
                     block_reads = {str(s) for s in block.free_symbols}
                 except Exception:
                     block_reads = OrderedSet()
                 used_before_assignment |= (block_reads - symbols_that_may_be_used)
                 for e in block.parent_graph.out_edges(block):
-                    # Collect read-before-assigned symbols (states are in order; see
-                    # blockorder_topological_sort above).
                     read_symbols = e.data.read_symbols()
                     read_symbols -= symbols_that_may_be_used
                     used_before_assignment |= read_symbols
@@ -443,8 +420,7 @@ class LoopToMap(xf.MultiStateTransformation):
         for state in loop_states:
             other_access_nodes |= set(n.data for n in state.data_nodes() if not sdfg.arrays[n.data].transient)
 
-        # Lazy: ``read_and_write_sets()`` walks every state and edge, and the cheap refusals
-        # above take 41k of channel_flow's 44k probes.
+        # Lazy: it walks every state and edge, and the cheap refusals above take 41k of 44k.
         _, write_set = self.loop.read_and_write_sets()
 
         write_memlets: Dict[str, List[memlet.Memlet]] = defaultdict(list)
@@ -460,27 +436,21 @@ class LoopToMap(xf.MultiStateTransformation):
                 # Take all writes that are not conflicted into consideration
                 if dn.data in write_set:
                     for e in state.in_edges(dn):
-                        # An empty memlet is an ordering edge; its missing subset would read
-                        # below as an unindexed whole-array write.
+                        # An empty memlet is an ordering edge; it has no subset to test.
                         if e.data is None or e.data.is_empty():
                             continue
                         if e.data.dynamic and e.data.wcr is None:
-                            # An axis pinned to the iter var gives each iteration its own
-                            # slab, so a lane firing cannot race.
                             dst_subset = e.data.get_dst_subset(e, state)
                             if not (dst_subset and _check_range(dst_subset, a, itersym, b, step)):
                                 return False
 
-                        # Unique write index per iteration: match ``a*i+b``, ``|a| >= 1``, i the
-                        # iteration variable (which must be used).
+                        # Unique per iteration: ``a*i+b`` with ``|a| >= 1`` and ``i`` used.
                         if e.data.wcr is None:
                             dst_subset = e.data.get_dst_subset(e, state)
                             ok = bool(dst_subset) and _check_range(dst_subset, a, itersym, b, step)
-                            # NestedSDFG body propagates a whole-array external write hiding an
-                            # inner per-iteration write; look past the connector.
+                            # The connector memlet hides the inner per-iteration write.
                             if not ok and isinstance(e.src, nodes.NestedSDFG):
                                 ok = _nested_writes_iter_indexed(e.src, e.src_conn, itersym, a, b, step)
-                                # An inner read at another iter position still races.
                                 if ok and not _nested_reads_match_writes(e.src, e.src_conn, itersym, a, b, step):
                                     ok = False
                             if not ok and not permissive:
@@ -488,8 +458,6 @@ class LoopToMap(xf.MultiStateTransformation):
 
                         write_memlets[dn.data].append(e.data)
 
-        # A read of a written array must be loop-invariant or match the writes' ``a*i+b``;
-        # the checks below only see overlaps within one iteration.
         for state in loop_states:
             for dn in state.data_nodes():
                 data = dn.data
@@ -501,7 +469,6 @@ class LoopToMap(xf.MultiStateTransformation):
                     src_subset = e.data.get_src_subset(e, state)
                     if src_subset is None:
                         continue
-                    # Loop-invariant read (no itersym) -- safe, same input every iteration.
                     free = OrderedSet()
                     for rb, re_, _ in src_subset.ndrange():
                         for expr in (rb, re_):
@@ -509,12 +476,9 @@ class LoopToMap(xf.MultiStateTransformation):
                                 free |= set(expr.free_symbols)
                     if itersym not in free:
                         continue
-                    # itersym-dependent read: must match a*i+b like the writes, else this
-                    # iteration reads a value another iteration writes.
                     if not _check_range(src_subset, a, itersym, b, step) and not permissive:
                         return False
 
-        # Fixed for the whole loop, so compute once and share with every dependence test below.
         varying = loop_varying_symbols(self.loop)
 
         # Two injective writes still collide across iterations (``A[5*i]``, ``A[3*i]`` at 15).
@@ -537,11 +501,9 @@ class LoopToMap(xf.MultiStateTransformation):
                 data = dn.data
                 if data in write_memlets:
                     for e in state.out_edges(dn):
-                        # As above: an empty memlet is an ordering edge, not a read.
                         if e.data is None or e.data.is_empty():
                             continue
 
-                        # Container read AND written: match only if the locations can't race.
                         src_subset = e.data.get_src_subset(e, state)
                         if not self.test_read_memlet(sdfg, state, e, itersym, itervar, start, end, step, write_memlets,
                                                      e.data, src_subset, varying):
@@ -557,8 +519,7 @@ class LoopToMap(xf.MultiStateTransformation):
                                              mmlt.subset, varying):
                     return False
 
-        # Iteration variable + other symbols must not be used on later edges/blocks before
-        # reassignment.
+        # No later edge or block may read these symbols before reassigning them.
         in_order_blocks = list(
             cfg_analysis.blockorder_topological_sort(sdfg, recursive=True, ignore_nonstate_blocks=False))
         # First check the outgoing edges of the loop itself.
@@ -641,7 +602,6 @@ class LoopToMap(xf.MultiStateTransformation):
             # Step-aware disjointness; the fallback below drops constant dims and the stride.
             if _read_write_dims_disjoint(read, write, itersym, step, start, varying):
                 continue
-            # Same injective index (syrk's ``C[i, :i+1]``) confines it to one iteration.
             if _read_write_same_iteration(read, write, itersym):
                 continue
             # A transpose settles no single dimension, yet the dependence is distance-0.
@@ -695,8 +655,7 @@ class LoopToMap(xf.MultiStateTransformation):
             for node in state.data_nodes():
                 if node.data != name:
                     continue
-                # itersym in the subset means not thread-local; assumes the loop is a valid Map,
-                # i.e. every edge carrying the array depends on itersym consistently.
+                # itersym in the subset means not thread-local (assumes a valid Map).
                 for e in state.out_edges(node):
                     src_subset = e.data.get_src_subset(e, state)
                     if src_subset and itervar in src_subset.free_symbols:
@@ -739,8 +698,7 @@ class LoopToMap(xf.MultiStateTransformation):
                         if e.data.data and e.data.data in sdfg.arrays:
                             write_set.add(e.data.data)
 
-        # Headers at EVERY depth: stopping at a branch leaves the containers it reads below
-        # without a connector.
+        # Headers at EVERY depth: stopping at a branch loses the containers it reads.
         for block in self.loop.all_control_flow_blocks():
             if isinstance(block, (LoopRegion, ConditionalBlock)):
                 free_syms = {s for c in block.get_meta_codeblocks() for s in c.get_free_symbols()}
@@ -828,8 +786,7 @@ class LoopToMap(xf.MultiStateTransformation):
             for s, m in sdfg.parent_nsdfg_node.symbol_mapping.items():
                 if s not in cnode.symbol_mapping:
                     cnode.symbol_mapping[s] = symbolic.pystr_to_symbolic(s)
-                    # A mapping entry the mapped SDFG never declared (other passes write mapping
-                    # entries without one): type it off the symbol instead of refusing.
+                    # Other passes map symbols without declaring them; type it off the symbol.
                     nsdfg.symbols[s] = sdfg.symbols.get(s, symbolic.symbol(s).dtype)
         for name in read_set:
             r = body.add_read(name)
@@ -845,14 +802,12 @@ class LoopToMap(xf.MultiStateTransformation):
         for sym, dtype in nsymbols.items():
             nsdfg.symbols[sym] = dtype
 
-        # Mapping a symbol the nested SDFG assigns itself makes the outer one appear to need
-        # it, and a later pruning pass then desyncs the mapping.
+        # Mapping a symbol the nested SDFG assigns itself desyncs a later pruning pass.
         internally_defined = set()
         for e in nsdfg.all_interstate_edges():
             internally_defined.update(e.data.assignments.keys())
 
-        # Propagate free symbols in nested array shapes/strides/offsets: deepcopy carries them
-        # but they must be added to the NestedSDFG's symbol mapping.
+        # deepcopy carries shape/stride symbols but not their mapping entries.
         for desc in nsdfg.arrays.values():
             for sym in desc.free_symbols:
                 sym_name = str(sym)
@@ -889,8 +844,8 @@ class LoopToMap(xf.MultiStateTransformation):
                 if vtype is None:
                     nsdfg.symbols[k] = ktype
 
-        # The registrations above can free a symbol after ``add_nested_sdfg`` fixed the mapping;
-        # a free symbol missing from the node's mapping fails validation, so self-map leftovers.
+        # The registrations above can free a symbol after the mapping was fixed; validation
+        # rejects one that is missing, so self-map the leftovers.
         nconnectors = cnode.in_connectors.keys() | cnode.out_connectors.keys()
         for sym in sorted(nsdfg.free_symbols):
             if sym in nconnectors or sym in cnode.symbol_mapping:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -91,8 +91,7 @@ def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
                 free = OrderedSet()
                 for rb, re, _ in outer.ndrange():
                     for expr in (rb, re):
-                        if hasattr(expr, 'free_symbols'):
-                            free |= set(expr.free_symbols)
+                        free |= OrderedSet(symbolic.pystr_to_symbolic(expr).free_symbols)
                 if itersym not in free:
                     continue
                 if not _check_range(outer, a, itersym, b, step):
@@ -330,8 +329,7 @@ class LoopToMap(xf.MultiStateTransformation):
         # Loops containing break, continue, or returns may not be turned into a map.
         for blk in self.loop.all_control_flow_blocks():
             if isinstance(blk, (BreakBlock, ContinueBlock, ReturnBlock)):
-                if not permissive:
-                    return False
+                return False
 
         # We cannot handle symbols read from data containers unless they are scalar.
         for expr in (start, end, step):
@@ -472,8 +470,7 @@ class LoopToMap(xf.MultiStateTransformation):
                     free = OrderedSet()
                     for rb, re_, _ in src_subset.ndrange():
                         for expr in (rb, re_):
-                            if hasattr(expr, 'free_symbols'):
-                                free |= set(expr.free_symbols)
+                            free |= OrderedSet(symbolic.pystr_to_symbolic(expr).free_symbols)
                     if itersym not in free:
                         continue
                     if not _check_range(src_subset, a, itersym, b, step) and not permissive:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -39,6 +39,95 @@ def _check_range(subset, a, itersym, b, step):
     return found
 
 
+def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
+    """Whether every write to ``conn``'s array INSIDE ``nsdfg_node`` is indexed by the (mapped)
+    iteration variable.
+
+    A NestedSDFG loop body propagates a whole-array external write memlet (union over the loop)
+    that hides the per-iteration write. Look past the connector: rewrite inner write subsets
+    through ``symbol_mapping`` into the outer itersym; each must match the ``a*i+b`` pattern
+    :func:`_check_range` enforces. Conservative: needs ≥1 inner write and ALL must pass; nested
+    NestedSDFGs recurse, composing symbol maps.
+
+    Example: ``for i: if c: b[i] = a[i] + 1`` after a ``LoopToMap -> MapToForLoop`` round-trip
+    (guard forced a NestedSDFG body). The external connector memlet ``b[0:N]`` (union, no ``i``)
+    fails _check_range, but the inner ``b[i]`` maps through {i: i} to ``b[i]`` → matches ``1*i+0``
+    → independence proven → LoopToMap fires.
+
+    :param nsdfg_node: NestedSDFG node feeding the outer write.
+    :param conn: output connector (== inner array name) written.
+    :param itersym: outer loop iteration symbol.
+    :returns: True iff every inner write to ``conn`` is iter-indexed.
+    """
+    repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
+    found = False
+    for state in nsdfg_node.sdfg.all_states():
+        for dn in state.data_nodes():
+            if dn.data != conn or state.in_degree(dn) == 0:
+                continue
+            for e in state.in_edges(dn):
+                if e.data is None or e.data.wcr is not None:
+                    return False
+                if isinstance(e.src, nodes.NestedSDFG):
+                    if not _nested_writes_iter_indexed(e.src, e.src_conn, itersym, a, b, step):
+                        return False
+                    found = True
+                    continue
+                dst_subset = e.data.get_dst_subset(e, state)
+                if dst_subset is None:
+                    return False
+                outer = copy.deepcopy(dst_subset)
+                outer.replace(repl)
+                if not _check_range(outer, a, itersym, b, step):
+                    return False
+                found = True
+    return found
+
+
+def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
+    """Whether every read of ``conn``'s array INSIDE ``nsdfg_node`` matches the SAME ``a*i+b``
+    pattern as the writes, or is loop-invariant.
+
+    Companion of :func:`_nested_writes_iter_indexed`, which only proves write UNIQUENESS. A
+    loop-carried READ at a DIFFERENT iter-indexed position (``a[i] = ... + a[i+1] * ...``) still
+    races: iteration ``i`` reads ``a[i+1]`` while ``i+1`` writes it. Conservative: each inner read
+    must match ``a*i+b`` OR be loop-invariant (no outer ``itersym``). Nested NestedSDFGs recurse.
+
+    :returns: True if no carried-read pattern found; False if any inner read hits the carrier
+              array outside the write's affine form.
+    """
+    repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
+    for state in nsdfg_node.sdfg.all_states():
+        for dn in state.data_nodes():
+            if dn.data != conn or state.out_degree(dn) == 0:
+                continue
+            for e in state.out_edges(dn):
+                if e.data is None:
+                    continue
+                if isinstance(e.dst, nodes.NestedSDFG):
+                    # The read enters another nested SDFG; descend.
+                    if not _nested_reads_match_writes(e.dst, e.dst_conn, itersym, a, b, step):
+                        return False
+                    continue
+                src_subset = e.data.get_src_subset(e, state)
+                if src_subset is None:
+                    return False
+                outer = copy.deepcopy(src_subset)
+                outer.replace(repl)
+                # Loop-invariant read (no itersym) -- safe, same value every iteration.
+                free = set()
+                for rb, re, _ in outer.ndrange():
+                    for expr in (rb, re):
+                        if hasattr(expr, 'free_symbols'):
+                            free |= set(expr.free_symbols)
+                if itersym not in free:
+                    continue
+                # itersym-dependent read: must match the writes' a*i+b, else it's a carried read.
+                if not _check_range(outer, a, itersym, b, step):
+                    return False
+    return True
+
+
 def _dependent_indices(itervar: str, subset: subsets.Subset) -> Set[int]:
     """ Finds the indices or ranges of a subset that depend on the iteration
         variable. Returns their index in the subset's indices/ranges list.
@@ -56,6 +145,307 @@ def _sanitize_by_index(indices: Set[int], subset: subsets.Subset) -> subsets.Ran
     return subsets.Range([t for i, t in enumerate(subset.ndrange()) if i in indices])
 
 
+def _affine_coeffs(expr, itersym):
+    """ Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if
+        ``expr`` is not affine in ``itersym``.
+
+        Derived, not searched for. ``expand`` + ``coeff`` + ``simplify`` is the obvious spelling
+        but it is superlinear in the size of the index expression: on a deeply tiled nest (the
+        two-level tiled Jacobi stencil, whose indices carry every enclosing tile origin) the
+        expansion blows up and ``coeff``'s ``as_independent`` walk over the resulting sum does not
+        come back -- ``LoopToMap.can_be_applied`` never returned, so the pipeline hung.
+
+        For an expression polynomial in ``itersym`` the coefficients are exact by construction:
+        the derivative IS ``a`` when the degree is at most one (and still mentions ``itersym``
+        when it is higher, which is the degree test), and evaluating at zero IS ``b``. Both are
+        structural, and neither expands the expression. Non-polynomial in ``itersym`` (an
+        ``int_floor`` of it, say) is not affine and is refused, as before.
+    """
+    e = symbolic.pystr_to_symbolic(expr)
+    if not e.is_polynomial(itersym):
+        return None
+    a = sp.diff(e, itersym)
+    if itersym in a.free_symbols:  # degree >= 2 -> not affine
+        return None
+    return a, e.subs(itersym, 0)
+
+
+def _same_injective_index(idx1, idx2, itersym) -> bool:
+    """ True iff ``idx1`` and ``idx2`` are the SAME injective affine function ``a*i+b``
+        (``a != 0``) of the iteration variable.
+
+        When two accesses index a dimension by such a function, a collision on that dimension
+        (``a*p+b == a*q+b``) forces the two iterations to coincide (``p == q``). Any overlap between
+        them is therefore confined to a single iteration -- where program order in the map body is
+        preserved -- and never becomes a cross-iteration dependency. Used both for write/write
+        overlap (:func:`_writes_may_overlap`) and read/write RAW (:func:`_read_write_same_iteration`).
+
+        Both indices and the iteration symbol are re-parsed through the symbol registry (via their
+        string form) before the comparison: a read subset and a write subset can carry copies of the
+        iteration variable that share the NAME ``i`` but different sympy assumptions, so ``idx1 -
+        idx2`` would not simplify to zero and ``coeff`` would not see them as the same symbol.
+        Canonicalizing drops the assumption metadata and makes both refer to one registry symbol.
+    """
+    sym = symbolic.pystr_to_symbolic(str(itersym))
+    e1 = symbolic.pystr_to_symbolic(str(idx1))
+    e2 = symbolic.pystr_to_symbolic(str(idx2))
+    coeffs = _affine_coeffs(e1, sym)
+    return coeffs is not None and coeffs[0] != 0 and sp.simplify(e1 - e2) == 0
+
+
+def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
+    """ True iff ``idx1`` at any iteration can never equal ``idx2`` at any
+        iteration, for any pair of in-domain iterations and any loop bounds.
+
+        Uses the linear-Diophantine solvability criterion. The iteration
+        variable ``i`` only takes the strided values ``start + step * t``
+        (``t`` a non-negative integer), so the accesses are reparameterized
+        w.r.t. the iteration counter ``t``: ``a * i + b == (a*step)*t +
+        (a*start + b)``. Writing ``A_k = a_k*step`` and ``B_k = a_k*start +
+        b_k``, ``A1*t1 + B1 == A2*t2 + B2`` has an integer solution iff
+        ``gcd(A1, A2)`` divides ``B2 - B1``. If it does not, the accesses
+        never alias -- even accounting for the loop's stride (so a stride-2
+        ``a[i] = a[i-1] + ...`` writes odd indices / reads even indices and is
+        provably disjoint). The Diophantine ranges over ALL integers ``t``,
+        which is conservative w.r.t. the bounded iteration domain (a solution
+        only outside the domain still reports "may alias"), hence sound.
+
+        ``step``/``start`` default to ``1``/``0`` (identity reparameterization)
+        so callers that pass only the affine indices keep the classic behavior.
+    """
+    f1 = _affine_coeffs(idx1, itersym)
+    f2 = _affine_coeffs(idx2, itersym)
+    if f1 is None or f2 is None:
+        return False
+    a1, b1 = f1
+    a2, b2 = f2
+    if not (a1.is_Integer and a2.is_Integer):
+        return False
+    step_s = symbolic.pystr_to_symbolic(step)
+    start_s = symbolic.pystr_to_symbolic(start)
+    # Plain arithmetic, not ``sp.simplify``. Nothing below asks these for a canonical form -- only
+    # ``is_Integer`` / ``is_number`` and a gcd -- and sympy already folds numeric products and sums
+    # on construction. ``simplify`` is the general simplifier: it descends into ``factor_terms``
+    # and ``Factors``, which on this kernel's write set ran long enough to look like a hang (the
+    # two-level tiled Jacobi stencil, whose every write pair reaches here). Only the DIFFERENCE
+    # needs cancellation, and only across a product an ``Add`` will not flatten on its own
+    # (``2*(t + 1) - 2*t - 2``), which is exactly what ``expand`` is for.
+    A1 = a1 * step_s
+    A2 = a2 * step_s
+    B1 = a1 * start_s + b1
+    B2 = a2 * start_s + b2
+    diff = sp.expand(B2 - B1)
+    if A1 == 0 and A2 == 0:
+        return diff.is_number and diff != 0
+    # A strided or offset loop yields symbolic ``A_k`` only when the step/start
+    # are symbolic; the gcd criterion then cannot be evaluated -- stay safe.
+    if not (A1.is_Integer and A2.is_Integer):
+        return False
+    g = sp.igcd(int(A1), int(A2))
+    if g == 0:
+        return diff.is_number and diff != 0
+    if not diff.is_number:
+        return False
+    if not diff.is_Integer:
+        return True
+    return sp.Integer(diff) % g != 0
+
+
+def loop_varying_symbols(loop: LoopRegion) -> Set[str]:
+    """ Symbols whose value can change *while* ``loop`` runs, other than its own iterator:
+        the iterators of loops and maps nested inside its body, and everything its
+        interstate edges assign.
+
+        Every OTHER symbol a body subset mentions -- an enclosing loop's iterator, an array
+        size, a free parameter -- holds one fixed value for the loop's whole execution, so a
+        symbolic comparison of two indices that mention it is a valid statement about every
+        pair of iterations. That is what :func:`_read_write_dims_disjoint` needs.
+    """
+    varying: Set[str] = set()
+    for cfr in loop.all_control_flow_regions(recursive=True):
+        if isinstance(cfr, LoopRegion) and cfr is not loop and cfr.loop_variable:
+            varying.add(cfr.loop_variable)
+    for state in loop.all_states():
+        for node in state.nodes():
+            if isinstance(node, nodes.MapEntry):
+                varying.update(node.map.params)
+    for e in loop.all_interstate_edges():
+        varying.update(e.data.assignments.keys())
+    return varying
+
+
+def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, itersym, step, start,
+                              varying: Set[str]) -> bool:
+    """ True iff some dimension's read/write point-indices are provably disjoint
+        across every pair of in-domain iterations (step-aware
+        linear-Diophantine, see :func:`_dim_provably_disjoint`).
+
+        This is the read/write analog of the write/write per-dimension test in
+        :func:`_writes_may_overlap`. It additionally accounts for the loop STEP
+        (stride-2 write-odds/read-evens) and keeps CONSTANT disproving
+        dimensions (``aa[0, i]`` write vs ``aa[1, i-1]`` read -- row 0 can never
+        equal row 1), which the propagate+intersect fallback drops when it
+        restricts to iteration-dependent dimensions only.
+
+        ``varying`` is :func:`loop_varying_symbols` for the loop being lifted.
+    """
+    rnd = list(read.ndrange())
+    wnd = list(write.ndrange())
+    if len(rnd) != len(wnd) or len(rnd) == 0:
+        return False
+    for (rb, re_, _), (wb, we_, _) in zip(rnd, wnd):
+        if rb != re_ or wb != we_:  # non-point dimension: cannot decide here
+            continue
+        # SOUNDNESS: the verdict is valid only when every symbol in the dimension holds ONE
+        # value for the loop's whole execution. ``itersym`` is exempt -- the Diophantine test
+        # reparameterizes it independently for the reading and the writing iteration. A symbol
+        # that varies INSIDE the body is not: ``a[i-1, j-1]`` vs ``a[i, j]`` seen from the ``i``
+        # loop makes ``j-1`` and ``j`` look like two distinct constants, yet the sets overlap as
+        # ``j`` sweeps -- a genuine diagonal recurrence (TSVC s119's OUTER loop). An ENCLOSING
+        # loop's iterator is fixed here, and admitting it is what lets s119's inner loop prove
+        # row ``i-1`` can never be row ``i`` (previously refused, losing all its parallelism).
+        # ``ndrange()`` yields plain ints as well as sympy exprs; ``sympify`` gives both a
+        # uniform ``.free_symbols`` (an int has none) without a ``getattr`` guard.
+        rw_syms = {s.name for s in sp.sympify(rb).free_symbols} | {s.name for s in sp.sympify(wb).free_symbols}
+        if rw_syms & varying:
+            continue
+        if _dim_provably_disjoint(rb, wb, itersym, step, start):
+            return True
+    return False
+
+
+def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, itersym) -> bool:
+    """ True iff some point dimension indexes both ``read`` and ``write`` by the SAME injective
+        affine function of the iteration variable (see :func:`_same_injective_index`).
+
+        Then a read/write collision on that dimension forces the reading and writing iterations to
+        coincide, so the read and write touch the same element only WITHIN one iteration (where the
+        map body preserves program order) and never across iterations. This is the read/write analog
+        of the injective-index rule in :func:`_writes_may_overlap`: it recognizes that iteration
+        ``i`` reads and writes only its own slab (e.g. syrk's ``C[i, :i+1]`` row), so lifting the
+        loop to a DOALL map is safe even though the read and write overlap in-iteration.
+
+        Only ONE such dimension is required: if a collision on dimension ``d`` already forces
+        ``p == q``, no pair of distinct iterations can address the same multidimensional element.
+    """
+    rnd = list(read.ndrange())
+    wnd = list(write.ndrange())
+    if len(rnd) != len(wnd) or len(rnd) == 0:
+        return False
+    for (rb, re_, _), (wb, we_, _) in zip(rnd, wnd):
+        if rb != re_ or wb != we_:  # only point dimensions carry an injective index
+            continue
+        if _same_injective_index(rb, wb, itersym):
+            return True
+    return False
+
+
+def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset, itersym, varying: Set[str]) -> bool:
+    """ Prove that two point subsets ``sub1``, ``sub2`` of the same container can only address
+        the same element when their loop iterations coincide.
+
+        Substitute the iteration variable by a fresh symbol ``p`` in ``sub1`` and ``q`` in ``sub2``
+        and build the collision system ``{sub1[d]|i=p == sub2[d]|i=q  for every dim d}`` (all other
+        symbols are free parameters). If this affine system linearly implies ``p == q`` -- i.e. a
+        rational combination ``sum_d lam_d * (sub1[d]|p - sub2[d]|q)`` equals ``p - q`` identically
+        -- then a cross-iteration collision is impossible: any overlap between the two accesses
+        happens only within a single iteration, where program order in the map body is preserved.
+
+        Whenever such a certificate exists, ``sub1@p == sub2@q`` forces ``p == q``, so the equality
+        holds on the whole (affine) solution set and the proof is sound for every parameter value.
+        Conservative: returns ``False`` on any non-point subset, any non-affine index, or when no
+        certificate is found, so the caller keeps its safe ``may-alias`` answer.
+
+        This handles transpose/permutation-symmetric accesses such as covariance's ``cov[i,j]`` and
+        ``cov[j,i]``, where the iteration variable lands in *different* dimensions of the two
+        accesses so no single dimension is provably disjoint, yet a collision forces ``i == j`` (the
+        diagonal of one iteration). Used for write/write pairs (:func:`_writes_may_overlap`) and for
+        read/write pairs (:meth:`LoopToMap.test_read_memlet`).
+
+        ``varying`` is :func:`loop_varying_symbols` for the loop being lifted.
+    """
+    nd1 = list(sub1.ndrange())
+    nd2 = list(sub2.ndrange())
+    if len(nd1) != len(nd2) or len(nd1) == 0:
+        return False
+    p, q = sp.Dummy('p'), sp.Dummy('q')
+    eqs = []
+    params: Set[str] = set()
+    for (b1, e1, _), (b2, e2, _) in zip(nd1, nd2):
+        if b1 != e1 or b2 != e2:  # only point subsets participate in the collision system
+            return False
+        x1 = symbolic.pystr_to_symbolic(b1)
+        x2 = symbolic.pystr_to_symbolic(b2)
+        # SOUNDNESS: every symbol but ``itersym`` becomes ONE parameter shared by both accesses,
+        # which describes the loop only while that symbol holds a single value for the loop's whole
+        # execution. A symbol that varies INSIDE the body (an inner loop/map iterator, an interstate
+        # assignment) takes independent values in the two iterations, and sharing it manufactures a
+        # bogus certificate: read ``aa[j,i]`` vs write ``aa[i,j]`` seen from the ``i`` loop "proves"
+        # p == q, yet p really reads ``aa[j_p, p]`` and q writes ``aa[q, j_q]``, which alias for
+        # p != q -- TSVC s114's OUTER transpose anti-dependence, a genuine carried dependence.
+        if any(str(s) in varying for s in x1.free_symbols) or any(str(s) in varying for s in x2.free_symbols):
+            return False
+        eqs.append(sp.expand(x1.subs(itersym, p) - x2.subs(itersym, q)))
+        params |= {s for s in (set(x1.free_symbols) | set(x2.free_symbols)) if str(s) != str(itersym)}
+    monomials = [p, q] + sorted(params, key=str)
+    # Require every equation affine (total degree <= 1) in {p, q, params}; bail conservatively
+    # on anything non-linear (e.g. ``A[i*i]``) where a linear certificate would be unsound.
+    for eq in eqs:
+        try:
+            if sp.Poly(eq, *monomials).total_degree() > 1:
+                return False
+        except sp.PolynomialError:
+            return False
+    # Look for rationals ``lam_d`` with ``sum_d lam_d * eq_d == p - q`` as a polynomial identity in
+    # {p, q, params}. Matching every monomial's coefficient to that of ``p - q`` gives a linear
+    # system in the ``lam_d``; a solution is a soundness certificate that a collision forces p == q.
+    lambdas = list(sp.symbols(f'_l2m_lam0:{len(eqs)}'))
+    diff = sp.expand(sum(l * e for l, e in zip(lambdas, eqs)) - (p - q))
+    lin_eqs = [diff.coeff(mono) for mono in monomials]
+    const = diff
+    for mono in monomials:
+        const = const.subs(mono, 0)
+    lin_eqs.append(const)
+    return len(sp.linsolve(lin_eqs, lambdas)) > 0
+
+
+def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, start, varying: Set[str]) -> bool:
+    """ Conservatively decide whether two write memlets to the same container
+        can address the same element on different loop iterations. Returns
+        ``False`` only if some subset dimension is provably disjoint (the
+        multidimensional element can then never coincide), or if a collision
+        provably forces the two iterations to coincide (see
+        :func:`_collision_forces_same_iteration`).
+
+        ``step``/``start`` describe the loop's strided iteration domain and are
+        threaded into the per-dimension disjointness test, so a step-4 unrolled
+        body's writes ``a[i], a[i+1], a[i+2], a[i+3]`` (all distinct modulo 4)
+        are recognised as disjoint.
+
+        ``varying`` is :func:`loop_varying_symbols` for the loop being lifted.
+    """
+    nd1 = list(m1.subset.ndrange())
+    nd2 = list(m2.subset.ndrange())
+    if len(nd1) != len(nd2):
+        return True
+    for (b1, e1, _), (b2, e2, _) in zip(nd1, nd2):
+        if b1 != e1 or b2 != e2:  # non-point range dimension: cannot decide here
+            continue
+        # Both writes index this dim by the same injective function of the iter var: a collision
+        # forces the two iterations equal, so they coincide only within one iteration (program
+        # order in the map body), never across distinct iterations.
+        if _same_injective_index(b1, b2, itersym):
+            return False
+        if _dim_provably_disjoint(b1, b2, itersym, step, start):
+            return False
+    # No single dimension settled it. Fall back to the whole-subset collision system: the iter var
+    # may appear in different dimensions of the two writes (a transpose), yet a collision can still
+    # force the two iterations to coincide.
+    if _collision_forces_same_iteration(m1.subset, m2.subset, itersym, varying):
+        return False
+    return True
+
+
 @properties.make_properties
 @xf.explicit_cf_compatible
 class LoopToMap(xf.MultiStateTransformation):
@@ -71,67 +461,141 @@ class LoopToMap(xf.MultiStateTransformation):
         return [sdutil.node_path_graph(cls.loop)]
 
     def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
+
+        def refuse(reason: str) -> bool:
+            """Refuse the match. Reason dropped; diagnostics live in the pipeline driver."""
+            return False
+
         # If loop information cannot be determined, fail.
         start = loop_analysis.get_init_assignment(self.loop)
         end = loop_analysis.get_loop_end(self.loop)
         step = loop_analysis.get_loop_stride(self.loop)
         itervar = self.loop.loop_variable
         if start is None or end is None or step is None or itervar is None:
-            return False
+            return refuse(f"loop information incomplete - start={start}, end={end}, step={step}, itervar={itervar}")
 
         sset = {}
         sset.update(sdfg.symbols)
         sset.update(sdfg.arrays)
         t = dtypes.result_type_of(infer_expr_type(start, sset), infer_expr_type(step, sset), infer_expr_type(end, sset))
-        # We may only convert something to map if the bounds are all integer-derived types. Otherwise most map schedules
-        # except for sequential would be invalid.
+        # Bounds must be integer-derived: non-sequential map schedules are otherwise invalid.
         if not t in dtypes.INTEGER_TYPES:
-            return False
+            return refuse(f"loop bounds are not integer types - result_type={t}")
 
         # Loops containing break, continue, or returns may not be turned into a map.
         for blk in self.loop.all_control_flow_blocks():
             if isinstance(blk, (BreakBlock, ContinueBlock, ReturnBlock)):
-                return False
+                if not permissive:
+                    return refuse(f"loop body contains a {type(blk).__name__}")
 
         # We cannot handle symbols read from data containers unless they are scalar.
         for expr in (start, end, step):
             if symbolic.contains_sympy_functions(expr):
-                return False
+                return refuse(f"bound expression reads a non-scalar data container - expr={expr}")
 
-        _, write_set = self.loop.read_and_write_sets()
+        # Refuse when the range (start/end/step) references a symbol the body defines via an
+        # interstate assignment. After conversion the body → a ``loop_body`` NSDFG (assignment
+        # goes with it) but the Map's range stays outer, referencing a symbol only defined inside
+        # the NSDFG → ``Missing symbols on nested SDFG`` downstream.
+        range_syms: Set[str] = set()
+        for expr in (start, end, step):
+            try:
+                range_syms |= {str(s) for s in expr.free_symbols}
+            except AttributeError:
+                pass
+        body_assigned_syms: Set[str] = set()
+        for e in self.loop.all_interstate_edges():
+            body_assigned_syms.update(e.data.assignments.keys())
+        if range_syms & body_assigned_syms:
+            return refuse(f"loop range references symbol(s) {range_syms & body_assigned_syms} assigned inside the body")
+
         loop_states = set(self.loop.all_states())
         all_loop_blocks = set(self.loop.all_control_flow_blocks())
 
         # Cannot have StructView in loop body
         for loop_state in loop_states:
             if [n for n in loop_state.data_nodes() if isinstance(n.desc(sdfg), dt.StructureView)]:
-                return False
+                return refuse(f"loop body contains a StructureView in state {loop_state}")
 
-        # Collect symbol reads and writes from inter-state assignments
-        in_order_loop_blocks = list(
-            cfg_analysis.blockorder_topological_sort(self.loop, recursive=True, ignore_nonstate_blocks=False))
+        # A loop that provably runs at most once carries no cross-iteration dependence, so it is
+        # trivially DOALL -- accept here, skipping the dependence analysis below (which a clamped
+        # ``Max``/``Min`` bound would otherwise confound). This maps the single-iteration middle
+        # segment a range split leaves behind (e.g. the ``{x}`` clamp of the s1113 broadcast split),
+        # where the dependence analysis has nothing to prove. The structural guards above still gate.
+        if loop_analysis.loop_provably_at_most_one_iteration(self.loop):
+            return True
+
+        # Collect symbol reads and writes from inter-state assignments. The read-before-assigned
+        # analysis needs the loop's blocks in topological order, but that (dominator-heavy) sort is
+        # only meaningful when the loop body actually has inter-state assignments. A loop whose
+        # interstate edges carry none -- the common single-statement post-MapToForLoop case, ~all of
+        # a stencil's probes -- has nothing to check, so skip the sort and leave
+        # ``symbols_that_may_be_used`` at its initial ``{itervar}`` (identical to what the loop below
+        # would produce with no assignments).
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
-        for block in in_order_loop_blocks:
-            for e in block.parent_graph.out_edges(block):
-                # Collect read-before-assigned symbols (this works because the states are always in order,
-                # see above call to `blockorder_topological_sort`)
-                read_symbols = e.data.read_symbols()
-                read_symbols -= symbols_that_may_be_used
-                used_before_assignment |= read_symbols
-                # If symbol was read before it is assigned, the loop cannot be parallel
-                assigned_symbols = set()
-                for k, v in e.data.assignments.items():
-                    try:
-                        fsyms = symbolic.pystr_to_symbolic(v).free_symbols
-                    except AttributeError:
-                        fsyms = set()
-                    if not k in fsyms:
-                        assigned_symbols.add(k)
-                if assigned_symbols & used_before_assignment:
-                    return False
+        if any(e.data.assignments for block in self.loop.all_control_flow_blocks()
+               for e in block.parent_graph.out_edges(block)):
+            in_order_loop_blocks = list(
+                cfg_analysis.blockorder_topological_sort(self.loop, recursive=True, ignore_nonstate_blocks=False))
+            for block in in_order_loop_blocks:
+                # ``blockorder_topological_sort`` emits a ConditionalBlock BEFORE the blocks nested in
+                # its branches, yet the conditional's own out-edges execute AFTER those branches. A
+                # symbol assigned on EVERY branch of an exhaustive conditional (one with an else arm)
+                # is therefore already defined once the conditional exits, so count it as assigned
+                # before this block's reads/out-edges are examined. Without this, a loop-local scalar
+                # set in both arms of an if/else and read afterwards is misreported as a loop-carried
+                # dependency, which refuses embarrassingly-parallel loops (the CloudSC nblks loop).
+                if isinstance(block, ConditionalBlock) and any(c is None for c, _ in block.branches):
+                    per_branch = []
+                    for _cond, body in block.branches:
+                        assigned_in_branch = set()
+                        for inner in body.all_control_flow_blocks():
+                            for ie in inner.parent_graph.out_edges(inner):
+                                assigned_in_branch |= set(ie.data.assignments.keys())
+                        per_branch.append(assigned_in_branch)
+                    if per_branch:
+                        symbols_that_may_be_used |= set.intersection(*per_branch)
 
-                symbols_that_may_be_used |= e.data.assignments.keys()
+                # A symbol read in the block's own dataflow (e.g. a memlet subset ``b[im]``) is read
+                # before any symbol the block assigns on its out-edges; if the loop later reassigns it,
+                # it is loop-carried. The per-edge ``read_symbols()`` below only sees interstate-edge
+                # reads, so fold in these in-state reads.
+                try:
+                    block_reads = {str(s) for s in block.free_symbols}
+                except Exception:
+                    block_reads = set()
+                used_before_assignment |= (block_reads - symbols_that_may_be_used)
+                for e in block.parent_graph.out_edges(block):
+                    # Collect read-before-assigned symbols (states are in order; see
+                    # blockorder_topological_sort above).
+                    read_symbols = e.data.read_symbols()
+                    read_symbols -= symbols_that_may_be_used
+                    used_before_assignment |= read_symbols
+                    # If symbol was read before it is assigned, the loop cannot be parallel
+                    assigned_symbols = set()
+                    for k, v in e.data.assignments.items():
+                        try:
+                            fsyms = {str(s) for s in symbolic.pystr_to_symbolic(v).free_symbols}
+                        except AttributeError:
+                            fsyms = set()
+                        if k in fsyms and k not in symbols_that_may_be_used:
+                            # Self-recurrent assignment (k = f(k), e.g. k = k + inc) whose ``k`` has
+                            # NOT been (re)assigned earlier this iteration is a loop-carried recurrence:
+                            # each iteration reads the previous value, so the loop cannot be
+                            # parallelized. Affine induction variables are substituted to a closed form
+                            # upstream, so a self-recurrence that survives to here is a genuine carried
+                            # dependency. If ``k`` was already assigned earlier in the iteration (e.g.
+                            # reset ``k = 0`` then ``k = k + 1``) it is a loop-local counter, not carried,
+                            # so it is handled by the read-before-assignment check below instead.
+                            return refuse(f"self-recurrent carried symbol '{k}' (assignment {k} = {v})")
+                        if k not in fsyms:
+                            assigned_symbols.add(k)
+                    if assigned_symbols & used_before_assignment:
+                        return refuse("carried symbol dependency - "
+                                      f"{assigned_symbols & used_before_assignment} read before being assigned")
+
+                    symbols_that_may_be_used |= e.data.assignments.keys()
 
         # Get access nodes from other states to isolate local loop variables
         other_access_nodes: Set[str] = set()
@@ -142,6 +606,12 @@ class LoopToMap(xf.MultiStateTransformation):
         # Add non-transient nodes from loop state
         for state in loop_states:
             other_access_nodes |= set(n.data for n in state.data_nodes() if not sdfg.arrays[n.data].transient)
+
+        # read_and_write_sets() walks every state/edge of the loop and is only needed from here
+        # on (the per-array write analysis below). Computing it lazily -- after the cheaper
+        # bound/break/StructView/carried-symbol refusals above -- lets a loop refused by any of
+        # those return without paying for it (on channel_flow that is ~41k of ~44k probes).
+        _, write_set = self.loop.read_and_write_sets()
 
         write_memlets: Dict[str, List[memlet.Memlet]] = defaultdict(list)
 
@@ -156,31 +626,96 @@ class LoopToMap(xf.MultiStateTransformation):
                 # Take all writes that are not conflicted into consideration
                 if dn.data in write_set:
                     for e in state.in_edges(dn):
+                        # An EMPTY memlet is a happens-before edge, not a write: no data moves
+                        # along it, so it cannot carry a dependency from one iteration into the
+                        # next, and the intra-iteration order it encodes survives verbatim inside
+                        # the map body. It has no subset, so the ``a*i+b`` test below would read it
+                        # as an unindexed whole-array write and refuse a perfectly parallel loop --
+                        # which is what ``StateFusionExtended`` produces for an intra-iteration WAR
+                        # (TSVC ``s1251``: ``s = b[i]+c[i]; b[i] = a[i]+d[i]; a[i] = s*e[i]`` fuses
+                        # with ordering edges into ``a``/``d`` and stopped parallelizing).
+                        # ``_read_and_write_sets`` already skips empty memlets for the same reason.
+                        if e.data is None or e.data.is_empty():
+                            continue
                         if e.data.dynamic and e.data.wcr is None:
-                            # A dynamic write (no WCR) is still safe across
-                            # outer-loop iterations if its destination subset
-                            # pins an axis to the iteration variable (same
-                            # ``a*i+b`` pattern enforced below for non-dynamic
-                            # writes). Each iteration then writes to a disjoint
-                            # slab -- whether a given lane fires or not
-                            # cannot race with another iteration's write.
+                            # Dynamic write (no WCR) is safe across iterations if its dst subset
+                            # pins an axis to the iter var (same ``a*i+b`` as non-dynamic below):
+                            # each iteration writes a disjoint slab, so a lane firing or not can't
+                            # race another iteration's write.
                             dst_subset = e.data.get_dst_subset(e, state)
                             if not (dst_subset and _check_range(dst_subset, a, itersym, b, step)):
-                                return False
-                        if e.data is None:
-                            continue
+                                return refuse(f"dynamic write to {dn.data} is not indexed by the iteration variable "
+                                              f"- dst_subset={dst_subset}")
 
-                        # To be sure that the value is only written at unique
-                        # indices per loop iteration, we want to match symbols
-                        # of the form "a*i+b" where |a| >= 1, and i is the iteration
-                        # variable. The iteration variable must be used.
+                        # Unique write index per iteration: match ``a*i+b``, ``|a| >= 1``, i the
+                        # iteration variable (which must be used).
                         if e.data.wcr is None:
                             dst_subset = e.data.get_dst_subset(e, state)
-                            if not (dst_subset and _check_range(dst_subset, a, itersym, b, step)) and not permissive:
-                                return False
-                        # End of check
+                            ok = bool(dst_subset) and _check_range(dst_subset, a, itersym, b, step)
+                            # NestedSDFG body propagates a whole-array external write hiding an
+                            # inner per-iteration write; look past the connector.
+                            if not ok and isinstance(e.src, nodes.NestedSDFG):
+                                ok = _nested_writes_iter_indexed(e.src, e.src_conn, itersym, a, b, step)
+                                # NSDFG descent only proves WRITE uniqueness. A carried READ at a
+                                # DIFFERENT iter position (``a[i+1]`` while writing ``a[i]``) is a
+                                # forward/backward dependence that races. Require every inner read
+                                # of ``conn`` to match the writes' ``a*i+b`` (or be loop-invariant).
+                                if ok and not _nested_reads_match_writes(e.src, e.src_conn, itersym, a, b, step):
+                                    ok = False
+                            if not ok and not permissive:
+                                return refuse(f"write to {dn.data} is not uniquely indexed by the iteration variable "
+                                              f"(needs an a*i+b subset) - dst_subset={dst_subset}")
 
                         write_memlets[dn.data].append(e.data)
+
+        # Carried-read check: for every array also written, each in-loop READ subset must be
+        # loop-invariant (no itersym) or match the writes' ``a*i+b``. A read at a DIFFERENT iter
+        # offset (``a[i+1]`` while writing ``a[i]``) is a carried dependency that races (iter ``i``
+        # reads ``a[i+1]`` while ``i+1`` writes it). The same-iteration disjoint check below only
+        # catches within-ONE-iteration overlaps; cross-iteration carries slip through.
+        for state in loop_states:
+            for dn in state.data_nodes():
+                data = dn.data
+                if data not in write_memlets:
+                    continue
+                for e in state.out_edges(dn):
+                    if e.data is None:
+                        continue
+                    src_subset = e.data.get_src_subset(e, state)
+                    if src_subset is None:
+                        continue
+                    # Loop-invariant read (no itersym) -- safe, same input every iteration.
+                    free = set()
+                    for rb, re_, _ in src_subset.ndrange():
+                        for expr in (rb, re_):
+                            if hasattr(expr, 'free_symbols'):
+                                free |= set(expr.free_symbols)
+                    if itersym not in free:
+                        continue
+                    # itersym-dependent read: must match a*i+b like the writes, else this
+                    # iteration reads a value another iteration writes.
+                    if not _check_range(src_subset, a, itersym, b, step) and not permissive:
+                        return refuse(f"read of {data} at {src_subset} is iter-indexed but does not match the "
+                                      f"write pattern a*i+b -- loop-carried forward/backward dependency")
+
+        # Fixed for the whole loop, so compute once and share with every dependence test below.
+        varying = loop_varying_symbols(self.loop)
+
+        # Two distinct-affine writes to the same container can hit the same element on different
+        # iterations even when each is individually injective (``A[5*i]`` and ``A[3*i]`` collide
+        # at ``A[15]``); parallelizing reorders them. Allow only if some dim is provably disjoint
+        # for all iterations (``A[2*i]`` vs ``A[2*i+1]``).
+        for data, mmlts in write_memlets.items():
+            distinct: Dict[str, memlet.Memlet] = {}
+            for m in mmlts:
+                if m.wcr is None:
+                    distinct.setdefault(str(m.subset), m)
+            reps = list(distinct.values())
+            for x in range(len(reps)):
+                for y in range(x + 1, len(reps)):
+                    if _writes_may_overlap(reps[x], reps[y], itersym, step, start, varying) and not permissive:
+                        return refuse(f"writes {reps[x].subset} and {reps[y].subset} to {data} "
+                                      "may overlap across iterations")
 
         # After looping over relevant writes, consider reads that may overlap
         for state in loop_states:
@@ -190,15 +725,18 @@ class LoopToMap(xf.MultiStateTransformation):
                 data = dn.data
                 if data in write_memlets:
                     for e in state.out_edges(dn):
-                        if e.data is None:
+                        # Mirror of the write scan above: an empty memlet is a happens-before
+                        # edge, not a read, and its missing subset would be taken for a
+                        # whole-array read.
+                        if e.data is None or e.data.is_empty():
                             continue
 
-                        # If the same container is both read and written, only match if
-                        # it read and written at locations that will not create data races
+                        # Container read AND written: match only if the locations can't race.
                         src_subset = e.data.get_src_subset(e, state)
                         if not self.test_read_memlet(sdfg, state, e, itersym, itervar, start, end, step, write_memlets,
-                                                     e.data, src_subset):
-                            return False
+                                                     e.data, src_subset, varying):
+                            return refuse(f"read-after-write conflict on {data} within the loop body "
+                                          f"- src_subset={src_subset}")
 
         # Consider reads in inter-state edges (could be in assignments or in condition)
         isread_set: Set[memlet.Memlet] = set()
@@ -207,18 +745,20 @@ class LoopToMap(xf.MultiStateTransformation):
         for mmlt in isread_set:
             if mmlt.data in write_memlets:
                 if not self.test_read_memlet(sdfg, None, None, itersym, itervar, start, end, step, write_memlets, mmlt,
-                                             mmlt.subset):
-                    return False
+                                             mmlt.subset, varying):
+                    return refuse(f"read-after-write conflict on {mmlt.data} via an inter-state edge "
+                                  f"- subset={mmlt.subset}")
 
-        # Check that the iteration variable and other symbols are not used on other edges or blocks before they are
-        # reassigned.
+        # Iteration variable + other symbols must not be used on later edges/blocks before
+        # reassignment.
         in_order_blocks = list(
             cfg_analysis.blockorder_topological_sort(sdfg, recursive=True, ignore_nonstate_blocks=False))
         # First check the outgoing edges of the loop itself.
         reassigned_symbols: Set[str] = None
         for oe in graph.out_edges(self.loop):
             if symbols_that_may_be_used & oe.data.read_symbols():
-                return False
+                return refuse("loop-defined symbol(s) used after the loop on its outgoing edge - "
+                              f"{symbols_that_may_be_used & oe.data.read_symbols()}")
             # Check for symbols that are set by all outgoing edges
             # TODO: Handle case of subset of out_edges
             if reassigned_symbols is None:
@@ -238,13 +778,15 @@ class LoopToMap(xf.MultiStateTransformation):
 
             # Check state contents
             if symbols_that_may_be_used & block.free_symbols:
-                return False
+                return refuse(f"loop-defined symbol(s) used after the loop in block {block} - "
+                              f"{symbols_that_may_be_used & block.free_symbols}")
 
             # Check inter-state edges
             reassigned_symbols = None
             for e in block.parent_graph.out_edges(block):
                 if symbols_that_may_be_used & e.data.read_symbols():
-                    return False
+                    return refuse("loop-defined symbol(s) used after the loop on an inter-state edge - "
+                                  f"{symbols_that_may_be_used & e.data.read_symbols()}")
 
                 # Check for symbols that are set by all outgoing edges
                 # TODO: Handle case of subset of out_edges
@@ -262,8 +804,8 @@ class LoopToMap(xf.MultiStateTransformation):
     def test_read_memlet(self, sdfg: SDFG, state: SDFGState, edge: gr.MultiConnectorEdge[memlet.Memlet],
                          itersym: symbolic.SymbolicType, itervar: str, start: symbolic.SymbolicType,
                          end: symbolic.SymbolicType, step: symbolic.SymbolicType,
-                         write_memlets: Dict[str, List[memlet.Memlet]], mmlt: memlet.Memlet, src_subset: subsets.Range):
-        # Import as necessary
+                         write_memlets: Dict[str, List[memlet.Memlet]], mmlt: memlet.Memlet, src_subset: subsets.Range,
+                         varying: Set[str]):
         from dace.sdfg.propagation import propagate_subset, align_memlet
 
         a = sp.Wild('a', exclude=[itersym])
@@ -274,7 +816,13 @@ class LoopToMap(xf.MultiStateTransformation):
             # If pointers are involved, give up
             return False
         if not _check_range(src_subset, a, itersym, b, step):
-            return False
+            # ``_check_range`` accepts only reads that MOVE with the iteration (some dim
+            # ``a*i+b``, ``|a| >= 1``). An itersym read not matching that is conservatively a
+            # conflict. A loop-INVARIANT read (no itersym) is a conflict only if it overlaps a
+            # write: ``a[0]`` is safe against writes to ``a[1:N]`` but not ``a[0:N]``. Defer both
+            # to the propagated-overlap check below.
+            if itersym in src_subset.free_symbols:
+                return False
 
         # Always use the source data container for the memlet test
         if state is not None and edge is not None:
@@ -285,8 +833,40 @@ class LoopToMap(xf.MultiStateTransformation):
         for candidate in write_memlets[data]:
             # Simple case: read and write are in the same subset
             read = src_subset
-            write = candidate.dst_subset
+            # A one-sided copy memlet (e.g. a whole-array ``a[0:N] -> a`` boundary
+            # passthrough) carries its subset in ``.subset`` and leaves
+            # ``.dst_subset`` None; fall back to ``.subset`` so the dependency test
+            # doesn't crash on ``None.ndrange()``.
+            write = candidate.dst_subset if candidate.dst_subset is not None else candidate.subset
             if read == write:
+                continue
+            # Step-aware per-dimension disjointness: if any dimension's read/write
+            # indices can never coincide for any pair of in-domain iterations
+            # (linear-Diophantine over the strided iteration counter), the accesses
+            # never alias -- no cross-iteration RAW. This is strictly more precise
+            # than the propagate+intersect fallback below, which drops constant
+            # disproving dims and ignores the loop stride.
+            if _read_write_dims_disjoint(read, write, itersym, step, start, varying):
+                continue
+            # Same-iteration collision: if some point dimension indexes both the read and the write
+            # by the same injective function of the iter var (e.g. syrk's ``C[i, :i+1]`` -- row ``i``
+            # read and written by iteration ``i``), a collision forces the read and write iterations
+            # to coincide. The overlap is then confined to one iteration (program order in the map
+            # body preserves it) and is never a cross-iteration RAW. Mirrors the write/write
+            # injective-index rule in :func:`_writes_may_overlap`.
+            if _read_write_same_iteration(read, write, itersym):
+                continue
+            # Same-iteration collision across SEVERAL dimensions at once: the iteration variable can
+            # land in DIFFERENT dimensions of the read and the write (a transpose), so no single
+            # dimension is disjoint and none carries the same injective index, yet the whole-subset
+            # collision system still certifies that any alias forces the reading and the writing
+            # iteration to coincide. Such a dependence has distance 0 in THIS loop's dimension, i.e.
+            # it is loop-INDEPENDENT: it lives inside one iteration, whose body ``apply`` transplants
+            # verbatim into the map, so it never becomes a cross-iteration dependency and does not
+            # block a DOALL lift. TSVC s114's inner loop ``aa[i,j] = aa[j,i] + bb[i,j]`` (for a fixed
+            # ``i``, read and write alias only at ``j == i``) is exactly this case; the ``varying``
+            # guard inside the certificate is what keeps its OUTER ``i`` loop sequential.
+            if _collision_forces_same_iteration(read, write, itersym, varying):
                 continue
             ridx = _dependent_indices(itervar, read)
             widx = _dependent_indices(itervar, write)
@@ -302,8 +882,8 @@ class LoopToMap(xf.MultiStateTransformation):
                                       sdfg.arrays[data], [itervar],
                                       subsets.Range([(start, end, step)]),
                                       use_dst=True)
-            t_pread = _sanitize_by_index(indices, pread.src_subset)
-            pwrite = _sanitize_by_index(indices, pwrite.dst_subset)
+            t_pread = _sanitize_by_index(indices, pread.src_subset if pread.src_subset is not None else pread.subset)
+            pwrite = _sanitize_by_index(indices, pwrite.dst_subset if pwrite.dst_subset is not None else pwrite.subset)
             if subsets.intersects(t_pread, pwrite) is False:
                 continue
             return False
@@ -338,16 +918,14 @@ class LoopToMap(xf.MultiStateTransformation):
                     continue
                 for e in state.out_edges(node):
                     src_subset = e.data.get_src_subset(e, state)
-                    # If the iteration variable is in the subsets symbols, then the array cannot be thread-local.
-                    # Here we use the assumption that the for-loop can be turned to a valid Map, i.e., all other edges
-                    # carrying the array depend on the iteration variable in a consistent manner.
+                    # itersym in the subset → not thread-local. Assumes the loop is a valid Map
+                    # (all edges carrying the array depend on itersym consistently).
                     if src_subset and itervar in src_subset.free_symbols:
                         return False
                 for e in state.in_edges(node):
                     dst_subset = e.data.get_dst_subset(e, state)
-                    # If the iteration variable is in the subsets symbols, then the array cannot be thread-local.
-                    # Here we use the assumption that the for-loop can be turned to a valid Map, i.e., all other edges
-                    # carrying the array depend on the iteration variable in a consistent manner.
+                    # itersym in the subset → not thread-local. Assumes the loop is a valid Map
+                    # (all edges carrying the array depend on itersym consistently).
                     if dst_subset and itervar in dst_subset.free_symbols:
                         return False
         return True
@@ -384,16 +962,15 @@ class LoopToMap(xf.MultiStateTransformation):
                         if e.data.data and e.data.data in sdfg.arrays:
                             write_set.add(e.data.data)
 
-        # Add headers of any nested loops and conditional blocks
-        nodelist = list(self.loop.nodes())
-        while nodelist:
-            node = nodelist.pop()
-            if isinstance(node, (LoopRegion, ConditionalBlock)):
-                code_blocks = node.get_meta_codeblocks()
-                free_syms = {s for c in code_blocks for s in c.get_free_symbols()}
-                free_syms = {s for s in free_syms if s in sdfg.arrays.keys()}
-                read_set |= set(free_syms)
-                nodelist.extend(node.nodes())
+        # Add headers of any nested loops and conditional blocks, at EVERY depth: a walk that
+        # recurses only into LoopRegion / ConditionalBlock stops at a ConditionalBlock's branch,
+        # which is a plain ControlFlowRegion. A container a header below that point reads then
+        # never enters the read set, so it stays a free symbol of the body instead of becoming a
+        # connector -- and the parent's interstate edge is left referencing an undefined symbol.
+        for block in self.loop.all_control_flow_blocks():
+            if isinstance(block, (LoopRegion, ConditionalBlock)):
+                free_syms = {s for c in block.get_meta_codeblocks() for s in c.get_free_symbols()}
+                read_set |= {s for s in free_syms if s in sdfg.arrays}
 
         # Add data from edges
         for edge in self.loop.all_interstate_edges():
@@ -444,7 +1021,7 @@ class LoopToMap(xf.MultiStateTransformation):
         read_set -= view_set
         write_set -= view_set
 
-        # Create NestedSDFG and add the loop contents to it. Gaher symbols defined in the NestedSDFG.
+        # Create NestedSDFG and add the loop contents to it. Gather symbols defined in it.
         fsymbols = set(sdfg.free_symbols)
         body = graph.add_state_before(self.loop, 'single_state_body')
         nsdfg = SDFG('loop_body', constants=sdfg.constants_prop, parent=body)
@@ -477,7 +1054,9 @@ class LoopToMap(xf.MultiStateTransformation):
             for s, m in sdfg.parent_nsdfg_node.symbol_mapping.items():
                 if s not in cnode.symbol_mapping:
                     cnode.symbol_mapping[s] = symbolic.pystr_to_symbolic(s)
-                    nsdfg.add_symbol(s, sdfg.symbols[s])
+                    # A mapping entry the mapped SDFG never declared (other passes write mapping
+                    # entries without one) is not a reason to refuse: type it off the symbol.
+                    nsdfg.symbols[s] = sdfg.symbols.get(s, symbolic.symbol(s).dtype)
         for name in read_set:
             r = body.add_read(name)
             body.add_edge(r, None, cnode, name, memlet.Memlet.from_array(name, sdfg.arrays[name]))
@@ -492,19 +1071,16 @@ class LoopToMap(xf.MultiStateTransformation):
         for sym, dtype in nsymbols.items():
             nsdfg.symbols[sym] = dtype
 
-        # Symbols that the nested SDFG assigns on its own interstate edges
-        # are internal -- they must not be surfaced onto the NestedSDFG
-        # node's ``symbol_mapping``. Doing so would make the outer SDFG
-        # appear to need them as free symbols; a later pruning pass that
-        # removes them from ``sdfg.symbols`` would then desync the mapping
-        # (codegen reads ``sdfg.symbols[sym]`` and raises ``KeyError``).
+        # Symbols the nested SDFG assigns on its own interstate edges are internal → keep off the
+        # node's ``symbol_mapping``. Surfacing them makes the outer SDFG appear to need them as
+        # free symbols; a later pruning pass removing them from ``sdfg.symbols`` desyncs the
+        # mapping (codegen ``sdfg.symbols[sym]`` → KeyError).
         internally_defined = set()
         for e in nsdfg.all_interstate_edges():
             internally_defined.update(e.data.assignments.keys())
 
-        # Propagate free symbols referenced by nested array shapes/strides/offsets:
-        # ``copy.deepcopy`` of the descriptor carries the symbols, but they
-        # must be added to the NestedSDFG's symbol mapping.
+        # Propagate free symbols in nested array shapes/strides/offsets: deepcopy carries them
+        # but they must be added to the NestedSDFG's symbol mapping.
         for desc in nsdfg.arrays.values():
             for sym in desc.free_symbols:
                 sym_name = str(sym)
@@ -541,6 +1117,16 @@ class LoopToMap(xf.MultiStateTransformation):
                 if vtype is None:
                     nsdfg.symbols[k] = ktype
 
+        # The registrations above can free a symbol after ``add_nested_sdfg`` fixed the mapping;
+        # a free symbol missing from the node's mapping fails validation, so self-map leftovers.
+        nconnectors = cnode.in_connectors.keys() | cnode.out_connectors.keys()
+        for sym in sorted(nsdfg.free_symbols):
+            if sym in nconnectors or sym in cnode.symbol_mapping:
+                continue
+            cnode.symbol_mapping[sym] = symbolic.pystr_to_symbolic(sym)
+            if sym not in nsdfg.symbols and sym in sdfg.symbols:
+                nsdfg.symbols[sym] = sdfg.symbols[sym]
+
         if (step < 0) == True:
             # If step is negative, we have to flip start and end to produce a correct map with a positive increment.
             start, end, step = end, start, -step
@@ -548,7 +1134,7 @@ class LoopToMap(xf.MultiStateTransformation):
         source_nodes = body.source_nodes()
         sink_nodes = body.sink_nodes()
 
-        # Check intermediate notes
+        # Check intermediate nodes
         intermediate_nodes: List[nodes.AccessNode] = []
         for node in body.nodes():
             if isinstance(node, nodes.AccessNode) and body.in_degree(node) > 0 and node not in sink_nodes:
@@ -577,9 +1163,7 @@ class LoopToMap(xf.MultiStateTransformation):
         # Filter out views
         containers_to_read = {c for c in containers_to_read if not isinstance(sdfg.arrays[c], dt.View)}
         for rd in containers_to_read:
-            # We are guaranteed that this is always a scalar, because
-            # can_be_applied makes sure there are no sympy functions in each of
-            # the loop expresions
+            # Guaranteed scalar: can_be_applied rejects sympy functions in the loop expressions.
             access_node = body.add_read(rd)
             body.add_memlet_path(access_node, entry, dst_conn=rd, memlet=memlet.Memlet(rd))
 
@@ -605,7 +1189,9 @@ class LoopToMap(xf.MultiStateTransformation):
 
         # Direct edges among source and sink access nodes must pass through a tasklet.
         # We first gather them and handle them later.
-        direct_edges: Set[gr.MultiConnectorEdge[memlet.Memlet]] = set()
+        # List, not a set: ``MultiConnectorEdge`` hashes by id(), so set order varies run to run
+        # (it tracks allocation history) and would perturb the node insertion order below.
+        direct_edges: List[gr.MultiConnectorEdge[memlet.Memlet]] = []
         for n1 in source_nodes:
             if not isinstance(n1, nodes.AccessNode):
                 continue
@@ -614,7 +1200,7 @@ class LoopToMap(xf.MultiStateTransformation):
                     continue
                 for e in body.edges_between(n1, n2):
                     e.data.try_initialize(sdfg, body, e)
-                    direct_edges.add(e)
+                    direct_edges.append(e)
                     body.remove_edge(e)
 
         # Reroute all memlets through the entry and exit nodes
@@ -654,7 +1240,7 @@ class LoopToMap(xf.MultiStateTransformation):
             src: str = e.src.data
             dst: str = e.dst.data
             if e.data.subset.num_elements() == 1:
-                t = body.add_tasklet(f"{n1}_{n2}", {'__inp'}, {'__out'}, "__out =  __inp")
+                t = body.add_tasklet(f"{src}_{dst}", {'__inp'}, {'__out'}, "__out =  __inp")
                 src_conn, dst_conn = '__out', '__inp'
             else:
                 desc = sdfg.arrays[src]
@@ -665,14 +1251,16 @@ class LoopToMap(xf.MultiStateTransformation):
                                               find_new_name=True)
                 t = body.add_access(tname)
                 src_conn, dst_conn = None, None
-            body.add_memlet_path(n1,
+            # Endpoints must come from ``e``; ``n1``/``n2`` here are the leftover values of the
+            # collection loops above, so every edge would be wired to the same last-seen pair.
+            body.add_memlet_path(e.src,
                                  entry,
                                  t,
                                  memlet=memlet.Memlet(data=src, subset=e.data.src_subset),
                                  dst_conn=dst_conn)
             body.add_memlet_path(t,
                                  exit,
-                                 n2,
+                                 e.dst,
                                  memlet=memlet.Memlet(data=dst,
                                                       subset=e.data.dst_subset,
                                                       wcr=e.data.wcr,
@@ -688,9 +1276,8 @@ class LoopToMap(xf.MultiStateTransformation):
         # Delete the loop and connected edges.
         graph.remove_node(self.loop)
 
-        # If this had made a variable a free symbol, we can remove it from the SDFG symbols.
-        # Guard both branches with ``in sdfg.symbols`` -- the array-descriptor-symbol
-        # propagation above may have already cleared entries that were also free.
+        # Remove any variable this turned into a free symbol. Guard both branches with ``in
+        # sdfg.symbols`` -- the array-descriptor-symbol propagation above may have cleared them.
         for var in sdfg.free_symbols - fsymbols:
             if var not in sdfg.symbols:
                 continue
@@ -699,6 +1286,13 @@ class LoopToMap(xf.MultiStateTransformation):
                     sdfg.remove_symbol(var)
             else:
                 sdfg.remove_symbol(var)
+
+        # Deregistering does not un-free a symbol whose uses remain; the parent node must map it.
+        if sdfg.parent_nsdfg_node is not None:
+            pnode = sdfg.parent_nsdfg_node
+            pconnectors = pnode.in_connectors.keys() | pnode.out_connectors.keys()
+            for var in sorted((sdfg.free_symbols - fsymbols) - pnode.symbol_mapping.keys() - pconnectors):
+                pnode.symbol_mapping[var] = symbolic.pystr_to_symbolic(var)
 
         # Also remove arrays that are unique to the loop body
         for name in unique_set:

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -223,10 +223,12 @@ def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, iters
     for (rb, re_, _), (wb, we_, _) in zip(rnd, wnd):
         if rb != re_ or wb != we_:  # non-point dimension: cannot decide here
             continue
-        # SOUNDNESS: valid only while every symbol here holds one value for the whole loop.
-        # ``itersym`` is exempt (reparameterized per access); a body-varying symbol is not --
-        # ``a[i-1, j-1]`` vs ``a[i, j]`` looks constant per dimension yet overlaps as ``j`` sweeps.
-        rw_syms = {s.name for s in sp.sympify(rb).free_symbols} | {s.name for s in sp.sympify(wb).free_symbols}
+        # SOUNDNESS: only ``itersym`` may vary here (it is reparameterized per access). A
+        # body-varying symbol looks constant per dimension yet aliases as it sweeps.
+        rw_syms = {s.name
+                   for s in symbolic.pystr_to_symbolic(rb).free_symbols
+                   } | {s.name
+                        for s in symbolic.pystr_to_symbolic(wb).free_symbols}
         if rw_syms & varying:
             continue
         if _dim_provably_disjoint(rb, wb, itersym, step, start):
@@ -271,9 +273,8 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
             return False
         x1 = symbolic.pystr_to_symbolic(b1)
         x2 = symbolic.pystr_to_symbolic(b2)
-        # SOUNDNESS: sharing a symbol between the two accesses is only valid while it holds one
-        # value for the whole loop. A body-varying one takes independent values per iteration, and
-        # sharing it certifies ``p == q`` for accesses that really do alias across iterations.
+        # SOUNDNESS: a symbol shared by both accesses must hold one value for the whole loop;
+        # a body-varying one would certify ``p == q`` for accesses that really do alias.
         if any(str(s) in varying for s in x1.free_symbols) or any(str(s) in varying for s in x2.free_symbols):
             return False
         eqs.append(sp.expand(x1.subs(itersym, p) - x2.subs(itersym, q)))
@@ -287,9 +288,8 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
                 return False
         except sp.PolynomialError:
             return False
-    # Look for rationals ``lam_d`` with ``sum_d lam_d * eq_d == p - q`` as a polynomial identity in
-    # {p, q, params}. Matching every monomial's coefficient to that of ``p - q`` gives a linear
-    # system in the ``lam_d``; a solution is a soundness certificate that a collision forces p == q.
+    # Rationals ``lam_d`` with ``sum_d lam_d * eq_d == p - q`` as a polynomial identity: matching
+    # monomial coefficients gives a linear system whose solution certifies a collision forces p == q.
     lambdas = list(sp.symbols(f'_l2m_lam0:{len(eqs)}'))
     diff = sp.expand(sum(l * e for l, e in zip(lambdas, eqs)) - (p - q))
     lin_eqs = [diff.coeff(mono) for mono in monomials]
@@ -313,16 +313,14 @@ def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, sta
     for (b1, e1, _), (b2, e2, _) in zip(nd1, nd2):
         if b1 != e1 or b2 != e2:  # non-point range dimension: cannot decide here
             continue
-        # Both writes index this dim by the same injective function of the iter var: a collision
-        # forces the two iterations equal, so they coincide only within one iteration (program
-        # order in the map body), never across distinct iterations.
+        # Same injective index in both writes: a collision forces the iterations equal, so the
+        # overlap stays inside one iteration, where the map body keeps program order.
         if _same_injective_index(b1, b2, itersym):
             return False
         if _dim_provably_disjoint(b1, b2, itersym, step, start):
             return False
-    # No single dimension settled it. Fall back to the whole-subset collision system: the iter var
-    # may appear in different dimensions of the two writes (a transpose), yet a collision can still
-    # force the two iterations to coincide.
+    # No dimension settled it: the iter var may sit in different dimensions of the two writes
+    # (a transpose), so try the whole-subset collision system.
     if _collision_forces_same_iteration(m1.subset, m2.subset, itersym, varying):
         return False
     return True
@@ -344,17 +342,13 @@ class LoopToMap(xf.MultiStateTransformation):
 
     def can_be_applied(self, graph, expr_index, sdfg, permissive=False):
 
-        def refuse(reason: str) -> bool:
-            """Refuse the match. Reason dropped; diagnostics live in the pipeline driver."""
-            return False
-
         # If loop information cannot be determined, fail.
         start = loop_analysis.get_init_assignment(self.loop)
         end = loop_analysis.get_loop_end(self.loop)
         step = loop_analysis.get_loop_stride(self.loop)
         itervar = self.loop.loop_variable
         if start is None or end is None or step is None or itervar is None:
-            return refuse(f"loop information incomplete - start={start}, end={end}, step={step}, itervar={itervar}")
+            return False
 
         sset = {}
         sset.update(sdfg.symbols)
@@ -362,23 +356,21 @@ class LoopToMap(xf.MultiStateTransformation):
         t = dtypes.result_type_of(infer_expr_type(start, sset), infer_expr_type(step, sset), infer_expr_type(end, sset))
         # Bounds must be integer-derived: non-sequential map schedules are otherwise invalid.
         if not t in dtypes.INTEGER_TYPES:
-            return refuse(f"loop bounds are not integer types - result_type={t}")
+            return False
 
         # Loops containing break, continue, or returns may not be turned into a map.
         for blk in self.loop.all_control_flow_blocks():
             if isinstance(blk, (BreakBlock, ContinueBlock, ReturnBlock)):
                 if not permissive:
-                    return refuse(f"loop body contains a {type(blk).__name__}")
+                    return False
 
         # We cannot handle symbols read from data containers unless they are scalar.
         for expr in (start, end, step):
             if symbolic.contains_sympy_functions(expr):
-                return refuse(f"bound expression reads a non-scalar data container - expr={expr}")
+                return False
 
-        # Refuse when the range (start/end/step) references a symbol the body defines via an
-        # interstate assignment. After conversion the body → a ``loop_body`` NSDFG (assignment
-        # goes with it) but the Map's range stays outer, referencing a symbol only defined inside
-        # the NSDFG → ``Missing symbols on nested SDFG`` downstream.
+        # A range symbol the body assigns moves into the loop_body NSDFG while the Map's range
+        # stays outside it: ``Missing symbols on nested SDFG`` downstream.
         range_syms: Set[str] = set()
         for expr in (start, end, step):
             try:
@@ -389,7 +381,7 @@ class LoopToMap(xf.MultiStateTransformation):
         for e in self.loop.all_interstate_edges():
             body_assigned_syms.update(e.data.assignments.keys())
         if range_syms & body_assigned_syms:
-            return refuse(f"loop range references symbol(s) {range_syms & body_assigned_syms} assigned inside the body")
+            return False
 
         loop_states = set(self.loop.all_states())
         all_loop_blocks = set(self.loop.all_control_flow_blocks())
@@ -397,16 +389,15 @@ class LoopToMap(xf.MultiStateTransformation):
         # Cannot have StructView in loop body
         for loop_state in loop_states:
             if [n for n in loop_state.data_nodes() if isinstance(n.desc(sdfg), dt.StructureView)]:
-                return refuse(f"loop body contains a StructureView in state {loop_state}")
+                return False
 
         # At most one iteration carries no cross-iteration dependence: trivially DOALL, and the
         # analysis below would only be confounded by the clamped ``Min``/``Max`` bound.
         if loop_analysis.loop_provably_at_most_one_iteration(self.loop):
             return True
 
-        # Symbol reads and writes from interstate assignments. The dominator-heavy topological
-        # sort below only means anything when there are assignments, so skip it when there are none
-        # (most loops) -- the result is identical.
+        # The dominator-heavy sort below only means anything when the body has interstate
+        # assignments; with none (most loops) the result is identical, so skip it.
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
         if any(e.data.assignments for block in self.loop.all_control_flow_blocks()
@@ -414,10 +405,8 @@ class LoopToMap(xf.MultiStateTransformation):
             in_order_loop_blocks = list(
                 cfg_analysis.blockorder_topological_sort(self.loop, recursive=True, ignore_nonstate_blocks=False))
             for block in in_order_loop_blocks:
-                # The sort emits a ConditionalBlock before its branches, but its out-edges run
-                # after them. A symbol assigned on every branch of an exhaustive conditional is
-                # defined on exit, so count it assigned here -- otherwise a scalar set in both arms
-                # and read afterwards reads as loop-carried.
+                # The sort emits a ConditionalBlock before its branches though its out-edges run
+                # after them, so count what every branch of an exhaustive one assigns as defined.
                 if isinstance(block, ConditionalBlock) and any(c is None for c, _ in block.branches):
                     per_branch = []
                     for _cond, body in block.branches:
@@ -429,10 +418,8 @@ class LoopToMap(xf.MultiStateTransformation):
                     if per_branch:
                         symbols_that_may_be_used |= set.intersection(*per_branch)
 
-                # A symbol read in the block's own dataflow (e.g. a memlet subset ``b[im]``) is read
-                # before any symbol the block assigns on its out-edges; if the loop later reassigns it,
-                # it is loop-carried. The per-edge ``read_symbols()`` below only sees interstate-edge
-                # reads, so fold in these in-state reads.
+                # ``read_symbols()`` below sees only interstate-edge reads, but a symbol read in
+                # the block's own dataflow (``b[im]``) is read before the block's out-edges assign.
                 try:
                     block_reads = {str(s) for s in block.free_symbols}
                 except Exception:
@@ -452,16 +439,13 @@ class LoopToMap(xf.MultiStateTransformation):
                         except AttributeError:
                             fsyms = set()
                         if k in fsyms and k not in symbols_that_may_be_used:
-                            # ``k = f(k)`` with no earlier assignment this iteration reads the
-                            # previous iteration's value: a carried recurrence. Affine induction
-                            # variables are already in closed form upstream, so what reaches here is
-                            # genuine; a counter reset first is caught by the read-before-assign check.
-                            return refuse(f"self-recurrent carried symbol '{k}' (assignment {k} = {v})")
+                            # ``k = f(k)`` unassigned earlier this iteration reads the previous
+                            # one's value. Affine induction variables are in closed form upstream.
+                            return False
                         if k not in fsyms:
                             assigned_symbols.add(k)
                     if assigned_symbols & used_before_assignment:
-                        return refuse("carried symbol dependency - "
-                                      f"{assigned_symbols & used_before_assignment} read before being assigned")
+                        return False
 
                     symbols_that_may_be_used |= e.data.assignments.keys()
 
@@ -475,10 +459,8 @@ class LoopToMap(xf.MultiStateTransformation):
         for state in loop_states:
             other_access_nodes |= set(n.data for n in state.data_nodes() if not sdfg.arrays[n.data].transient)
 
-        # read_and_write_sets() walks every state/edge of the loop and is only needed from here
-        # on (the per-array write analysis below). Computing it lazily -- after the cheaper
-        # bound/break/StructView/carried-symbol refusals above -- lets a loop refused by any of
-        # those return without paying for it (on channel_flow that is ~41k of ~44k probes).
+        # ``read_and_write_sets()`` walks every state and edge and is only needed below, so a
+        # loop refused by the cheaper checks above never pays for it (channel_flow: 41k of 44k).
         _, write_set = self.loop.read_and_write_sets()
 
         write_memlets: Dict[str, List[memlet.Memlet]] = defaultdict(list)
@@ -494,21 +476,16 @@ class LoopToMap(xf.MultiStateTransformation):
                 # Take all writes that are not conflicted into consideration
                 if dn.data in write_set:
                     for e in state.in_edges(dn):
-                        # An empty memlet is an ordering edge, not a write: it carries no data
-                        # across iterations, and the order it encodes survives inside the map body.
-                        # Having no subset, the ``a*i+b`` test below would read it as a whole-array
-                        # write. ``_read_and_write_sets`` skips them for the same reason.
+                        # An empty memlet is an ordering edge, not a write, and its missing
+                        # subset would read below as an unindexed whole-array write.
                         if e.data is None or e.data.is_empty():
                             continue
                         if e.data.dynamic and e.data.wcr is None:
-                            # Dynamic write (no WCR) is safe across iterations if its dst subset
-                            # pins an axis to the iter var (same ``a*i+b`` as non-dynamic below):
-                            # each iteration writes a disjoint slab, so a lane firing or not can't
-                            # race another iteration's write.
+                            # A dynamic write whose subset pins an axis to the iter var gives
+                            # each iteration a disjoint slab, so a lane firing cannot race.
                             dst_subset = e.data.get_dst_subset(e, state)
                             if not (dst_subset and _check_range(dst_subset, a, itersym, b, step)):
-                                return refuse(f"dynamic write to {dn.data} is not indexed by the iteration variable "
-                                              f"- dst_subset={dst_subset}")
+                                return False
 
                         # Unique write index per iteration: match ``a*i+b``, ``|a| >= 1``, i the
                         # iteration variable (which must be used).
@@ -519,21 +496,17 @@ class LoopToMap(xf.MultiStateTransformation):
                             # inner per-iteration write; look past the connector.
                             if not ok and isinstance(e.src, nodes.NestedSDFG):
                                 ok = _nested_writes_iter_indexed(e.src, e.src_conn, itersym, a, b, step)
-                                # NSDFG descent only proves WRITE uniqueness. A carried READ at a
-                                # DIFFERENT iter position (``a[i+1]`` while writing ``a[i]``) is a
-                                # forward/backward dependence that races. Require every inner read
-                                # of ``conn`` to match the writes' ``a*i+b`` (or be loop-invariant).
+                                # Write uniqueness is not enough: an inner read at another iter
+                                # position (``a[i+1]`` while writing ``a[i]``) still races.
                                 if ok and not _nested_reads_match_writes(e.src, e.src_conn, itersym, a, b, step):
                                     ok = False
                             if not ok and not permissive:
-                                return refuse(f"write to {dn.data} is not uniquely indexed by the iteration variable "
-                                              f"(needs an a*i+b subset) - dst_subset={dst_subset}")
+                                return False
 
                         write_memlets[dn.data].append(e.data)
 
-        # Carried-read check: a read of a written array must be loop-invariant or match the
-        # writes' ``a*i+b``. ``a[i] = a[i+1]`` races; the disjointness checks below only see
-        # overlaps within one iteration.
+        # A read of a written array must be loop-invariant or match the writes' ``a*i+b``:
+        # ``a[i] = a[i+1]`` races, and the checks below only see overlaps within one iteration.
         for state in loop_states:
             for dn in state.data_nodes():
                 data = dn.data
@@ -556,16 +529,13 @@ class LoopToMap(xf.MultiStateTransformation):
                     # itersym-dependent read: must match a*i+b like the writes, else this
                     # iteration reads a value another iteration writes.
                     if not _check_range(src_subset, a, itersym, b, step) and not permissive:
-                        return refuse(f"read of {data} at {src_subset} is iter-indexed but does not match the "
-                                      f"write pattern a*i+b -- loop-carried forward/backward dependency")
+                        return False
 
         # Fixed for the whole loop, so compute once and share with every dependence test below.
         varying = loop_varying_symbols(self.loop)
 
-        # Two distinct-affine writes to the same container can hit the same element on different
-        # iterations even when each is individually injective (``A[5*i]`` and ``A[3*i]`` collide
-        # at ``A[15]``); parallelizing reorders them. Allow only if some dim is provably disjoint
-        # for all iterations (``A[2*i]`` vs ``A[2*i+1]``).
+        # Two individually injective writes still collide across iterations (``A[5*i]`` and
+        # ``A[3*i]`` at ``A[15]``); allow only when some dimension is provably disjoint.
         for data, mmlts in write_memlets.items():
             distinct: Dict[str, memlet.Memlet] = {}
             for m in mmlts:
@@ -575,8 +545,7 @@ class LoopToMap(xf.MultiStateTransformation):
             for x in range(len(reps)):
                 for y in range(x + 1, len(reps)):
                     if _writes_may_overlap(reps[x], reps[y], itersym, step, start, varying) and not permissive:
-                        return refuse(f"writes {reps[x].subset} and {reps[y].subset} to {data} "
-                                      "may overlap across iterations")
+                        return False
 
         # After looping over relevant writes, consider reads that may overlap
         for state in loop_states:
@@ -586,9 +555,7 @@ class LoopToMap(xf.MultiStateTransformation):
                 data = dn.data
                 if data in write_memlets:
                     for e in state.out_edges(dn):
-                        # Mirror of the write scan above: an empty memlet is a happens-before
-                        # edge, not a read, and its missing subset would be taken for a
-                        # whole-array read.
+                        # As in the write scan: an empty memlet is an ordering edge, not a read.
                         if e.data is None or e.data.is_empty():
                             continue
 
@@ -596,8 +563,7 @@ class LoopToMap(xf.MultiStateTransformation):
                         src_subset = e.data.get_src_subset(e, state)
                         if not self.test_read_memlet(sdfg, state, e, itersym, itervar, start, end, step, write_memlets,
                                                      e.data, src_subset, varying):
-                            return refuse(f"read-after-write conflict on {data} within the loop body "
-                                          f"- src_subset={src_subset}")
+                            return False
 
         # Consider reads in inter-state edges (could be in assignments or in condition)
         isread_set: Set[memlet.Memlet] = set()
@@ -607,8 +573,7 @@ class LoopToMap(xf.MultiStateTransformation):
             if mmlt.data in write_memlets:
                 if not self.test_read_memlet(sdfg, None, None, itersym, itervar, start, end, step, write_memlets, mmlt,
                                              mmlt.subset, varying):
-                    return refuse(f"read-after-write conflict on {mmlt.data} via an inter-state edge "
-                                  f"- subset={mmlt.subset}")
+                    return False
 
         # Iteration variable + other symbols must not be used on later edges/blocks before
         # reassignment.
@@ -618,8 +583,7 @@ class LoopToMap(xf.MultiStateTransformation):
         reassigned_symbols: Set[str] = None
         for oe in graph.out_edges(self.loop):
             if symbols_that_may_be_used & oe.data.read_symbols():
-                return refuse("loop-defined symbol(s) used after the loop on its outgoing edge - "
-                              f"{symbols_that_may_be_used & oe.data.read_symbols()}")
+                return False
             # Check for symbols that are set by all outgoing edges
             # TODO: Handle case of subset of out_edges
             if reassigned_symbols is None:
@@ -639,15 +603,13 @@ class LoopToMap(xf.MultiStateTransformation):
 
             # Check state contents
             if symbols_that_may_be_used & block.free_symbols:
-                return refuse(f"loop-defined symbol(s) used after the loop in block {block} - "
-                              f"{symbols_that_may_be_used & block.free_symbols}")
+                return False
 
             # Check inter-state edges
             reassigned_symbols = None
             for e in block.parent_graph.out_edges(block):
                 if symbols_that_may_be_used & e.data.read_symbols():
-                    return refuse("loop-defined symbol(s) used after the loop on an inter-state edge - "
-                                  f"{symbols_that_may_be_used & e.data.read_symbols()}")
+                    return False
 
                 # Check for symbols that are set by all outgoing edges
                 # TODO: Handle case of subset of out_edges
@@ -677,9 +639,8 @@ class LoopToMap(xf.MultiStateTransformation):
             # If pointers are involved, give up
             return False
         if not _check_range(src_subset, a, itersym, b, step):
-            # ``_check_range`` accepts only reads that move with the iteration. A loop-invariant
-            # read conflicts only if it overlaps a write (``a[0]`` vs ``a[1:N]`` does not), so defer
-            # both to the propagated-overlap check below.
+            # A loop-invariant read conflicts only if it overlaps a write (``a[0]`` vs ``a[1:N]``
+            # does not), so defer to the propagated-overlap check below.
             if itersym in src_subset.free_symbols:
                 return False
 
@@ -692,27 +653,21 @@ class LoopToMap(xf.MultiStateTransformation):
         for candidate in write_memlets[data]:
             # Simple case: read and write are in the same subset
             read = src_subset
-            # A one-sided copy memlet (e.g. a whole-array ``a[0:N] -> a`` boundary
-            # passthrough) carries its subset in ``.subset`` and leaves
-            # ``.dst_subset`` None; fall back to ``.subset`` so the dependency test
-            # doesn't crash on ``None.ndrange()``.
+            # A one-sided copy memlet (``a[0:N] -> a``) leaves ``dst_subset`` None and carries
+            # its subset in ``.subset``.
             write = candidate.dst_subset if candidate.dst_subset is not None else candidate.subset
             if read == write:
                 continue
-            # Step-aware per-dimension disjointness (Diophantine over the strided counter): no
-            # pair of iterations can collide, so no cross-iteration RAW. More precise than the
-            # propagate+intersect fallback, which drops constant dims and the stride.
+            # Step-aware per-dimension disjointness: no pair of iterations collides, so no
+            # cross-iteration RAW. The fallback below drops constant dims and the stride.
             if _read_write_dims_disjoint(read, write, itersym, step, start, varying):
                 continue
-            # Same-iteration collision: one dimension indexing read and write by the same
-            # injective function of the iter var (syrk's ``C[i, :i+1]``) confines any overlap to a
-            # single iteration, where the map body preserves program order.
+            # One dimension indexing read and write by the same injective function of the iter
+            # var (syrk's ``C[i, :i+1]``) confines the overlap to a single iteration.
             if _read_write_same_iteration(read, write, itersym):
                 continue
-            # Same across several dimensions at once: a transpose puts the iter var in different
-            # dimensions of read and write, so no single dimension settles it, yet the collision
-            # system still forces the two iterations to coincide -- a distance-0, loop-independent
-            # dependence that ``apply`` transplants into the map body unchanged.
+            # A transpose puts the iter var in different dimensions of read and write: no single
+            # dimension settles it, but a distance-0 dependence still lives inside one iteration.
             if _collision_forces_same_iteration(read, write, itersym, varying):
                 continue
             ridx = _dependent_indices(itervar, read)
@@ -763,16 +718,14 @@ class LoopToMap(xf.MultiStateTransformation):
             for node in state.data_nodes():
                 if node.data != name:
                     continue
+                # itersym in the subset means not thread-local; assumes the loop is a valid Map,
+                # i.e. every edge carrying the array depends on itersym consistently.
                 for e in state.out_edges(node):
                     src_subset = e.data.get_src_subset(e, state)
-                    # itersym in the subset → not thread-local. Assumes the loop is a valid Map
-                    # (all edges carrying the array depend on itersym consistently).
                     if src_subset and itervar in src_subset.free_symbols:
                         return False
                 for e in state.in_edges(node):
                     dst_subset = e.data.get_dst_subset(e, state)
-                    # itersym in the subset → not thread-local. Assumes the loop is a valid Map
-                    # (all edges carrying the array depend on itersym consistently).
                     if dst_subset and itervar in dst_subset.free_symbols:
                         return False
         return True
@@ -809,9 +762,8 @@ class LoopToMap(xf.MultiStateTransformation):
                         if e.data.data and e.data.data in sdfg.arrays:
                             write_set.add(e.data.data)
 
-        # Headers of nested loops and conditionals, at EVERY depth: recursing only into
-        # LoopRegion / ConditionalBlock stops at a branch, which is a plain ControlFlowRegion, and
-        # a container read below that point never becomes a connector -- it stays a free symbol.
+        # Headers at EVERY depth: recursing only into LoopRegion / ConditionalBlock stops at a
+        # branch, and a container read below that never becomes a connector.
         for block in self.loop.all_control_flow_blocks():
             if isinstance(block, (LoopRegion, ConditionalBlock)):
                 free_syms = {s for c in block.get_meta_codeblocks() for s in c.get_free_symbols()}
@@ -916,10 +868,8 @@ class LoopToMap(xf.MultiStateTransformation):
         for sym, dtype in nsymbols.items():
             nsdfg.symbols[sym] = dtype
 
-        # Symbols the nested SDFG assigns on its own interstate edges are internal → keep off the
-        # node's ``symbol_mapping``. Surfacing them makes the outer SDFG appear to need them as
-        # free symbols; a later pruning pass removing them from ``sdfg.symbols`` desyncs the
-        # mapping (codegen ``sdfg.symbols[sym]`` → KeyError).
+        # Symbols the nested SDFG assigns itself are internal: mapping them makes the outer SDFG
+        # appear to need them, and a later pruning pass then desyncs the mapping.
         internally_defined = set()
         for e in nsdfg.all_interstate_edges():
             internally_defined.update(e.data.assignments.keys())
@@ -1032,10 +982,8 @@ class LoopToMap(xf.MultiStateTransformation):
         if view_assignments:
             graph.add_state_before(body, "map_views", assignments=view_assignments)
 
-        # Direct edges among source and sink access nodes must pass through a tasklet.
-        # We first gather them and handle them later.
-        # List, not a set: ``MultiConnectorEdge`` hashes by id(), so set order varies run to run
-        # (it tracks allocation history) and would perturb the node insertion order below.
+        # Direct edges among source and sink access nodes must pass through a tasklet; gather
+        # them first. A list, not a set: ``MultiConnectorEdge`` hashes by id(), so set order varies.
         direct_edges: List[gr.MultiConnectorEdge[memlet.Memlet]] = []
         for n1 in source_nodes:
             if not isinstance(n1, nodes.AccessNode):

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -88,11 +88,7 @@ def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
                     return False
                 outer = copy.deepcopy(src_subset)
                 outer.replace(repl)
-                free = OrderedSet()
-                for rb, re, _ in outer.ndrange():
-                    for expr in (rb, re):
-                        free |= OrderedSet(symbolic.pystr_to_symbolic(expr).free_symbols)
-                if itersym not in free:
+                if itersym not in outer.free_symbols:
                     continue
                 if not _check_range(outer, a, itersym, b, step):
                     return False
@@ -117,12 +113,9 @@ def _sanitize_by_index(indices: Set[int], subset: subsets.Subset) -> subsets.Ran
 
 
 def _affine_coeffs(expr, itersym):
-    """Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if not affine.
-
-        The derivative is ``a`` (still naming ``itersym`` above degree one, which is the
-        degree test) and the value at zero is ``b``; ``expand`` + ``coeff`` hung on tiled
-        indices.
-    """
+    """``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if not affine. Derivative and
+    value at zero, since ``expand`` + ``coeff`` hung on tiled indices; a derivative still naming
+    ``itersym`` is the degree test."""
     e = symbolic.pystr_to_symbolic(expr)
     if not e.is_polynomial(itersym):
         return None
@@ -142,12 +135,9 @@ def _same_injective_index(idx1, idx2, itersym) -> bool:
 
 
 def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
-    """True iff ``idx1`` at any iteration can never equal ``idx2`` at any iteration.
-
-        Over the counter ``t`` (``i == start + step*t``), ``A1*t1 + B1 == A2*t2 + B2`` is
-        solvable iff ``gcd(A1, A2)`` divides ``B2 - B1``; ranging over all integers is
-        conservative, hence sound.
-    """
+    """True iff ``idx1`` at any iteration can never equal ``idx2`` at any iteration. Over the
+    counter ``t`` (``i == start + step*t``), ``A1*t1 + B1 == A2*t2 + B2`` is solvable iff
+    ``gcd(A1, A2)`` divides ``B2 - B1``; ranging ``t`` over all integers is conservative."""
     f1 = _affine_coeffs(idx1, itersym)
     f2 = _affine_coeffs(idx2, itersym)
     if f1 is None or f2 is None:
@@ -164,8 +154,6 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
     B1 = a1 * start_s + b1
     B2 = a2 * start_s + b2
     diff = sp.expand(B2 - B1)
-    if A1 == 0 and A2 == 0:
-        return diff.is_number and diff != 0
     # A symbolic step or start leaves ``A_k`` symbolic, and the gcd criterion undecidable.
     if not (A1.is_Integer and A2.is_Integer):
         return False
@@ -234,12 +222,10 @@ def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, iter
 
 def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset, itersym,
                                      varying: OrderedSet[str]) -> bool:
-    """Prove two point subsets of one container collide only when their iterations coincide.
-
-        With ``itersym`` replaced by ``p`` and ``q``, rationals ``lam_d`` with
-        ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` certify it for every parameter
-        value; this is what catches transposes (``cov[i,j]`` vs ``cov[j,i]``).
-    """
+    """Prove two point subsets of one container collide only when their iterations coincide:
+    with ``itersym`` replaced by ``p`` and ``q``, rationals ``lam_d`` with
+    ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` certify it for every parameter value.
+    Catches transposes (``cov[i,j]`` vs ``cov[j,i]``)."""
     nd1 = list(sub1.ndrange())
     nd2 = list(sub2.ndrange())
     if len(nd1) != len(nd2) or len(nd1) == 0:
@@ -361,9 +347,8 @@ class LoopToMap(xf.MultiStateTransformation):
         if loop_analysis.loop_provably_at_most_one_iteration(self.loop):
             return True
 
-        # The dominator-heavy sort below is a no-op without interstate assignments.
-        symbols_that_may_be_used: Set[str] = {itervar}
-        used_before_assignment: Set[str] = set()
+        symbols_that_may_be_used: OrderedSet[str] = OrderedSet([itervar])
+        used_before_assignment: OrderedSet[str] = OrderedSet()
         if any(e.data.assignments for block in self.loop.all_control_flow_blocks()
                for e in block.parent_graph.out_edges(block)):
             in_order_loop_blocks = list(
@@ -376,14 +361,16 @@ class LoopToMap(xf.MultiStateTransformation):
                         assigned_in_branch = OrderedSet()
                         for inner in body.all_control_flow_blocks():
                             for ie in inner.parent_graph.out_edges(inner):
-                                assigned_in_branch |= set(ie.data.assignments.keys())
+                                assigned_in_branch |= OrderedSet(ie.data.assignments.keys())
                         per_branch.append(assigned_in_branch)
                     if per_branch:
-                        symbols_that_may_be_used |= set.intersection(*per_branch)
+                        # OrderedSet, so intersect through its own API -- ``set.intersection``
+                        # is an unbound descriptor and raises on anything but a ``set``.
+                        symbols_that_may_be_used |= per_branch[0].intersection(*per_branch[1:])
 
                 # ``read_symbols()`` misses the block's own dataflow reads, which come first.
                 try:
-                    block_reads = {str(s) for s in block.free_symbols}
+                    block_reads = OrderedSet(str(s) for s in block.free_symbols)
                 except Exception:
                     block_reads = OrderedSet()
                 used_before_assignment |= (block_reads - symbols_that_may_be_used)
@@ -391,7 +378,6 @@ class LoopToMap(xf.MultiStateTransformation):
                     read_symbols = e.data.read_symbols()
                     read_symbols -= symbols_that_may_be_used
                     used_before_assignment |= read_symbols
-                    # If symbol was read before it is assigned, the loop cannot be parallel
                     assigned_symbols = OrderedSet()
                     for k, v in e.data.assignments.items():
                         try:
@@ -467,11 +453,7 @@ class LoopToMap(xf.MultiStateTransformation):
                     src_subset = e.data.get_src_subset(e, state)
                     if src_subset is None:
                         continue
-                    free = OrderedSet()
-                    for rb, re_, _ in src_subset.ndrange():
-                        for expr in (rb, re_):
-                            free |= OrderedSet(symbolic.pystr_to_symbolic(expr).free_symbols)
-                    if itersym not in free:
+                    if itersym not in src_subset.free_symbols:
                         continue
                     if not _check_range(src_subset, a, itersym, b, step) and not permissive:
                         return False

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -40,24 +40,10 @@ def _check_range(subset, a, itersym, b, step):
 
 
 def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
-    """Whether every write to ``conn``'s array INSIDE ``nsdfg_node`` is indexed by the (mapped)
-    iteration variable.
-
-    A NestedSDFG loop body propagates a whole-array external write memlet (union over the loop)
-    that hides the per-iteration write. Look past the connector: rewrite inner write subsets
-    through ``symbol_mapping`` into the outer itersym; each must match the ``a*i+b`` pattern
-    :func:`_check_range` enforces. Conservative: needs ≥1 inner write and ALL must pass; nested
-    NestedSDFGs recurse, composing symbol maps.
-
-    Example: ``for i: if c: b[i] = a[i] + 1`` after a ``LoopToMap -> MapToForLoop`` round-trip
-    (guard forced a NestedSDFG body). The external connector memlet ``b[0:N]`` (union, no ``i``)
-    fails _check_range, but the inner ``b[i]`` maps through {i: i} to ``b[i]`` → matches ``1*i+0``
-    → independence proven → LoopToMap fires.
-
-    :param nsdfg_node: NestedSDFG node feeding the outer write.
-    :param conn: output connector (== inner array name) written.
-    :param itersym: outer loop iteration symbol.
-    :returns: True iff every inner write to ``conn`` is iter-indexed.
+    """Whether every write to ``conn``'s array inside ``nsdfg_node`` is indexed by the mapped
+    iteration variable. The external connector memlet is the union over the loop and hides the
+    per-iteration write, so rewrite the inner subsets through ``symbol_mapping`` and check each
+    against ``a*i+b``. Needs at least one inner write; nested NestedSDFGs recurse.
     """
     repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
     found = False
@@ -85,16 +71,8 @@ def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
 
 
 def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
-    """Whether every read of ``conn``'s array INSIDE ``nsdfg_node`` matches the SAME ``a*i+b``
-    pattern as the writes, or is loop-invariant.
-
-    Companion of :func:`_nested_writes_iter_indexed`, which only proves write UNIQUENESS. A
-    loop-carried READ at a DIFFERENT iter-indexed position (``a[i] = ... + a[i+1] * ...``) still
-    races: iteration ``i`` reads ``a[i+1]`` while ``i+1`` writes it. Conservative: each inner read
-    must match ``a*i+b`` OR be loop-invariant (no outer ``itersym``). Nested NestedSDFGs recurse.
-
-    :returns: True if no carried-read pattern found; False if any inner read hits the carrier
-              array outside the write's affine form.
+    """Whether every read of ``conn``'s array inside ``nsdfg_node`` matches the writes' ``a*i+b`` or
+    is loop-invariant. Write uniqueness alone is not enough: ``a[i] = ... a[i+1]`` still races.
     """
     repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
     for state in nsdfg_node.sdfg.all_states():
@@ -146,20 +124,11 @@ def _sanitize_by_index(indices: Set[int], subset: subsets.Subset) -> subsets.Ran
 
 
 def _affine_coeffs(expr, itersym):
-    """ Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if
-        ``expr`` is not affine in ``itersym``.
+    """Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if not affine in ``itersym``.
 
-        Derived, not searched for. ``expand`` + ``coeff`` + ``simplify`` is the obvious spelling
-        but it is superlinear in the size of the index expression: on a deeply tiled nest (the
-        two-level tiled Jacobi stencil, whose indices carry every enclosing tile origin) the
-        expansion blows up and ``coeff``'s ``as_independent`` walk over the resulting sum does not
-        come back -- ``LoopToMap.can_be_applied`` never returned, so the pipeline hung.
-
-        For an expression polynomial in ``itersym`` the coefficients are exact by construction:
-        the derivative IS ``a`` when the degree is at most one (and still mentions ``itersym``
-        when it is higher, which is the degree test), and evaluating at zero IS ``b``. Both are
-        structural, and neither expands the expression. Non-polynomial in ``itersym`` (an
-        ``int_floor`` of it, say) is not affine and is refused, as before.
+        Derived, not searched: the derivative is ``a`` (and still mentions ``itersym`` above degree
+        one, which is the degree test), the value at zero is ``b``. ``expand`` + ``coeff`` is
+        superlinear and hung ``can_be_applied`` on deeply tiled index expressions.
     """
     e = symbolic.pystr_to_symbolic(expr)
     if not e.is_polynomial(itersym):
@@ -171,21 +140,7 @@ def _affine_coeffs(expr, itersym):
 
 
 def _same_injective_index(idx1, idx2, itersym) -> bool:
-    """ True iff ``idx1`` and ``idx2`` are the SAME injective affine function ``a*i+b``
-        (``a != 0``) of the iteration variable.
-
-        When two accesses index a dimension by such a function, a collision on that dimension
-        (``a*p+b == a*q+b``) forces the two iterations to coincide (``p == q``). Any overlap between
-        them is therefore confined to a single iteration -- where program order in the map body is
-        preserved -- and never becomes a cross-iteration dependency. Used both for write/write
-        overlap (:func:`_writes_may_overlap`) and read/write RAW (:func:`_read_write_same_iteration`).
-
-        Both indices and the iteration symbol are re-parsed through the symbol registry (via their
-        string form) before the comparison: a read subset and a write subset can carry copies of the
-        iteration variable that share the NAME ``i`` but different sympy assumptions, so ``idx1 -
-        idx2`` would not simplify to zero and ``coeff`` would not see them as the same symbol.
-        Canonicalizing drops the assumption metadata and makes both refer to one registry symbol.
-    """
+    """True iff ``idx1`` and ``idx2`` are the same injective affine ``a*i+b`` (``a != 0``) of ``itersym``."""
     sym = symbolic.pystr_to_symbolic(str(itersym))
     e1 = symbolic.pystr_to_symbolic(str(idx1))
     e2 = symbolic.pystr_to_symbolic(str(idx2))
@@ -194,24 +149,13 @@ def _same_injective_index(idx1, idx2, itersym) -> bool:
 
 
 def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
-    """ True iff ``idx1`` at any iteration can never equal ``idx2`` at any
-        iteration, for any pair of in-domain iterations and any loop bounds.
+    """True iff ``idx1`` at any iteration can never equal ``idx2`` at any iteration.
 
-        Uses the linear-Diophantine solvability criterion. The iteration
-        variable ``i`` only takes the strided values ``start + step * t``
-        (``t`` a non-negative integer), so the accesses are reparameterized
-        w.r.t. the iteration counter ``t``: ``a * i + b == (a*step)*t +
-        (a*start + b)``. Writing ``A_k = a_k*step`` and ``B_k = a_k*start +
-        b_k``, ``A1*t1 + B1 == A2*t2 + B2`` has an integer solution iff
-        ``gcd(A1, A2)`` divides ``B2 - B1``. If it does not, the accesses
-        never alias -- even accounting for the loop's stride (so a stride-2
-        ``a[i] = a[i-1] + ...`` writes odd indices / reads even indices and is
-        provably disjoint). The Diophantine ranges over ALL integers ``t``,
-        which is conservative w.r.t. the bounded iteration domain (a solution
-        only outside the domain still reports "may alias"), hence sound.
-
-        ``step``/``start`` default to ``1``/``0`` (identity reparameterization)
-        so callers that pass only the affine indices keep the classic behavior.
+        Linear-Diophantine criterion over the iteration counter ``t`` (``i == start + step*t``):
+        with ``A_k = a_k*step`` and ``B_k = a_k*start + b_k``, ``A1*t1 + B1 == A2*t2 + B2`` is
+        solvable iff ``gcd(A1, A2)`` divides ``B2 - B1``. Ranging over all integers ``t`` is
+        conservative w.r.t. the bounded domain, hence sound. ``step``/``start`` default to the
+        identity reparameterization.
     """
     f1 = _affine_coeffs(idx1, itersym)
     f2 = _affine_coeffs(idx2, itersym)
@@ -223,13 +167,8 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
         return False
     step_s = symbolic.pystr_to_symbolic(step)
     start_s = symbolic.pystr_to_symbolic(start)
-    # Plain arithmetic, not ``sp.simplify``. Nothing below asks these for a canonical form -- only
-    # ``is_Integer`` / ``is_number`` and a gcd -- and sympy already folds numeric products and sums
-    # on construction. ``simplify`` is the general simplifier: it descends into ``factor_terms``
-    # and ``Factors``, which on this kernel's write set ran long enough to look like a hang (the
-    # two-level tiled Jacobi stencil, whose every write pair reaches here). Only the DIFFERENCE
-    # needs cancellation, and only across a product an ``Add`` will not flatten on its own
-    # (``2*(t + 1) - 2*t - 2``), which is exactly what ``expand`` is for.
+    # ``expand``, not ``sp.simplify``: only the difference needs cancelling, and only across a
+    # product ``Add`` will not flatten. ``simplify`` looked like a hang on tiled write sets.
     A1 = a1 * step_s
     A2 = a2 * step_s
     B1 = a1 * start_s + b1
@@ -252,14 +191,9 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
 
 
 def loop_varying_symbols(loop: LoopRegion) -> Set[str]:
-    """ Symbols whose value can change *while* ``loop`` runs, other than its own iterator:
-        the iterators of loops and maps nested inside its body, and everything its
-        interstate edges assign.
-
-        Every OTHER symbol a body subset mentions -- an enclosing loop's iterator, an array
-        size, a free parameter -- holds one fixed value for the loop's whole execution, so a
-        symbolic comparison of two indices that mention it is a valid statement about every
-        pair of iterations. That is what :func:`_read_write_dims_disjoint` needs.
+    """Symbols that can change while ``loop`` runs, other than its own iterator: nested loop and map
+    iterators, and everything its interstate edges assign. Every other symbol a body subset
+    mentions holds one value for the whole execution, which is what the disjointness tests need.
     """
     varying: Set[str] = set()
     for cfr in loop.all_control_flow_regions(recursive=True):
@@ -276,18 +210,11 @@ def loop_varying_symbols(loop: LoopRegion) -> Set[str]:
 
 def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, itersym, step, start,
                               varying: Set[str]) -> bool:
-    """ True iff some dimension's read/write point-indices are provably disjoint
-        across every pair of in-domain iterations (step-aware
-        linear-Diophantine, see :func:`_dim_provably_disjoint`).
+    """True iff some dimension's read/write point-indices are provably disjoint across every pair of
+    in-domain iterations (step-aware, see :func:`_dim_provably_disjoint`).
 
-        This is the read/write analog of the write/write per-dimension test in
-        :func:`_writes_may_overlap`. It additionally accounts for the loop STEP
-        (stride-2 write-odds/read-evens) and keeps CONSTANT disproving
-        dimensions (``aa[0, i]`` write vs ``aa[1, i-1]`` read -- row 0 can never
-        equal row 1), which the propagate+intersect fallback drops when it
-        restricts to iteration-dependent dimensions only.
-
-        ``varying`` is :func:`loop_varying_symbols` for the loop being lifted.
+        Unlike the propagate+intersect fallback this keeps constant disproving dimensions
+        (``aa[0, i]`` vs ``aa[1, i-1]``). ``varying`` is :func:`loop_varying_symbols`.
     """
     rnd = list(read.ndrange())
     wnd = list(write.ndrange())
@@ -296,16 +223,9 @@ def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, iters
     for (rb, re_, _), (wb, we_, _) in zip(rnd, wnd):
         if rb != re_ or wb != we_:  # non-point dimension: cannot decide here
             continue
-        # SOUNDNESS: the verdict is valid only when every symbol in the dimension holds ONE
-        # value for the loop's whole execution. ``itersym`` is exempt -- the Diophantine test
-        # reparameterizes it independently for the reading and the writing iteration. A symbol
-        # that varies INSIDE the body is not: ``a[i-1, j-1]`` vs ``a[i, j]`` seen from the ``i``
-        # loop makes ``j-1`` and ``j`` look like two distinct constants, yet the sets overlap as
-        # ``j`` sweeps -- a genuine diagonal recurrence (TSVC s119's OUTER loop). An ENCLOSING
-        # loop's iterator is fixed here, and admitting it is what lets s119's inner loop prove
-        # row ``i-1`` can never be row ``i`` (previously refused, losing all its parallelism).
-        # ``ndrange()`` yields plain ints as well as sympy exprs; ``sympify`` gives both a
-        # uniform ``.free_symbols`` (an int has none) without a ``getattr`` guard.
+        # SOUNDNESS: valid only while every symbol here holds one value for the whole loop.
+        # ``itersym`` is exempt (reparameterized per access); a body-varying symbol is not --
+        # ``a[i-1, j-1]`` vs ``a[i, j]`` looks constant per dimension yet overlaps as ``j`` sweeps.
         rw_syms = {s.name for s in sp.sympify(rb).free_symbols} | {s.name for s in sp.sympify(wb).free_symbols}
         if rw_syms & varying:
             continue
@@ -315,18 +235,8 @@ def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, iters
 
 
 def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, itersym) -> bool:
-    """ True iff some point dimension indexes both ``read`` and ``write`` by the SAME injective
-        affine function of the iteration variable (see :func:`_same_injective_index`).
-
-        Then a read/write collision on that dimension forces the reading and writing iterations to
-        coincide, so the read and write touch the same element only WITHIN one iteration (where the
-        map body preserves program order) and never across iterations. This is the read/write analog
-        of the injective-index rule in :func:`_writes_may_overlap`: it recognizes that iteration
-        ``i`` reads and writes only its own slab (e.g. syrk's ``C[i, :i+1]`` row), so lifting the
-        loop to a DOALL map is safe even though the read and write overlap in-iteration.
-
-        Only ONE such dimension is required: if a collision on dimension ``d`` already forces
-        ``p == q``, no pair of distinct iterations can address the same multidimensional element.
+    """True iff some point dimension indexes read and write by the same injective function of
+    ``itersym``, so any overlap happens within one iteration, where program order holds.
     """
     rnd = list(read.ndrange())
     wnd = list(write.ndrange())
@@ -341,28 +251,13 @@ def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, iter
 
 
 def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset, itersym, varying: Set[str]) -> bool:
-    """ Prove that two point subsets ``sub1``, ``sub2`` of the same container can only address
-        the same element when their loop iterations coincide.
+    """Prove two point subsets of one container collide only when their iterations coincide.
 
-        Substitute the iteration variable by a fresh symbol ``p`` in ``sub1`` and ``q`` in ``sub2``
-        and build the collision system ``{sub1[d]|i=p == sub2[d]|i=q  for every dim d}`` (all other
-        symbols are free parameters). If this affine system linearly implies ``p == q`` -- i.e. a
-        rational combination ``sum_d lam_d * (sub1[d]|p - sub2[d]|q)`` equals ``p - q`` identically
-        -- then a cross-iteration collision is impossible: any overlap between the two accesses
-        happens only within a single iteration, where program order in the map body is preserved.
-
-        Whenever such a certificate exists, ``sub1@p == sub2@q`` forces ``p == q``, so the equality
-        holds on the whole (affine) solution set and the proof is sound for every parameter value.
-        Conservative: returns ``False`` on any non-point subset, any non-affine index, or when no
-        certificate is found, so the caller keeps its safe ``may-alias`` answer.
-
-        This handles transpose/permutation-symmetric accesses such as covariance's ``cov[i,j]`` and
-        ``cov[j,i]``, where the iteration variable lands in *different* dimensions of the two
-        accesses so no single dimension is provably disjoint, yet a collision forces ``i == j`` (the
-        diagonal of one iteration). Used for write/write pairs (:func:`_writes_may_overlap`) and for
-        read/write pairs (:meth:`LoopToMap.test_read_memlet`).
-
-        ``varying`` is :func:`loop_varying_symbols` for the loop being lifted.
+        Substitute ``itersym`` by ``p`` in ``sub1`` and ``q`` in ``sub2`` and look for rationals
+        ``lam_d`` with ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` identically. Such a
+        certificate holds for every parameter value, so it is sound; without one the caller keeps
+        its may-alias answer. Catches transposed accesses (``cov[i,j]`` vs ``cov[j,i]``), where
+        the iteration variable lands in different dimensions.
     """
     nd1 = list(sub1.ndrange())
     nd2 = list(sub2.ndrange())
@@ -376,13 +271,9 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
             return False
         x1 = symbolic.pystr_to_symbolic(b1)
         x2 = symbolic.pystr_to_symbolic(b2)
-        # SOUNDNESS: every symbol but ``itersym`` becomes ONE parameter shared by both accesses,
-        # which describes the loop only while that symbol holds a single value for the loop's whole
-        # execution. A symbol that varies INSIDE the body (an inner loop/map iterator, an interstate
-        # assignment) takes independent values in the two iterations, and sharing it manufactures a
-        # bogus certificate: read ``aa[j,i]`` vs write ``aa[i,j]`` seen from the ``i`` loop "proves"
-        # p == q, yet p really reads ``aa[j_p, p]`` and q writes ``aa[q, j_q]``, which alias for
-        # p != q -- TSVC s114's OUTER transpose anti-dependence, a genuine carried dependence.
+        # SOUNDNESS: sharing a symbol between the two accesses is only valid while it holds one
+        # value for the whole loop. A body-varying one takes independent values per iteration, and
+        # sharing it certifies ``p == q`` for accesses that really do alias across iterations.
         if any(str(s) in varying for s in x1.free_symbols) or any(str(s) in varying for s in x2.free_symbols):
             return False
         eqs.append(sp.expand(x1.subs(itersym, p) - x2.subs(itersym, q)))
@@ -410,19 +301,10 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
 
 
 def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, start, varying: Set[str]) -> bool:
-    """ Conservatively decide whether two write memlets to the same container
-        can address the same element on different loop iterations. Returns
-        ``False`` only if some subset dimension is provably disjoint (the
-        multidimensional element can then never coincide), or if a collision
-        provably forces the two iterations to coincide (see
-        :func:`_collision_forces_same_iteration`).
+    """Whether two writes to the same container may hit one element from different iterations.
 
-        ``step``/``start`` describe the loop's strided iteration domain and are
-        threaded into the per-dimension disjointness test, so a step-4 unrolled
-        body's writes ``a[i], a[i+1], a[i+2], a[i+3]`` (all distinct modulo 4)
-        are recognised as disjoint.
-
-        ``varying`` is :func:`loop_varying_symbols` for the loop being lifted.
+        Per dimension first (same injective index, or provably disjoint), then the whole-subset
+        collision system. ``varying`` is :func:`loop_varying_symbols`.
     """
     nd1 = list(m1.subset.ndrange())
     nd2 = list(m2.subset.ndrange())
@@ -517,21 +399,14 @@ class LoopToMap(xf.MultiStateTransformation):
             if [n for n in loop_state.data_nodes() if isinstance(n.desc(sdfg), dt.StructureView)]:
                 return refuse(f"loop body contains a StructureView in state {loop_state}")
 
-        # A loop that provably runs at most once carries no cross-iteration dependence, so it is
-        # trivially DOALL -- accept here, skipping the dependence analysis below (which a clamped
-        # ``Max``/``Min`` bound would otherwise confound). This maps the single-iteration middle
-        # segment a range split leaves behind (e.g. the ``{x}`` clamp of the s1113 broadcast split),
-        # where the dependence analysis has nothing to prove. The structural guards above still gate.
+        # At most one iteration carries no cross-iteration dependence: trivially DOALL, and the
+        # analysis below would only be confounded by the clamped ``Min``/``Max`` bound.
         if loop_analysis.loop_provably_at_most_one_iteration(self.loop):
             return True
 
-        # Collect symbol reads and writes from inter-state assignments. The read-before-assigned
-        # analysis needs the loop's blocks in topological order, but that (dominator-heavy) sort is
-        # only meaningful when the loop body actually has inter-state assignments. A loop whose
-        # interstate edges carry none -- the common single-statement post-MapToForLoop case, ~all of
-        # a stencil's probes -- has nothing to check, so skip the sort and leave
-        # ``symbols_that_may_be_used`` at its initial ``{itervar}`` (identical to what the loop below
-        # would produce with no assignments).
+        # Symbol reads and writes from interstate assignments. The dominator-heavy topological
+        # sort below only means anything when there are assignments, so skip it when there are none
+        # (most loops) -- the result is identical.
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
         if any(e.data.assignments for block in self.loop.all_control_flow_blocks()
@@ -539,13 +414,10 @@ class LoopToMap(xf.MultiStateTransformation):
             in_order_loop_blocks = list(
                 cfg_analysis.blockorder_topological_sort(self.loop, recursive=True, ignore_nonstate_blocks=False))
             for block in in_order_loop_blocks:
-                # ``blockorder_topological_sort`` emits a ConditionalBlock BEFORE the blocks nested in
-                # its branches, yet the conditional's own out-edges execute AFTER those branches. A
-                # symbol assigned on EVERY branch of an exhaustive conditional (one with an else arm)
-                # is therefore already defined once the conditional exits, so count it as assigned
-                # before this block's reads/out-edges are examined. Without this, a loop-local scalar
-                # set in both arms of an if/else and read afterwards is misreported as a loop-carried
-                # dependency, which refuses embarrassingly-parallel loops (the CloudSC nblks loop).
+                # The sort emits a ConditionalBlock before its branches, but its out-edges run
+                # after them. A symbol assigned on every branch of an exhaustive conditional is
+                # defined on exit, so count it assigned here -- otherwise a scalar set in both arms
+                # and read afterwards reads as loop-carried.
                 if isinstance(block, ConditionalBlock) and any(c is None for c, _ in block.branches):
                     per_branch = []
                     for _cond, body in block.branches:
@@ -580,14 +452,10 @@ class LoopToMap(xf.MultiStateTransformation):
                         except AttributeError:
                             fsyms = set()
                         if k in fsyms and k not in symbols_that_may_be_used:
-                            # Self-recurrent assignment (k = f(k), e.g. k = k + inc) whose ``k`` has
-                            # NOT been (re)assigned earlier this iteration is a loop-carried recurrence:
-                            # each iteration reads the previous value, so the loop cannot be
-                            # parallelized. Affine induction variables are substituted to a closed form
-                            # upstream, so a self-recurrence that survives to here is a genuine carried
-                            # dependency. If ``k`` was already assigned earlier in the iteration (e.g.
-                            # reset ``k = 0`` then ``k = k + 1``) it is a loop-local counter, not carried,
-                            # so it is handled by the read-before-assignment check below instead.
+                            # ``k = f(k)`` with no earlier assignment this iteration reads the
+                            # previous iteration's value: a carried recurrence. Affine induction
+                            # variables are already in closed form upstream, so what reaches here is
+                            # genuine; a counter reset first is caught by the read-before-assign check.
                             return refuse(f"self-recurrent carried symbol '{k}' (assignment {k} = {v})")
                         if k not in fsyms:
                             assigned_symbols.add(k)
@@ -626,15 +494,10 @@ class LoopToMap(xf.MultiStateTransformation):
                 # Take all writes that are not conflicted into consideration
                 if dn.data in write_set:
                     for e in state.in_edges(dn):
-                        # An EMPTY memlet is a happens-before edge, not a write: no data moves
-                        # along it, so it cannot carry a dependency from one iteration into the
-                        # next, and the intra-iteration order it encodes survives verbatim inside
-                        # the map body. It has no subset, so the ``a*i+b`` test below would read it
-                        # as an unindexed whole-array write and refuse a perfectly parallel loop --
-                        # which is what ``StateFusionExtended`` produces for an intra-iteration WAR
-                        # (TSVC ``s1251``: ``s = b[i]+c[i]; b[i] = a[i]+d[i]; a[i] = s*e[i]`` fuses
-                        # with ordering edges into ``a``/``d`` and stopped parallelizing).
-                        # ``_read_and_write_sets`` already skips empty memlets for the same reason.
+                        # An empty memlet is an ordering edge, not a write: it carries no data
+                        # across iterations, and the order it encodes survives inside the map body.
+                        # Having no subset, the ``a*i+b`` test below would read it as a whole-array
+                        # write. ``_read_and_write_sets`` skips them for the same reason.
                         if e.data is None or e.data.is_empty():
                             continue
                         if e.data.dynamic and e.data.wcr is None:
@@ -668,11 +531,9 @@ class LoopToMap(xf.MultiStateTransformation):
 
                         write_memlets[dn.data].append(e.data)
 
-        # Carried-read check: for every array also written, each in-loop READ subset must be
-        # loop-invariant (no itersym) or match the writes' ``a*i+b``. A read at a DIFFERENT iter
-        # offset (``a[i+1]`` while writing ``a[i]``) is a carried dependency that races (iter ``i``
-        # reads ``a[i+1]`` while ``i+1`` writes it). The same-iteration disjoint check below only
-        # catches within-ONE-iteration overlaps; cross-iteration carries slip through.
+        # Carried-read check: a read of a written array must be loop-invariant or match the
+        # writes' ``a*i+b``. ``a[i] = a[i+1]`` races; the disjointness checks below only see
+        # overlaps within one iteration.
         for state in loop_states:
             for dn in state.data_nodes():
                 data = dn.data
@@ -816,11 +677,9 @@ class LoopToMap(xf.MultiStateTransformation):
             # If pointers are involved, give up
             return False
         if not _check_range(src_subset, a, itersym, b, step):
-            # ``_check_range`` accepts only reads that MOVE with the iteration (some dim
-            # ``a*i+b``, ``|a| >= 1``). An itersym read not matching that is conservatively a
-            # conflict. A loop-INVARIANT read (no itersym) is a conflict only if it overlaps a
-            # write: ``a[0]`` is safe against writes to ``a[1:N]`` but not ``a[0:N]``. Defer both
-            # to the propagated-overlap check below.
+            # ``_check_range`` accepts only reads that move with the iteration. A loop-invariant
+            # read conflicts only if it overlaps a write (``a[0]`` vs ``a[1:N]`` does not), so defer
+            # both to the propagated-overlap check below.
             if itersym in src_subset.free_symbols:
                 return False
 
@@ -840,32 +699,20 @@ class LoopToMap(xf.MultiStateTransformation):
             write = candidate.dst_subset if candidate.dst_subset is not None else candidate.subset
             if read == write:
                 continue
-            # Step-aware per-dimension disjointness: if any dimension's read/write
-            # indices can never coincide for any pair of in-domain iterations
-            # (linear-Diophantine over the strided iteration counter), the accesses
-            # never alias -- no cross-iteration RAW. This is strictly more precise
-            # than the propagate+intersect fallback below, which drops constant
-            # disproving dims and ignores the loop stride.
+            # Step-aware per-dimension disjointness (Diophantine over the strided counter): no
+            # pair of iterations can collide, so no cross-iteration RAW. More precise than the
+            # propagate+intersect fallback, which drops constant dims and the stride.
             if _read_write_dims_disjoint(read, write, itersym, step, start, varying):
                 continue
-            # Same-iteration collision: if some point dimension indexes both the read and the write
-            # by the same injective function of the iter var (e.g. syrk's ``C[i, :i+1]`` -- row ``i``
-            # read and written by iteration ``i``), a collision forces the read and write iterations
-            # to coincide. The overlap is then confined to one iteration (program order in the map
-            # body preserves it) and is never a cross-iteration RAW. Mirrors the write/write
-            # injective-index rule in :func:`_writes_may_overlap`.
+            # Same-iteration collision: one dimension indexing read and write by the same
+            # injective function of the iter var (syrk's ``C[i, :i+1]``) confines any overlap to a
+            # single iteration, where the map body preserves program order.
             if _read_write_same_iteration(read, write, itersym):
                 continue
-            # Same-iteration collision across SEVERAL dimensions at once: the iteration variable can
-            # land in DIFFERENT dimensions of the read and the write (a transpose), so no single
-            # dimension is disjoint and none carries the same injective index, yet the whole-subset
-            # collision system still certifies that any alias forces the reading and the writing
-            # iteration to coincide. Such a dependence has distance 0 in THIS loop's dimension, i.e.
-            # it is loop-INDEPENDENT: it lives inside one iteration, whose body ``apply`` transplants
-            # verbatim into the map, so it never becomes a cross-iteration dependency and does not
-            # block a DOALL lift. TSVC s114's inner loop ``aa[i,j] = aa[j,i] + bb[i,j]`` (for a fixed
-            # ``i``, read and write alias only at ``j == i``) is exactly this case; the ``varying``
-            # guard inside the certificate is what keeps its OUTER ``i`` loop sequential.
+            # Same across several dimensions at once: a transpose puts the iter var in different
+            # dimensions of read and write, so no single dimension settles it, yet the collision
+            # system still forces the two iterations to coincide -- a distance-0, loop-independent
+            # dependence that ``apply`` transplants into the map body unchanged.
             if _collision_forces_same_iteration(read, write, itersym, varying):
                 continue
             ridx = _dependent_indices(itervar, read)
@@ -962,11 +809,9 @@ class LoopToMap(xf.MultiStateTransformation):
                         if e.data.data and e.data.data in sdfg.arrays:
                             write_set.add(e.data.data)
 
-        # Add headers of any nested loops and conditional blocks, at EVERY depth: a walk that
-        # recurses only into LoopRegion / ConditionalBlock stops at a ConditionalBlock's branch,
-        # which is a plain ControlFlowRegion. A container a header below that point reads then
-        # never enters the read set, so it stays a free symbol of the body instead of becoming a
-        # connector -- and the parent's interstate edge is left referencing an undefined symbol.
+        # Headers of nested loops and conditionals, at EVERY depth: recursing only into
+        # LoopRegion / ConditionalBlock stops at a branch, which is a plain ControlFlowRegion, and
+        # a container read below that point never becomes a connector -- it stays a free symbol.
         for block in self.loop.all_control_flow_blocks():
             if isinstance(block, (LoopRegion, ConditionalBlock)):
                 free_syms = {s for c in block.get_meta_codeblocks() for s in c.get_free_symbols()}

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -17,6 +17,7 @@ from dace.sdfg.state import BreakBlock, ContinueBlock, ControlFlowRegion, LoopRe
 import dace.transformation.helpers as helpers
 from dace.transformation import transformation as xf
 from dace.transformation.passes.analysis import loop_analysis
+from ordered_set import OrderedSet
 
 
 def _check_range(subset, a, itersym, b, step):
@@ -40,10 +41,8 @@ def _check_range(subset, a, itersym, b, step):
 
 
 def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
-    """Whether every write to ``conn``'s array inside ``nsdfg_node`` is indexed by the mapped
-    iteration variable. The external connector memlet is the union over the loop and hides the
-    per-iteration write, so rewrite the inner subsets through ``symbol_mapping`` and check each
-    against ``a*i+b``. Needs at least one inner write; nested NestedSDFGs recurse.
+    """Whether every write to ``conn`` inside ``nsdfg_node`` is ``a*i+b``-indexed. The connector
+    memlet is the union over the loop, so look at the inner subsets through ``symbol_mapping``.
     """
     repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
     found = False
@@ -71,8 +70,8 @@ def _nested_writes_iter_indexed(nsdfg_node, conn, itersym, a, b, step) -> bool:
 
 
 def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
-    """Whether every read of ``conn``'s array inside ``nsdfg_node`` matches the writes' ``a*i+b`` or
-    is loop-invariant. Write uniqueness alone is not enough: ``a[i] = ... a[i+1]`` still races.
+    """Whether every read of ``conn`` inside ``nsdfg_node`` matches the writes' ``a*i+b`` or is
+    loop-invariant; write uniqueness alone lets ``a[i] = a[i+1]`` race.
     """
     repl = {symbolic.symbol(k): symbolic.pystr_to_symbolic(str(v)) for k, v in nsdfg_node.symbol_mapping.items()}
     for state in nsdfg_node.sdfg.all_states():
@@ -93,7 +92,7 @@ def _nested_reads_match_writes(nsdfg_node, conn, itersym, a, b, step) -> bool:
                 outer = copy.deepcopy(src_subset)
                 outer.replace(repl)
                 # Loop-invariant read (no itersym) -- safe, same value every iteration.
-                free = set()
+                free = OrderedSet()
                 for rb, re, _ in outer.ndrange():
                     for expr in (rb, re):
                         if hasattr(expr, 'free_symbols'):
@@ -126,9 +125,8 @@ def _sanitize_by_index(indices: Set[int], subset: subsets.Subset) -> subsets.Ran
 def _affine_coeffs(expr, itersym):
     """Return ``(a, b)`` with ``expr == a*itersym + b``, or ``None`` if not affine in ``itersym``.
 
-        Derived, not searched: the derivative is ``a`` (and still mentions ``itersym`` above degree
-        one, which is the degree test), the value at zero is ``b``. ``expand`` + ``coeff`` is
-        superlinear and hung ``can_be_applied`` on deeply tiled index expressions.
+        The derivative is ``a`` (still mentioning ``itersym`` above degree one, which is the
+        degree test) and the value at zero is ``b``; ``expand`` + ``coeff`` hung on tiled indices.
     """
     e = symbolic.pystr_to_symbolic(expr)
     if not e.is_polynomial(itersym):
@@ -151,11 +149,8 @@ def _same_injective_index(idx1, idx2, itersym) -> bool:
 def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
     """True iff ``idx1`` at any iteration can never equal ``idx2`` at any iteration.
 
-        Linear-Diophantine criterion over the iteration counter ``t`` (``i == start + step*t``):
-        with ``A_k = a_k*step`` and ``B_k = a_k*start + b_k``, ``A1*t1 + B1 == A2*t2 + B2`` is
-        solvable iff ``gcd(A1, A2)`` divides ``B2 - B1``. Ranging over all integers ``t`` is
-        conservative w.r.t. the bounded domain, hence sound. ``step``/``start`` default to the
-        identity reparameterization.
+        Over the counter ``t`` (``i == start + step*t``), ``A1*t1 + B1 == A2*t2 + B2`` is solvable
+        iff ``gcd(A1, A2)`` divides ``B2 - B1``. All-integer ``t`` is conservative, hence sound.
     """
     f1 = _affine_coeffs(idx1, itersym)
     f2 = _affine_coeffs(idx2, itersym)
@@ -190,12 +185,11 @@ def _dim_provably_disjoint(idx1, idx2, itersym, step=1, start=0) -> bool:
     return sp.Integer(diff) % g != 0
 
 
-def loop_varying_symbols(loop: LoopRegion) -> Set[str]:
-    """Symbols that can change while ``loop`` runs, other than its own iterator: nested loop and map
-    iterators, and everything its interstate edges assign. Every other symbol a body subset
-    mentions holds one value for the whole execution, which is what the disjointness tests need.
+def loop_varying_symbols(loop: LoopRegion) -> OrderedSet[str]:
+    """Symbols that can change while ``loop`` runs: nested loop and map iterators, and what its
+    interstate edges assign. Every other symbol holds one value, which the tests below rely on.
     """
-    varying: Set[str] = set()
+    varying: OrderedSet[str] = OrderedSet()
     for cfr in loop.all_control_flow_regions(recursive=True):
         if isinstance(cfr, LoopRegion) and cfr is not loop and cfr.loop_variable:
             varying.add(cfr.loop_variable)
@@ -209,12 +203,10 @@ def loop_varying_symbols(loop: LoopRegion) -> Set[str]:
 
 
 def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, itersym, step, start,
-                              varying: Set[str]) -> bool:
+                              varying: OrderedSet[str]) -> bool:
     """True iff some dimension's read/write point-indices are provably disjoint across every pair of
-    in-domain iterations (step-aware, see :func:`_dim_provably_disjoint`).
-
-        Unlike the propagate+intersect fallback this keeps constant disproving dimensions
-        (``aa[0, i]`` vs ``aa[1, i-1]``). ``varying`` is :func:`loop_varying_symbols`.
+    in-domain iterations. Unlike propagate+intersect this keeps constant disproving dimensions
+        (``aa[0, i]`` vs ``aa[1, i-1]``).
     """
     rnd = list(read.ndrange())
     wnd = list(write.ndrange())
@@ -223,8 +215,7 @@ def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, iters
     for (rb, re_, _), (wb, we_, _) in zip(rnd, wnd):
         if rb != re_ or wb != we_:  # non-point dimension: cannot decide here
             continue
-        # SOUNDNESS: only ``itersym`` may vary here (it is reparameterized per access). A
-        # body-varying symbol looks constant per dimension yet aliases as it sweeps.
+        # SOUNDNESS: a body-varying symbol looks constant per dimension yet aliases as it sweeps.
         rw_syms = {s.name
                    for s in symbolic.pystr_to_symbolic(rb).free_symbols
                    } | {s.name
@@ -237,8 +228,8 @@ def _read_write_dims_disjoint(read: subsets.Subset, write: subsets.Subset, iters
 
 
 def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, itersym) -> bool:
-    """True iff some point dimension indexes read and write by the same injective function of
-    ``itersym``, so any overlap happens within one iteration, where program order holds.
+    """True iff a point dimension indexes read and write by the same injective function of
+    ``itersym``: any overlap is then within one iteration, where program order holds.
     """
     rnd = list(read.ndrange())
     wnd = list(write.ndrange())
@@ -252,14 +243,13 @@ def _read_write_same_iteration(read: subsets.Subset, write: subsets.Subset, iter
     return False
 
 
-def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset, itersym, varying: Set[str]) -> bool:
+def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset, itersym,
+                                     varying: OrderedSet[str]) -> bool:
     """Prove two point subsets of one container collide only when their iterations coincide.
 
-        Substitute ``itersym`` by ``p`` in ``sub1`` and ``q`` in ``sub2`` and look for rationals
-        ``lam_d`` with ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` identically. Such a
-        certificate holds for every parameter value, so it is sound; without one the caller keeps
-        its may-alias answer. Catches transposed accesses (``cov[i,j]`` vs ``cov[j,i]``), where
-        the iteration variable lands in different dimensions.
+        With ``itersym`` replaced by ``p`` in ``sub1`` and ``q`` in ``sub2``, rationals ``lam_d``
+        with ``sum_d lam_d * (sub1[d]|p - sub2[d]|q) == p - q`` certify it for every parameter
+        value. Catches transposes (``cov[i,j]`` vs ``cov[j,i]``); without one, may-alias stands.
     """
     nd1 = list(sub1.ndrange())
     nd2 = list(sub2.ndrange())
@@ -267,29 +257,26 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
         return False
     p, q = sp.Dummy('p'), sp.Dummy('q')
     eqs = []
-    params: Set[str] = set()
+    params: OrderedSet[sp.Symbol] = OrderedSet()
     for (b1, e1, _), (b2, e2, _) in zip(nd1, nd2):
         if b1 != e1 or b2 != e2:  # only point subsets participate in the collision system
             return False
         x1 = symbolic.pystr_to_symbolic(b1)
         x2 = symbolic.pystr_to_symbolic(b2)
-        # SOUNDNESS: a symbol shared by both accesses must hold one value for the whole loop;
-        # a body-varying one would certify ``p == q`` for accesses that really do alias.
+        # SOUNDNESS: sharing a body-varying symbol certifies ``p == q`` for aliasing accesses.
         if any(str(s) in varying for s in x1.free_symbols) or any(str(s) in varying for s in x2.free_symbols):
             return False
         eqs.append(sp.expand(x1.subs(itersym, p) - x2.subs(itersym, q)))
         params |= {s for s in (set(x1.free_symbols) | set(x2.free_symbols)) if str(s) != str(itersym)}
-    monomials = [p, q] + sorted(params, key=str)
-    # Require every equation affine (total degree <= 1) in {p, q, params}; bail conservatively
-    # on anything non-linear (e.g. ``A[i*i]``) where a linear certificate would be unsound.
+    monomials = [p, q] + list(params)
+    # Every equation must be affine in {p, q, params}: on ``A[i*i]`` a linear certificate lies.
     for eq in eqs:
         try:
             if sp.Poly(eq, *monomials).total_degree() > 1:
                 return False
         except sp.PolynomialError:
             return False
-    # Rationals ``lam_d`` with ``sum_d lam_d * eq_d == p - q`` as a polynomial identity: matching
-    # monomial coefficients gives a linear system whose solution certifies a collision forces p == q.
+    # Matching monomial coefficients of ``sum_d lam_d * eq_d == p - q`` gives a linear system.
     lambdas = list(sp.symbols(f'_l2m_lam0:{len(eqs)}'))
     diff = sp.expand(sum(l * e for l, e in zip(lambdas, eqs)) - (p - q))
     lin_eqs = [diff.coeff(mono) for mono in monomials]
@@ -300,11 +287,11 @@ def _collision_forces_same_iteration(sub1: subsets.Subset, sub2: subsets.Subset,
     return len(sp.linsolve(lin_eqs, lambdas)) > 0
 
 
-def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, start, varying: Set[str]) -> bool:
+def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, start, varying: OrderedSet[str]) -> bool:
     """Whether two writes to the same container may hit one element from different iterations.
 
-        Per dimension first (same injective index, or provably disjoint), then the whole-subset
-        collision system. ``varying`` is :func:`loop_varying_symbols`.
+        Per dimension first (same injective index, or provably disjoint), then the collision
+        system.
     """
     nd1 = list(m1.subset.ndrange())
     nd2 = list(m2.subset.ndrange())
@@ -313,14 +300,13 @@ def _writes_may_overlap(m1: memlet.Memlet, m2: memlet.Memlet, itersym, step, sta
     for (b1, e1, _), (b2, e2, _) in zip(nd1, nd2):
         if b1 != e1 or b2 != e2:  # non-point range dimension: cannot decide here
             continue
-        # Same injective index in both writes: a collision forces the iterations equal, so the
-        # overlap stays inside one iteration, where the map body keeps program order.
+        # Same injective index: a collision forces the iterations equal, so the overlap is
+        # inside one iteration, where the map body keeps program order.
         if _same_injective_index(b1, b2, itersym):
             return False
         if _dim_provably_disjoint(b1, b2, itersym, step, start):
             return False
-    # No dimension settled it: the iter var may sit in different dimensions of the two writes
-    # (a transpose), so try the whole-subset collision system.
+    # A transpose puts the iter var in different dimensions, so try the whole subset.
     if _collision_forces_same_iteration(m1.subset, m2.subset, itersym, varying):
         return False
     return True
@@ -369,15 +355,15 @@ class LoopToMap(xf.MultiStateTransformation):
             if symbolic.contains_sympy_functions(expr):
                 return False
 
-        # A range symbol the body assigns moves into the loop_body NSDFG while the Map's range
-        # stays outside it: ``Missing symbols on nested SDFG`` downstream.
-        range_syms: Set[str] = set()
+        # A range symbol the body assigns moves into the loop_body NSDFG, the range does not:
+        # ``Missing symbols on nested SDFG`` downstream.
+        range_syms: OrderedSet[str] = OrderedSet()
         for expr in (start, end, step):
             try:
                 range_syms |= {str(s) for s in expr.free_symbols}
             except AttributeError:
                 pass
-        body_assigned_syms: Set[str] = set()
+        body_assigned_syms: OrderedSet[str] = OrderedSet()
         for e in self.loop.all_interstate_edges():
             body_assigned_syms.update(e.data.assignments.keys())
         if range_syms & body_assigned_syms:
@@ -391,13 +377,12 @@ class LoopToMap(xf.MultiStateTransformation):
             if [n for n in loop_state.data_nodes() if isinstance(n.desc(sdfg), dt.StructureView)]:
                 return False
 
-        # At most one iteration carries no cross-iteration dependence: trivially DOALL, and the
-        # analysis below would only be confounded by the clamped ``Min``/``Max`` bound.
+        # At most one iteration cannot carry a dependence, and a clamped bound only confuses
+        # the analysis below.
         if loop_analysis.loop_provably_at_most_one_iteration(self.loop):
             return True
 
-        # The dominator-heavy sort below only means anything when the body has interstate
-        # assignments; with none (most loops) the result is identical, so skip it.
+        # The dominator-heavy sort below is a no-op without interstate assignments.
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
         if any(e.data.assignments for block in self.loop.all_control_flow_blocks()
@@ -405,12 +390,12 @@ class LoopToMap(xf.MultiStateTransformation):
             in_order_loop_blocks = list(
                 cfg_analysis.blockorder_topological_sort(self.loop, recursive=True, ignore_nonstate_blocks=False))
             for block in in_order_loop_blocks:
-                # The sort emits a ConditionalBlock before its branches though its out-edges run
-                # after them, so count what every branch of an exhaustive one assigns as defined.
+                # The sort emits a ConditionalBlock before its branches though its out-edges
+                # run after them: what every branch of an exhaustive one assigns is defined.
                 if isinstance(block, ConditionalBlock) and any(c is None for c, _ in block.branches):
                     per_branch = []
                     for _cond, body in block.branches:
-                        assigned_in_branch = set()
+                        assigned_in_branch = OrderedSet()
                         for inner in body.all_control_flow_blocks():
                             for ie in inner.parent_graph.out_edges(inner):
                                 assigned_in_branch |= set(ie.data.assignments.keys())
@@ -418,12 +403,12 @@ class LoopToMap(xf.MultiStateTransformation):
                     if per_branch:
                         symbols_that_may_be_used |= set.intersection(*per_branch)
 
-                # ``read_symbols()`` below sees only interstate-edge reads, but a symbol read in
-                # the block's own dataflow (``b[im]``) is read before the block's out-edges assign.
+                # ``read_symbols()`` below misses reads in the block's own dataflow (``b[im]``),
+                # which happen before its out-edges assign.
                 try:
                     block_reads = {str(s) for s in block.free_symbols}
                 except Exception:
-                    block_reads = set()
+                    block_reads = OrderedSet()
                 used_before_assignment |= (block_reads - symbols_that_may_be_used)
                 for e in block.parent_graph.out_edges(block):
                     # Collect read-before-assigned symbols (states are in order; see
@@ -432,15 +417,14 @@ class LoopToMap(xf.MultiStateTransformation):
                     read_symbols -= symbols_that_may_be_used
                     used_before_assignment |= read_symbols
                     # If symbol was read before it is assigned, the loop cannot be parallel
-                    assigned_symbols = set()
+                    assigned_symbols = OrderedSet()
                     for k, v in e.data.assignments.items():
                         try:
                             fsyms = {str(s) for s in symbolic.pystr_to_symbolic(v).free_symbols}
                         except AttributeError:
                             fsyms = set()
                         if k in fsyms and k not in symbols_that_may_be_used:
-                            # ``k = f(k)`` unassigned earlier this iteration reads the previous
-                            # one's value. Affine induction variables are in closed form upstream.
+                            # ``k = f(k)`` not assigned earlier reads the previous iteration.
                             return False
                         if k not in fsyms:
                             assigned_symbols.add(k)
@@ -459,8 +443,8 @@ class LoopToMap(xf.MultiStateTransformation):
         for state in loop_states:
             other_access_nodes |= set(n.data for n in state.data_nodes() if not sdfg.arrays[n.data].transient)
 
-        # ``read_and_write_sets()`` walks every state and edge and is only needed below, so a
-        # loop refused by the cheaper checks above never pays for it (channel_flow: 41k of 44k).
+        # Lazy: ``read_and_write_sets()`` walks every state and edge, and the cheap refusals
+        # above take 41k of channel_flow's 44k probes.
         _, write_set = self.loop.read_and_write_sets()
 
         write_memlets: Dict[str, List[memlet.Memlet]] = defaultdict(list)
@@ -476,13 +460,13 @@ class LoopToMap(xf.MultiStateTransformation):
                 # Take all writes that are not conflicted into consideration
                 if dn.data in write_set:
                     for e in state.in_edges(dn):
-                        # An empty memlet is an ordering edge, not a write, and its missing
-                        # subset would read below as an unindexed whole-array write.
+                        # An empty memlet is an ordering edge; its missing subset would read
+                        # below as an unindexed whole-array write.
                         if e.data is None or e.data.is_empty():
                             continue
                         if e.data.dynamic and e.data.wcr is None:
-                            # A dynamic write whose subset pins an axis to the iter var gives
-                            # each iteration a disjoint slab, so a lane firing cannot race.
+                            # An axis pinned to the iter var gives each iteration its own
+                            # slab, so a lane firing cannot race.
                             dst_subset = e.data.get_dst_subset(e, state)
                             if not (dst_subset and _check_range(dst_subset, a, itersym, b, step)):
                                 return False
@@ -496,8 +480,7 @@ class LoopToMap(xf.MultiStateTransformation):
                             # inner per-iteration write; look past the connector.
                             if not ok and isinstance(e.src, nodes.NestedSDFG):
                                 ok = _nested_writes_iter_indexed(e.src, e.src_conn, itersym, a, b, step)
-                                # Write uniqueness is not enough: an inner read at another iter
-                                # position (``a[i+1]`` while writing ``a[i]``) still races.
+                                # An inner read at another iter position still races.
                                 if ok and not _nested_reads_match_writes(e.src, e.src_conn, itersym, a, b, step):
                                     ok = False
                             if not ok and not permissive:
@@ -505,8 +488,8 @@ class LoopToMap(xf.MultiStateTransformation):
 
                         write_memlets[dn.data].append(e.data)
 
-        # A read of a written array must be loop-invariant or match the writes' ``a*i+b``:
-        # ``a[i] = a[i+1]`` races, and the checks below only see overlaps within one iteration.
+        # A read of a written array must be loop-invariant or match the writes' ``a*i+b``;
+        # the checks below only see overlaps within one iteration.
         for state in loop_states:
             for dn in state.data_nodes():
                 data = dn.data
@@ -519,7 +502,7 @@ class LoopToMap(xf.MultiStateTransformation):
                     if src_subset is None:
                         continue
                     # Loop-invariant read (no itersym) -- safe, same input every iteration.
-                    free = set()
+                    free = OrderedSet()
                     for rb, re_, _ in src_subset.ndrange():
                         for expr in (rb, re_):
                             if hasattr(expr, 'free_symbols'):
@@ -534,8 +517,7 @@ class LoopToMap(xf.MultiStateTransformation):
         # Fixed for the whole loop, so compute once and share with every dependence test below.
         varying = loop_varying_symbols(self.loop)
 
-        # Two individually injective writes still collide across iterations (``A[5*i]`` and
-        # ``A[3*i]`` at ``A[15]``); allow only when some dimension is provably disjoint.
+        # Two injective writes still collide across iterations (``A[5*i]``, ``A[3*i]`` at 15).
         for data, mmlts in write_memlets.items():
             distinct: Dict[str, memlet.Memlet] = {}
             for m in mmlts:
@@ -555,7 +537,7 @@ class LoopToMap(xf.MultiStateTransformation):
                 data = dn.data
                 if data in write_memlets:
                     for e in state.out_edges(dn):
-                        # As in the write scan: an empty memlet is an ordering edge, not a read.
+                        # As above: an empty memlet is an ordering edge, not a read.
                         if e.data is None or e.data.is_empty():
                             continue
 
@@ -639,8 +621,7 @@ class LoopToMap(xf.MultiStateTransformation):
             # If pointers are involved, give up
             return False
         if not _check_range(src_subset, a, itersym, b, step):
-            # A loop-invariant read conflicts only if it overlaps a write (``a[0]`` vs ``a[1:N]``
-            # does not), so defer to the propagated-overlap check below.
+            # A loop-invariant read conflicts only if it overlaps a write; defer to below.
             if itersym in src_subset.free_symbols:
                 return False
 
@@ -653,21 +634,17 @@ class LoopToMap(xf.MultiStateTransformation):
         for candidate in write_memlets[data]:
             # Simple case: read and write are in the same subset
             read = src_subset
-            # A one-sided copy memlet (``a[0:N] -> a``) leaves ``dst_subset`` None and carries
-            # its subset in ``.subset``.
+            # A one-sided copy memlet (``a[0:N] -> a``) carries its subset in ``.subset``.
             write = candidate.dst_subset if candidate.dst_subset is not None else candidate.subset
             if read == write:
                 continue
-            # Step-aware per-dimension disjointness: no pair of iterations collides, so no
-            # cross-iteration RAW. The fallback below drops constant dims and the stride.
+            # Step-aware disjointness; the fallback below drops constant dims and the stride.
             if _read_write_dims_disjoint(read, write, itersym, step, start, varying):
                 continue
-            # One dimension indexing read and write by the same injective function of the iter
-            # var (syrk's ``C[i, :i+1]``) confines the overlap to a single iteration.
+            # Same injective index (syrk's ``C[i, :i+1]``) confines it to one iteration.
             if _read_write_same_iteration(read, write, itersym):
                 continue
-            # A transpose puts the iter var in different dimensions of read and write: no single
-            # dimension settles it, but a distance-0 dependence still lives inside one iteration.
+            # A transpose settles no single dimension, yet the dependence is distance-0.
             if _collision_forces_same_iteration(read, write, itersym, varying):
                 continue
             ridx = _dependent_indices(itervar, read)
@@ -762,8 +739,8 @@ class LoopToMap(xf.MultiStateTransformation):
                         if e.data.data and e.data.data in sdfg.arrays:
                             write_set.add(e.data.data)
 
-        # Headers at EVERY depth: recursing only into LoopRegion / ConditionalBlock stops at a
-        # branch, and a container read below that never becomes a connector.
+        # Headers at EVERY depth: stopping at a branch leaves the containers it reads below
+        # without a connector.
         for block in self.loop.all_control_flow_blocks():
             if isinstance(block, (LoopRegion, ConditionalBlock)):
                 free_syms = {s for c in block.get_meta_codeblocks() for s in c.get_free_symbols()}
@@ -852,7 +829,7 @@ class LoopToMap(xf.MultiStateTransformation):
                 if s not in cnode.symbol_mapping:
                     cnode.symbol_mapping[s] = symbolic.pystr_to_symbolic(s)
                     # A mapping entry the mapped SDFG never declared (other passes write mapping
-                    # entries without one) is not a reason to refuse: type it off the symbol.
+                    # entries without one): type it off the symbol instead of refusing.
                     nsdfg.symbols[s] = sdfg.symbols.get(s, symbolic.symbol(s).dtype)
         for name in read_set:
             r = body.add_read(name)
@@ -868,8 +845,8 @@ class LoopToMap(xf.MultiStateTransformation):
         for sym, dtype in nsymbols.items():
             nsdfg.symbols[sym] = dtype
 
-        # Symbols the nested SDFG assigns itself are internal: mapping them makes the outer SDFG
-        # appear to need them, and a later pruning pass then desyncs the mapping.
+        # Mapping a symbol the nested SDFG assigns itself makes the outer one appear to need
+        # it, and a later pruning pass then desyncs the mapping.
         internally_defined = set()
         for e in nsdfg.all_interstate_edges():
             internally_defined.update(e.data.assignments.keys())
@@ -983,7 +960,7 @@ class LoopToMap(xf.MultiStateTransformation):
             graph.add_state_before(body, "map_views", assignments=view_assignments)
 
         # Direct edges among source and sink access nodes must pass through a tasklet; gather
-        # them first. A list, not a set: ``MultiConnectorEdge`` hashes by id(), so set order varies.
+        # them in a list, since ``MultiConnectorEdge`` hashes by id().
         direct_edges: List[gr.MultiConnectorEdge[memlet.Memlet]] = []
         for n1 in source_nodes:
             if not isinstance(n1, nodes.AccessNode):

--- a/dace/transformation/passes/analysis/loop_analysis.py
+++ b/dace/transformation/passes/analysis/loop_analysis.py
@@ -97,3 +97,41 @@ def get_loop_stride(loop: LoopRegion) -> Optional[symbolic.SymbolicType]:
     if update_assignment:
         return update_assignment - symbolic.pystr_to_symbolic(loop.loop_variable)
     return None
+
+
+def _provably_le(a: symbolic.SymbolicType, b: symbolic.SymbolicType) -> bool:
+    """Prove ``a <= b`` SOUNDLY, returning ``False`` when it cannot be decided (never a guess).
+
+    Beyond a concrete numeric verdict and sympy's own non-positivity engine (which respects the
+    codebase's non-negative symbols), this proves the ``Min`` / ``Max`` clamp shape a range split
+    leaves behind: ``Min(..., t) <= t`` for any of its own args ``t``, ``t <= Max(..., t)``, and the
+    combined ``Min(..., t) <= t <= Max(..., t)`` sharing a term ``t``.
+    """
+    diff = symbolic.simplify(a - b)
+    if diff.is_number:
+        return bool(diff <= 0)
+    if diff.is_nonpositive:  # sympy assumption engine; None (undecided) is falsy -> not proven
+        return True
+    a_min = a.args if isinstance(a, sympy.Min) else ()
+    b_max = b.args if isinstance(b, sympy.Max) else ()
+    if b in a_min:  # a = Min(..., b, ...) <= b
+        return True
+    if a in b_max:  # a <= Max(..., a, ...) = b
+        return True
+    return bool(a_min and b_max and (set(a_min) & set(b_max)))  # a <= shared t <= b
+
+
+def loop_provably_at_most_one_iteration(loop: LoopRegion) -> bool:
+    """Whether ``loop`` provably runs at most once (zero or one iterations).
+
+    Such a loop carries no cross-iteration dependence by construction, so it is trivially DOALL --
+    a ``LoopToMap`` can map it without any dependence analysis. Restricted to the unit ascending
+    stride so the inclusive trip count is exactly ``end - start + 1``; the loop runs at most once iff
+    ``end <= start``. Conservative: returns ``False`` whenever the bound cannot be proven.
+    """
+    start = get_init_assignment(loop)
+    end = get_loop_end(loop)  # inclusive
+    step = get_loop_stride(loop)
+    if start is None or end is None or step is None or symbolic.simplify(step) != 1:
+        return False
+    return _provably_le(symbolic.simplify(end), symbolic.simplify(start))

--- a/tests/transformations/interstate/loop_to_map_test.py
+++ b/tests/transformations/interstate/loop_to_map_test.py
@@ -1126,6 +1126,92 @@ def test_mapped_symbol_the_child_does_not_declare():
     sdfg.compile()
 
 
+def test_read_and_write_confined_to_one_iteration():
+    """syrk shape: iteration ``i`` reads and writes row ``i``. The same injective index in both
+    subsets confines the overlap to a single iteration, where the map body keeps program order, so
+    the loop is DOALL. Without the same-iteration check the read-after-write refuses it."""
+
+    @dace.program
+    def syrk_like(C: dace.float64[20, 20], A: dace.float64[20]):
+        for i in range(20):
+            C[i, 0:i + 1] += A[i]
+
+    sdfg = syrk_like.to_sdfg(simplify=True)
+    assert sdfg.apply_transformations_repeated(LoopToMap, permissive=True) == 1
+
+    C = np.zeros((20, 20))
+    A = np.arange(20, dtype=np.float64)
+    ref = np.zeros((20, 20))
+    for i in range(20):
+        ref[i, 0:i + 1] += A[i]
+    sdfg(C=C, A=A)
+    assert np.allclose(C, ref)
+
+
+def test_strided_read_and_write_never_alias():
+    """Step-2 loop writing evens and reading odds: the linear-Diophantine test over the strided
+    iteration counter proves the two index sets never meet, so there is no carried RAW. The
+    propagate+intersect fallback ignores the stride and refuses this."""
+
+    @dace.program
+    def strided(A: dace.float64[40]):
+        for i in range(2, 40, 2):
+            A[i] = A[i - 1] * 2.0
+
+    sdfg = strided.to_sdfg(simplify=True)
+    assert sdfg.apply_transformations_repeated(LoopToMap, permissive=True) == 1
+
+    A = np.arange(40, dtype=np.float64)
+    ref = A.copy()
+    for i in range(2, 40, 2):
+        ref[i] = ref[i - 1] * 2.0
+    sdfg(A=A)
+    assert np.allclose(A, ref)
+
+
+def test_row_local_overlapping_columns():
+    """Read and write overlap column-wise but stay on the row the iteration owns. Propagating over
+    the loop makes the two sets overlap, so only the same-iteration check (identical injective index
+    in the row dimension) can accept this."""
+
+    @dace.program
+    def row_local(C: dace.float64[20, 20]):
+        for i in range(20):
+            C[i, 1:20] = C[i, 0:19] + 1.0
+
+    sdfg = row_local.to_sdfg(simplify=True)
+    assert sdfg.apply_transformations_repeated(LoopToMap, permissive=True) == 1
+
+    C = np.arange(400, dtype=np.float64).reshape(20, 20).copy()
+    ref = C.copy()
+    for i in range(20):
+        ref[i, 1:20] = ref[i, 0:19] + 1.0
+    sdfg(C=C)
+    assert np.allclose(C, ref)
+
+
+def test_transposed_read_and_write_alias_only_in_one_iteration():
+    """TSVC s114's inner shape: the iteration variable lands in a different dimension of the read
+    than of the write, so no single dimension settles it. The collision system still proves an alias
+    forces the two iterations to coincide (here only at ``j == 3``), which is loop-independent."""
+
+    @dace.program
+    def transposed(aa: dace.float64[20, 20], bb: dace.float64[20, 20]):
+        for j in range(20):
+            aa[3, j] = aa[j, 3] + bb[3, j]
+
+    sdfg = transposed.to_sdfg(simplify=True)
+    assert sdfg.apply_transformations_repeated(LoopToMap, permissive=True) == 1
+
+    aa = np.arange(400, dtype=np.float64).reshape(20, 20).copy()
+    bb = np.ones((20, 20))
+    ref = aa.copy()
+    for j in range(20):
+        ref[3, j] = ref[j, 3] + bb[3, j]
+    sdfg(aa=aa, bb=bb)
+    assert np.allclose(aa, ref)
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()

--- a/tests/transformations/interstate/loop_to_map_test.py
+++ b/tests/transformations/interstate/loop_to_map_test.py
@@ -452,7 +452,48 @@ def test_symbol_array_mix_2(parallel):
     body_start.add_edge(t, 'o', body_start.add_write('B'), None, dace.Memlet('B[i]'))
 
     sdfg.apply_transformations_repeated([LoopLifting])
-    assert sdfg.apply_transformations(LoopToMap) == (1 if parallel else 0)
+    # Both variants carry ``sym`` (read in ``B[i]`` before the body edge reassigns it
+    # to ``A[i-1]``), so LoopToMap must refuse: a Map would pin ``sym`` to 0.0 and
+    # compute ``B[i]=0``. The ``parallel`` variant only adds an ``A`` write.
+    assert sdfg.apply_transformations(LoopToMap) == 0
+
+
+_CN = dace.symbol('_CN')
+
+
+@dace.program
+def _carried_symbol_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
+    im = _CN - 1
+    for i in range(_CN):
+        a[i] = b[i] + b[im]
+        im = i
+
+
+@dace.program
+def _peeled_affine_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
+    a[0] = b[0] + b[_CN - 1]  # wrapping first iteration, peeled off
+    for i in range(1, _CN):
+        a[i] = b[i] + b[i - 1]  # induction substituted -> affine
+
+
+def _only_loop(sdfg: dace.SDFG) -> LoopRegion:
+    return next(n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, LoopRegion))
+
+
+def test_loop2map_rejects_unpeeled_carried_symbol():
+    """Wrap-around induction ``im = N-1; a[i] = b[i] + b[im]; im = i`` (TSVC s291):
+    ``im`` is read (in ``b[im]``) before it is reassigned, so it is loop-carried and
+    LoopToMap must refuse -- a Map would pin ``im`` to ``N-1`` and compute
+    ``b[i] + b[N-1]`` everywhere."""
+    sdfg = _carried_symbol_loop.to_sdfg(simplify=True)
+    assert not LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
+
+
+def test_loop2map_accepts_peeled_affine_form():
+    """Once peeled and the induction substituted, ``a[i] = b[i] + b[i-1]`` is affine
+    and LoopToMap accepts it."""
+    sdfg = _peeled_affine_loop.to_sdfg(simplify=True)
+    assert LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
 
 
 @pytest.mark.parametrize('overwrite', (False, True))
@@ -940,6 +981,151 @@ def test_dynamic_write_slab_separated_by_iteration_var():
     assert not any(isinstance(n, LoopRegion) for n, _ in sdfg.all_nodes_recursive())
 
 
+def test_loop_to_map_with_loop_invariant_if():
+    """A loop whose body is guarded by a loop-invariant condition is
+    parallelizable: ``for i: if c: b[i]=a[i]+1`` -> one map, value-preserving
+    for the guard taken and not-taken. (The guard becomes a per-iteration
+    ``NestedSDFG``-wrapped conditional inside the map.)"""
+    N = dace.symbol('N')
+
+    @dace.program
+    def loop_invariant_if(a: dace.float64[N], b: dace.float64[N], c: dace.int32[1]):
+        for i in range(N):
+            if c[0] > 0:
+                b[i] = a[i] + 1.0
+
+    for cv in (1, 0):
+        sdfg = loop_invariant_if.to_sdfg(simplify=True)
+        assert sdfg.apply_transformations_repeated(LoopToMap) == 1
+        sdfg.validate()
+        assert not any(isinstance(n, LoopRegion) for n, _ in sdfg.all_nodes_recursive())
+        n = 12
+        a = np.random.rand(n)
+        b = np.zeros(n)
+        sdfg(a=a.copy(), b=b, c=np.array([cv], np.int32), N=n)
+        assert np.allclose(b, a + 1.0 if cv > 0 else 0.0), f"mismatch c={cv}"
+
+
+def test_loop_to_map_round_trip_through_nested_sdfg_recovers_map():
+    """Parallelizing a loop-invariant-guarded loop, de-parallelizing it, then
+    re-parallelizing recovers the map. The ``LoopToMap->MapToForLoop`` round-
+    trip propagates a whole-array external write memlet (``b[i]`` -> ``b[0:N]``)
+    on the ``NestedSDFG`` the guard forces; the write-pattern check now looks
+    *past* the connector at the inner per-iteration write
+    (:func:`_nested_writes_iter_indexed`), so independence is still proven."""
+    from dace.transformation.dataflow.map_for_loop import MapToForLoop
+    from dace.transformation.passes.pattern_matching import PatternMatchAndApplyRepeated
+    N = dace.symbol('N')
+
+    @dace.program
+    def loop_invariant_if(a: dace.float64[N], b: dace.float64[N], c: dace.int32[1]):
+        for i in range(N):
+            if c[0] > 0:
+                b[i] = a[i] + 1.0
+
+    sdfg = loop_invariant_if.to_sdfg(simplify=True)
+    assert sdfg.apply_transformations_repeated(LoopToMap) == 1, "first LoopToMap must fire"
+    PatternMatchAndApplyRepeated([MapToForLoop()]).apply_pass(sdfg, {})
+    sdfg.validate()
+    assert sdfg.apply_transformations_repeated(LoopToMap) == 1, \
+        "re-parallelize must recover the map after the round-trip"
+
+
+def test_refuse_when_body_assigns_loop_range_symbol():
+    """A loop whose range expression reads a symbol that the loop body
+    re-assigns via an interstate-edge assignment must NOT be converted to
+    a Map: the assignment would move into the new ``loop_body`` NestedSDFG
+    with the body, but the Map's range stays at the outer scope -- so the
+    range ends up referencing a symbol defined only inside the new NSDFG
+    (``Missing symbols on nested SDFG: ['KP1']`` at validation time).
+
+    This pattern shows up in the canonicalized cloudsc SDFG (the
+    ``kfdia_plus_1_N = kfdia + 1`` interstate-edge assignment ends up
+    inside a loop whose condition reads ``kfdia_plus_1_N``). The check is
+    a structural-soundness gate -- a strictly additive ``return False``
+    that leaves the loop as a ``LoopRegion`` (sequential codegen still
+    handles it cleanly).
+    """
+    from dace.memlet import Memlet
+
+    sdfg = dace.SDFG("refuse_body_assigns_loop_range_symbol")
+    sdfg.add_symbol("K", dace.int32)
+    sdfg.add_symbol("KP1", dace.int32)
+    sdfg.add_array("a", (dace.symbol("K"), ), dace.float32)
+
+    init = sdfg.add_state("init", is_start_block=True)
+    # ``KP1`` defined before the loop -- the body's interstate-edge
+    # ``KP1 = K + 1`` is a redundant re-assignment that nonetheless
+    # creates the bad-pattern shape.
+    sdfg.add_edge(init, init, dace.InterstateEdge(assignments={}))  # placeholder no-op
+
+    loop = LoopRegion("for_j", condition_expr="j < KP1", loop_var="j", initialize_expr="j = 0", update_expr="j = j + 1")
+    sdfg.add_node(loop)
+    sdfg.add_edge(init, loop, dace.InterstateEdge(assignments={"KP1": "K + 1"}))
+
+    # Body: a single state with a write to ``a[j]``. Critically, an
+    # interstate edge inside the loop reassigns ``KP1`` (loop-invariant
+    # value, but structurally placed inside the loop body).
+    body = loop.add_state("body", is_start_block=True)
+    after = loop.add_state("after")
+    loop.add_edge(body, after, dace.InterstateEdge(assignments={"KP1": "K + 1"}))
+    t = body.add_tasklet("t", {}, {"o"}, "o = 1.0")
+    w = body.add_write("a")
+    body.add_edge(t, "o", w, None, Memlet("a[j]"))
+
+    sdfg.validate()
+
+    # The loop's range reads ``KP1``; the body has an interstate edge
+    # assigning ``KP1``. ``LoopToMap.can_be_applied`` must refuse.
+    applied = sdfg.apply_transformations_repeated(LoopToMap)
+    assert applied == 0, "LoopToMap must refuse to convert a loop whose range reads a body-assigned symbol"
+
+    # The loop remains as a LoopRegion; SDFG stays valid.
+    assert any(isinstance(c, LoopRegion) for c in sdfg.all_control_flow_regions(recursive=True))
+    sdfg.validate()
+
+
+def test_mapped_symbol_the_child_does_not_declare():
+    """A parent node maps a symbol its nested SDFG never declares -- what other passes leave behind
+    (``move_loop_into_map``, ``condition_map_interchange``, ``map_fission`` and this pass all write
+    ``symbol_mapping`` entries without a matching declaration).  Applying here inside that SDFG
+    types the new loop body off exactly that mapping, so an undeclared entry used to raise
+    ``KeyError`` instead of transforming.  Seen on QE ``vexx_bp_k_gpu`` as ``KeyError: 'jcurr'``.
+    """
+    inner = dace.SDFG("inner")
+    inner.add_array("A", (20, ), dace.float64)
+
+    loop = LoopRegion("loop", condition_expr="i < 10", loop_var="i", initialize_expr="i = 0", update_expr="i = i + 1")
+    inner.add_node(loop, is_start_block=True)
+    body = loop.add_state("body", is_start_block=True)
+    wt = body.add_tasklet("wt", {}, {"o"}, "o = 1.0")
+    body.add_edge(wt, "o", body.add_write("A"), None, dace.Memlet("A[i]"))
+
+    sdfg = dace.SDFG("l2m_mapped_but_undeclared")
+    sdfg.add_array("A", (20, ), dace.float64)
+    sdfg.add_symbol("k", dace.int32)
+    state = sdfg.add_state("main", is_start_block=True)
+    nnode = state.add_nested_sdfg(inner, {}, {"A"})
+    state.add_edge(nnode, "A", state.add_write("A"), None, dace.Memlet("A[0:20]"))
+    nnode.symbol_mapping["k"] = dace.symbol("k")
+    assert "k" not in inner.symbols, "the mapping entry must be the undeclared one under test"
+
+    assert sdfg.apply_transformations_repeated(LoopToMap, permissive=True) == 1
+
+    bodies = [
+        node for node, _ in sdfg.all_nodes_recursive()
+        if isinstance(node, nodes.NestedSDFG) and node.sdfg.name.startswith("loop_body")
+    ]
+    assert len(bodies) == 1, f"expected one lifted loop body (got {len(bodies)})"
+    for node in bodies:
+        undeclared = node.symbol_mapping.keys() - node.sdfg.symbols.keys() - node.in_connectors.keys()
+        assert not undeclared, f"{node.sdfg.name}: mapped without a declared type: {sorted(undeclared)}"
+    assert bodies[0].sdfg.symbols["k"] == dace.int32, "the carried-in symbol kept its type"
+
+    sdfg.validate()
+    sdfg.compile()
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
@@ -981,4 +1167,6 @@ if __name__ == "__main__":
     test_self_loop_to_map()
     test_nested_sdfg_nested_loop()
     test_stride_symbol_propagated_to_nested_sdfg()
+    test_loop_to_map_with_loop_invariant_if()
     test_dynamic_write_slab_separated_by_iteration_var()
+    test_refuse_when_body_assigns_loop_range_symbol()

--- a/tests/transformations/interstate/loop_to_map_test.py
+++ b/tests/transformations/interstate/loop_to_map_test.py
@@ -9,7 +9,7 @@ import pytest
 
 import dace
 from dace.sdfg import nodes
-from dace.sdfg.state import LoopRegion
+from dace.sdfg.state import ConditionalBlock, ControlFlowRegion, LoopRegion
 from dace.transformation.interstate import LoopToMap, StateFusion
 from dace.transformation.interstate.loop_lifting import LoopLifting
 
@@ -1269,3 +1269,40 @@ if __name__ == "__main__":
     test_loop_to_map_with_loop_invariant_if()
     test_dynamic_write_slab_separated_by_iteration_var()
     test_refuse_when_body_assigns_loop_range_symbol()
+
+
+def branchy_symbol_loop() -> dace.SDFG:
+    """A loop whose body is a two-armed conditional, each arm assigning ``s`` on its own
+    interstate edge and writing ``A[i]`` from it."""
+    sdfg = dace.SDFG('l2m_branchy_symbol')
+    sdfg.add_array('A', [20], dace.float64)
+    sdfg.add_symbol('s', dace.int64)
+    loop = LoopRegion('loop', 'i < 20', 'i', 'i = 0', 'i = i + 1', sdfg=sdfg)
+    sdfg.add_node(loop, is_start_block=True)
+
+    cond = ConditionalBlock('choose', sdfg=sdfg, parent=loop)
+    loop.add_node(cond, is_start_block=True)
+    for label, expr, condition in (('then', 'i + 1', 'i % 2 == 0'), ('else', 'i + 2', None)):
+        region = ControlFlowRegion(f'{label}_body', sdfg=sdfg)
+        first = region.add_state(f'{label}_first', is_start_block=True)
+        second = region.add_state(f'{label}_second')
+        region.add_edge(first, second, dace.InterstateEdge(assignments={'s': expr}))
+        t = second.add_tasklet(f'{label}_write', {}, {'o'}, 'o = s')
+        second.add_edge(t, 'o', second.add_write('A'), None, dace.Memlet('A[i]'))
+        cond.add_branch(dace.properties.CodeBlock(condition) if condition else None, region)
+
+    sdfg.validate()
+    return sdfg
+
+
+def test_conditional_body_does_not_crash_the_match():
+    """Every arm assigns ``s`` before reading it, so the loop is a Map. The branch-intersection
+    bookkeeping must not raise: a raised exception is swallowed as 'does not apply', which
+    silently disables LoopToMap for every loop shaped like this."""
+    sdfg = branchy_symbol_loop()
+    assert sdfg.apply_transformations(LoopToMap) == 1
+
+    A = np.zeros(20)
+    sdfg(A=A)
+    expected = np.array([(i + 1) if i % 2 == 0 else (i + 2) for i in range(20)], dtype=np.float64)
+    assert np.allclose(A, expected)

--- a/tests/transformations/interstate/loop_to_map_test.py
+++ b/tests/transformations/interstate/loop_to_map_test.py
@@ -457,26 +457,39 @@ def test_symbol_array_mix_2(parallel):
     # compute ``B[i]=0``. The ``parallel`` variant only adds an ``A`` write.
     assert sdfg.apply_transformations(LoopToMap) == 0
 
+    if parallel:
+        # A is read-only in this arm, so pin the exact sequential semantics too: B[i] = sym-at-entry =
+        # A[i-2] (B[1] = sym's 0.0 init). Guards against any future lift that zeroes the carry.
+        A = np.arange(1.0, 21.0)
+        B = np.full(20, -999.0)
+        sdfg(A=A.copy(), B=B)
+        expected = np.full(20, -999.0)
+        sym = 0.0
+        for i in range(1, 20):
+            expected[i] = sym
+            sym = A[i - 1]
+        assert np.allclose(B, expected)
 
-_CN = dace.symbol('_CN')
+
+CN = dace.symbol('CN')
 
 
 @dace.program
-def _carried_symbol_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
-    im = _CN - 1
-    for i in range(_CN):
+def carried_symbol_loop(a: dace.float64[CN], b: dace.float64[CN]):
+    im = CN - 1
+    for i in range(CN):
         a[i] = b[i] + b[im]
         im = i
 
 
 @dace.program
-def _peeled_affine_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
-    a[0] = b[0] + b[_CN - 1]  # wrapping first iteration, peeled off
-    for i in range(1, _CN):
+def peeled_affine_loop(a: dace.float64[CN], b: dace.float64[CN]):
+    a[0] = b[0] + b[CN - 1]  # wrapping first iteration, peeled off
+    for i in range(1, CN):
         a[i] = b[i] + b[i - 1]  # induction substituted -> affine
 
 
-def _only_loop(sdfg: dace.SDFG) -> LoopRegion:
+def only_loop(sdfg: dace.SDFG) -> LoopRegion:
     return next(n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, LoopRegion))
 
 
@@ -485,15 +498,15 @@ def test_loop2map_rejects_unpeeled_carried_symbol():
     ``im`` is read (in ``b[im]``) before it is reassigned, so it is loop-carried and
     LoopToMap must refuse -- a Map would pin ``im`` to ``N-1`` and compute
     ``b[i] + b[N-1]`` everywhere."""
-    sdfg = _carried_symbol_loop.to_sdfg(simplify=True)
-    assert not LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
+    sdfg = carried_symbol_loop.to_sdfg(simplify=True)
+    assert not LoopToMap.can_be_applied_to(sdfg, loop=only_loop(sdfg))
 
 
 def test_loop2map_accepts_peeled_affine_form():
     """Once peeled and the induction substituted, ``a[i] = b[i] + b[i-1]`` is affine
     and LoopToMap accepts it."""
-    sdfg = _peeled_affine_loop.to_sdfg(simplify=True)
-    assert LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
+    sdfg = peeled_affine_loop.to_sdfg(simplify=True)
+    assert LoopToMap.can_be_applied_to(sdfg, loop=only_loop(sdfg))
 
 
 @pytest.mark.parametrize('overwrite', (False, True))


### PR DESCRIPTION
LoopToMap crashes or refuses on loop shapes it can prove safe, and pays for the dependence proof even on loops it refuses for cheaper reasons. This collects those fixes with a test per behaviour, taking the corpus to 44 cases.

```python
# refused before; the read and the write never share an element
for i in range(2, 40, 2):
    A[i] = A[i - 1] * 2.0
```