### PR TITLE
codegen: decide the OpenMP simd clause in a preprocessing pass

### DIFF
--- a/dace/codegen/codegen.py
+++ b/dace/codegen/codegen.py
@@ -17,6 +17,7 @@ from dace.sdfg import infer_types
 from dace.codegen.instrumentation import InstrumentationProvider
 from dace.sdfg.state import SDFGState
 from dace.transformation.pass_pipeline import FixedPointPipeline
+from dace.transformation.passes.mark_simd_maps import MarkSIMDMaps
 from dace.transformation.passes.simplification.control_flow_raising import ControlFlowRaising
 
 
@@ -206,6 +207,10 @@ def generate_code(sdfg: SDFG, validate=True) -> List[CodeObject]:
 
     # Recursively expand library nodes that have not yet been expanded
     sdfg.expand_library_nodes()
+
+    # Decide which maps may carry an OpenMP simd clause; the CPU target only renders it.
+    if config.Config.get_bool('compiler', 'cpu', 'simd_maps'):
+        MarkSIMDMaps().apply_pass(sdfg, {})
 
     # After expansion, run another pass of connector/type inference
     infer_types.infer_connector_types(sdfg)

--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1897,6 +1897,11 @@ class CPUCodeGen(TargetCodeGenerator):
             if node.map.schedule == dtypes.ScheduleType.CPU_Multicore and node.map.collapse > 1:
                 map_header += ' collapse(%d)' % node.map.collapse
 
+            # ``MarkSIMDMaps`` decided this; stamp the clause onto the existing pragma.
+            if node.map.schedule == dtypes.ScheduleType.CPU_Multicore and node.map.omp_simd:
+                head, sep, rest = map_header.partition(' for')
+                map_header = f'{head}{sep} simd{rest}'
+
         if node.map.unroll:
             if node.map.schedule in (dtypes.ScheduleType.CPU_Multicore, dtypes.ScheduleType.CPU_Persistent):
                 raise ValueError("An OpenMP map cannot be unrolled (" + node.map.label + ")")
@@ -1944,6 +1949,10 @@ class CPUCodeGen(TargetCodeGenerator):
                     if node.map.unroll_factor:
                         unroll_pragma += f" {node.map.unroll_factor}"
                     result.write(unroll_pragma, cfg, state_id, node)
+                elif (node.map.omp_simd and node.map.schedule == dtypes.ScheduleType.Sequential
+                      and i == len(node.map.range) - 1):
+                    # Innermost dimension only: the pragma must precede the ``for`` it vectorizes.
+                    result.write("#pragma omp simd", cfg, state_id, node)
 
                 result.write(
                     "for (auto %s = %s; %s < %s; %s += %s) {\n" %

--- a/dace/config_schema.yml
+++ b/dace/config_schema.yml
@@ -340,6 +340,16 @@ required:
                         description: Additional linked libraries required by target
                         default: ''
 
+                    simd_maps:
+                        type: bool
+                        default: true
+                        title: Vectorize innermost CPU maps with OpenMP simd
+                        description: >
+                            Runs ``MarkSIMDMaps`` before code generation, which sets
+                            ``Map.omp_simd`` on the innermost Sequential and CPU_Multicore maps
+                            whose body holds no further loop or map. Set false to emit no
+                            ``simd`` clause; maps already carrying ``omp_simd`` still render it.
+
                     openmp_sections:
                         type: bool
                         default: false

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -1039,7 +1039,7 @@ class Map(object):
     omp_simd = Property(dtype=bool,
                         default=False,
                         desc="Vectorize the innermost loop with an OpenMP simd clause",
-                        serialize_if=lambda m: m.schedule in dtypes.CPU_SCHEDULES)
+                        serialize_if=lambda m: m.omp_simd)
 
     gpu_block_size = ListProperty(element_type=int,
                                   default=None,

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -1036,6 +1036,10 @@ class Map(object):
                               default=0,
                               desc="OpenMP schedule chunk size",
                               serialize_if=lambda m: m.schedule in dtypes.CPU_SCHEDULES)
+    omp_simd = Property(dtype=bool,
+                        default=False,
+                        desc="Vectorize the innermost loop with an OpenMP simd clause",
+                        serialize_if=lambda m: m.schedule in dtypes.CPU_SCHEDULES)
 
     gpu_block_size = ListProperty(element_type=int,
                                   default=None,

--- a/dace/transformation/dataflow/map_expansion.py
+++ b/dace/transformation/dataflow/map_expansion.py
@@ -114,6 +114,9 @@ class MapExpansion(pm.SingleStateTransformation):
         # Reuse the map that is already existing for the first one.
         current_map.params = new_maps[0].params
         current_map.range = new_maps[0].range
+        # ``collapse`` counts the loops the schedule fuses, and the reused map has fewer of them
+        # now; leaving it stale emits ``collapse(2)`` on a one-dimensional loop.
+        current_map.collapse = min(current_map.collapse, len(current_map.params))
         new_maps.pop(0)
 
         # Create new map entries and exits

--- a/dace/transformation/passes/mark_simd_maps.py
+++ b/dace/transformation/passes/mark_simd_maps.py
@@ -66,25 +66,20 @@ def map_has_minmax_wcr(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
     return False
 
 
-def map_wcr_is_simd_safe(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
-    """ True if every WCR out-edge of this map's exit is a safe ``simd`` target: no ``min``/``max``,
-        and no scatter (a target subset indexed by this map's own parameter, as in
-        ``hist[bin(a[i])] += 1``). Sequential maps lower WCR to a plain ``wcr_fixed::reduce``, so a
-        scatter really can alias across lanes; CPU_Multicore goes through the atomic path instead.
+def map_has_wcr(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
+    """ True if any out-edge of this map's exit carries a WCR.
+
+        A Sequential map lowers WCR to a plain ``wcr_fixed::reduce``, a read-modify-write of the
+        target in the loop body: an accumulation into a fixed location carries across iterations,
+        and a scatter (``hist[bin(a[i])] += 1``) can alias across them. ``simd`` asserts neither
+        happens, so a Sequential map that reduces gets no clause. CPU_Multicore goes through
+        ``reduce_atomic`` instead, which composes with the clause.
     """
-    if map_has_minmax_wcr(state, map_entry):
-        return False
     try:
         map_exit = state.exit_node(map_entry)
     except (KeyError, StopIteration):
-        return True
-    map_params = set(map_entry.map.params)
-    for iedge in state.in_edges(map_exit):
-        if iedge.data is None or iedge.data.wcr is None or iedge.data.subset is None:
-            continue
-        if {str(s) for s in iedge.data.subset.free_symbols} & map_params:
-            return False
-    return True
+        return False
+    return any(e.data is not None and e.data.wcr is not None for e in state.in_edges(map_exit))
 
 
 @dataclass(unsafe_hash=True)
@@ -153,5 +148,5 @@ class MarkSIMDMaps(ppl.Pass):
             # with ``simd``, so only the min/max combine withholds the clause here.
             return map_body_is_leaf(state, map_entry) and not map_has_minmax_wcr(state, map_entry)
         if map_entry.map.schedule == dtypes.ScheduleType.Sequential:
-            return map_body_is_leaf(state, map_entry) and map_wcr_is_simd_safe(state, map_entry)
+            return map_body_is_leaf(state, map_entry) and not map_has_wcr(state, map_entry)
         return False

--- a/dace/transformation/passes/mark_simd_maps.py
+++ b/dace/transformation/passes/mark_simd_maps.py
@@ -125,29 +125,22 @@ class MarkSIMDMaps(ppl.Pass):
                 ]
                 for entry in candidates:
                     # The clause vectorizes the loop it precedes, so a multidimensional map has to
-                    # give its innermost dimension a map of its own first.
+                    # give its innermost dimension a map of its own first. MapExpansion returns the
+                    # new nest outermost-first, and propagates the scope it rewrote by itself, so
+                    # ``annotate`` stays off: a whole-SDFG propagation per map is quadratic.
                     if len(entry.map.params) > 1:
-                        MapExpansion.apply_to(nsdfg,
-                                              options={
-                                                  'expansion_limit': len(entry.map.params) - 1,
-                                                  'inner_schedule': dtypes.ScheduleType.Sequential
-                                              },
-                                              map_entry=entry,
-                                              verify=False,
-                                              save=False)
-                        entry = self.innermost_entry(state, entry)
+                        entry = MapExpansion.apply_to(nsdfg,
+                                                      options={
+                                                          'expansion_limit': len(entry.map.params) - 1,
+                                                          'inner_schedule': dtypes.ScheduleType.Sequential
+                                                      },
+                                                      map_entry=entry,
+                                                      verify=False,
+                                                      annotate=False,
+                                                      save=False)[-1]
                     entry.map.omp_simd = True
                     marked.add((nsdfg.cfg_id, entry.map.label))
         return marked or None
-
-    def innermost_entry(self, state: SDFGState, entry: nodes.MapEntry) -> nodes.MapEntry:
-        """ The innermost MapEntry of the nest ``entry`` now heads, after expansion. """
-        scope = state.scope_children()
-        while True:
-            inner = [n for n in scope[entry] if isinstance(n, nodes.MapEntry)]
-            if not inner:
-                return entry
-            entry = inner[0]
 
     def map_takes_simd(self, state: SDFGState, map_entry: nodes.MapEntry) -> bool:
         """ Whether this map's innermost loop can carry the clause. """

--- a/dace/transformation/passes/mark_simd_maps.py
+++ b/dace/transformation/passes/mark_simd_maps.py
@@ -13,6 +13,8 @@ from dace.sdfg.state import LoopRegion, SDFGState
 from dace.transformation import pass_pipeline as ppl, transformation
 from dace.transformation.dataflow import MapExpansion
 
+OMP_DIRECTIVE = '#pragma omp'
+
 
 def map_body_is_leaf(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
     """ True if the map's body holds no Map and no loop, at any depth.
@@ -32,22 +34,30 @@ def map_body_is_leaf(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
                 return False
         for st in sdfg.all_states():
             for n in st.nodes():
-                if isinstance(n, nodes.MapEntry):
+                if not node_is_loop_free(n, seen):
                     return False
-                if isinstance(n, nodes.NestedSDFG) and (n.sdfg is None or not loop_and_map_free(n.sdfg, seen)):
-                    return False
+        return True
+
+    def node_is_loop_free(n: nodes.Node, seen: Set[int]) -> bool:
+        if isinstance(n, nodes.MapEntry):
+            return False
+        # A library node still to be expanded is undecidable here: its expansion routinely
+        # lowers to a Map, and an ``omp parallel for`` inside a simd region does not compile.
+        if isinstance(n, nodes.LibraryNode):
+            return False
+        # Neither does a directive the tasklet brings itself -- the OpenMP Reduce expansion
+        # writes ``#pragma omp parallel for`` straight into the tasklet body.
+        if isinstance(n, nodes.Tasklet):
+            return OMP_DIRECTIVE not in n.code.as_string
+        if isinstance(n, nodes.NestedSDFG):
+            return n.sdfg is not None and loop_and_map_free(n.sdfg, seen)
         return True
 
     try:
         map_exit = state.exit_node(map_entry)
     except (KeyError, StopIteration):
         return False
-    for n in state.all_nodes_between(map_entry, map_exit):
-        if isinstance(n, nodes.MapEntry):
-            return False
-        if isinstance(n, nodes.NestedSDFG) and (n.sdfg is None or not loop_and_map_free(n.sdfg, set())):
-            return False
-    return True
+    return all(node_is_loop_free(n, set()) for n in state.all_nodes_between(map_entry, map_exit))
 
 
 def map_has_minmax_wcr(state: SDFGState, map_entry: nodes.MapEntry) -> bool:

--- a/dace/transformation/passes/mark_simd_maps.py
+++ b/dace/transformation/passes/mark_simd_maps.py
@@ -1,0 +1,157 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+""" Marks the maps whose innermost loop can carry an OpenMP ``simd`` clause. """
+
+from dataclasses import dataclass
+from typing import Optional, Set, Tuple
+
+import networkx as nx
+
+from dace import SDFG, dtypes, properties
+from dace.frontend import operations
+from dace.sdfg import nodes
+from dace.sdfg.state import LoopRegion, SDFGState
+from dace.transformation import pass_pipeline as ppl, transformation
+from dace.transformation.dataflow import MapExpansion
+
+
+def map_body_is_leaf(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
+    """ True if the map's body holds no Map and no loop, at any depth.
+
+        A NestedSDFG is opened rather than refused on sight: an outlined body is often just
+        straight-line dataflow. Inside one a loop takes two forms, a ``LoopRegion`` and a back
+        edge in a plain state machine; a ``ConditionalBlock`` lowers to an ``if`` the vectorizer
+        masks, so it does not disqualify. Anything undecidable reads as not a leaf.
+    """
+
+    def loop_and_map_free(sdfg: SDFG, seen: Set[int]) -> bool:
+        if id(sdfg) in seen:  # self-referential: refuse rather than recurse
+            return False
+        seen.add(id(sdfg))
+        for cfr in sdfg.all_control_flow_regions():
+            if isinstance(cfr, LoopRegion) or not nx.is_directed_acyclic_graph(cfr.nx):
+                return False
+        for st in sdfg.all_states():
+            for n in st.nodes():
+                if isinstance(n, nodes.MapEntry):
+                    return False
+                if isinstance(n, nodes.NestedSDFG) and (n.sdfg is None or not loop_and_map_free(n.sdfg, seen)):
+                    return False
+        return True
+
+    try:
+        map_exit = state.exit_node(map_entry)
+    except (KeyError, StopIteration):
+        return False
+    for n in state.all_nodes_between(map_entry, map_exit):
+        if isinstance(n, nodes.MapEntry):
+            return False
+        if isinstance(n, nodes.NestedSDFG) and (n.sdfg is None or not loop_and_map_free(n.sdfg, set())):
+            return False
+    return True
+
+
+def map_has_minmax_wcr(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
+    """ True if a WCR out-edge of this map's exit reduces with ``min``/``max``, whose
+        NaN-preserving compare/branch combine vectorizers do not reliably fold.
+    """
+    try:
+        map_exit = state.exit_node(map_entry)
+    except (KeyError, StopIteration):
+        return False
+    for iedge in state.in_edges(map_exit):
+        if iedge.data is None or iedge.data.wcr is None:
+            continue
+        if operations.detect_reduction_type(iedge.data.wcr) in (dtypes.ReductionType.Min, dtypes.ReductionType.Max):
+            return True
+    return False
+
+
+def map_wcr_is_simd_safe(state: SDFGState, map_entry: nodes.MapEntry) -> bool:
+    """ True if every WCR out-edge of this map's exit is a safe ``simd`` target: no ``min``/``max``,
+        and no scatter (a target subset indexed by this map's own parameter, as in
+        ``hist[bin(a[i])] += 1``). Sequential maps lower WCR to a plain ``wcr_fixed::reduce``, so a
+        scatter really can alias across lanes; CPU_Multicore goes through the atomic path instead.
+    """
+    if map_has_minmax_wcr(state, map_entry):
+        return False
+    try:
+        map_exit = state.exit_node(map_entry)
+    except (KeyError, StopIteration):
+        return True
+    map_params = set(map_entry.map.params)
+    for iedge in state.in_edges(map_exit):
+        if iedge.data is None or iedge.data.wcr is None or iedge.data.subset is None:
+            continue
+        if {str(s) for s in iedge.data.subset.free_symbols} & map_params:
+            return False
+    return True
+
+
+@dataclass(unsafe_hash=True)
+@properties.make_properties
+@transformation.explicit_cf_compatible
+class MarkSIMDMaps(ppl.Pass):
+    """
+    Sets ``Map.omp_simd`` on the CPU maps whose innermost loop can carry an OpenMP ``simd`` clause.
+    Code generation only renders the clause; the safety analysis lives here.
+    """
+
+    CATEGORY: str = 'Optimization Preparation'
+
+    def modifies(self) -> ppl.Modifies:
+        return ppl.Modifies.Nodes
+
+    def should_reapply(self, modified: ppl.Modifies) -> bool:
+        return modified & (ppl.Modifies.States | ppl.Modifies.Nodes | ppl.Modifies.Memlets)
+
+    def apply_pass(self, sdfg: SDFG, _) -> Optional[Set[Tuple[int, str]]]:
+        """
+        Marks every qualifying map in ``sdfg`` and its nested SDFGs.
+
+        :param sdfg: The SDFG to modify.
+        :param _: Pipeline results, unused.
+        :return: The marked maps as ``(state id, map label)``, or ``None`` if none qualified.
+        """
+        marked: Set[Tuple[int, str]] = set()
+        for nsdfg in sdfg.all_sdfgs_recursive():
+            for state in nsdfg.all_states():
+                candidates = [
+                    n for n in state.nodes() if isinstance(n, nodes.MapEntry) and self.map_takes_simd(state, n)
+                ]
+                for entry in candidates:
+                    # The clause vectorizes the loop it precedes, so a multidimensional map has to
+                    # give its innermost dimension a map of its own first.
+                    if len(entry.map.params) > 1:
+                        MapExpansion.apply_to(nsdfg,
+                                              options={
+                                                  'expansion_limit': len(entry.map.params) - 1,
+                                                  'inner_schedule': dtypes.ScheduleType.Sequential
+                                              },
+                                              map_entry=entry,
+                                              verify=False,
+                                              save=False)
+                        entry = self.innermost_entry(state, entry)
+                    entry.map.omp_simd = True
+                    marked.add((nsdfg.cfg_id, entry.map.label))
+        return marked or None
+
+    def innermost_entry(self, state: SDFGState, entry: nodes.MapEntry) -> nodes.MapEntry:
+        """ The innermost MapEntry of the nest ``entry`` now heads, after expansion. """
+        scope = state.scope_children()
+        while True:
+            inner = [n for n in scope[entry] if isinstance(n, nodes.MapEntry)]
+            if not inner:
+                return entry
+            entry = inner[0]
+
+    def map_takes_simd(self, state: SDFGState, map_entry: nodes.MapEntry) -> bool:
+        """ Whether this map's innermost loop can carry the clause. """
+        if map_entry.map.unroll:  # its own pragma, and an unrolled body is not a loop to vectorize
+            return False
+        if map_entry.map.schedule == dtypes.ScheduleType.CPU_Multicore:
+            # A conflicted WCR write lowers through ``wcr_fixed::reduce_atomic``, which composes
+            # with ``simd``, so only the min/max combine withholds the clause here.
+            return map_body_is_leaf(state, map_entry) and not map_has_minmax_wcr(state, map_entry)
+        if map_entry.map.schedule == dtypes.ScheduleType.Sequential:
+            return map_body_is_leaf(state, map_entry) and map_wcr_is_simd_safe(state, map_entry)
+        return False

--- a/tests/codegen/omp_simd_test.py
+++ b/tests/codegen/omp_simd_test.py
@@ -142,6 +142,48 @@ def test_multicore_reduction_keeps_the_clause_and_the_value():
     assert np.allclose(out[0], a.sum())
 
 
+def test_unexpanded_library_node_withholds_the_clause():
+    """A library node in the body expands to a Map after this pass has run, and an
+    ``omp parallel for`` lexically inside a simd region is not valid OpenMP."""
+    sdfg = dace.SDFG('library_node_body')
+    sdfg.add_array('a', (8, 16), dace.float64)
+    sdfg.add_array('out', (8, ), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    entry, exit_node = state.add_map('outer', {'i': '0:8'}, schedule=dtypes.ScheduleType.CPU_Multicore)
+    red = state.add_reduce('lambda x, y: x + y', None, 0)
+    state.add_memlet_path(state.add_read('a'), entry, red, memlet=dace.Memlet('a[i, 0:16]'))
+    state.add_memlet_path(red, exit_node, state.add_write('out'), memlet=dace.Memlet('out[i]'))
+    sdfg.validate()
+
+    mark(sdfg)
+    assert not any(n.map.omp_simd for _, n in entries(sdfg))
+
+    a = np.random.rand(8, 16)
+    out = np.zeros(8)
+    sdfg(a=a, out=out)
+    assert np.allclose(out, a.sum(axis=1))
+
+
+def test_tasklet_carrying_a_directive_withholds_the_clause():
+    """The OpenMP Reduce expansion writes ``#pragma omp parallel for`` into the tasklet body, and
+    that construct is illegal inside a simd region."""
+    sdfg = dace.SDFG('directive_in_tasklet')
+    sdfg.add_array('a', (8, ), dace.float64)
+    sdfg.add_array('b', (8, ), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('carries_a_pragma', {'i': '0:8'}, {'inp': dace.Memlet('a[i]')},
+                             '#pragma omp parallel for\nfor (int k = 0; k < 1; ++k) o = inp;',
+                             {'o': dace.Memlet('b[i]')},
+                             schedule=dtypes.ScheduleType.CPU_Multicore,
+                             language=dace.Language.CPP,
+                             external_edges=True)
+    sdfg.validate()
+
+    mark(sdfg)
+    assert not any(n.map.omp_simd for _, n in entries(sdfg))
+    assert ' simd' not in sdfg.generate_code()[0].clean_code
+
+
 def double_tasklet(state) -> None:
     """``b_out[0] = a_in[0] * 2`` as plain dataflow."""
     t = state.add_tasklet('nt', {'a': None}, {'b': None}, 'b = a * 2.0')
@@ -206,6 +248,23 @@ def test_outlined_body_is_opened_not_refused(payload, leaf):
     assert outer.map.omp_simd is leaf
 
 
+def test_the_mark_survives_a_round_trip():
+    """The pass marks Sequential maps too, so the property has to serialize for them -- otherwise
+    a save/load between the pass and code generation silently drops the clause."""
+    sdfg = dace.SDFG('roundtrip_seq_simd')
+    sdfg.add_array('a', (8, ), dace.float64)
+    sdfg.add_array('b', (8, ), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('m', {'i': '0:8'}, {'inp': dace.Memlet('a[i]')},
+                             'o = inp * 2.0', {'o': dace.Memlet('b[i]')},
+                             schedule=dtypes.ScheduleType.Sequential,
+                             external_edges=True)
+    next(n for _, n in entries(sdfg)).map.omp_simd = True
+
+    restored = dace.SDFG.from_json(sdfg.to_json())
+    assert all(n.map.omp_simd for _, n in entries(restored))
+
+
 def test_config_switch_suppresses_the_clause():
     """The escape hatch keeps the pass out of code generation entirely."""
 
@@ -228,7 +287,10 @@ if __name__ == '__main__':
     for wcr_target in ('hist[i]', 'hist[0]'):
         test_sequential_wcr_withholds_the_clause(wcr_target)
     test_multicore_reduction_keeps_the_clause_and_the_value()
+    test_unexpanded_library_node_withholds_the_clause()
+    test_tasklet_carrying_a_directive_withholds_the_clause()
     for name, is_leaf in (('straight', True), ('nested', True), ('loopregion', False), ('backedge', False), ('map',
                                                                                                              False)):
         test_outlined_body_is_opened_not_refused(name, is_leaf)
+    test_the_mark_survives_a_round_trip()
     test_config_switch_suppresses_the_clause()

--- a/tests/codegen/omp_simd_test.py
+++ b/tests/codegen/omp_simd_test.py
@@ -101,21 +101,45 @@ def test_minmax_reduction_withholds_the_clause():
     assert ' simd' not in sdfg.generate_code()[0].clean_code
 
 
-def test_sequential_scatter_withholds_the_clause():
-    """A Sequential map lowers a conflicted WCR to a non-atomic reduce, so a target indexed by the
-    map's own parameter can alias across lanes."""
-    sdfg = dace.SDFG('scatter_wcr_map')
+@pytest.mark.parametrize('target', ('hist[i]', 'hist[0]'))
+def test_sequential_wcr_withholds_the_clause(target):
+    """A Sequential map lowers WCR to a non-atomic read-modify-write in the loop body: a scatter can
+    alias across lanes, and an accumulation into a fixed location carries across iterations. Neither
+    is what ``simd`` asserts."""
+    sdfg = dace.SDFG(f"seq_wcr_{target.replace('[', '_').replace(']', '')}")
     sdfg.add_array('a', (64, ), dace.float64)
     sdfg.add_array('hist', (64, ), dace.float64)
     state = sdfg.add_state('main', is_start_block=True)
-    state.add_mapped_tasklet('scatter', {'i': '0:64'}, {'inp': dace.Memlet('a[i]')},
-                             'o = inp', {'o': dace.Memlet('hist[i]', wcr='lambda x, y: x + y')},
+    state.add_mapped_tasklet('accumulate', {'i': '0:64'}, {'inp': dace.Memlet('a[i]')},
+                             'o = inp', {'o': dace.Memlet(target, wcr='lambda x, y: x + y')},
                              schedule=dtypes.ScheduleType.Sequential,
                              external_edges=True)
     sdfg.validate()
 
     mark(sdfg)
     assert not any(n.map.omp_simd for _, n in entries(sdfg))
+    assert ' simd' not in sdfg.generate_code()[0].clean_code
+
+
+def test_multicore_reduction_keeps_the_clause_and_the_value():
+    """CPU_Multicore lowers a conflicted WCR through ``reduce_atomic``, which composes with the
+    clause, so the sum still lands."""
+    sdfg = dace.SDFG('multicore_wcr_map')
+    sdfg.add_array('a', (1024, ), dace.float64)
+    sdfg.add_array('out', (1, ), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('reduce_sum', {'i': '0:1024'}, {'inp': dace.Memlet('a[i]')},
+                             'o = inp', {'o': dace.Memlet('out[0]', wcr='lambda x, y: x + y')},
+                             schedule=dtypes.ScheduleType.CPU_Multicore,
+                             external_edges=True)
+    sdfg.validate()
+
+    assert '#pragma omp parallel for simd' in sdfg.generate_code()[0].clean_code
+
+    a = np.random.rand(1024)
+    out = np.zeros(1)
+    sdfg(a=a, out=out)
+    assert np.allclose(out[0], a.sum())
 
 
 def double_tasklet(state) -> None:
@@ -201,7 +225,9 @@ if __name__ == '__main__':
     test_multidimensional_map_vectorizes_its_innermost_dimension()
     test_outer_map_of_a_nest_is_not_marked()
     test_minmax_reduction_withholds_the_clause()
-    test_sequential_scatter_withholds_the_clause()
+    for wcr_target in ('hist[i]', 'hist[0]'):
+        test_sequential_wcr_withholds_the_clause(wcr_target)
+    test_multicore_reduction_keeps_the_clause_and_the_value()
     for name, is_leaf in (('straight', True), ('nested', True), ('loopregion', False), ('backedge', False), ('map',
                                                                                                              False)):
         test_outlined_body_is_opened_not_refused(name, is_leaf)

--- a/tests/codegen/omp_simd_test.py
+++ b/tests/codegen/omp_simd_test.py
@@ -2,10 +2,13 @@
 """ Tests for ``MarkSIMDMaps`` and the OpenMP ``simd`` clause it drives. """
 
 import numpy as np
+import pytest
+
 import dace
 from dace import dtypes
 from dace.sdfg import nodes
 from dace.sdfg import infer_types
+from dace.sdfg.state import LoopRegion
 from dace.transformation.passes.mark_simd_maps import MarkSIMDMaps
 
 
@@ -115,6 +118,70 @@ def test_sequential_scatter_withholds_the_clause():
     assert not any(n.map.omp_simd for _, n in entries(sdfg))
 
 
+def double_tasklet(state) -> None:
+    """``b_out[0] = a_in[0] * 2`` as plain dataflow."""
+    t = state.add_tasklet('nt', {'a': None}, {'b': None}, 'b = a * 2.0')
+    state.add_edge(state.add_read('a_in'), None, t, 'a', dace.Memlet('a_in[0]'))
+    state.add_edge(t, 'b', state.add_write('b_out'), None, dace.Memlet('b_out[0]'))
+
+
+def inner_sdfg(payload: str) -> dace.SDFG:
+    nsdfg = dace.SDFG(f'inner_{payload}')
+    nsdfg.add_array('a_in', [1], dace.float64)
+    nsdfg.add_array('b_out', [1], dace.float64)
+    if payload == 'loopregion':
+        loop = LoopRegion('nloop', 'k < 1', 'k', 'k = 0', 'k = k + 1')
+        nsdfg.add_node(loop, is_start_block=True)
+        double_tasklet(loop.add_state(is_start_block=True))
+    elif payload == 'backedge':
+        s0 = nsdfg.add_state(is_start_block=True)
+        s1 = nsdfg.add_state()
+        double_tasklet(s1)
+        # The cycle is the point; the conditions keep it from ever being taken.
+        nsdfg.add_edge(s0, s1, dace.InterstateEdge(condition='1 > 0'))
+        nsdfg.add_edge(s1, s0, dace.InterstateEdge(condition='0 > 1'))
+    elif payload == 'map':
+        nsdfg.add_state().add_mapped_tasklet('innermap',
+                                             dict(k='0:1'),
+                                             dict(a=dace.Memlet('a_in[0]')),
+                                             'b = a * 2.0',
+                                             dict(b=dace.Memlet('b_out[0]')),
+                                             external_edges=True)
+    elif payload == 'nested':
+        nstate = nsdfg.add_state()
+        deeper = nstate.add_nested_sdfg(inner_sdfg('straight'), {'a_in': None}, {'b_out': None})
+        nstate.add_edge(nstate.add_read('a_in'), None, deeper, 'a_in', dace.Memlet('a_in[0]'))
+        nstate.add_edge(deeper, 'b_out', nstate.add_write('b_out'), None, dace.Memlet('b_out[0]'))
+    else:
+        double_tasklet(nsdfg.add_state())
+    return nsdfg
+
+
+def outlined_body_sdfg(payload: str) -> dace.SDFG:
+    sdfg = dace.SDFG(f'simd_outlined_{payload}')
+    sdfg.add_array('A', [10], dace.float64)
+    sdfg.add_array('B', [10], dace.float64)
+    state = sdfg.add_state()
+    entry, exit_node = state.add_map('outermap', dict(i='0:10'), schedule=dtypes.ScheduleType.CPU_Multicore)
+    body = state.add_nested_sdfg(inner_sdfg(payload), {'a_in': None}, {'b_out': None})
+    state.add_memlet_path(state.add_read('A'), entry, body, dst_conn='a_in', memlet=dace.Memlet('A[i]'))
+    state.add_memlet_path(body, exit_node, state.add_write('B'), src_conn='b_out', memlet=dace.Memlet('B[i]'))
+    sdfg.validate()
+    return sdfg
+
+
+@pytest.mark.parametrize('payload,leaf', [('straight', True), ('nested', True), ('loopregion', False),
+                                          ('backedge', False), ('map', False)])
+def test_outlined_body_is_opened_not_refused(payload, leaf):
+    """An outlined body (what the Fortran frontend emits for every map) is opened rather than
+    refused on sight; a loop -- ``LoopRegion`` or back edge -- or a map inside withholds the
+    clause."""
+    sdfg = outlined_body_sdfg(payload)
+    mark(sdfg)
+    outer = next(n for _, n in entries(sdfg) if n.map.params == ['i'])
+    assert outer.map.omp_simd is leaf
+
+
 def test_config_switch_suppresses_the_clause():
     """The escape hatch keeps the pass out of code generation entirely."""
 
@@ -135,4 +202,7 @@ if __name__ == '__main__':
     test_outer_map_of_a_nest_is_not_marked()
     test_minmax_reduction_withholds_the_clause()
     test_sequential_scatter_withholds_the_clause()
+    for name, is_leaf in (('straight', True), ('nested', True), ('loopregion', False), ('backedge', False), ('map',
+                                                                                                             False)):
+        test_outlined_body_is_opened_not_refused(name, is_leaf)
     test_config_switch_suppresses_the_clause()

--- a/tests/codegen/omp_simd_test.py
+++ b/tests/codegen/omp_simd_test.py
@@ -8,6 +8,7 @@ import dace
 from dace import dtypes
 from dace.sdfg import nodes
 from dace.sdfg import infer_types
+from dace.sdfg import propagation
 from dace.sdfg.state import LoopRegion
 from dace.transformation.passes.mark_simd_maps import MarkSIMDMaps
 
@@ -265,6 +266,46 @@ def test_the_mark_survives_a_round_trip():
     assert all(n.map.omp_simd for _, n in entries(restored))
 
 
+def test_the_pass_propagates_only_the_scopes_it_rewrote():
+    """``apply_to`` propagates memlets over the whole SDFG once per application unless told not to,
+    which is quadratic in the map count and never finished on a model-sized graph. MapExpansion
+    propagates the scope it rewrote by itself, and that scope is all this pass disturbs."""
+    sdfg = dace.SDFG('propagation_scope')
+    previous = None
+    for k in range(4):
+        sdfg.add_array(f'a{k}', (64, 64), dace.float64)
+        sdfg.add_array(f'b{k}', (64, 64), dace.float64)
+        state = sdfg.add_state(f's{k}', is_start_block=(k == 0))
+        if previous is not None:
+            sdfg.add_edge(previous, state, dace.InterstateEdge())
+        previous = state
+        state.add_mapped_tasklet(f'm{k}', {
+            'i': '0:64',
+            'j': '0:64'
+        }, {'inp': dace.Memlet(f'a{k}[i, j]')},
+                                 'o = inp * 2.0', {'o': dace.Memlet(f'b{k}[i, j]')},
+                                 external_edges=True)
+    sdfg.validate()
+
+    whole_sdfg_calls = []
+    original = propagation.propagate_memlets_sdfg
+    propagation.propagate_memlets_sdfg = lambda *args, **kwargs: whole_sdfg_calls.append(args)
+    try:
+        marked = mark(sdfg)
+    finally:
+        propagation.propagate_memlets_sdfg = original
+
+    assert len(marked) == 4
+    assert not whole_sdfg_calls, 'expansion must not drag a whole-SDFG memlet propagation behind it'
+
+    # What the expansion did touch is still propagated: the outer map hands the inner one a row.
+    for state in sdfg.all_states():
+        outer = next(n for n in state.nodes() if isinstance(n, nodes.MapEntry) and n.map.params == ['i'])
+        inner = next(n for n in state.nodes() if isinstance(n, nodes.MapEntry) and n.map.params == ['j'])
+        edge = next(e for e in state.edges_between(outer, inner) if e.data.data is not None)
+        assert str(edge.data.subset) == 'i, 0:64'
+
+
 def test_config_switch_suppresses_the_clause():
     """The escape hatch keeps the pass out of code generation entirely."""
 
@@ -293,4 +334,5 @@ if __name__ == '__main__':
                                                                                                              False)):
         test_outlined_body_is_opened_not_refused(name, is_leaf)
     test_the_mark_survives_a_round_trip()
+    test_the_pass_propagates_only_the_scopes_it_rewrote()
     test_config_switch_suppresses_the_clause()

--- a/tests/codegen/omp_simd_test.py
+++ b/tests/codegen/omp_simd_test.py
@@ -70,6 +70,82 @@ def test_multidimensional_map_vectorizes_its_innermost_dimension():
     assert np.allclose(b, a * 2.0)
 
 
+@pytest.mark.parametrize('extents', [(8, 12), (4, 6, 10)])
+def test_the_marked_multidimensional_map_expands_in_order(extents):
+    """The clause needs the innermost dimension in a loop of its own, so the pass runs
+    ``MapExpansion`` on the maps it marks. What that leaves behind is asserted here: one
+    single-dimension scope per dimension, in the original order and with the original ranges,
+    nested and re-joined in mirror order, each scope handing the next its slice, and only the
+    innermost one carrying the clause."""
+    params = ['i', 'j', 'k'][:len(extents)]
+    point = ', '.join(params)
+    sdfg = dace.SDFG(f'expand_{len(extents)}d')
+    sdfg.add_array('a', extents, dace.float64)
+    sdfg.add_array('b', extents, dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('nd', {
+        p: f'0:{ext}'
+        for p, ext in zip(params, extents)
+    }, {'inp': dace.Memlet(f'a[{point}]')},
+                             'o = inp * 2.0', {'o': dace.Memlet(f'b[{point}]')},
+                             schedule=dtypes.ScheduleType.CPU_Multicore,
+                             external_edges=True)
+    sdfg.validate()
+    original = next(n for _, n in entries(sdfg))
+    assert original.map.params == params
+    original_ranges = list(original.map.range.ranges)
+
+    assert mark(sdfg)
+    sdfg.validate()
+
+    # One scope per dimension, and they form a single nest rather than siblings.
+    scope = state.scope_dict()
+    map_entries = [n for _, n in entries(sdfg)]
+    assert len(map_entries) == len(extents)
+    chain = [next(n for n in map_entries if scope[n] is None)]
+    while True:
+        inner = [n for n in map_entries if scope[n] is chain[-1]]
+        if not inner:
+            break
+        assert len(inner) == 1
+        chain.append(inner[0])
+    assert len(chain) == len(extents)
+
+    # Outermost first, one parameter each, ranges untouched -- a permuted nest computes garbage.
+    assert [e.map.params for e in chain] == [[p] for p in params]
+    assert [e.map.range.ranges[0] for e in chain] == original_ranges
+
+    # Only the innermost loop is vectorized, and only it was made Sequential to be one.
+    assert chain[0].map.schedule == dtypes.ScheduleType.CPU_Multicore
+    assert all(e.map.schedule == dtypes.ScheduleType.Sequential for e in chain[1:])
+    assert chain[-1].map.omp_simd
+    assert not any(e.map.omp_simd for e in chain[:-1])
+
+    # The exits mirror the entries: one per entry, re-joining innermost first.
+    exits = [state.exit_node(e) for e in chain]
+    assert len(set(id(x) for x in exits)) == len(chain)
+    assert [state.entry_node(x) for x in exits] == chain
+    assert all(state.edges_between(exits[i], exits[i - 1]) for i in range(len(chain) - 1, 0, -1))
+
+    # Each entry hands the next its slice, and the tasklet still sees a single point.
+    for i in range(len(chain) - 1):
+        edge = next(e for e in state.edges_between(chain[i], chain[i + 1]) if e.data.data == 'a')
+        assert str(edge.data.subset) == ', '.join(params[:i + 1] + [f'0:{ext}' for ext in extents[i + 1:]])
+    tasklet = next(n for n in state.nodes() if isinstance(n, nodes.Tasklet))
+    assert str(state.in_edges(tasklet)[0].data.subset) == point
+    assert str(state.out_edges(tasklet)[0].data.subset) == point
+    written = next(e for e in state.out_edges(exits[0]) if e.data.data == 'b')
+    assert str(written.data.subset) == ', '.join(f'0:{ext}' for ext in extents)
+
+    # One vectorized loop in the nest, not one per level.
+    assert sdfg.generate_code()[0].clean_code.count('#pragma omp simd') == 1
+
+    a = np.random.rand(*extents)
+    b = np.zeros(extents)
+    sdfg(a=a, b=b)
+    assert np.allclose(b, a * 2.0)
+
+
 def test_outer_map_of_a_nest_is_not_marked():
     """A map whose body holds another map is not the loop the clause belongs on."""
 
@@ -135,6 +211,8 @@ def test_multicore_reduction_keeps_the_clause_and_the_value():
                              external_edges=True)
     sdfg.validate()
 
+    mark(sdfg)
+    assert all(n.map.omp_simd for _, n in entries(sdfg))
     assert '#pragma omp parallel for simd' in sdfg.generate_code()[0].clean_code
 
     a = np.random.rand(1024)
@@ -266,10 +344,11 @@ def test_the_mark_survives_a_round_trip():
     assert all(n.map.omp_simd for _, n in entries(restored))
 
 
-def test_the_pass_propagates_only_the_scopes_it_rewrote():
-    """``apply_to`` propagates memlets over the whole SDFG once per application unless told not to,
-    which is quadratic in the map count and never finished on a model-sized graph. MapExpansion
-    propagates the scope it rewrote by itself, and that scope is all this pass disturbs."""
+def test_expansion_does_not_trigger_whole_sdfg_propagation(monkeypatch):
+    """Performance regression guard. ``apply_to`` propagates memlets over the whole SDFG once per
+    application unless told not to, which is quadratic in the map count and hung code generation on
+    a model-sized graph for hours. MapExpansion propagates the scope it rewrote by itself, and that
+    scope is all this pass disturbs."""
     sdfg = dace.SDFG('propagation_scope')
     previous = None
     for k in range(4):
@@ -288,12 +367,8 @@ def test_the_pass_propagates_only_the_scopes_it_rewrote():
     sdfg.validate()
 
     whole_sdfg_calls = []
-    original = propagation.propagate_memlets_sdfg
-    propagation.propagate_memlets_sdfg = lambda *args, **kwargs: whole_sdfg_calls.append(args)
-    try:
-        marked = mark(sdfg)
-    finally:
-        propagation.propagate_memlets_sdfg = original
+    monkeypatch.setattr(propagation, 'propagate_memlets_sdfg', lambda *args, **kwargs: whole_sdfg_calls.append(args))
+    marked = mark(sdfg)
 
     assert len(marked) == 4
     assert not whole_sdfg_calls, 'expansion must not drag a whole-SDFG memlet propagation behind it'
@@ -323,6 +398,8 @@ def test_config_switch_suppresses_the_clause():
 if __name__ == '__main__':
     test_leaf_map_is_marked_and_vectorized()
     test_multidimensional_map_vectorizes_its_innermost_dimension()
+    for map_extents in ((8, 12), (4, 6, 10)):
+        test_the_marked_multidimensional_map_expands_in_order(map_extents)
     test_outer_map_of_a_nest_is_not_marked()
     test_minmax_reduction_withholds_the_clause()
     for wcr_target in ('hist[i]', 'hist[0]'):
@@ -334,5 +411,6 @@ if __name__ == '__main__':
                                                                                                              False)):
         test_outlined_body_is_opened_not_refused(name, is_leaf)
     test_the_mark_survives_a_round_trip()
-    test_the_pass_propagates_only_the_scopes_it_rewrote()
+    with pytest.MonkeyPatch.context() as mp:
+        test_expansion_does_not_trigger_whole_sdfg_propagation(mp)
     test_config_switch_suppresses_the_clause()

--- a/tests/codegen/omp_simd_test.py
+++ b/tests/codegen/omp_simd_test.py
@@ -1,0 +1,138 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests for ``MarkSIMDMaps`` and the OpenMP ``simd`` clause it drives. """
+
+import numpy as np
+import dace
+from dace import dtypes
+from dace.sdfg import nodes
+from dace.sdfg import infer_types
+from dace.transformation.passes.mark_simd_maps import MarkSIMDMaps
+
+
+def entries(sdfg: dace.SDFG):
+    return [(state, n) for state in sdfg.all_states() for n in state.nodes() if isinstance(n, nodes.MapEntry)]
+
+
+def mark(sdfg: dace.SDFG):
+    """ Runs the pass the way code generation does: after schedules are resolved. """
+    infer_types.set_default_schedule_and_storage_types(sdfg, None)
+    return MarkSIMDMaps().apply_pass(sdfg, {})
+
+
+def test_leaf_map_is_marked_and_vectorized():
+    """A one-dimensional leaf map takes the clause on its own ``parallel for``."""
+
+    @dace.program
+    def axpy(a: dace.float64[256], b: dace.float64[256]):
+        for i in dace.map[0:256]:
+            b[i] = a[i] * 2.0 + 1.0
+
+    sdfg = axpy.to_sdfg(simplify=True)
+    assert mark(sdfg)
+    assert all(n.map.omp_simd for _, n in entries(sdfg))
+    assert '#pragma omp parallel for simd' in sdfg.generate_code()[0].clean_code
+
+    a = np.random.rand(256)
+    b = np.zeros(256)
+    sdfg(a=a, b=b)
+    assert np.allclose(b, a * 2.0 + 1.0)
+
+
+def test_multidimensional_map_vectorizes_its_innermost_dimension():
+    """The clause vectorizes the loop it precedes, so the innermost dimension gets a map of its
+    own (``MapExpansion``) and only that one is marked."""
+
+    @dace.program
+    def scale(a: dace.float64[64, 64], b: dace.float64[64, 64]):
+        for i, j in dace.map[0:64, 0:64]:
+            b[i, j] = a[i, j] * 2.0
+
+    sdfg = scale.to_sdfg(simplify=True)
+    assert len(entries(sdfg)) == 1
+    assert mark(sdfg)
+
+    all_entries = entries(sdfg)
+    assert len(all_entries) == 2, "the innermost dimension must become a map of its own"
+    marked = [n for _, n in all_entries if n.map.omp_simd]
+    assert len(marked) == 1 and marked[0].map.params == ['j']
+
+    code = sdfg.generate_code()[0].clean_code
+    assert '#pragma omp parallel for' in code
+    assert '#pragma omp simd' in code
+
+    a = np.random.rand(64, 64)
+    b = np.zeros((64, 64))
+    sdfg(a=a, b=b)
+    assert np.allclose(b, a * 2.0)
+
+
+def test_outer_map_of_a_nest_is_not_marked():
+    """A map whose body holds another map is not the loop the clause belongs on."""
+
+    @dace.program
+    def nested(a: dace.float64[32, 32], b: dace.float64[32, 32]):
+        for i in dace.map[0:32]:
+            for j in dace.map[0:32]:
+                b[i, j] = a[i, j] + 1.0
+
+    sdfg = nested.to_sdfg(simplify=True)
+    mark(sdfg)
+    marked = [n for _, n in entries(sdfg) if n.map.omp_simd]
+    assert len(marked) == 1 and marked[0].map.params == ['j']
+
+
+def test_minmax_reduction_withholds_the_clause():
+    """``min``/``max`` combine with a NaN-preserving compare vectorizers do not reliably fold."""
+    sdfg = dace.SDFG('minmax_wcr_map')
+    sdfg.add_array('a', (128, ), dace.float64)
+    sdfg.add_array('out', (1, ), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('reduce_max', {'i': '0:128'}, {'inp': dace.Memlet('a[i]')},
+                             'o = inp', {'o': dace.Memlet('out[0]', wcr='lambda x, y: max(x, y)')},
+                             schedule=dtypes.ScheduleType.CPU_Multicore,
+                             external_edges=True)
+    sdfg.validate()
+
+    mark(sdfg)
+    assert not any(n.map.omp_simd for _, n in entries(sdfg))
+    assert ' simd' not in sdfg.generate_code()[0].clean_code
+
+
+def test_sequential_scatter_withholds_the_clause():
+    """A Sequential map lowers a conflicted WCR to a non-atomic reduce, so a target indexed by the
+    map's own parameter can alias across lanes."""
+    sdfg = dace.SDFG('scatter_wcr_map')
+    sdfg.add_array('a', (64, ), dace.float64)
+    sdfg.add_array('hist', (64, ), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('scatter', {'i': '0:64'}, {'inp': dace.Memlet('a[i]')},
+                             'o = inp', {'o': dace.Memlet('hist[i]', wcr='lambda x, y: x + y')},
+                             schedule=dtypes.ScheduleType.Sequential,
+                             external_edges=True)
+    sdfg.validate()
+
+    mark(sdfg)
+    assert not any(n.map.omp_simd for _, n in entries(sdfg))
+
+
+def test_config_switch_suppresses_the_clause():
+    """The escape hatch keeps the pass out of code generation entirely."""
+
+    @dace.program
+    def axpy2(a: dace.float64[128], b: dace.float64[128]):
+        for i in dace.map[0:128]:
+            b[i] = a[i] + 1.0
+
+    sdfg = axpy2.to_sdfg(simplify=True)
+    with dace.config.set_temporary('compiler', 'cpu', 'simd_maps', value=False):
+        assert ' simd' not in sdfg.generate_code()[0].clean_code
+    assert ' simd' in sdfg.generate_code()[0].clean_code
+
+
+if __name__ == '__main__':
+    test_leaf_map_is_marked_and_vectorized()
+    test_multidimensional_map_vectorizes_its_innermost_dimension()
+    test_outer_map_of_a_nest_is_not_marked()
+    test_minmax_reduction_withholds_the_clause()
+    test_sequential_scatter_withholds_the_clause()
+    test_config_switch_suppresses_the_clause()

--- a/tests/openmp_test.py
+++ b/tests/openmp_test.py
@@ -56,19 +56,19 @@ def test_omp_props():
     mapnode.schedule = dtypes.ScheduleType.CPU_Multicore
 
     code = sdfg.generate_code()[0].clean_code
-    assert ("#pragma omp parallel for" in code)
+    assert ("#pragma omp parallel for simd" in code)
 
     mapnode.omp_num_threads = 10
     code = sdfg.generate_code()[0].clean_code
-    assert ("#pragma omp parallel for num_threads(10)" in code)
+    assert ("#pragma omp parallel for simd num_threads(10)" in code)
 
     mapnode.omp_schedule = dtypes.OMPScheduleType.Guided
     code = sdfg.generate_code()[0].clean_code
-    assert ("#pragma omp parallel for schedule(guided) num_threads(10)" in code)
+    assert ("#pragma omp parallel for simd schedule(guided) num_threads(10)" in code)
 
     mapnode.omp_chunk_size = 5
     code = sdfg.generate_code()[0].clean_code
-    assert ("#pragma omp parallel for schedule(guided, 5) num_threads(10)" in code)
+    assert ("#pragma omp parallel for simd schedule(guided, 5) num_threads(10)" in code)
 
     json = sdfg.to_json()
     assert (key_exists(json, 'omp_num_threads'))

--- a/tests/transformations/map_expansion_test.py
+++ b/tests/transformations/map_expansion_test.py
@@ -205,9 +205,39 @@ def test_expand_with_dependency_edges():
     assert np.all(B == B_expected)
 
 
+def test_collapse_is_clamped_to_the_remaining_dimensions():
+    """``collapse(n)`` fuses the next n loops. The first map is reused with fewer parameters, so a
+    stale count would emit ``collapse(2)`` on a one-dimensional loop, which no compiler accepts."""
+    sdfg = dace.SDFG('expansion_collapse')
+    sdfg.add_array('a', (16, 16), dace.float64)
+    sdfg.add_array('b', (16, 16), dace.float64)
+    state = sdfg.add_state('main', is_start_block=True)
+    state.add_mapped_tasklet('m', {
+        'i': '0:16',
+        'j': '0:16'
+    }, {'inp': dace.Memlet('a[i, j]')},
+                             'o = inp * 2.0', {'o': dace.Memlet('b[i, j]')},
+                             schedule=dace.ScheduleType.CPU_Multicore,
+                             external_edges=True)
+    entry = next(n for n in state.nodes() if isinstance(n, dace.nodes.MapEntry))
+    entry.map.collapse = 2
+
+    assert sdfg.apply_transformations(MapExpansion) == 1
+    for node in state.nodes():
+        if isinstance(node, dace.nodes.MapEntry):
+            assert node.map.collapse <= len(node.map.params)
+    assert 'collapse(2)' not in sdfg.generate_code()[0].clean_code
+
+    a = np.random.rand(16, 16)
+    b = np.zeros((16, 16))
+    sdfg(a=a, b=b)
+    assert np.allclose(b, a * 2.0)
+
+
 if __name__ == '__main__':
     test_expand_with_inputs()
     test_expand_without_inputs()
     test_expand_without_dynamic_inputs()
     test_expand_with_limits()
     test_expand_with_dependency_edges()
+    test_collapse_is_clamped_to_the_remaining_dimensions()


### PR DESCRIPTION
MarkSIMDMaps marks the innermost Sequential and CPU_Multicore maps whose body holds no further loop or map, splitting a multidimensional map with MapExpansion first since the clause vectorizes the loop it precedes, and withholding it from min/max reductions and Sequential scatters. Code generation only renders what the pass decided.

```
#pragma omp parallel for      // outer dimension
    #pragma omp simd          // innermost, split off by the pass
```