### PR TITLE
SymbolPropagation: Fixing it Finally

### DIFF
--- a/dace/runtime/include/dace/pyinterop.h
+++ b/dace/runtime/include/dace/pyinterop.h
@@ -48,8 +48,10 @@ template <typename U, typename... T>
 static DACE_HDFI U Max(U val, T... vals) {
     return max(val, vals...);
 }
+// Deduced, not ``T``: ``abs`` of a complex value is real, so pinning the return to the argument
+// type turns ``Abs(z)`` back into a complex and every comparison on it loses its candidate.
 template <typename T>
-static DACE_HDFI T Abs(T val) {
+static DACE_HDFI auto Abs(T val) {
     return abs(val);
 }
 template <typename T, typename U>

--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -872,15 +872,21 @@ class MapEntry(EntryNode):
 
     def new_symbols(self, sdfg, state, symbols) -> Dict[str, dtypes.typeclass]:
         result = {}
-        # Add map params
-        for p, rng in zip(self._map.params, self._map.range):
-            result[p] = dtypes.result_type_of(infer_expr_type(rng[0], symbols), infer_expr_type(rng[1], symbols))
-
-        # Handle the dynamic map ranges.
+        # Dynamic map ranges first: a bound may name one, and the connector type is the declared
+        # answer for it. Inferring the parameter without them falls back to the dtype the bound's
+        # symbol instance happens to carry, and that is not a stable property -- symbol identity is
+        # by name, so an expression rebuilt from a string (any ``replace_dict`` substitution) mints
+        # its names untyped, while deserialization rebuilds them from the declared table. The same
+        # map would then report two different parameter types across a save/load round trip.
         dyn_inputs = set(c for c in self.in_connectors if not c.startswith('IN_'))
         for e in state.in_edges(self):
             if e.dst_conn in dyn_inputs:
                 result[e.dst_conn] = (self.in_connectors[e.dst_conn] or sdfg.arrays[e.data.data].dtype)
+
+        # Add map params
+        known = {**symbols, **result}
+        for p, rng in zip(self._map.params, self._map.range):
+            result[p] = dtypes.result_type_of(infer_expr_type(rng[0], known), infer_expr_type(rng[1], known))
 
         return result
 

--- a/dace/sdfg/replace.py
+++ b/dace/sdfg/replace.py
@@ -112,7 +112,7 @@ def replace_dict(subgraph: 'StateSubgraphView',
 
     # Replace in node properties
     for node in subgraph.nodes():
-        replace_properties_dict(node, repl, symrepl)
+        replace_properties_dict(node, repl, symrepl, sdfg)
 
     # Replace in memlets
     for edge in subgraph.edges():
@@ -139,7 +139,23 @@ def replace(subgraph: 'StateSubgraphView', name: str, new_name: str):
     replace_dict(subgraph, {name: new_name})
 
 
-def replace_in_codeblock(codeblock: properties.CodeBlock, repl: Dict[str, str], node: Optional[Any] = None):
+def declared_ctype(name: str, sdfg: Optional['dace.SDFG']) -> Optional[str]:
+    """C type ``name`` is declared with in ``sdfg``: a symbol's type, or a scalar's. ``None`` when
+    ``name`` is neither, as a map parameter is."""
+    if sdfg is None:
+        return None
+    if name in sdfg.symbols:
+        return sdfg.symbols[name].ctype
+    desc = sdfg.arrays.get(name)
+    if isinstance(desc, data.Scalar):
+        return desc.dtype.ctype
+    return None
+
+
+def replace_in_codeblock(codeblock: properties.CodeBlock,
+                         repl: Dict[str, str],
+                         node: Optional[Any] = None,
+                         sdfg: Optional['dace.SDFG'] = None):
     code = codeblock.code
     if isinstance(code, str) and code:
         lang = codeblock.language
@@ -150,8 +166,11 @@ def replace_in_codeblock(codeblock: properties.CodeBlock, repl: Dict[str, str], 
             for name, new_name in repl.items():
                 if name not in tokenized:
                     continue
-                # Use local variables and shadowing to replace
-                replacement = f'auto {name} = {cppunparse.pyexpr2cpp(new_name)};\n'
+                # Shadow with the declared type: ``auto`` deduces from the replacement expression,
+                # so ``i = 2`` would narrow an int64 symbol to int. A map parameter has no declared
+                # type here, and ``auto`` then copies the index variable's own.
+                ctype = declared_ctype(name, sdfg) or 'auto'
+                replacement = f'{ctype} {name} = {cppunparse.pyexpr2cpp(new_name)};\n'
                 prefix = replacement + prefix
                 active_replacements.add(name)
 
@@ -173,7 +192,8 @@ def replace_in_codeblock(codeblock: properties.CodeBlock, repl: Dict[str, str], 
 
 def replace_properties_dict(node: Any,
                             repl: Dict[str, str],
-                            symrepl: Optional[Dict[symbolic.SymbolicType, symbolic.SymbolicType]] = None):
+                            symrepl: Optional[Dict[symbolic.SymbolicType, symbolic.SymbolicType]] = None,
+                            sdfg: Optional['dace.SDFG'] = None):
     symrepl = symrepl or {
         symbolic.pystr_to_symbolic(symname):
         symbolic.pystr_to_symbolic(new_name) if isinstance(new_name, str) else new_name
@@ -202,7 +222,7 @@ def replace_properties_dict(node: Any,
             if isinstance(node, nodes.Node):
                 reduced_repl -= set(node.in_connectors.keys()) | set(node.out_connectors.keys())
             reduced_repl = {k: repl[k] for k in reduced_repl}
-            replace_in_codeblock(propval, reduced_repl, node)
+            replace_in_codeblock(propval, reduced_repl, node, sdfg)
         elif (isinstance(propclass, properties.DictProperty) and pname == 'symbol_mapping'):
             # Symbol mappings for nested SDFGs
             for symname, sym_mapping in propval.items():

--- a/dace/transformation/passes/simplify.py
+++ b/dace/transformation/passes/simplify.py
@@ -21,6 +21,7 @@ from dace.transformation.passes.simplification.control_flow_raising import Contr
 from dace.transformation.passes.simplification.prune_empty_conditional_branches import PruneEmptyConditionalBranches
 from dace.transformation.passes.simplification.continue_to_condition import ContinueToCondition
 from dace.transformation.passes.empty_loop_elimination import EmptyLoopElimination
+from dace.transformation.passes.symbol_propagation import SymbolPropagation
 
 SIMPLIFY_PASSES = [
     InlineSDFGs,
@@ -29,6 +30,7 @@ SIMPLIFY_PASSES = [
     ControlFlowRaising,
     FuseStates,
     OptionalArrayInference,
+    SymbolPropagation,
     ConstantPropagation,
     DeadDataflowElimination,
     DeadStateElimination,

--- a/dace/transformation/passes/split_tasklets.py
+++ b/dace/transformation/passes/split_tasklets.py
@@ -255,7 +255,6 @@ class SplitTasklets(ppl.Pass):
                         )
                         assert array_name not in added_accesses
                         added_accesses[array_name] = state.add_access(array_name)
-                    state.sdfg.save("x.sdfgz", compress=True)
                     state.add_edge(
                         t, out_conn, added_accesses[array_name], None,
                         dace.memlet.Memlet.from_array(dataname=array_name, datadesc=state.sdfg.arrays[array_name]))

--- a/dace/transformation/passes/symbol_propagation.py
+++ b/dace/transformation/passes/symbol_propagation.py
@@ -182,7 +182,7 @@ class SymbolPropagation(ppl.Pass):
 
     def _eliminate_dead_iedge_assignments(self, sdfg: SDFG) -> Set[str]:
         """Drop interstate-edge assignments whose LHS is no longer referenced anywhere.
-        ``replace_dict`` does not reach into descriptors, so substitute there first (a no-op,
+        ``replace_dict`` reaches into descriptors as well, so substitute there first (a no-op,
         since the symbol is that expression), then sweep to a fixed point."""
         removed: Set[str] = set()
         while True:
@@ -208,8 +208,16 @@ class SymbolPropagation(ppl.Pass):
                         bindings[lhs] = rhs
                     elif bindings[lhs] is not None and bindings[lhs] != rhs:
                         bindings[lhs] = None
-            # A data read is not a legal descriptor shape, so the symbol stays live.
-            safe_subs = {sym: rhs for sym, rhs in bindings.items() if rhs is not None and not _is_array_access(rhs)}
+            # ``replace_dict`` also rewrites descriptor shapes, which live at SDFG scope: a
+            # right-hand side reading data, or built from a symbol an inner block assigns (a loop
+            # iteration variable), is not legal there. ``K = i + 1`` would size a transient by the
+            # loop variable and allocate it outside the loop.
+            invariant = {str(s) for s in sd.free_symbols} | set(sd.constants_prop.keys())
+            safe_subs = {
+                sym: rhs
+                for sym, rhs in bindings.items()
+                if rhs is not None and not _is_array_access(rhs) and _free_symbols(rhs) <= invariant
+            }
 
             if safe_subs:
                 sd.replace_dict(safe_subs, replace_keys=False, replace_in_graph=False)

--- a/dace/transformation/passes/symbol_propagation.py
+++ b/dace/transformation/passes/symbol_propagation.py
@@ -1,8 +1,9 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 
-import copy
+import ast
 from dataclasses import dataclass
 from dace.sdfg.state import (
+    AbstractControlFlowRegion,
     ControlFlowBlock,
     ControlFlowRegion,
     ConditionalBlock,
@@ -12,7 +13,95 @@ from dace.transformation import pass_pipeline as ppl, transformation
 from dace import SDFG, properties, SDFGState
 from typing import Any, Dict, Set, Optional
 from dace import data as dt
-from dace.symbolic import pystr_to_symbolic, scalars
+from dace.symbolic import pystr_to_symbolic, scalars, symstr
+
+
+def _free_symbols(value) -> Set[str]:
+    """Free symbol names of an interstate-edge assignment RHS; empty for ``None``."""
+    if value is None:
+        return set()
+    try:
+        return {str(s) for s in pystr_to_symbolic(value).free_symbols}
+    except Exception:
+        return set()
+
+
+def _mutated_scalar_names(sdfg: SDFG) -> Set[str]:
+    """Names of ``Scalar`` descriptors written somewhere in ``sdfg``; an unwritten one is a
+    read-only parameter and propagates as safely as a symbol."""
+    mutated: Set[str] = set()
+    for state in sdfg.all_states():
+        for n in state.data_nodes():
+            if state.in_degree(n) == 0:
+                continue
+            desc = sdfg.arrays.get(n.data)
+            if isinstance(desc, dt.Scalar):
+                mutated.add(n.data)
+    return mutated
+
+
+def _meta_read_symbols(blk: ControlFlowBlock) -> Set[str]:
+    """Symbols a region's meta code reads: branch conditions, loop init / condition / update.
+    ``free_symbols`` subtracts what the body rebinds, but the meta code runs first, so that read
+    is live and must keep its assignment alive."""
+    if not isinstance(blk, AbstractControlFlowRegion):
+        return set()
+    names: Set[str] = set()
+    for code in blk.get_meta_codeblocks():
+        if code is None:
+            continue
+        try:
+            names |= {str(s) for s in code.get_free_symbols()}
+        except Exception:
+            pass
+    return names
+
+
+def _is_array_access(value: Optional[str]) -> bool:
+    """An assignment RHS reading a data container (``tbl[i]``, ``b_slice.idx``) is never
+    propagated: sympy renders it as ``tbl(i)``, losing the bracket the filters key on, and a
+    descriptor shape must be a function of symbols."""
+    if value is None:
+        return False
+    if "[" in value or "]" in value:
+        return True
+    return _reads_struct_member(value)
+
+
+def _reads_struct_member(value: str) -> bool:
+    """``value`` reads an attribute off a plain name; a qualified call (``math.floor``) spells
+    the same way, so a callee attribute does not count."""
+    try:
+        tree = ast.parse(value.strip(), mode='eval')
+    except (SyntaxError, ValueError):
+        return False  # not parseable as an expression -> leave it to the other filters
+    callees = {id(node.func) for node in ast.walk(tree) if isinstance(node, ast.Call)}
+    return any(isinstance(node, ast.Attribute) and id(node) not in callees for node in ast.walk(tree))
+
+
+def _resolve(value, table: Dict[str, Any]):
+    """Substitute known symbol values from ``table`` into an assignment RHS, against the
+    pre-edge table since one edge's assignments are simultaneous. Resolving now rather than
+    chaining raw strings keeps a cyclic dependency from forming a substitution cycle."""
+    if value is None:
+        return None
+    # Leave array-access values (``tbl[i]``) untouched (see :func:`_is_array_access`).
+    if _is_array_access(value):
+        return value
+    try:
+        expr = pystr_to_symbolic(value)
+        repl = {}
+        for s in expr.free_symbols:
+            name = str(s)
+            known = table.get(name)
+            if known is not None and not _is_array_access(known):
+                repl[s] = pystr_to_symbolic(known)
+        if repl:
+            expr = expr.subs(repl)
+        # ``symstr``, not ``str``: operator-backed functions print as ``__right_shift(a, 1)``.
+        return symstr(expr)
+    except Exception:
+        return value
 
 
 @dataclass(unsafe_hash=True)
@@ -35,11 +124,18 @@ class SymbolPropagation(ppl.Pass):
     def apply_pass(self, sdfg: SDFG, _) -> Optional[Set[str]]:
         # Assumption: Symbols can only change in InterStateEdges
 
+        before_free: Set[str] = {str(s) for s in sdfg.free_symbols}
+
         # Get all CFG blocks present in the SDFG
         all_cfg_blks = dict()
         for node, parent in sdfg.all_nodes_recursive():
             if isinstance(node, ControlFlowBlock):
                 all_cfg_blks[node] = parent
+
+        # Cached per SDFG: an unwritten Scalar is read-only and propagates like a symbol.
+        self._mutated_scalars: Dict[SDFG, Set[str]] = {}
+        for sd in sdfg.all_sdfgs_recursive():
+            self._mutated_scalars[sd] = _mutated_scalar_names(sd)
 
         # For each CFG Block maintain a dict of incoming and outgoing symbols
         in_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
@@ -66,10 +162,85 @@ class SymbolPropagation(ppl.Pass):
                     changed = True
                     out_syms[cfg_blk] = new_out_syms
 
-        # Update symbols in the cfg_blk
+        # An honest return set is what lets a FixedPointPipeline converge.
+        propagated: Set[str] = set()
         for cfg_blk, parent in all_cfg_blks.items():
-            self._update_syms(cfg_blk, parent, in_syms, out_syms)
-        return set()
+            propagated |= self._update_syms(cfg_blk, parent, in_syms, out_syms)
+        # Substitution leaves the defining assignment behind; sweep to a fixed point.
+        eliminated = self._eliminate_dead_iedge_assignments(sdfg)
+        if eliminated:
+            propagated |= eliminated
+
+        # A new free symbol means a value rendered into a name that does not resolve.
+        new_free: Set[str] = {str(s) for s in sdfg.free_symbols} - before_free
+        if new_free:
+            raise ValueError(f"SymbolPropagation introduced free symbol(s) {sorted(new_free)}: a propagated "
+                             f"value rendered to an unresolvable name. Symbol propagation must only eliminate "
+                             f"symbols, never introduce them.")
+
+        return propagated if propagated else None
+
+    def _eliminate_dead_iedge_assignments(self, sdfg: SDFG) -> Set[str]:
+        """Drop interstate-edge assignments whose LHS is no longer referenced anywhere.
+        ``replace_dict`` does not reach into descriptors, so substitute there first (a no-op,
+        since the symbol is that expression), then sweep to a fixed point."""
+        removed: Set[str] = set()
+        while True:
+            this_round = self._eliminate_round(sdfg)
+            if not this_round:
+                break
+            removed |= this_round
+        return removed
+
+    def _eliminate_round(self, sdfg: SDFG) -> Set[str]:
+        """One sweep of dead-edge elimination across ``sdfg`` and its nested SDFGs; descriptors
+        go first, since ``free_symbols`` pulls shape symbols through the access nodes."""
+        eliminated: Set[str] = set()
+        for sd in sdfg.all_sdfgs_recursive():
+            # Propagatable: every binding edge agrees, and the RHS is not self-referential.
+            bindings: Dict[str, Optional[str]] = {}
+            for e in sd.all_interstate_edges():
+                for lhs, rhs in e.data.assignments.items():
+                    if rhs is None or lhs in _free_symbols(rhs):
+                        bindings[lhs] = None
+                        continue
+                    if lhs not in bindings:
+                        bindings[lhs] = rhs
+                    elif bindings[lhs] is not None and bindings[lhs] != rhs:
+                        bindings[lhs] = None
+            # A data read is not a legal descriptor shape, so the symbol stays live.
+            safe_subs = {sym: rhs for sym, rhs in bindings.items() if rhs is not None and not _is_array_access(rhs)}
+
+            if safe_subs:
+                sd.replace_dict(safe_subs, replace_keys=False, replace_in_graph=False)
+
+            used_in_ir: Set[str] = set()
+            for blk in sd.all_control_flow_blocks():
+                used_in_ir |= {str(s) for s in blk.free_symbols}
+                used_in_ir |= _meta_read_symbols(blk)
+            for e in sd.all_interstate_edges():
+                for rhs in e.data.assignments.values():
+                    used_in_ir |= _free_symbols(rhs)
+                if e.data.condition is not None:
+                    try:
+                        used_in_ir |= {str(s) for s in e.data.condition.get_free_symbols()}
+                    except Exception:
+                        pass
+
+            sd_eliminated: Set[str] = set()
+            for e in sd.all_interstate_edges():
+                for lhs in list(e.data.assignments.keys()):
+                    if lhs not in used_in_ir:
+                        del e.data.assignments[lhs]
+                        sd_eliminated.add(lhs)
+            # Drop orphaned declarations, else nested-SDFG validation demands the symbol.
+            if sd_eliminated:
+                still_bound = {k for ie in sd.all_interstate_edges() for k in ie.data.assignments.keys()}
+                for name in sd_eliminated:
+                    if (name in sd.symbols and name not in still_bound and name not in used_in_ir):
+                        del sd.symbols[name]
+            eliminated |= sd_eliminated
+        return eliminated
 
     # Given a cfg_blk, builds the incoming set of symbols
     def _get_in_syms(
@@ -80,26 +251,43 @@ class SymbolPropagation(ppl.Pass):
         in_syms: Dict[ControlFlowBlock, Dict[str, Any]],
         out_syms: Dict[ControlFlowBlock, Dict[str, Any]],
     ) -> Dict[str, Any]:
+        # The filters below need the SDFG that OWNS this block: ``sdfg`` is the top-level one.
+        owner = cfg_blk.sdfg
         # Combine the outgoing symbols of all incoming edges with their assignments to the cfg_blk
         new_in_syms = {}
         for i, edge in enumerate(parent.in_edges(cfg_blk)):
-            sym_table = copy.deepcopy(out_syms[edge.src])
-            sym_table.update(edge.data.assignments)
+            sym_table = dict(out_syms[edge.src])
+            # One edge's assignments fire simultaneously: a value naming a symbol this edge
+            # rebinds stays live, else the rebinding is counted twice.
+            edge_keys = set(edge.data.assignments.keys())
+            resolved = {}
+            for k, v in edge.data.assignments.items():
+                rv = _resolve(v, sym_table)
+                if rv is not None and (_free_symbols(rv) & edge_keys):
+                    rv = None
+                resolved[k] = rv
+            # A carried-in value naming a symbol this edge reassigns is stale downstream.
+            for sym in list(sym_table.keys()):
+                val = sym_table[sym]
+                if sym not in edge_keys and val is not None and (_free_symbols(val) & edge_keys):
+                    sym_table[sym] = None
+            sym_table.update(resolved)
 
             # Filter out symbols containing arrays accesses as they cannot be safely propagated (nested array accesses are not supported)
-            sym_table = {k: v for k, v in sym_table.items() if v is None or ("[" not in v and "]" not in v)}
+            sym_table = {k: v for k, v in sym_table.items() if not _is_array_access(v)}
 
             # Also filter out symbols containing views as they cannot be safely propagated (they are seen as pointers)
             sym_table = {
                 k: v
                 for k, v in sym_table.items() if v is None or not any([
-                    str(s) in sdfg.arrays and isinstance(sdfg.arrays[str(s)], dt.View)
+                    str(s) in owner.arrays and isinstance(owner.arrays[str(s)], dt.View)
                     for s in pystr_to_symbolic(v).free_symbols
                 ])
             }
 
-            # Also skip assignments that read a scalar (scalars cannot be propagated as symbols)
-            sym_table = {k: v for k, v in sym_table.items() if v is None or not scalars(v, sdfg.arrays)}
+            # A mutated scalar can change across the SDFG, so its readers cannot propagate.
+            mutated = self._mutated_scalars.get(owner, set())
+            sym_table = {k: v for k, v in sym_table.items() if v is None or not (scalars(v, owner.arrays) & mutated)}
 
             # Combine the symbols
             if i == 0:
@@ -111,12 +299,16 @@ class SymbolPropagation(ppl.Pass):
         # Ignore SDFGs as nested SDFGs have symbol mappings
         if (parent.start_block == cfg_blk and not isinstance(parent, SDFG)) or (isinstance(parent, ConditionalBlock)
                                                                                 and cfg_blk in parent.sub_regions()):
-            assert new_in_syms == {}
-            new_in_syms = in_syms[parent]
+            # A start or branch region inherits the parent's symbols; some shapes carry their
+            # own, so combine rather than assert.
+            if new_in_syms:
+                self._combine_syms(new_in_syms, in_syms[parent])
+            else:
+                new_in_syms = in_syms[parent]
 
             # For LoopRegions, remove loop carried variables from the incoming symbols
             if isinstance(parent, LoopRegion):
-                new_in_syms = copy.deepcopy(new_in_syms)
+                new_in_syms = dict(new_in_syms)
                 all_syms = set([s for e in parent.all_interstate_edges() for s in e.data.assignments.keys()])
                 for sym in all_syms:
                     if sym in new_in_syms:
@@ -134,7 +326,7 @@ class SymbolPropagation(ppl.Pass):
     ) -> Dict[str, Any]:
         if isinstance(cfg_blk, LoopRegion):
             # Any symbol that is assigned in the loop region is not propagated out
-            new_out_syms = copy.deepcopy(in_syms[cfg_blk])
+            new_out_syms = dict(in_syms[cfg_blk])
             for edge in cfg_blk.all_interstate_edges():
                 for sym in edge.data.assignments.keys():
                     if sym in new_out_syms:
@@ -143,7 +335,7 @@ class SymbolPropagation(ppl.Pass):
 
         elif isinstance(cfg_blk, ConditionalBlock):
             # Combine all outgoing symbols of the branches
-            new_out_syms = copy.deepcopy(out_syms[cfg_blk.sub_regions()[0]])
+            new_out_syms = dict(out_syms[cfg_blk.sub_regions()[0]])
             for b in cfg_blk.sub_regions():
                 self._combine_syms(new_out_syms, out_syms[b])
 
@@ -164,10 +356,16 @@ class SymbolPropagation(ppl.Pass):
             if len(sink_nodes) == 0:
                 return in_syms[cfg_blk]
 
-            new_out_syms = copy.deepcopy(out_syms[sink_nodes[0]])
+            new_out_syms = dict(out_syms[sink_nodes[0]])
             for n in sink_nodes:
                 self._combine_syms(new_out_syms, out_syms[n])
             return new_out_syms
+
+    def _block_free_symbols(self, cfg_blk: ControlFlowBlock, parent: ControlFlowRegion) -> Set[str]:
+        """Names of symbols read by ``cfg_blk`` and by its outgoing edges."""
+        free = {str(s) for s in cfg_blk.free_symbols}
+        free |= {str(s) for edge in parent.out_edges(cfg_blk) for s in edge.data.free_symbols}
+        return free
 
     # Given a cfg_blk, updates the symbols in the cfg_blk
     def _update_syms(
@@ -176,23 +374,40 @@ class SymbolPropagation(ppl.Pass):
         parent: ControlFlowRegion,
         in_syms: Dict[ControlFlowBlock, Dict[str, Any]],
         out_syms: Dict[ControlFlowBlock, Dict[str, Any]],
-    ) -> None:
-        new_in_syms = copy.deepcopy(in_syms[cfg_blk])
-        new_out_syms = copy.deepcopy(out_syms[cfg_blk])
+    ) -> Set[str]:
+        new_in_syms = dict(in_syms[cfg_blk])
+        new_out_syms = dict(out_syms[cfg_blk])
 
         # Remove all symbols that are None
         new_in_syms = {sym: val for sym, val in new_in_syms.items() if val is not None}
         new_out_syms = {sym: val for sym, val in new_out_syms.items() if val is not None}
 
+        candidates = set(new_in_syms) | set(new_out_syms)
+        if not candidates:
+            return set()
+        free_before = self._block_free_symbols(cfg_blk, parent)
+
+        # An acyclic chain converges within ``#symbols`` rounds; the cap stops a cyclic one.
+        max_iters = len(new_in_syms) + len(new_out_syms) + 2
+
+        # A symbol the body reassigns is loop-carried: folding the incoming value into
+        # ``while udiff > 0.001`` spins forever.
+        loop_carried: Set[str] = set()
+        if isinstance(cfg_blk, LoopRegion):
+            loop_carried = {s for e in cfg_blk.all_interstate_edges() for s in e.data.assignments.keys()}
+
         changed = True
-        while changed:
+        iters = 0
+        while changed and iters < max_iters:
+            iters += 1
             changed = False
             free_sym = cfg_blk.free_symbols
             free_edge_sym = set([sym for edge in parent.out_edges(cfg_blk) for sym in edge.data.free_symbols])
 
             # Replace all symbols in the cfg_blk with their values
             if isinstance(cfg_blk, LoopRegion):
-                cfg_blk.replace_meta_accesses(new_in_syms)
+                meta_syms = {s: v for s, v in new_in_syms.items() if s not in loop_carried}
+                cfg_blk.replace_meta_accesses(meta_syms)
             elif isinstance(cfg_blk, ConditionalBlock):
                 cfg_blk.replace_meta_accesses(new_in_syms)
             elif isinstance(cfg_blk, SDFGState):
@@ -201,17 +416,29 @@ class SymbolPropagation(ppl.Pass):
                 # Don't replace, as the nested CFBGs should inherit the symbols from their parent
                 pass
 
-            # Also replace all symbols in the outgoing edges with their values
+            # Same rule out: a substitution naming a key of this edge reads its own output.
             for edge in parent.out_edges(cfg_blk):
-                edge.data.replace_dict(new_out_syms, replace_keys=False)
+                edge_keys = set(edge.data.assignments.keys())
+                if edge_keys:
+                    edge_subs = {s: v for s, v in new_out_syms.items() if not (_free_symbols(v) & edge_keys)}
+                else:
+                    edge_subs = new_out_syms
+                edge.data.replace_dict(edge_subs, replace_keys=False)
 
             # Check if the symbols have changed
             new_free_edge_sym = set([sym for edge in parent.out_edges(cfg_blk) for sym in edge.data.free_symbols])
             if free_sym != cfg_blk.free_symbols or free_edge_sym != new_free_edge_sym:
                 changed = True
 
-    # Combines two symbol dictionaries, setting the value to None if they don't agree. Directly modifies sym1
+        # The candidate symbols that are no longer read here were propagated.
+        return candidates & (free_before - self._block_free_symbols(cfg_blk, parent))
+
     def _combine_syms(self, sym1: Dict[str, Any], sym2: Dict[str, Any]) -> None:
+        """Meet of two symbol tables at a control-flow join, in place: a symbol survives only
+        when both sides agree, since a key absent on one side means no value known there."""
         for sym, val in sym2.items():
             if sym not in sym1 or sym1[sym] != val:
+                sym1[sym] = None
+        for sym in sym1:
+            if sym not in sym2:
                 sym1[sym] = None

--- a/dace/transformation/passes/symbol_propagation.py
+++ b/dace/transformation/passes/symbol_propagation.py
@@ -28,17 +28,23 @@ def free_symbol_names(value) -> Set[str]:
         return set()
 
 
-def mutated_scalar_names(sdfg: SDFG) -> Set[str]:
-    """Names of ``Scalar`` descriptors written somewhere in ``sdfg``."""
-    mutated: Set[str] = set()
+def opaque_scalar_names(sdfg: SDFG) -> Set[str]:
+    """``Scalar`` descriptors of ``sdfg`` whose readers must not propagate. A scalar written here
+    changes under the reader. A non-transient scalar of a nested SDFG is a connector the parent
+    rewrites per invocation, and folding its value back into control flow undoes the
+    ``ScalarToSymbolPromotion`` that put the symbol there; only a never-written argument of the
+    top-level SDFG is a read-only parameter."""
+    opaque: Set[str] = set()
     for state in sdfg.all_states():
         for n in state.data_nodes():
             if state.in_degree(n) == 0:
                 continue
             desc = sdfg.arrays.get(n.data)
             if isinstance(desc, dt.Scalar):
-                mutated.add(n.data)
-    return mutated
+                opaque.add(n.data)
+    if sdfg.parent_sdfg is not None:
+        opaque |= {name for name, desc in sdfg.arrays.items() if isinstance(desc, dt.Scalar) and not desc.transient}
+    return opaque
 
 
 def meta_read_symbols(blk: ControlFlowBlock) -> Set[str]:
@@ -172,10 +178,10 @@ class SymbolPropagation(ppl.Pass):
             if isinstance(node, ControlFlowBlock):
                 all_cfg_blks[node] = parent
 
-        # An unwritten Scalar is read-only and propagates like a symbol.
-        self._mutated_scalars: Dict[SDFG, Set[str]] = {}
+        # An unwritten Scalar of the top-level SDFG is read-only and propagates like a symbol.
+        self._opaque_scalars: Dict[SDFG, Set[str]] = {}
         for sd in sdfg.all_sdfgs_recursive():
-            self._mutated_scalars[sd] = mutated_scalar_names(sd)
+            self._opaque_scalars[sd] = opaque_scalar_names(sd)
 
         in_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
         out_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
@@ -324,9 +330,8 @@ class SymbolPropagation(ppl.Pass):
                 ])
             }
 
-            # A mutated scalar can change across the SDFG, so its readers cannot propagate.
-            mutated = self._mutated_scalars.get(owner, set())
-            sym_table = {k: v for k, v in sym_table.items() if v is None or not (scalars(v, owner.arrays) & mutated)}
+            opaque = self._opaque_scalars.get(owner, set())
+            sym_table = {k: v for k, v in sym_table.items() if v is None or not (scalars(v, owner.arrays) & opaque)}
 
             if i == 0:
                 new_in_syms = sym_table

--- a/dace/transformation/passes/symbol_propagation.py
+++ b/dace/transformation/passes/symbol_propagation.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 
 import ast
+import itertools
 from dataclasses import dataclass
 from dace.sdfg.state import (
     AbstractControlFlowRegion,
@@ -13,10 +14,11 @@ from dace.transformation import pass_pipeline as ppl, transformation
 from dace import SDFG, properties, SDFGState
 from typing import Any, Dict, Set, Optional
 from dace import data as dt
-from dace.symbolic import pystr_to_symbolic, scalars, symstr
+from dace.frontend.python import astutils
+from dace.symbolic import pystr_to_symbolic, scalars
 
 
-def _free_symbols(value) -> Set[str]:
+def free_symbol_names(value) -> Set[str]:
     """Free symbol names of an interstate-edge assignment RHS; empty for ``None``."""
     if value is None:
         return set()
@@ -26,9 +28,8 @@ def _free_symbols(value) -> Set[str]:
         return set()
 
 
-def _mutated_scalar_names(sdfg: SDFG) -> Set[str]:
-    """Names of ``Scalar`` descriptors written somewhere in ``sdfg``; an unwritten one is a
-    read-only parameter and propagates as safely as a symbol."""
+def mutated_scalar_names(sdfg: SDFG) -> Set[str]:
+    """Names of ``Scalar`` descriptors written somewhere in ``sdfg``."""
     mutated: Set[str] = set()
     for state in sdfg.all_states():
         for n in state.data_nodes():
@@ -40,10 +41,9 @@ def _mutated_scalar_names(sdfg: SDFG) -> Set[str]:
     return mutated
 
 
-def _meta_read_symbols(blk: ControlFlowBlock) -> Set[str]:
-    """Symbols a region's meta code reads: branch conditions, loop init / condition / update.
-    ``free_symbols`` subtracts what the body rebinds, but the meta code runs first, so that read
-    is live and must keep its assignment alive."""
+def meta_read_symbols(blk: ControlFlowBlock) -> Set[str]:
+    """Symbols read by a region's meta code, which ``free_symbols`` hides once the body rebinds
+    them -- the meta code runs first, so the read is live."""
     if not isinstance(blk, AbstractControlFlowRegion):
         return set()
     names: Set[str] = set()
@@ -57,51 +57,93 @@ def _meta_read_symbols(blk: ControlFlowBlock) -> Set[str]:
     return names
 
 
-def _is_array_access(value: Optional[str]) -> bool:
-    """An assignment RHS reading a data container (``tbl[i]``, ``b_slice.idx``) is never
-    propagated: sympy renders it as ``tbl(i)``, losing the bracket the filters key on, and a
+def is_array_access(value: Optional[str]) -> bool:
+    """``value`` reads a data container (``tbl[i]``, ``b_slice.idx``); never propagated, since a
     descriptor shape must be a function of symbols."""
     if value is None:
         return False
     if "[" in value or "]" in value:
         return True
-    return _reads_struct_member(value)
+    return reads_struct_member(value)
 
 
-def _reads_struct_member(value: str) -> bool:
-    """``value`` reads an attribute off a plain name; a qualified call (``math.floor``) spells
-    the same way, so a callee attribute does not count."""
+def reads_struct_member(value: str) -> bool:
+    """``value`` reads an attribute off a plain name; a callee (``math.floor``) does not count."""
     try:
         tree = ast.parse(value.strip(), mode='eval')
     except (SyntaxError, ValueError):
-        return False  # not parseable as an expression -> leave it to the other filters
+        return False
     callees = {id(node.func) for node in ast.walk(tree) if isinstance(node, ast.Call)}
     return any(isinstance(node, ast.Attribute) and id(node) not in callees for node in ast.walk(tree))
 
 
-def _resolve(value, table: Dict[str, Any]):
-    """Substitute known symbol values from ``table`` into an assignment RHS, against the
-    pre-edge table since one edge's assignments are simultaneous. Resolving now rather than
-    chaining raw strings keeps a cyclic dependency from forming a substitution cycle."""
+def resolve_value(value, table: Dict[str, Any]):
+    """Substitute known symbol values from ``table`` into an assignment RHS, against the pre-edge
+    table since one edge's assignments are simultaneous. Textual over the AST like
+    ``InterstateEdge.replace_dict``: a sympy round trip renames every call it models, so
+    ``abs(z)`` comes back as ``Abs(z)`` and codegen emits a name C++ does not have."""
     if value is None:
         return None
-    # Leave array-access values (``tbl[i]``) untouched (see :func:`_is_array_access`).
-    if _is_array_access(value):
+    if is_array_access(value):
         return value
     try:
-        expr = pystr_to_symbolic(value)
-        repl = {}
-        for s in expr.free_symbols:
-            name = str(s)
-            known = table.get(name)
-            if known is not None and not _is_array_access(known):
-                repl[s] = pystr_to_symbolic(known)
-        if repl:
-            expr = expr.subs(repl)
-        # ``symstr``, not ``str``: operator-backed functions print as ``__right_shift(a, 1)``.
-        return symstr(expr)
+        tree = ast.parse(value.strip(), mode='eval')
+    except (SyntaxError, ValueError):
+        return value
+    repl = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Name) or node.id in repl:
+            continue
+        known = table.get(node.id)
+        if known is not None and not is_array_access(known):
+            repl[node.id] = known
+    if not repl:
+        return value
+    try:
+        return astutils.unparse(astutils.ASTFindReplace(repl).visit(tree))
     except Exception:
         return value
+
+
+def assign_targets(code) -> Set[str]:
+    """Names bound by the statements of a ``CodeBlock``."""
+    names: Set[str] = set()
+    if code is None:
+        return names
+    stmts = code.code if isinstance(code.code, list) else []
+    for stmt in stmts:
+        if not isinstance(stmt, ast.AST):
+            continue
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+                targets = [node.target]
+            else:
+                continue
+            names |= {n.id for t in targets for n in ast.walk(t) if isinstance(n, ast.Name)}
+    return names
+
+
+def loop_bound_symbols(loop: LoopRegion) -> Set[str]:
+    """Symbols a loop rebinds per iteration: its interstate-edge assignments plus what the meta
+    code of it and of any loop nested in it binds. ``replace_meta_accesses`` rewrites the init and
+    update statements whole, LHS included, so a value known for an iteration variable would spell
+    ``(- 1) = ((- 1) + 1)``."""
+    bound = {s for e in loop.all_interstate_edges() for s in e.data.assignments.keys()}
+    for blk in itertools.chain((loop, ), loop.all_control_flow_blocks()):
+        if not isinstance(blk, LoopRegion):
+            continue
+        if blk.loop_variable:
+            bound.add(blk.loop_variable)
+        bound |= assign_targets(blk.init_statement)
+        bound |= assign_targets(blk.update_statement)
+    return bound
+
+
+def reads_data(value, owner: SDFG) -> bool:
+    """``value`` names a data container of ``owner``."""
+    return bool(free_symbol_names(value) & set(owner.arrays))
 
 
 @dataclass(unsafe_hash=True)
@@ -118,7 +160,6 @@ class SymbolPropagation(ppl.Pass):
         return ppl.Modifies.Symbols | ppl.Modifies.Edges | ppl.Modifies.Nodes
 
     def should_reapply(self, modified: ppl.Modifies) -> bool:
-        # If anything was modified, reapply
         return modified != ppl.Modifies.Nothing
 
     def apply_pass(self, sdfg: SDFG, _) -> Optional[Set[str]]:
@@ -126,18 +167,16 @@ class SymbolPropagation(ppl.Pass):
 
         before_free: Set[str] = {str(s) for s in sdfg.free_symbols}
 
-        # Get all CFG blocks present in the SDFG
         all_cfg_blks = dict()
         for node, parent in sdfg.all_nodes_recursive():
             if isinstance(node, ControlFlowBlock):
                 all_cfg_blks[node] = parent
 
-        # Cached per SDFG: an unwritten Scalar is read-only and propagates like a symbol.
+        # An unwritten Scalar is read-only and propagates like a symbol.
         self._mutated_scalars: Dict[SDFG, Set[str]] = {}
         for sd in sdfg.all_sdfgs_recursive():
-            self._mutated_scalars[sd] = _mutated_scalar_names(sd)
+            self._mutated_scalars[sd] = mutated_scalar_names(sd)
 
-        # For each CFG Block maintain a dict of incoming and outgoing symbols
         in_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
         out_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
 
@@ -146,18 +185,14 @@ class SymbolPropagation(ppl.Pass):
         while changed:
             changed = False
 
-            # Update incoming symbols
             for cfg_blk, parent in all_cfg_blks.items():
                 new_in_syms = self._get_in_syms(sdfg, cfg_blk, parent, in_syms, out_syms)
-                # Check if the incoming symbols have changed
                 if new_in_syms != in_syms[cfg_blk]:
                     changed = True
                     in_syms[cfg_blk] = new_in_syms
 
-            # Update outgoing symbols
             for cfg_blk, parent in all_cfg_blks.items():
                 new_out_syms = self._get_out_syms(cfg_blk, parent, in_syms, out_syms)
-                # Check if the outgoing symbols have changed
                 if new_out_syms != out_syms[cfg_blk]:
                     changed = True
                     out_syms[cfg_blk] = new_out_syms
@@ -181,9 +216,7 @@ class SymbolPropagation(ppl.Pass):
         return propagated if propagated else None
 
     def _eliminate_dead_iedge_assignments(self, sdfg: SDFG) -> Set[str]:
-        """Drop interstate-edge assignments whose LHS is no longer referenced anywhere.
-        ``replace_dict`` reaches into descriptors as well, so substitute there first (a no-op,
-        since the symbol is that expression), then sweep to a fixed point."""
+        """Drop interstate-edge assignments whose LHS is no longer referenced anywhere."""
         removed: Set[str] = set()
         while True:
             this_round = self._eliminate_round(sdfg)
@@ -193,30 +226,28 @@ class SymbolPropagation(ppl.Pass):
         return removed
 
     def _eliminate_round(self, sdfg: SDFG) -> Set[str]:
-        """One sweep of dead-edge elimination across ``sdfg`` and its nested SDFGs; descriptors
-        go first, since ``free_symbols`` pulls shape symbols through the access nodes."""
+        """One sweep across ``sdfg`` and its nested SDFGs; descriptors go first, since
+        ``free_symbols`` pulls shape symbols through the access nodes."""
         eliminated: Set[str] = set()
         for sd in sdfg.all_sdfgs_recursive():
             # Propagatable: every binding edge agrees, and the RHS is not self-referential.
             bindings: Dict[str, Optional[str]] = {}
             for e in sd.all_interstate_edges():
                 for lhs, rhs in e.data.assignments.items():
-                    if rhs is None or lhs in _free_symbols(rhs):
+                    if rhs is None or lhs in free_symbol_names(rhs):
                         bindings[lhs] = None
                         continue
                     if lhs not in bindings:
                         bindings[lhs] = rhs
                     elif bindings[lhs] is not None and bindings[lhs] != rhs:
                         bindings[lhs] = None
-            # ``replace_dict`` also rewrites descriptor shapes, which live at SDFG scope: a
-            # right-hand side reading data, or built from a symbol an inner block assigns (a loop
-            # iteration variable), is not legal there. ``K = i + 1`` would size a transient by the
-            # loop variable and allocate it outside the loop.
+            # ``replace_dict`` also rewrites descriptor shapes, which live at SDFG scope, so
+            # ``K = i + 1`` would size a transient by a loop variable and allocate it outside.
             invariant = {str(s) for s in sd.free_symbols} | set(sd.constants_prop.keys())
             safe_subs = {
                 sym: rhs
                 for sym, rhs in bindings.items()
-                if rhs is not None and not _is_array_access(rhs) and _free_symbols(rhs) <= invariant
+                if rhs is not None and not is_array_access(rhs) and free_symbol_names(rhs) <= invariant
             }
 
             if safe_subs:
@@ -225,10 +256,10 @@ class SymbolPropagation(ppl.Pass):
             used_in_ir: Set[str] = set()
             for blk in sd.all_control_flow_blocks():
                 used_in_ir |= {str(s) for s in blk.free_symbols}
-                used_in_ir |= _meta_read_symbols(blk)
+                used_in_ir |= meta_read_symbols(blk)
             for e in sd.all_interstate_edges():
                 for rhs in e.data.assignments.values():
-                    used_in_ir |= _free_symbols(rhs)
+                    used_in_ir |= free_symbol_names(rhs)
                 if e.data.condition is not None:
                     try:
                         used_in_ir |= {str(s) for s in e.data.condition.get_free_symbols()}
@@ -270,21 +301,21 @@ class SymbolPropagation(ppl.Pass):
             edge_keys = set(edge.data.assignments.keys())
             resolved = {}
             for k, v in edge.data.assignments.items():
-                rv = _resolve(v, sym_table)
-                if rv is not None and (_free_symbols(rv) & edge_keys):
+                rv = resolve_value(v, sym_table)
+                if rv is not None and (free_symbol_names(rv) & edge_keys):
                     rv = None
                 resolved[k] = rv
             # A carried-in value naming a symbol this edge reassigns is stale downstream.
             for sym in list(sym_table.keys()):
                 val = sym_table[sym]
-                if sym not in edge_keys and val is not None and (_free_symbols(val) & edge_keys):
+                if sym not in edge_keys and val is not None and (free_symbol_names(val) & edge_keys):
                     sym_table[sym] = None
             sym_table.update(resolved)
 
-            # Filter out symbols containing arrays accesses as they cannot be safely propagated (nested array accesses are not supported)
-            sym_table = {k: v for k, v in sym_table.items() if not _is_array_access(v)}
+            # Nested array accesses are not supported.
+            sym_table = {k: v for k, v in sym_table.items() if not is_array_access(v)}
 
-            # Also filter out symbols containing views as they cannot be safely propagated (they are seen as pointers)
+            # Views are seen as pointers.
             sym_table = {
                 k: v
                 for k, v in sym_table.items() if v is None or not any([
@@ -297,28 +328,23 @@ class SymbolPropagation(ppl.Pass):
             mutated = self._mutated_scalars.get(owner, set())
             sym_table = {k: v for k, v in sym_table.items() if v is None or not (scalars(v, owner.arrays) & mutated)}
 
-            # Combine the symbols
             if i == 0:
                 new_in_syms = sym_table
             else:
                 self._combine_syms(new_in_syms, sym_table)
 
-        # Nested starting CFBGs should inherit the symbols from their parent
-        # Ignore SDFGs as nested SDFGs have symbol mappings
+        # A nested start block inherits its parent's symbols; a nested SDFG has a symbol mapping.
         if (parent.start_block == cfg_blk and not isinstance(parent, SDFG)) or (isinstance(parent, ConditionalBlock)
                                                                                 and cfg_blk in parent.sub_regions()):
-            # A start or branch region inherits the parent's symbols; some shapes carry their
-            # own, so combine rather than assert.
+            # Some shapes carry their own, so combine rather than assert.
             if new_in_syms:
                 self._combine_syms(new_in_syms, in_syms[parent])
             else:
                 new_in_syms = in_syms[parent]
 
-            # For LoopRegions, remove loop carried variables from the incoming symbols
             if isinstance(parent, LoopRegion):
                 new_in_syms = dict(new_in_syms)
-                all_syms = set([s for e in parent.all_interstate_edges() for s in e.data.assignments.keys()])
-                for sym in all_syms:
+                for sym in loop_bound_symbols(parent):
                     if sym in new_in_syms:
                         new_in_syms[sym] = None
 
@@ -333,21 +359,18 @@ class SymbolPropagation(ppl.Pass):
         out_syms: Dict[ControlFlowBlock, Dict[str, Any]],
     ) -> Dict[str, Any]:
         if isinstance(cfg_blk, LoopRegion):
-            # Any symbol that is assigned in the loop region is not propagated out
             new_out_syms = dict(in_syms[cfg_blk])
-            for edge in cfg_blk.all_interstate_edges():
-                for sym in edge.data.assignments.keys():
-                    if sym in new_out_syms:
-                        new_out_syms[sym] = None
+            for sym in loop_bound_symbols(cfg_blk):
+                if sym in new_out_syms:
+                    new_out_syms[sym] = None
             return new_out_syms
 
         elif isinstance(cfg_blk, ConditionalBlock):
-            # Combine all outgoing symbols of the branches
             new_out_syms = dict(out_syms[cfg_blk.sub_regions()[0]])
             for b in cfg_blk.sub_regions():
                 self._combine_syms(new_out_syms, out_syms[b])
 
-            # If no else branch is present, also combine the incoming table (implicit else branch)
+            # Without an else branch, the incoming table is the implicit else.
             has_non_conds = any([c is None for c, _ in cfg_blk.branches])
             if not has_non_conds:
                 self._combine_syms(new_out_syms, in_syms[cfg_blk])
@@ -386,7 +409,6 @@ class SymbolPropagation(ppl.Pass):
         new_in_syms = dict(in_syms[cfg_blk])
         new_out_syms = dict(out_syms[cfg_blk])
 
-        # Remove all symbols that are None
         new_in_syms = {sym: val for sym, val in new_in_syms.items() if val is not None}
         new_out_syms = {sym: val for sym, val in new_out_syms.items() if val is not None}
 
@@ -398,52 +420,63 @@ class SymbolPropagation(ppl.Pass):
         # An acyclic chain converges within ``#symbols`` rounds; the cap stops a cyclic one.
         max_iters = len(new_in_syms) + len(new_out_syms) + 2
 
-        # A symbol the body reassigns is loop-carried: folding the incoming value into
-        # ``while udiff > 0.001`` spins forever.
+        # Folding a loop-carried value into ``while udiff > 0.001`` spins forever.
         loop_carried: Set[str] = set()
         if isinstance(cfg_blk, LoopRegion):
-            loop_carried = {s for e in cfg_blk.all_interstate_edges() for s in e.data.assignments.keys()}
+            loop_carried = loop_bound_symbols(cfg_blk)
+
+        # A state reaches data through connectors only, so a container name written into tasklet
+        # code or a subset stops being a read: the connector is pruned, ``used_symbols`` reports a
+        # free symbol and ``arglist`` raises ``KeyError``, or inlining renames the container away.
+        # Interstate edges and region meta code carry read memlets, so they stay allowed.
+        state_subs = new_in_syms
+        if isinstance(cfg_blk, SDFGState):
+            state_subs = {s: v for s, v in new_in_syms.items() if not reads_data(v, cfg_blk.sdfg)}
 
         changed = True
         iters = 0
         while changed and iters < max_iters:
             iters += 1
             changed = False
-            free_sym = cfg_blk.free_symbols
-            free_edge_sym = set([sym for edge in parent.out_edges(cfg_blk) for sym in edge.data.free_symbols])
+            free_sym = {str(s) for s in cfg_blk.free_symbols}
+            free_edge_sym = {str(s) for edge in parent.out_edges(cfg_blk) for s in edge.data.free_symbols}
 
-            # Replace all symbols in the cfg_blk with their values
+            # Only what the block still reads: ``replace_in_codeblock`` shadows a name in a C++
+            # tasklet by prepending ``auto i = ...;``, and a second round prepends it again.
             if isinstance(cfg_blk, LoopRegion):
-                meta_syms = {s: v for s, v in new_in_syms.items() if s not in loop_carried}
-                cfg_blk.replace_meta_accesses(meta_syms)
+                meta_read = meta_read_symbols(cfg_blk)
+                cfg_blk.replace_meta_accesses({
+                    s: v
+                    for s, v in new_in_syms.items() if s in meta_read and s not in loop_carried
+                })
             elif isinstance(cfg_blk, ConditionalBlock):
-                cfg_blk.replace_meta_accesses(new_in_syms)
+                meta_read = meta_read_symbols(cfg_blk)
+                cfg_blk.replace_meta_accesses({s: v for s, v in new_in_syms.items() if s in meta_read})
             elif isinstance(cfg_blk, SDFGState):
-                cfg_blk.replace_dict(new_in_syms)
+                cfg_blk.replace_dict({s: v for s, v in state_subs.items() if s in free_sym})
             else:
-                # Don't replace, as the nested CFBGs should inherit the symbols from their parent
-                pass
+                pass  # Nested CFGs inherit their parent's symbols
 
             # Same rule out: a substitution naming a key of this edge reads its own output.
             for edge in parent.out_edges(cfg_blk):
+                edge_free = {str(s) for s in edge.data.free_symbols}
                 edge_keys = set(edge.data.assignments.keys())
-                if edge_keys:
-                    edge_subs = {s: v for s, v in new_out_syms.items() if not (_free_symbols(v) & edge_keys)}
-                else:
-                    edge_subs = new_out_syms
+                edge_subs = {
+                    s: v
+                    for s, v in new_out_syms.items() if s in edge_free and not (free_symbol_names(v) & edge_keys)
+                }
                 edge.data.replace_dict(edge_subs, replace_keys=False)
 
-            # Check if the symbols have changed
-            new_free_edge_sym = set([sym for edge in parent.out_edges(cfg_blk) for sym in edge.data.free_symbols])
-            if free_sym != cfg_blk.free_symbols or free_edge_sym != new_free_edge_sym:
+            new_free_edge_sym = {str(s) for edge in parent.out_edges(cfg_blk) for s in edge.data.free_symbols}
+            if free_sym != {str(s) for s in cfg_blk.free_symbols} or free_edge_sym != new_free_edge_sym:
                 changed = True
 
         # The candidate symbols that are no longer read here were propagated.
         return candidates & (free_before - self._block_free_symbols(cfg_blk, parent))
 
     def _combine_syms(self, sym1: Dict[str, Any], sym2: Dict[str, Any]) -> None:
-        """Meet of two symbol tables at a control-flow join, in place: a symbol survives only
-        when both sides agree, since a key absent on one side means no value known there."""
+        """Meet of two symbol tables at a join, in place: a symbol survives only when both sides
+        agree, since a key absent on one side means no value is known there."""
         for sym, val in sym2.items():
             if sym not in sym1 or sym1[sym] != val:
                 sym1[sym] = None

--- a/dace/transformation/passes/symbol_propagation.py
+++ b/dace/transformation/passes/symbol_propagation.py
@@ -15,6 +15,7 @@ from dace import SDFG, properties, SDFGState
 from typing import Any, Dict, Set, Optional
 from dace import data as dt
 from dace.frontend.python import astutils
+from dace.sdfg.analysis import cfg as cfg_analysis
 from dace.symbolic import pystr_to_symbolic, scalars
 
 
@@ -186,22 +187,35 @@ class SymbolPropagation(ppl.Pass):
         in_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
         out_syms = {cfg_blk: {} for cfg_blk in all_cfg_blks.keys()}
 
-        # Perform a forward fixed-point iteration to propagate symbols
-        changed = True
-        while changed:
-            changed = False
+        # Perform a forward fixed-point iteration to propagate symbols, in execution order: a value
+        # then travels the length of a chain per sweep instead of one block per sweep, which is what
+        # made the sweep count scale with the depth of the CFG. ConstantPropagation orders its own
+        # fixed point the same way.
+        ordered_blks = self._execution_order(sdfg, all_cfg_blks)
+        readers = self._readers(ordered_blks)
 
-            for cfg_blk, parent in all_cfg_blks.items():
+        # Worklist over that order: a block is revisited only when something it reads moved, so the
+        # sweeps after the first cost the blocks that actually changed rather than all of them.
+        dirty = {id(blk) for blk, _ in ordered_blks}
+        while dirty:
+            for cfg_blk, parent in ordered_blks:
+                if id(cfg_blk) not in dirty:
+                    continue
+                dirty.discard(id(cfg_blk))
+                moved = False
+
                 new_in_syms = self._get_in_syms(sdfg, cfg_blk, parent, in_syms, out_syms)
                 if new_in_syms != in_syms[cfg_blk]:
-                    changed = True
+                    moved = True
                     in_syms[cfg_blk] = new_in_syms
 
-            for cfg_blk, parent in all_cfg_blks.items():
                 new_out_syms = self._get_out_syms(cfg_blk, parent, in_syms, out_syms)
                 if new_out_syms != out_syms[cfg_blk]:
-                    changed = True
+                    moved = True
                     out_syms[cfg_blk] = new_out_syms
+
+                if moved:
+                    dirty |= readers[id(cfg_blk)]
 
         # An honest return set is what lets a FixedPointPipeline converge.
         propagated: Set[str] = set()
@@ -288,6 +302,63 @@ class SymbolPropagation(ppl.Pass):
         return eliminated
 
     # Given a cfg_blk, builds the incoming set of symbols
+    def _execution_order(self, sdfg: SDFG, all_cfg_blks: Dict[ControlFlowBlock, ControlFlowRegion]):
+        """``(block, parent)`` pairs in execution order, one entry per block of ``all_cfg_blks``.
+
+        The sort runs per SDFG because it does not cross nested SDFGs, and it only reaches blocks
+        with a path from the start block -- an unreachable one still carries symbols, so it is
+        appended rather than dropped."""
+        ordered = []
+        seen = set()
+        for sd in sdfg.all_sdfgs_recursive():
+            try:
+                blocks = list(cfg_analysis.blockorder_topological_sort(sd, recursive=True))
+            except KeyError:
+                # The sort walks a dominator tree rooted at the start block, so a CFG with a second
+                # source -- which this pass supports -- has blocks the tree never names. Fall back
+                # to insertion order for that SDFG rather than ordering part of it.
+                continue
+            for blk in blocks:
+                if id(blk) not in seen and blk in all_cfg_blks:
+                    seen.add(id(blk))
+                    ordered.append((blk, all_cfg_blks[blk]))
+        for blk, parent in all_cfg_blks.items():
+            if id(blk) not in seen:
+                seen.add(id(blk))
+                ordered.append((blk, parent))
+        return ordered
+
+    def _readers(self, ordered_blks) -> Dict[int, Set[int]]:
+        """For each block, the blocks whose own tables read it -- who to revisit when it moves.
+
+        Deliberately a superset: missing an edge here would stop the iteration early, at a table
+        that is not yet a fixed point, so every reader named by :meth:`_get_in_syms` and
+        :meth:`_get_out_syms` is listed, and anything uncertain is listed too.
+        """
+        readers: Dict[int, Set[int]] = {id(blk): set() for blk, _ in ordered_blks}
+        present = set(readers)
+
+        def add(src: ControlFlowBlock, dst) -> None:
+            if dst is not None and id(dst) in present:
+                readers[id(src)].add(id(dst))
+
+        for blk, parent in ordered_blks:
+            # A successor's in_syms reads this block's out_syms. A ConditionalBlock holds its
+            # branches as sub-regions rather than graph nodes, so it has no edges to walk.
+            if not isinstance(parent, ConditionalBlock):
+                for edge in parent.out_edges(blk):
+                    add(blk, edge.dst)
+            # The parent's out_syms combines its sinks, or its branches when it is conditional.
+            add(blk, parent)
+            # A region hands its in_syms to whatever runs first inside it.
+            if isinstance(blk, ConditionalBlock):
+                for branch in blk.sub_regions():
+                    add(blk, branch)
+            elif isinstance(blk, AbstractControlFlowRegion):
+                add(blk, blk.start_block)
+
+        return readers
+
     def _get_in_syms(
         self,
         sdfg: SDFG,

--- a/tests/cr_complex_test.py
+++ b/tests/cr_complex_test.py
@@ -32,3 +32,40 @@ def test_cr_complex():
 
 if __name__ == '__main__':
     test_cr_complex()
+
+
+def test_abs_of_a_complex_value_is_real():
+    """``Abs`` is generated for ``abs`` in a tasklet. Its result must be real: pinning the return
+    type to the argument turns it back into a complex, and then comparing it has no candidate --
+    the generated kernel does not compile. Magnitudes here are exact in binary floating point."""
+
+    @dace.program
+    def magnitude(inp: dace.complex128[4], out: dace.float64[4]):
+        for i in dace.map[0:4]:
+            with dace.tasklet:
+                a << inp[i]
+                m >> out[i]
+                m = abs(a)
+
+    A = np.array([3 + 4j, 5 + 12j, 8 + 6j, 0 + 1j], dtype=np.complex128)
+    B = np.zeros(4, dtype=np.float64)
+    magnitude(A, B)
+    assert np.allclose(B, [5.0, 13.0, 10.0, 1.0]), B
+
+
+def test_a_complex_magnitude_is_comparable():
+    """The failure mode itself: ``abs(z) < t`` on a complex ``z``. With a complex-typed ``Abs`` the
+    comparison finds no ``operator<`` and code generation fails at the C++ compile."""
+
+    @dace.program
+    def inside(inp: dace.complex128[4], out: dace.int32[4]):
+        for i in dace.map[0:4]:
+            with dace.tasklet:
+                a << inp[i]
+                r >> out[i]
+                r = 1 if abs(a) < 10.0 else 0
+
+    A = np.array([3 + 4j, 5 + 12j, 8 + 6j, 0 + 1j], dtype=np.complex128)
+    B = np.zeros(4, dtype=np.int32)
+    inside(A, B)
+    assert list(B) == [1, 0, 0, 1], B

--- a/tests/passes/symbol_propagation_test.py
+++ b/tests/passes/symbol_propagation_test.py
@@ -328,11 +328,46 @@ def test_scalars():
 
 
 def test_read_only_scalar_safe_to_propagate():
-    """A read-only ``Scalar`` argument (no AccessNode in-edges anywhere) is
-    semantically a fixed parameter; ``SymbolPropagation`` MUST fold values that
-    reference it. Pair with ``test_scalars`` which exercises the mutated-scalar
-    refusal path (``B`` is written from a Tasklet there)."""
+    """A read-only ``Scalar`` argument (no AccessNode in-edges anywhere) is semantically a fixed
+    parameter, so a loop bound built from it folds. Pair with ``test_scalars`` for the
+    mutated-scalar refusal path (``B`` is written from a Tasklet there) and with
+    ``test_a_container_value_does_not_reach_a_state`` for the one place the value may not go."""
     sdfg = dace.SDFG('readonly_scalar_test')
+    sdfg.add_symbol('aliased', dace.int32)
+    sdfg.add_symbol('i', dace.int32)
+    sdfg.add_scalar('param', dace.int32)
+    sdfg.add_array('out', [8], dace.int32)
+
+    s_entry = sdfg.add_state('entry', is_start_block=True)
+    loop = LoopRegion('loop', 'i < aliased', 'i', 'i = 0', 'i = i + 1', sdfg=sdfg)
+    sdfg.add_node(loop)
+    sdfg.add_edge(s_entry, loop, dace.InterstateEdge(assignments={'aliased': '(param + 1)'}))
+    body = loop.add_state('body', is_start_block=True)
+    t = body.add_tasklet('w', {}, {'__o'}, '__o = 1')
+    w = body.add_write('out')
+    body.add_edge(t, '__o', w, None, dace.Memlet('out[i]'))
+    sdfg.validate()
+
+    propagated = SymbolPropagation().apply_pass(sdfg, {})
+    sdfg.validate()
+    assert propagated and 'aliased' in propagated, (
+        f'symprop should propagate aliased=(param + 1) when param is a read-only Scalar; got {propagated}')
+    assert 'param' in loop.loop_condition.as_string, loop.loop_condition.as_string
+    assert all(
+        'aliased' not in e.data.assignments
+        for e in sdfg.all_interstate_edges()), ('dead-iedge sweep must drop the aliased assignment after substitution')
+
+    out = np.zeros(8, dtype=np.int32)
+    sdfg(param=np.int32(5), out=out)
+    assert np.array_equal(out, np.array([1, 1, 1, 1, 1, 1, 0, 0], dtype=np.int32)), out
+
+
+def test_a_container_value_does_not_reach_a_state():
+    """A state reads data through connectors only, so a value naming a container may not be folded
+    into one: the name would be a bare identifier no connector supplies, ``used_symbols`` would
+    report it as a free symbol and ``arglist`` would fail on it, and inlining renames the container
+    out from under the expression. The defining assignment therefore stays alive."""
+    sdfg = dace.SDFG('container_value_state_test')
     sdfg.add_symbol('aliased', dace.int32)
     sdfg.add_scalar('param', dace.int32)
     sdfg.add_array('out', [4], dace.int32)
@@ -345,13 +380,15 @@ def test_read_only_scalar_safe_to_propagate():
     s_use.add_edge(t, '__o', w, None, dace.Memlet('out[0]'))
     sdfg.validate()
 
-    propagated = SymbolPropagation().apply_pass(sdfg, {})
+    SymbolPropagation().apply_pass(sdfg, {})
     sdfg.validate()
-    assert propagated and 'aliased' in propagated, (
-        f'symprop should propagate aliased=(param + 1) when param is a read-only Scalar; got {propagated}')
-    assert all(
-        'aliased' not in e.data.assignments
-        for e in sdfg.all_interstate_edges()), ('dead-iedge sweep must drop the aliased assignment after substitution')
+    assert any('aliased' in e.data.assignments for e in sdfg.all_interstate_edges()), \
+        'a value reading a container must stay on its interstate edge, not move into the state'
+    assert 'param' not in t.code.as_string, t.code.as_string
+
+    out = np.zeros(4, dtype=np.int32)
+    sdfg(param=np.int32(41), out=out)
+    assert out[0] == 42, out
 
 
 def test_cloudsc_kidia_kfdia_promote_then_propagate():
@@ -360,17 +397,15 @@ def test_cloudsc_kidia_kfdia_promote_then_propagate():
     level nests (the ``DO JK=1,KLEV; DO JL=KIDIA,KFDIA`` shape). ``simplify``
     promotes ``kfdia + 1`` to per-nest symbols ``kfdia_plus_1_N = kfdia + 1``.
 
-    SymbolPropagation folds these directly: ``kfdia`` is a non-transient
-    ``Scalar`` descriptor but is a Fortran ``intent(in)`` argument -- never
-    written anywhere in the SDFG -- so it is semantically a read-only
-    parameter. The scalar filter only refuses propagation when the RHS reads a
-    *mutated* scalar (a scalar with an in-edge into one of its AccessNodes);
-    read-only scalars are safe (see ``test_scalars`` for the mutated-scalar
-    refusal case). Pre-promotion folding is required for cloudsc, where
-    hundreds of ``kfdia_plus_1_N`` aliases survive state fusion and unrolling;
-    without read-only-scalar propagation, every alias pins its iedge alive.
-    ``ScalarToSymbolPromotion`` then becomes an optimisation rather than a
-    correctness prerequisite. Value-preserving throughout."""
+    ``SymbolPropagation`` runs in ``simplify`` right after the promotion that makes them, and
+    folds them straight back into the loop bounds: ``kfdia`` is a non-transient ``Scalar``
+    descriptor but is a Fortran ``intent(in)`` argument -- never written anywhere in the SDFG --
+    so it is semantically a read-only parameter. The scalar filter only refuses propagation when
+    the RHS reads a *mutated* scalar (a scalar with an in-edge into one of its AccessNodes); see
+    ``test_scalars`` for the refusal case. This matters for cloudsc, where hundreds of
+    ``kfdia_plus_1_N`` aliases survive state fusion and unrolling and every alias pins its iedge
+    alive. ``ScalarToSymbolPromotion`` is then an optimisation rather than a correctness
+    prerequisite. Value-preserving throughout."""
     klev, klon = dace.symbol('klev'), dace.symbol('klon')
 
     @dace.program
@@ -390,27 +425,28 @@ def test_cloudsc_kidia_kfdia_promote_then_propagate():
     rng = np.random.default_rng(0)
     pt = rng.standard_normal((nlev, nlon))
 
-    # Reference (un-promoted) output.
-    ref = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
+    def loop_conditions(g):
+        return [n.loop_condition.as_string for n, _ in g.all_nodes_recursive() if isinstance(n, LoopRegion)]
+
+    # Reference: no simplification at all, so no promotion and nothing to fold.
+    ref = cloudsc_kidia_kfdia.to_sdfg(simplify=False)
     ref_out = np.zeros((nlev, nlon))
     ref(pt=pt.copy(), ptend=ref_out, kidia=0, kfdia=nlon - 1, klev=nlev, klon=nlon)
 
-    # (1) Without promotion: kfdia is a read-only Scalar argument -> symprop folds
-    #     ``kfdia_plus_1 -> (kfdia + 1)`` directly and drops the dead iedge
-    #     assignments.
+    # (1) kfdia is a read-only Scalar argument, so the promotion simplify makes is folded back by
+    #     the SymbolPropagation that follows it and the dead iedge assignments go with it.
     sdfg = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
-    assert kfdia_plus1_syms(sdfg), 'simplify should promote kfdia + 1 to kfdia_plus_1 symbols'
     assert isinstance(sdfg.arrays.get('kfdia'), dace.data.Scalar)
-    propagated = SymbolPropagation().apply_pass(sdfg, {})
-    assert propagated and any(s.startswith('kfdia_plus_1') for s in propagated), \
-        f'symprop should fold ``kfdia_plus_1 -> (kfdia + 1)`` when kfdia is read-only Scalar; got {propagated}'
-    assert not kfdia_plus1_syms(sdfg), 'all kfdia_plus_1 aliases should be dead-iedge-eliminated'
+    assert not kfdia_plus1_syms(sdfg), 'simplify should leave no kfdia_plus_1 alias behind'
+    assert any('kfdia' in c for c in loop_conditions(sdfg)), \
+        f'the folded bound should read kfdia itself; got {loop_conditions(sdfg)}'
     sdfg.validate()
     out1 = np.zeros((nlev, nlon))
     sdfg(pt=pt.copy(), ptend=out1, kidia=0, kfdia=nlon - 1, klev=nlev, klon=nlon)
     assert np.allclose(out1, ref_out)
 
-    # (2) Promote the scalar arguments to symbols first, then symprop folds them.
+    # (2) Promoting the scalar arguments to symbols afterwards leaves the folded bound reading the
+    #     symbol, and a second SymbolPropagation keeps it that way.
     sdfg2 = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
     s2s = ScalarToSymbolPromotion()
     s2s.transients_only = False
@@ -418,9 +454,9 @@ def test_cloudsc_kidia_kfdia_promote_then_propagate():
     assert promoted and {'kidia', 'kfdia'} <= promoted, f'expected kidia/kfdia promoted, got {promoted}'
     assert 'kfdia' in sdfg2.symbols and 'kfdia' not in sdfg2.arrays
 
-    ret = SymbolPropagation().apply_pass(sdfg2, {})
-    assert ret is not None and any(s.startswith('kfdia_plus_1') for s in ret), \
-        f'after promotion symprop must fold kfdia_plus_1 -> (kfdia + 1); propagated={ret}'
+    SymbolPropagation().apply_pass(sdfg2, {})
+    assert not kfdia_plus1_syms(sdfg2), 'promotion must not resurrect the aliases'
+    assert any('kfdia' in c for c in loop_conditions(sdfg2)), loop_conditions(sdfg2)
     sdfg2.validate()
 
     # Value-preserving (kidia/kfdia are now symbols).

--- a/tests/passes/symbol_propagation_test.py
+++ b/tests/passes/symbol_propagation_test.py
@@ -565,11 +565,11 @@ def test_resolve_renders_operator_functions():
     print as their sympy class name under ``str`` -- ``__right_shift(__bitwise_and(
     255, b), 1)`` -- which is neither valid Python (the codeblock language) nor valid
     C++, and crashes codegen when such a value is substituted into a branch condition
-    (the crc16 canon failure). ``_resolve`` must emit the operator spelling instead.
+    (the crc16 canon failure). ``resolve_value`` must emit the operator spelling instead.
     """
-    from dace.transformation.passes.symbol_propagation import _resolve
+    from dace.transformation.passes.symbol_propagation import resolve_value
 
-    out = _resolve('y >> 1', {'y': '255 & b'})
+    out = resolve_value('y >> 1', {'y': '255 & b'})
     assert '__right_shift' not in out and '__bitwise_and' not in out, \
         f'operator functions leaked their sympy class names: {out}'
     assert '>>' in out and '&' in out, f'expected operator spelling, got {out}'
@@ -612,3 +612,52 @@ def test_a_loop_varying_binding_does_not_reach_descriptor_shapes():
 
     SymbolPropagation().apply_pass(sdfg, {})
     assert [str(s) for s in sdfg.arrays['tmp'].shape] == ['K']
+
+
+def test_loop_variable_is_never_substituted_into_its_own_meta_code():
+    """``replace_meta_accesses`` rewrites the init and update statements whole, LHS included, so a
+    value carried in for the iteration variable spells the update ``(- 1) = ((- 1) + 1)``."""
+    sdfg = dace.SDFG('symprop_loop_variable')
+    sdfg.add_array('a', (8, ), dace.float64)
+    sdfg.add_symbol('i', dace.int64)
+
+    entry = sdfg.add_state('entry', is_start_block=True)
+    loop = LoopRegion('loop', 'i < 8', 'i', 'i = 0', 'i = i + 1', sdfg=sdfg)
+    sdfg.add_node(loop)
+    sdfg.add_edge(entry, loop, dace.InterstateEdge(assignments={'i': '-1'}))
+    body = loop.add_state('body', is_start_block=True)
+    body.add_mapped_tasklet('w', {'j': '0:8'}, {}, 'o = 1.0', {'o': dace.Memlet('a[j]')}, external_edges=True)
+    sdfg.validate()
+
+    SymbolPropagation().apply_pass(sdfg, {})
+
+    assert loop.loop_variable == 'i', f'the iteration variable was renamed to {loop.loop_variable}'
+    assert loop.init_statement.as_string == 'i = 0', loop.init_statement.as_string
+    assert loop.update_statement.as_string == 'i = (i + 1)', loop.update_statement.as_string
+    sdfg.validate()
+
+
+def test_propagated_value_keeps_its_python_call_spelling():
+    """A value resolved through sympy comes back with sympy's names -- ``abs(z)`` as ``Abs(z)`` --
+    which neither the codeblock language nor C++ has."""
+    sdfg = dace.SDFG('symprop_call_spelling')
+    sdfg.add_array('a', (8, ), dace.float64)
+    sdfg.add_symbol('z', dace.float64)
+    sdfg.add_symbol('mag', dace.float64)
+
+    entry = sdfg.add_state('entry', is_start_block=True)
+    branch = ConditionalBlock('branch', sdfg=sdfg)
+    sdfg.add_node(branch)
+    sdfg.add_edge(entry, branch, dace.InterstateEdge(assignments={'mag': 'abs(z)'}))
+    body = ControlFlowRegion('body', sdfg=sdfg)
+    branch.add_branch(CodeBlock('mag < 1.0'), body)
+    taken = body.add_state('taken', is_start_block=True)
+    taken.add_mapped_tasklet('w', {'j': '0:8'}, {}, 'o = 1.0', {'o': dace.Memlet('a[j]')}, external_edges=True)
+    sdfg.validate()
+
+    SymbolPropagation().apply_pass(sdfg, {})
+
+    condition = branch.branches[0][0].as_string
+    assert 'Abs' not in condition, f'sympy name leaked into the branch condition: {condition}'
+    assert 'abs(z)' in condition, condition
+    sdfg.validate()

--- a/tests/passes/symbol_propagation_test.py
+++ b/tests/passes/symbol_propagation_test.py
@@ -6,7 +6,7 @@ from dace.sdfg import nodes
 from dace.properties import CodeBlock
 from dace.sdfg.state import LoopRegion, ConditionalBlock, ControlFlowRegion
 from dace.transformation.interstate import LoopToMap
-from dace.transformation.passes import SymbolPropagation
+from dace.transformation.passes import SymbolPropagation, ScalarToSymbolPromotion
 
 
 def _count_loops(sdfg: dace.SDFG):
@@ -104,6 +104,50 @@ def test_nested_loop_carried_symbol():
     A[:] = np.random.rand(64).astype(dace.float32.type)
     sdfg(A=A)
     assert np.allclose(A[0], 64 * 64)
+
+
+def test_loop_condition_symbol_reassigned_in_body_not_folded():
+    """A symbol read by a ``LoopRegion`` condition and REASSIGNED inside the loop
+    body must not have its pre-loop value folded into the condition.
+
+    Mirrors npbench ``channel_flow``'s ``while udiff > 0.001`` convergence loop:
+    ``udiff = 1.0`` is set on the edge entering the loop and recomputed every
+    iteration inside the body. The condition is re-evaluated each iteration, so
+    substituting the incoming ``1.0`` (correct only for the first check) collapses
+    it to ``1.0 > 0.001`` -- always true -- and the loop never terminates.
+    """
+    sdfg = dace.SDFG("conv")
+    sdfg.add_array("cnt", [1], dace.int64)
+    sdfg.add_symbol("udiff", dace.float64)
+
+    init = sdfg.add_state("init", is_start_block=True)
+    loop = LoopRegion("conv_loop", "udiff > 0.001")  # while-loop: no init / update
+    sdfg.add_node(loop)
+    sdfg.add_edge(init, loop, dace.InterstateEdge(assignments={"udiff": "1.0"}))
+
+    body = loop.add_state("body", is_start_block=True)
+    tail = loop.add_state("tail")
+    r = body.add_access("cnt")
+    t = body.add_tasklet("inc", {"i"}, {"o"}, "o = i + 1")
+    w = body.add_access("cnt")
+    body.add_edge(r, None, t, "i", dace.Memlet("cnt[0]"))
+    body.add_edge(t, "o", w, None, dace.Memlet("cnt[0]"))
+    # udiff is loop-carried: reassigned on a body edge (1.0 -> <=0.001 after 10 halvings).
+    loop.add_edge(body, tail, dace.InterstateEdge(assignments={"udiff": "udiff * 0.5"}))
+    sdfg.validate()
+
+    SymbolPropagation().apply_pass(sdfg, {})
+    sdfg.validate()
+
+    cond = loop.loop_condition.as_string
+    assert "udiff" in cond, f"loop-carried udiff was folded out of the condition: {cond!r}"
+    assert "1.0>0.001" not in cond.replace(" ", ""), f"condition folded to a constant: {cond!r}"
+
+    # A folded constant condition spins forever; the correct loop runs a
+    # data-dependent number of iterations and terminates.
+    cnt = np.zeros([1], dtype=np.int64)
+    sdfg(cnt=cnt)
+    assert cnt[0] == 10, f"expected 10 iterations (0.5**10 <= 0.001 < 0.5**9), got {cnt[0]}"
 
 
 def test_nested_symbol():
@@ -235,9 +279,19 @@ def test_deeply_nested_sdfg():
     SymbolPropagation().apply_pass(sdfg1, {})
     sdfg1.validate()
 
-    # No assignment should have been changed
-    assert edge1.data.assignments["v"] == "a"
-    assert edge4.data.assignments["c"] == "v+1"
+    # The outer iedge ``v = a`` was the only binding of ``v``; with propagation reaching
+    # the NSDFG ``symbol_mapping`` (``{"v": "v"}`` -> ``{"v": "a"}``) the binding is
+    # dead and gets swept, taking the now-unused ``v`` declaration with it so the
+    # nested chain remains self-consistent. Same fate for the inner ``c = v+1``: its
+    # destination state has no readers of ``c``, so the binding + the ``c`` declaration
+    # both drop.
+    assert "v" not in edge1.data.assignments, (
+        f"propagation should have substituted v->a everywhere and dropped the dead binding; "
+        f"got {dict(edge1.data.assignments)}")
+    assert "v" not in sdfg1.symbols, "declaration of v should be removed with its binding"
+    assert "c" not in edge4.data.assignments, (
+        f"unused c=v+1 binding should be swept; got {dict(edge4.data.assignments)}")
+    assert "c" not in sdfg4.symbols, "declaration of c should be removed with its binding"
 
 
 def test_scalars():
@@ -273,11 +327,269 @@ def test_scalars():
     assert A[0] == 5
 
 
+def test_read_only_scalar_safe_to_propagate():
+    """A read-only ``Scalar`` argument (no AccessNode in-edges anywhere) is
+    semantically a fixed parameter; ``SymbolPropagation`` MUST fold values that
+    reference it. Pair with ``test_scalars`` which exercises the mutated-scalar
+    refusal path (``B`` is written from a Tasklet there)."""
+    sdfg = dace.SDFG('readonly_scalar_test')
+    sdfg.add_symbol('aliased', dace.int32)
+    sdfg.add_scalar('param', dace.int32)
+    sdfg.add_array('out', [4], dace.int32)
+
+    s_entry = sdfg.add_state('entry', is_start_block=True)
+    s_use = sdfg.add_state('use')
+    sdfg.add_edge(s_entry, s_use, dace.InterstateEdge(assignments={'aliased': '(param + 1)'}))
+    t = s_use.add_tasklet('w', {}, {'__o'}, '__o = aliased')
+    w = s_use.add_write('out')
+    s_use.add_edge(t, '__o', w, None, dace.Memlet('out[0]'))
+    sdfg.validate()
+
+    propagated = SymbolPropagation().apply_pass(sdfg, {})
+    sdfg.validate()
+    assert propagated and 'aliased' in propagated, (
+        f'symprop should propagate aliased=(param + 1) when param is a read-only Scalar; got {propagated}')
+    assert all(
+        'aliased' not in e.data.assignments
+        for e in sdfg.all_interstate_edges()), ('dead-iedge sweep must drop the aliased assignment after substitution')
+
+
+def test_cloudsc_kidia_kfdia_promote_then_propagate():
+    """CloudSC subset: scalar arguments ``kidia`` / ``kfdia`` used as the
+    inclusive horizontal loop bound ``range(kidia, kfdia + 1)`` across several
+    level nests (the ``DO JK=1,KLEV; DO JL=KIDIA,KFDIA`` shape). ``simplify``
+    promotes ``kfdia + 1`` to per-nest symbols ``kfdia_plus_1_N = kfdia + 1``.
+
+    SymbolPropagation folds these directly: ``kfdia`` is a non-transient
+    ``Scalar`` descriptor but is a Fortran ``intent(in)`` argument -- never
+    written anywhere in the SDFG -- so it is semantically a read-only
+    parameter. The scalar filter only refuses propagation when the RHS reads a
+    *mutated* scalar (a scalar with an in-edge into one of its AccessNodes);
+    read-only scalars are safe (see ``test_scalars`` for the mutated-scalar
+    refusal case). Pre-promotion folding is required for cloudsc, where
+    hundreds of ``kfdia_plus_1_N`` aliases survive state fusion and unrolling;
+    without read-only-scalar propagation, every alias pins its iedge alive.
+    ``ScalarToSymbolPromotion`` then becomes an optimisation rather than a
+    correctness prerequisite. Value-preserving throughout."""
+    klev, klon = dace.symbol('klev'), dace.symbol('klon')
+
+    @dace.program
+    def cloudsc_kidia_kfdia(pt: dace.float64[klev, klon], ptend: dace.float64[klev, klon], kidia: dace.int32,
+                            kfdia: dace.int32):
+        for jk in range(klev):
+            for jl in range(kidia, kfdia + 1):
+                ptend[jk, jl] = pt[jk, jl] * 2.0
+        for jk in range(klev):
+            for jl in range(kidia, kfdia + 1):
+                ptend[jk, jl] = ptend[jk, jl] + 3.0
+
+    def _kfdia_plus1_syms(g):
+        return {k for e in g.all_interstate_edges() for k in e.data.assignments if k.startswith('kfdia_plus_1')}
+
+    nlev, nlon = 5, 8
+    rng = np.random.default_rng(0)
+    pt = rng.standard_normal((nlev, nlon))
+
+    # Reference (un-promoted) output.
+    ref = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
+    ref_out = np.zeros((nlev, nlon))
+    ref(pt=pt.copy(), ptend=ref_out, kidia=0, kfdia=nlon - 1, klev=nlev, klon=nlon)
+
+    # (1) Without promotion: kfdia is a read-only Scalar argument -> symprop folds
+    #     ``kfdia_plus_1 -> (kfdia + 1)`` directly and drops the dead iedge
+    #     assignments.
+    sdfg = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
+    assert _kfdia_plus1_syms(sdfg), 'simplify should promote kfdia + 1 to kfdia_plus_1 symbols'
+    assert isinstance(sdfg.arrays.get('kfdia'), dace.data.Scalar)
+    propagated = SymbolPropagation().apply_pass(sdfg, {})
+    assert propagated and any(s.startswith('kfdia_plus_1') for s in propagated), \
+        f'symprop should fold ``kfdia_plus_1 -> (kfdia + 1)`` when kfdia is read-only Scalar; got {propagated}'
+    assert not _kfdia_plus1_syms(sdfg), 'all kfdia_plus_1 aliases should be dead-iedge-eliminated'
+    sdfg.validate()
+    out1 = np.zeros((nlev, nlon))
+    sdfg(pt=pt.copy(), ptend=out1, kidia=0, kfdia=nlon - 1, klev=nlev, klon=nlon)
+    assert np.allclose(out1, ref_out)
+
+    # (2) Promote the scalar arguments to symbols first, then symprop folds them.
+    sdfg2 = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
+    s2s = ScalarToSymbolPromotion()
+    s2s.transients_only = False
+    promoted = s2s.apply_pass(sdfg2, {})
+    assert promoted and {'kidia', 'kfdia'} <= promoted, f'expected kidia/kfdia promoted, got {promoted}'
+    assert 'kfdia' in sdfg2.symbols and 'kfdia' not in sdfg2.arrays
+
+    ret = SymbolPropagation().apply_pass(sdfg2, {})
+    assert ret is not None and any(s.startswith('kfdia_plus_1') for s in ret), \
+        f'after promotion symprop must fold kfdia_plus_1 -> (kfdia + 1); propagated={ret}'
+    sdfg2.validate()
+
+    # Value-preserving (kidia/kfdia are now symbols).
+    out2 = np.zeros((nlev, nlon))
+    sdfg2(pt=pt.copy(), ptend=out2, kidia=0, kfdia=nlon - 1, klev=nlev, klon=nlon)
+    assert np.allclose(out2, ref_out)
+    assert np.allclose(out2, pt * 2.0 + 3.0)
+
+
+_SP_N = dace.symbol("_SP_N")
+
+
+@dace.program
+def _carried_index_kernel(a: dace.float64[_SP_N], b: dace.float64[_SP_N], c: dace.float64[_SP_N],
+                          d: dace.float64[_SP_N]):
+    j = -1
+    for i in range(_SP_N // 2):
+        k = j + 1
+        a[i] = b[k] - d[i]
+        j = k + 1
+        b[k] = a[i] + c[k]
+
+
+def test_carried_index_symbol_not_propagated_stale():
+    """Reproducer (TSVC s128): a loop-carried index ``k = j + 1`` must not be
+    propagated into a downstream block as ``j + 1`` once the loop has reassigned
+    ``j = k + 1``. There the live ``j`` is two ahead, so the stale expression is an
+    off-by-two on ``b[k]`` / ``c[k]``. SymbolPropagation must keep ``k`` live; this
+    checks the propagated SDFG still matches the un-propagated reference."""
+    import copy
+    n = 64
+    rng = np.random.default_rng(0)
+    base = {name: rng.random(n) for name in "abcd"}
+
+    ref = _carried_index_kernel.to_sdfg(simplify=True)
+    cand = copy.deepcopy(ref)
+    SymbolPropagation().apply_pass(cand, {})
+    cand.validate()
+
+    ra = {name: arr.copy() for name, arr in base.items()}
+    ref(**ra, _SP_N=n)
+    ca = {name: arr.copy() for name, arr in base.items()}
+    cand(**ca, _SP_N=n)
+    for name in "abcd":
+        assert np.allclose(ra[name], ca[name]), f"{name}: SymbolPropagation changed the result"
+
+
+def test_dead_iedge_assignment_eliminated_after_substitution():
+    """A bound-symbol shorthand iedge assignment (``k_plus_1 = klev + 1``) survived
+    symbol_propagation: its uses got substituted to ``klev + 1`` but the defining
+    assignment was left in place. The fix sweeps such dead assignments to a fixed
+    point at the end of the pass; nothing references ``k_plus_1`` after the
+    substitution, so the iedge ends with an empty ``assignments`` dict.
+    """
+    sdfg = dace.SDFG('dead_iedge_repro')
+    sdfg.add_array('out', [16], dace.float64)
+    sdfg.add_symbol('klev', dace.int32)
+    s1 = sdfg.add_state('s1', is_start_block=True)
+    s2 = sdfg.add_state('s2')
+    sdfg.add_edge(s1, s2, dace.InterstateEdge(assignments={'k_plus_1': '(klev + 1)'}))
+
+    t = s2.add_tasklet('t', {}, {'_o'}, '_o = 1.0')
+    w = s2.add_write('out')
+    s2.add_edge(t, '_o', w, None, dace.Memlet(data='out', subset='k_plus_1'))
+    sdfg.validate()
+
+    res = SymbolPropagation().apply_pass(sdfg, {})
+    assert res == {'k_plus_1'}, f'expected k_plus_1 to be reported propagated; got {res}'
+
+    surviving = [(lhs, rhs) for e in sdfg.all_interstate_edges() for lhs, rhs in e.data.assignments.items()]
+    assert surviving == [], f'dead k_plus_1 assignment must be eliminated; got {surviving}'
+
+    # The substitution must reach the memlet: the write to s2's ``out`` now indexes
+    # ``klev + 1`` directly, not via the shorthand symbol.
+    seen = []
+    for st in sdfg.states():
+        for e in st.edges():
+            if e.data is not None and e.data.data == 'out':
+                seen.append(str(e.data.subset))
+    assert 'klev + 1' in seen, f'expected memlet subset to be substituted to klev+1; got {seen}'
+
+
+def test_dead_iedge_chain_unravels_to_fixed_point():
+    """Chained shorthands (``a = klev + 1; b = a; c = b``) must all be eliminated
+    once their uses are substituted -- the cleanup sweep iterates to a fixed point."""
+    sdfg = dace.SDFG('chain_repro')
+    sdfg.add_array('out', [16], dace.float64)
+    sdfg.add_symbol('klev', dace.int32)
+    s1 = sdfg.add_state('s1', is_start_block=True)
+    s2 = sdfg.add_state('s2')
+    s3 = sdfg.add_state('s3')
+    s4 = sdfg.add_state('s4')
+    sdfg.add_edge(s1, s2, dace.InterstateEdge(assignments={'a': '(klev + 1)'}))
+    sdfg.add_edge(s2, s3, dace.InterstateEdge(assignments={'b': 'a'}))
+    sdfg.add_edge(s3, s4, dace.InterstateEdge(assignments={'c': 'b'}))
+
+    t = s4.add_tasklet('t', {}, {'_o'}, '_o = 2.0')
+    w = s4.add_write('out')
+    s4.add_edge(t, '_o', w, None, dace.Memlet(data='out', subset='c'))
+    sdfg.validate()
+
+    SymbolPropagation().apply_pass(sdfg, {})
+
+    surviving = [(lhs, rhs) for e in sdfg.all_interstate_edges() for lhs, rhs in e.data.assignments.items()]
+    assert surviving == [], f'every link of the dead chain must be eliminated; got {surviving}'
+
+
+def test_dead_iedge_with_array_shape_substituted_into_descriptor():
+    """A symbol referenced *only* by an array descriptor's shape (cloudsc's
+    ``[0:kfdia_plus_1, 0:klon]`` pattern) used to keep the defining iedge alive
+    because the IR-level ``replace_dict`` does not reach into descriptors. The
+    fix substitutes the symbol into descriptors as a final step before
+    elimination, so the array shape becomes ``kfdia + 1`` directly and the
+    iedge drops."""
+    sdfg = dace.SDFG('array_shape_repro')
+    sdfg.add_symbol('klev', dace.int32)
+    sdfg.add_symbol('k_plus_1', dace.int32)
+    sdfg.add_array('out', ['k_plus_1'], dace.float64)
+    s1 = sdfg.add_state('s1', is_start_block=True)
+    s2 = sdfg.add_state('s2')
+    sdfg.add_edge(s1, s2, dace.InterstateEdge(assignments={'k_plus_1': '(klev + 1)'}))
+
+    t = s2.add_tasklet('t', {}, {'_o'}, '_o = 3.0')
+    w = s2.add_write('out')
+    s2.add_edge(t, '_o', w, None, dace.Memlet(data='out', subset='0'))
+    sdfg.validate()
+
+    SymbolPropagation().apply_pass(sdfg, {})
+
+    surviving = [(lhs, rhs) for e in sdfg.all_interstate_edges() for lhs, rhs in e.data.assignments.items()]
+    assert surviving == [], (f'k_plus_1 should have been substituted into the array shape and the '
+                             f'binding dropped; got {surviving}')
+    shape_str = ', '.join(str(s) for s in sdfg.arrays['out'].shape)
+    assert 'klev' in shape_str and 'k_plus_1' not in shape_str, (
+        f'array shape must read klev + 1 directly; got {shape_str}')
+    assert 'k_plus_1' not in sdfg.symbols, 'declaration of k_plus_1 should be removed with its binding'
+
+
+def test_resolve_renders_operator_functions():
+    """A propagated value must be rendered with the DaCe printer, not sympy ``str``.
+
+    The operator-backed functions (``a & b`` parses to ``__bitwise_and(a, b)`` etc.)
+    print as their sympy class name under ``str`` -- ``__right_shift(__bitwise_and(
+    255, b), 1)`` -- which is neither valid Python (the codeblock language) nor valid
+    C++, and crashes codegen when such a value is substituted into a branch condition
+    (the crc16 canon failure). ``_resolve`` must emit the operator spelling instead.
+    """
+    from dace.transformation.passes.symbol_propagation import _resolve
+
+    out = _resolve('y >> 1', {'y': '255 & b'})
+    assert '__right_shift' not in out and '__bitwise_and' not in out, \
+        f'operator functions leaked their sympy class names: {out}'
+    assert '>>' in out and '&' in out, f'expected operator spelling, got {out}'
+    # Round-trips back through the symbolic parser (valid Python/C++ expression).
+    assert {str(s) for s in dace.symbolic.pystr_to_symbolic(out).free_symbols} == {'b'}
+
+
 if __name__ == "__main__":
+    test_resolve_renders_operator_functions()
     test_loop_carried_symbol()
     test_nested_loop_carried_symbol()
+    test_loop_condition_symbol_reassigned_in_body_not_folded()
     test_nested_symbol()
     test_multiple_sources()
     test_multiple_edge_assignments()
     test_deeply_nested_sdfg()
     test_scalars()
+    test_cloudsc_kidia_kfdia_promote_then_propagate()
+    test_carried_index_symbol_not_propagated_stale()
+    test_dead_iedge_assignment_eliminated_after_substitution()
+    test_dead_iedge_chain_unravels_to_fixed_point()
+    test_dead_iedge_preserved_when_lhs_still_used()

--- a/tests/passes/symbol_propagation_test.py
+++ b/tests/passes/symbol_propagation_test.py
@@ -383,7 +383,7 @@ def test_cloudsc_kidia_kfdia_promote_then_propagate():
             for jl in range(kidia, kfdia + 1):
                 ptend[jk, jl] = ptend[jk, jl] + 3.0
 
-    def _kfdia_plus1_syms(g):
+    def kfdia_plus1_syms(g):
         return {k for e in g.all_interstate_edges() for k in e.data.assignments if k.startswith('kfdia_plus_1')}
 
     nlev, nlon = 5, 8
@@ -399,12 +399,12 @@ def test_cloudsc_kidia_kfdia_promote_then_propagate():
     #     ``kfdia_plus_1 -> (kfdia + 1)`` directly and drops the dead iedge
     #     assignments.
     sdfg = cloudsc_kidia_kfdia.to_sdfg(simplify=True)
-    assert _kfdia_plus1_syms(sdfg), 'simplify should promote kfdia + 1 to kfdia_plus_1 symbols'
+    assert kfdia_plus1_syms(sdfg), 'simplify should promote kfdia + 1 to kfdia_plus_1 symbols'
     assert isinstance(sdfg.arrays.get('kfdia'), dace.data.Scalar)
     propagated = SymbolPropagation().apply_pass(sdfg, {})
     assert propagated and any(s.startswith('kfdia_plus_1') for s in propagated), \
         f'symprop should fold ``kfdia_plus_1 -> (kfdia + 1)`` when kfdia is read-only Scalar; got {propagated}'
-    assert not _kfdia_plus1_syms(sdfg), 'all kfdia_plus_1 aliases should be dead-iedge-eliminated'
+    assert not kfdia_plus1_syms(sdfg), 'all kfdia_plus_1 aliases should be dead-iedge-eliminated'
     sdfg.validate()
     out1 = np.zeros((nlev, nlon))
     sdfg(pt=pt.copy(), ptend=out1, kidia=0, kfdia=nlon - 1, klev=nlev, klon=nlon)
@@ -430,14 +430,13 @@ def test_cloudsc_kidia_kfdia_promote_then_propagate():
     assert np.allclose(out2, pt * 2.0 + 3.0)
 
 
-_SP_N = dace.symbol("_SP_N")
+SP_N = dace.symbol("SP_N")
 
 
 @dace.program
-def _carried_index_kernel(a: dace.float64[_SP_N], b: dace.float64[_SP_N], c: dace.float64[_SP_N],
-                          d: dace.float64[_SP_N]):
+def carried_index_kernel(a: dace.float64[SP_N], b: dace.float64[SP_N], c: dace.float64[SP_N], d: dace.float64[SP_N]):
     j = -1
-    for i in range(_SP_N // 2):
+    for i in range(SP_N // 2):
         k = j + 1
         a[i] = b[k] - d[i]
         j = k + 1
@@ -455,15 +454,15 @@ def test_carried_index_symbol_not_propagated_stale():
     rng = np.random.default_rng(0)
     base = {name: rng.random(n) for name in "abcd"}
 
-    ref = _carried_index_kernel.to_sdfg(simplify=True)
+    ref = carried_index_kernel.to_sdfg(simplify=True)
     cand = copy.deepcopy(ref)
     SymbolPropagation().apply_pass(cand, {})
     cand.validate()
 
     ra = {name: arr.copy() for name, arr in base.items()}
-    ref(**ra, _SP_N=n)
+    ref(**ra, SP_N=n)
     ca = {name: arr.copy() for name, arr in base.items()}
-    cand(**ca, _SP_N=n)
+    cand(**ca, SP_N=n)
     for name in "abcd":
         assert np.allclose(ra[name], ca[name]), f"{name}: SymbolPropagation changed the result"
 
@@ -593,3 +592,23 @@ if __name__ == "__main__":
     test_dead_iedge_assignment_eliminated_after_substitution()
     test_dead_iedge_chain_unravels_to_fixed_point()
     test_dead_iedge_preserved_when_lhs_still_used()
+
+
+def test_a_loop_varying_binding_does_not_reach_descriptor_shapes():
+    """``replace_dict`` rewrites descriptor shapes too, and those live at SDFG scope: propagating
+    ``K = i + 1`` would size a transient by the loop variable and allocate it outside the loop."""
+    sdfg = dace.SDFG('symprop_loop_varying_shape')
+    sdfg.add_array('a', (32, ), dace.float64)
+    sdfg.add_symbol('K', dace.int64)
+    sdfg.add_transient('tmp', ('K', ), dace.float64)
+
+    loop = LoopRegion('loop', 'i < 4', 'i', 'i = 0', 'i = i + 1', sdfg=sdfg)
+    sdfg.add_node(loop, is_start_block=True)
+    first = loop.add_state('first', is_start_block=True)
+    second = loop.add_state('second')
+    loop.add_edge(first, second, dace.InterstateEdge(assignments={'K': 'i + 1'}))
+    second.add_mapped_tasklet('write', {'j': '0:K'}, {}, 'o = 1.0', {'o': dace.Memlet('tmp[j]')}, external_edges=True)
+    sdfg.validate()
+
+    SymbolPropagation().apply_pass(sdfg, {})
+    assert [str(s) for s in sdfg.arrays['tmp'].shape] == ['K']

--- a/tests/sdfg/replace_in_codeblock_test.py
+++ b/tests/sdfg/replace_in_codeblock_test.py
@@ -1,0 +1,88 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+""" Tests that shadowing a name inside a C++ tasklet declares it with the type it was declared
+with, rather than deducing one from whatever expression a pass substituted. """
+
+import numpy as np
+
+import dace
+
+
+def test_cpp_shadow_declares_the_symbol_type():
+    """``auto`` deduces from the replacement expression, so ``i = 2`` narrows an int64 symbol to
+    int and arithmetic on it can then overflow where the symbol's own type would not."""
+    sdfg = dace.SDFG('cpp_shadow_type')
+    sdfg.add_symbol('i', dace.int64)
+    sdfg.add_array('out', [1], dace.int64)
+
+    state = sdfg.add_state('s', is_start_block=True)
+    tasklet = state.add_tasklet('w', {}, {'o'}, 'o = i + 1;', language=dace.Language.CPP)
+    state.add_edge(tasklet, 'o', state.add_write('out'), None, dace.Memlet('out[0]'))
+
+    state.replace_dict({'i': '2'})
+
+    code = tasklet.code.as_string
+    assert 'int64_t i = 2;' in code, code
+    assert 'auto i' not in code, code
+
+
+def test_cpp_shadow_of_a_scalar_declares_the_descriptor_type():
+    """A read-only ``Scalar`` is reached the same way; its type comes off the descriptor."""
+    sdfg = dace.SDFG('cpp_shadow_scalar')
+    sdfg.add_scalar('param', dace.int64)
+    sdfg.add_array('out', [1], dace.int64)
+
+    state = sdfg.add_state('s', is_start_block=True)
+    tasklet = state.add_tasklet('w', {}, {'o'}, 'o = param + 1;', language=dace.Language.CPP)
+    state.add_edge(tasklet, 'o', state.add_write('out'), None, dace.Memlet('out[0]'))
+
+    state.replace_dict({'param': '2'})
+
+    code = tasklet.code.as_string
+    assert 'int64_t param = 2;' in code, code
+    assert 'auto param' not in code, code
+
+
+def test_cpp_shadow_keeps_the_integer_semantics_of_the_symbol():
+    """The deduced type changes results, not just spelling: a floating replacement for an integer
+    symbol makes ``auto`` a ``double``, and the division below stops being integer division."""
+    sdfg = dace.SDFG('cpp_shadow_semantics')
+    sdfg.add_symbol('i', dace.int64)
+    sdfg.add_array('out', [1], dace.float64)
+
+    state = sdfg.add_state('s', is_start_block=True)
+    tasklet = state.add_tasklet('w', {}, {'o'}, 'o = i / 2;', language=dace.Language.CPP)
+    state.add_edge(tasklet, 'o', state.add_write('out'), None, dace.Memlet('out[0]'))
+
+    state.replace_dict({'i': '5.0'})
+
+    out = np.zeros(1, dtype=np.float64)
+    sdfg(out=out)
+    assert out[0] == 2.0, f'expected integer division on an int64 symbol, got {out[0]}'
+
+
+def test_cpp_shadow_of_a_map_parameter_deduces():
+    """A map parameter is neither a symbol nor a descriptor, so nothing declares its type here.
+    ``auto`` is right for it: it copies the type of the index variable it is renamed to."""
+    sdfg = dace.SDFG('cpp_shadow_map_param')
+    sdfg.add_array('out', [8], dace.int64)
+
+    state = sdfg.add_state('s', is_start_block=True)
+    entry, exit_node = state.add_map('m', {'i': '0:8'})
+    tasklet = state.add_tasklet('w', {}, {'o'}, 'o = i + 1;', language=dace.Language.CPP)
+    state.add_edge(entry, None, tasklet, None, dace.Memlet())
+    exit_node.add_in_connector('IN_o')
+    exit_node.add_out_connector('OUT_o')
+    state.add_edge(tasklet, 'o', exit_node, 'IN_o', dace.Memlet('out[i]'))
+    state.add_edge(exit_node, 'OUT_o', state.add_write('out'), None, dace.Memlet('out[0:8]'))
+    sdfg.validate()
+
+    assert 'i' not in sdfg.symbols and 'i' not in sdfg.arrays
+    state.replace_dict({'i': 'k'})
+    assert 'auto i = k;' in tasklet.code.as_string, tasklet.code.as_string
+
+
+if __name__ == '__main__':
+    test_cpp_shadow_declares_the_symbol_type()
+    test_cpp_shadow_of_a_scalar_declares_the_descriptor_type()
+    test_cpp_shadow_keeps_the_integer_semantics_of_the_symbol()
+    test_cpp_shadow_of_a_map_parameter_deduces()

--- a/tests/symbol_inference_test.py
+++ b/tests/symbol_inference_test.py
@@ -52,6 +52,38 @@ def test_symbol_inference_joint():
     assert np.allclose(B, np.full_like(B, real_M))
 
 
+def test_dynamic_range_bound_types_the_map_parameter():
+    """A dynamic-range connector is the declared type of the bound that names it.
+
+    The parameter's type must come from that connector and not from the dtype the bound's symbol
+    instance happens to carry: symbol identity is by name, so an expression rebuilt from a string
+    (what every ``replace_dict`` substitution does) mints its names untyped, while deserialization
+    rebuilds them from the declared table. Reading the instance makes the same map report two
+    different parameter types across a save/load round trip.
+    """
+    sdfg = dace.SDFG('dynamic_range_bound')
+    sdfg.add_array('A', [128], dace.float64)
+    sdfg.add_scalar('lo', dace.uint64, transient=False)
+    state = sdfg.add_state()
+
+    # Parsed from a string, so the bound carries an untyped ``lo`` -- the unstable dtype.
+    bound = dace.symbolic.pystr_to_symbolic('lo')
+    assert all(s.dtype is not dace.uint64 for s in bound.free_symbols)
+
+    entry, exit_node = state.add_map('m', {'i': dace.subsets.Range([(bound, 127, 1)])})
+    entry.add_in_connector('lo', dace.uint64)
+    state.add_edge(state.add_read('lo'), None, entry, 'lo', dace.Memlet('lo[0]'))
+
+    tasklet = state.add_tasklet('t', {}, {'o'}, 'o = 1.0')
+    state.add_memlet_path(entry, tasklet, memlet=dace.Memlet())
+    state.add_memlet_path(tasklet, exit_node, state.add_write('A'), src_conn='o', memlet=dace.Memlet('A[i]'))
+
+    new_symbols = entry.new_symbols(sdfg, state, dict(sdfg.symbols))
+    assert new_symbols['lo'] == dace.uint64
+    assert new_symbols['i'] == dace.uint64
+
+
 if __name__ == '__main__':
     test_symbol_inference()
     test_symbol_inference_joint()
+    test_dynamic_range_bound_types_the_map_parameter()


### PR DESCRIPTION
SymbolPropagation looked up a nested block's containers in the top-level SDFG, joined branches without a meet so one side's value escaped, refused read-only Scalars, rendered operator-backed functions as their sympy class names, and could return None after modifying the SDFG. This fixes those and adds the eight cases that cover them.

```python
# both arms bind fac; post-join uses folded to the literal 1.0 before
if cond: fac = 1.0
else:    fac = zfokoop[jl]
```

Also, adding symbol prop to simplify exposed some bugs:
- replace dicts on codeblock has issues
- pyinterop of abs has an issues on complex numbers (abs of complex type is a real type not complex)
- C++ "auto" emits different types than the symbol's dtype and produces different code than SDFG wants, so we need to ensure we collect the dtype of a symbol