### PR TITLE
[WIP] fix(autodiff): symbolic parsing, symbol identity, and nested-SDFG symbol maps

### DIFF
--- a/dace/autodiff/__init__.py
+++ b/dace/autodiff/__init__.py
@@ -25,19 +25,18 @@ Key Features
 
 """
 
-from .base_abc import BackwardImplementation, BackwardContext, BackwardResult, AutoDiffException
-from .backward_pass_generator import BackwardPassGenerator
-from .autodiff import add_backward_pass
+from dace.autodiff.base_abc import BackwardImplementation, BackwardContext, BackwardResult, AutoDiffException
+from dace.autodiff.backward_pass_generator import BackwardPassGenerator
+from dace.autodiff.autodiff import add_backward_pass
 
 try:
-    from .torch import make_backward_function
+    from dace.autodiff.torch import make_backward_function
     TORCH_INTEGRATION_AVAILABLE = True
 except ImportError:
     make_backward_function = None
     TORCH_INTEGRATION_AVAILABLE = False
 
-import sys
-from . import library
+from dace.autodiff import library
 
 __all__ = [
     # Main API

--- a/dace/autodiff/analysis.py
+++ b/dace/autodiff/analysis.py
@@ -2,7 +2,7 @@
 """
 Analysis helpers for autodiff
 """
-from typing import Dict, Set, Tuple, Optional
+from typing import Optional
 import collections
 
 from dace import graphlib as nx
@@ -11,10 +11,10 @@ from dace.sdfg import SDFG, SDFGState, nodes, utils as sdfg_utils
 from dace.transformation.passes import analysis
 from dace.sdfg.state import FunctionCallRegion
 
-AccessSets = Dict[SDFGState, Tuple[Set[str], Set[str]]]
+AccessSets = dict[SDFGState, tuple[set[str], set[str]]]
 
 
-def dependency_analysis(sdfg: SDFG) -> Dict[str, Set[str]]:
+def dependency_analysis(sdfg: SDFG) -> dict[str, set[str]]:
     """
     Analyze read dependencies of arrays in the SDFG.
 
@@ -43,7 +43,7 @@ def dependency_analysis(sdfg: SDFG) -> Dict[str, Set[str]]:
     return result
 
 
-def inverse_reachability(sdfg: SDFG) -> Dict[SDFGState, Set[SDFGState]]:
+def inverse_reachability(sdfg: SDFG) -> dict[SDFGState, set[SDFGState]]:
 
     reachability = analysis.StateReachability().apply_pass(sdfg, {})
     inverse_reachability = collections.defaultdict(set)

--- a/dace/autodiff/autodiff.md
+++ b/dace/autodiff/autodiff.md
@@ -143,11 +143,11 @@ dace/autodiff/
 │   ├── __init__.py                  # Package exports (46 lines)
 │   ├── dace_nodes.py                # Pure SDFG elements (487 lines)
 │   │   └── DaceNodeBackwardImplementations
-│   │       ├── _reverse_AccessNode()
-│   │       ├── _reverse_Tasklet()
-│   │       ├── _reverse_MapEntry()
-│   │       ├── _reverse_MapExit()
-│   │       └── _reverse_NestedSDFG()
+│   │       ├── reverse_access_node()
+│   │       ├── reverse_tasklet()
+│   │       ├── reverse_map_entry()
+│   │       ├── reverse_map_exit()
+│   │       └── reverse_nested_sdfg()
 │   ├── dace_reduction_nodes.py      # Reduction operations (307 lines)
 │   │   ├── ReverseReduce
 │   │   └── ... (reduction backward implementations)

--- a/dace/autodiff/autodiff.py
+++ b/dace/autodiff/autodiff.py
@@ -1,5 +1,5 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
-from typing import List, Union, Optional
+from typing import Union, Optional
 
 from dace.autodiff.backward_pass_generator import BackwardPassGenerator
 
@@ -9,10 +9,10 @@ from dace.sdfg.state import LoopRegion
 
 
 def add_backward_pass(sdfg: SDFG,
-                      outputs: List[Union[nodes.AccessNode, str]],
-                      inputs: List[Union[nodes.AccessNode, str]],
+                      outputs: list[Union[nodes.AccessNode, str]],
+                      inputs: list[Union[nodes.AccessNode, str]],
                       data_forwarding_strategy: str = "store_all",
-                      data_to_recompute: Optional[List[str]] = None,
+                      data_to_recompute: Optional[list[str]] = None,
                       simplify: bool = True,
                       separate_sdfgs: bool = False) -> Optional[SDFG]:
     """ Experimental: Add a backward pass to `state` using reverse-mode automatic differentiation.

--- a/dace/autodiff/backward_pass_generator.py
+++ b/dace/autodiff/backward_pass_generator.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import copy
-from typing import List, Tuple, Set, Dict, Union, Optional, Sequence
+from typing import Union, Optional
+from collections.abc import Sequence
 import sympy as sp
 from ordered_set import OrderedSet
 
@@ -65,10 +66,10 @@ class BackwardPassGenerator:
         given_gradients: Sequence[Union[nodes.AccessNode, str]],
         required_gradients: Sequence[Union[nodes.AccessNode, str]],
         backward_sdfg: SDFG,  # This can be the same as sdfg
-        array_grad_map: Optional[Dict[str, str]] = None,
-        conflicted_gradient_buffers: Optional[Set[str]] = None,
+        array_grad_map: Optional[dict[str, str]] = None,
+        conflicted_gradient_buffers: Optional[set[str]] = None,
         data_forwarding_strategy: str = "store_all",
-        data_to_recompute: Optional[List[str]] = None,
+        data_to_recompute: Optional[list[str]] = None,
     ):
 
         self.sdfg: SDFG = sdfg
@@ -76,10 +77,10 @@ class BackwardPassGenerator:
         self.backward_sdfg: SDFG = backward_sdfg
 
         given_gradients = [
-            n if isinstance(n, nodes.AccessNode) else self._str_to_access(n, "outputs") for n in given_gradients
+            n if isinstance(n, nodes.AccessNode) else self.str_to_access(n, "outputs") for n in given_gradients
         ]
         required_gradients = [
-            n if isinstance(n, nodes.AccessNode) else self._str_to_access(n, "inputs") for n in required_gradients
+            n if isinstance(n, nodes.AccessNode) else self.str_to_access(n, "inputs") for n in required_gradients
         ]
         required_gradients = [n for n in required_gradients if n is not None]
 
@@ -90,47 +91,47 @@ class BackwardPassGenerator:
         self.output_names = {n.data for n in given_gradients}
 
         #: Arrays descriptors for the gradients
-        self.backward_grad_arrays: Dict[str, dt.Array] = {}
+        self.backward_grad_arrays: dict[str, dt.Array] = {}
 
         #: Arrays descriptors for inputs that are required from the forward pass
-        self.backward_input_arrays: Dict[str, dt.Array] = {}
+        self.backward_input_arrays: dict[str, dt.Array] = {}
 
         #: Mapping from forward node -> backward node, and forward map -> backward map
-        self.reverse_map: Dict[nodes.Node, Union[nodes.Node, nodes.Map]] = {}
+        self.reverse_map: dict[nodes.Node, Union[nodes.Node, nodes.Map]] = {}
 
         #: Mapping from forward state -> backward state
-        self.reversed_states_map: Dict[SDFGState, SDFGState] = {}
+        self.reversed_states_map: dict[SDFGState, SDFGState] = {}
 
         #: Mapping from forward LoopRegion -> backward LoopRegion
-        self.reversed_loops_map: Dict[LoopRegion, LoopRegion] = {}
+        self.reversed_loops_map: dict[LoopRegion, LoopRegion] = {}
 
         #: Mapping from forward state -> backward state for loop states
-        self.reversed_loop_states_map: Dict[nodes.Node, nodes.Node] = {}
+        self.reversed_loop_states_map: dict[nodes.Node, nodes.Node] = {}
 
         #: Mapping between states and their subgraph views for AD processing
-        self.states_view_map: Dict[SDFGState, dstate.StateSubgraphView] = {}
+        self.states_view_map: dict[SDFGState, dstate.StateSubgraphView] = {}
 
         #: Mapping between loop states and their subgraph views for AD processing
-        self.loop_states_view_map: Dict[SDFGState, dstate.StateSubgraphView] = {}
+        self.loop_states_view_map: dict[SDFGState, dstate.StateSubgraphView] = {}
 
         #: Mapping between the map entry of a conditional assignment block and its zero-out AN
-        self.conditional_block_entry: Dict[nodes.MapEntry, nodes.AccessNode] = {}
+        self.conditional_block_entry: dict[nodes.MapEntry, nodes.AccessNode] = {}
 
         #: Mapping from forward_node -> BackwardResult for that node
-        self.result_map: Dict[nodes.Node, BackwardResult] = {}
+        self.result_map: dict[nodes.Node, BackwardResult] = {}
 
         #: Mapping from forward name to gradient name for arrays
-        self.array_grad_map: Dict[str, str] = array_grad_map or {}
+        self.array_grad_map: dict[str, str] = array_grad_map or {}
 
         #: Mapping from the backward access nodes that will be zeroed out
         # to the transients that contain the values before they are zeroed out
-        self.zeroed_out: Dict[nodes.AccessNode, List[nodes.AccessNode]] = {}
+        self.zeroed_out: dict[nodes.AccessNode, list[nodes.AccessNode]] = {}
 
         #: The read-only arrays of the forward SDFG. Used in data forwarding decisions
-        self.read_only_arrays: Set[str] = ad_utils.get_read_only_arrays(self.sdfg)
+        self.read_only_arrays: set[str] = ad_utils.get_read_only_arrays(self.sdfg)
 
         #: Mapping from overwritten input name to storing AccessNode
-        self.stored_inputs: Dict[str, nodes.AccessNode] = {}
+        self.stored_inputs: dict[str, nodes.AccessNode] = {}
 
         # Variable to check if backward has already been applied
         self._applied = False
@@ -139,28 +140,28 @@ class BackwardPassGenerator:
 
         # Topological ordering of the states
         self.state_order = ad_utils.get_state_topological_order(self.sdfg)
-        self.conflicted_gradient_buffers: Set[str] = conflicted_gradient_buffers or set()
+        self.conflicted_gradient_buffers: set[str] = conflicted_gradient_buffers or set()
 
-        self.interstate_symbols: Dict[str, str] = {}
+        self.interstate_symbols: dict[str, str] = {}
         for edge in self.sdfg.all_interstate_edges():
             for assign_symbol, assignment in edge.data.assignments.items():
                 self.interstate_symbols[assign_symbol] = assignment
 
         # Validate parameters and setup SDFG configuration
-        self._validate_gradients()
-        self._setup_sdfg_configuration(sdfg, backward_sdfg, given_gradients)
+        self.validate_gradients()
+        self.setup_sdfg_configuration(sdfg, backward_sdfg, given_gradients)
 
         # DaCe nodes backward implementations
         self.dace_node_impl = DaceNodeBackwardImplementations(self)
 
         #: List containing information about all the data to be forwarded to the backward pass
-        self.data_to_forward: List[Tuple[SDFGState, SDFGState, nodes.AccessNode, nodes.Node,
+        self.data_to_forward: list[tuple[SDFGState, SDFGState, nodes.AccessNode, nodes.Node,
                                          dstate.MultiConnectorEdge]] = []
 
         # Data forwarding manager
         self.data_forwarding_manager = DataForwardingManager(self)
 
-    def _validate_gradients(self) -> None:
+    def validate_gradients(self) -> None:
         """Validate that gradient arrays exist in the SDFG.
 
         Raises:
@@ -176,8 +177,8 @@ class BackwardPassGenerator:
             if inp not in self.sdfg.arrays:
                 raise AutoDiffException(f"Could not find input '{inp}' in SDFG array descriptors")
 
-    def _setup_sdfg_configuration(self, sdfg: SDFG, backward_sdfg: SDFG,
-                                  given_gradients: List[nodes.AccessNode]) -> None:
+    def setup_sdfg_configuration(self, sdfg: SDFG, backward_sdfg: SDFG,
+                                 given_gradients: list[nodes.AccessNode]) -> None:
         """Setup SDFG configuration for separate or combined forward/backward passes.
 
         :param sdfg: Forward SDFG.
@@ -216,11 +217,11 @@ class BackwardPassGenerator:
         defaults.update(kwargs)
         return BackwardPassGenerator(**defaults)
 
-    def backward(self) -> Tuple[BackwardResult, Dict[str, dt.Array], Dict[str, dt.Array]]:
+    def backward(self) -> tuple[BackwardResult, dict[str, dt.Array], dict[str, dt.Array]]:
         """Generate the backward pass in backward_sdfg."""
         return self.reverse_sdfg()
 
-    def reverse_sdfg(self) -> Tuple[BackwardResult, Dict[str, dt.Array], Dict[str, dt.Array]]:
+    def reverse_sdfg(self) -> tuple[BackwardResult, dict[str, dt.Array], dict[str, dt.Array]]:
         """Generate the backward pass by reversing all SDFG states.
 
         Processes all states in the SDFG and creates their backward counterparts,
@@ -239,19 +240,19 @@ class BackwardPassGenerator:
             raise AutoDiffException("Backward may only be called once. Instantiate a new BackwardPassGenerator.")
 
         # Create state views mapping and expand all the SDFG nodes
-        self._create_stateviews_mapping()
+        self.create_stateviews_mapping()
 
         # Reverse each state in the graph
-        self._reverse_states()
+        self.reverse_states()
 
         # Connect the new reversed states to the other states correctly
-        self._connect_reversed_states()
+        self.connect_reversed_states()
 
         # Fill the interstate edges with the correct conditions
-        self._fill_interstate_edge_conditions()
+        self.fill_interstate_edge_conditions()
 
         # Add interstate assignments for control flow decisions
-        self._add_interstate_edge_assignments()
+        self.add_interstate_edge_assignments()
 
         # Forward required data by the backward pass according to a user defined strategy
         self.data_forwarding_manager.forward_data_to_backward_pass()
@@ -260,16 +261,16 @@ class BackwardPassGenerator:
         # added yet. Add them now.
         for given_grad in sorted(self.given_gradients_data):
             if self.array_grad_name(given_grad) not in self.backward_sdfg.arrays:
-                self._add_gradient_data_descriptor(given_grad)
+                self.add_gradient_data_descriptor(given_grad)
 
         # Prepare the output
         required_grad_names = {name: self.array_grad_name(name) for name in self.required_gradients_data}
         given_grad_names = {name: self.array_grad_name(name) for name in self.given_gradients_data}
 
         # Set mapping from gradient name to whether it should be zeroed out on initialization
-        zero_init: Dict[str, bool] = {}
+        zero_init: dict[str, bool] = {}
         for node, bres in self.result_map.items():
-            forward_state = self._get_node_state(node=node)
+            forward_state = self.get_node_state(node=node)
             for zname, zinit in bres.zero_init.items():
                 # Reverse lookup
                 cname = next(k for k, v in bres.required_grad_names.items() if v == zname)
@@ -285,15 +286,15 @@ class BackwardPassGenerator:
                                 zero_init=zero_init)
         return result, self.backward_grad_arrays, self.backward_input_arrays
 
-    def _create_stateviews_mapping(self) -> None:
+    def create_stateviews_mapping(self) -> None:
         """Map each state in the SDFG to views that indicate what to differentiate."""
-        self._find_subgraph_to_differentiate()
+        self.find_subgraph_to_differentiate()
         # Expand until there is nothing left to expand
-        while self._expand_nodes():
+        while self.expand_nodes():
             # Nodes have been expanded again on the expanded graph; recalculate the forward graph
-            self._find_subgraph_to_differentiate()
+            self.find_subgraph_to_differentiate()
 
-    def _reverse_states(self) -> None:
+    def reverse_states(self) -> None:
         """Go through all states of the forward SDFG, reverse them and add them to the backward SDFG."""
         # For reversal we want to iterate through the states in reverse topological order
         for state in reversed(self.state_order):
@@ -335,15 +336,15 @@ class BackwardPassGenerator:
                 ad_utils.check_edges_type_in_state(state_subgraph_view)
 
                 # Recursively reverse the subgraph
-                self._reverse_subgraph(forward_state=state, backward_state=reversed_state, subgraph=state_subgraph_view)
+                self.reverse_subgraph(forward_state=state, backward_state=reversed_state, subgraph=state_subgraph_view)
 
         # We also reverse all the LoopRegions in the graph
         for node in self.sdfg.nodes():
             if not isinstance(node, LoopRegion):
                 continue
-            self._reverse_loop_region(node)
+            self.reverse_loop_region(node)
 
-    def _connect_reversed_states(self) -> None:
+    def connect_reversed_states(self) -> None:
         """Connect backward states corresponding to forward SDFG states.
 
         All incoming edges of a forward state become outgoing edges in the backward SDFG.
@@ -424,7 +425,7 @@ class BackwardPassGenerator:
 
                 bwd_parent_graph.add_edge(src=reversed_loop, dst=bwd_src, data=dace.InterstateEdge())
 
-    def _fill_interstate_edge_conditions_in_scope(self, graph: Union[SDFG, LoopRegion]) -> None:
+    def fill_interstate_edge_conditions_in_scope(self, graph: Union[SDFG, LoopRegion]) -> None:
         """
         Get all the nodes within this graph in topological order,
         Connect the states and call the function recursively on the nested scopes.
@@ -436,12 +437,12 @@ class BackwardPassGenerator:
         nodes = dace_utils.dfs_topological_sort(graph, graph.source_nodes())
         for node in nodes:
             # A list of the conditions on all the in edges for this state
-            in_edges_conditions: List[str] = []
+            in_edges_conditions: list[str] = []
             if isinstance(node, SDFG) or isinstance(node, LoopRegion):
                 # if this is not a reversed loop region
                 if not node in self.reversed_loops_map:
                     continue
-                self._fill_interstate_edge_conditions_in_scope(node)
+                self.fill_interstate_edge_conditions_in_scope(node)
             else:
 
                 if not isinstance(node, SDFGState):
@@ -482,7 +483,7 @@ class BackwardPassGenerator:
                     else:
                         new_bwd_edge_condition = f"({src_state_condition}) and ({current_edge_condition})"
 
-                    bwd_edge = self._get_backward_state_edge(edge)
+                    bwd_edge = self.get_backward_state_edge(edge)
 
                     # Add the condition to the edge
                     bwd_edge.data.condition = CodeBlock(new_bwd_edge_condition)
@@ -491,7 +492,7 @@ class BackwardPassGenerator:
                     if forward_state in self.loop_states_view_map:
 
                         # Get the corresponding edge between the loop states
-                        bwd_loop_edge = self._get_backward_loop_state_edge(edge)
+                        bwd_loop_edge = self.get_backward_loop_state_edge(edge)
 
                         # Add the same condition to the edge
                         bwd_loop_edge.data.condition = CodeBlock(new_bwd_edge_condition)
@@ -514,13 +515,13 @@ class BackwardPassGenerator:
             # Since we are doing topological sort before iterating
             conditions_map[node] = condition_for_state
 
-    def _fill_interstate_edge_conditions(self) -> None:
+    def fill_interstate_edge_conditions(self) -> None:
         """
         Go through all of the states in the forward graph and fill the necessary conditions in the backward states.
         Each edge in the backward SDFG will be the logical AND between the equivalent edge in the forward SDFG and
         all of the conditions that are necessary to get to this state in the forward pass.
         """
-        self._fill_interstate_edge_conditions_in_scope(self.sdfg)
+        self.fill_interstate_edge_conditions_in_scope(self.sdfg)
 
         # Iterate through all the loop regions and connect the loop states if necessary
         for loop in self.sdfg.all_control_flow_regions():
@@ -567,7 +568,7 @@ class BackwardPassGenerator:
                                    dst=leftover_loop_state,
                                    data=dace.InterstateEdge(condition=leftover_iterations_condition))
 
-    def _add_interstate_edge_assignments(self) -> None:
+    def add_interstate_edge_assignments(self) -> None:
         """
         We will need to add interstate assignments at the start of the backward SDFG
         This is necessary to make sure the control flow in the backward pass is correctly preserved.
@@ -627,7 +628,7 @@ class BackwardPassGenerator:
 
         return False
 
-    def _zero_out_gradient(self, forward_state: SDFGState, forward_node: nodes.AccessNode, memlet: Memlet) -> None:
+    def zero_out_gradient(self, forward_state: SDFGState, forward_node: nodes.AccessNode, memlet: Memlet) -> None:
         """
         Zero out gradients for overwritten arrays in the forward pass.
 
@@ -781,7 +782,7 @@ class BackwardPassGenerator:
         else:
             raise AutoDiffException("Unsupported data descriptor {}".format(array_desc))
 
-    def _remove_onnx_attribute_accessnodes(self, nodes_list: List[nodes.Node], state: SDFGState) -> None:
+    def remove_onnx_attribute_accessnodes(self, nodes_list: list[nodes.Node], state: SDFGState) -> None:
         """Remove ONNX attribute AccessNodes that don't need gradient tracking.
 
         For some ONNX operators, nodes have attributes as input connectors even if the inputs are actually constant.
@@ -797,7 +798,7 @@ class BackwardPassGenerator:
                         for edge in out_edges):
                     nodes_list.remove(node)
 
-    def _remove_maps_without_input_connectors(self, nodes_list: List[nodes.Node], state: SDFGState) -> None:
+    def remove_maps_without_input_connectors(self, nodes_list: list[nodes.Node], state: SDFGState) -> None:
         """Remove maps that don't have any input connectors from the nodes_list.
 
         These are maps that won't have an output in the backward pass and thus can be skipped from the reversal process.
@@ -820,7 +821,7 @@ class BackwardPassGenerator:
                     )[state_node] == node and state_node in nodes_list:
                         nodes_list.remove(state_node)
 
-    def _find_subgraph_to_differentiate(self) -> None:
+    def find_subgraph_to_differentiate(self) -> None:
         """Determine which nodes we need to reverse; this forms the subgraph we will differentiate.
 
         We do a reverse BFS from the target output node.
@@ -836,7 +837,7 @@ class BackwardPassGenerator:
 
         # Do the backward BFS iteratively
         for state in reversed(self.state_order):
-            state_given_gradients: List[nodes.AccessNode] = []
+            state_given_gradients: list[nodes.AccessNode] = []
 
             for node in state:
                 if isinstance(node, nodes.AccessNode) and node.data in given_gradients_all_states:
@@ -846,14 +847,14 @@ class BackwardPassGenerator:
             nodes_list = list(backward_nodes)
 
             # Clean up unwanted elements
-            self._remove_maps_without_input_connectors(nodes_list, state)
-            self._remove_onnx_attribute_accessnodes(nodes_list, state)
+            self.remove_maps_without_input_connectors(nodes_list, state)
+            self.remove_onnx_attribute_accessnodes(nodes_list, state)
 
             state_subgraph = dstate.StateSubgraphView(state, nodes_list)
 
-            state_subgraph = self._add_missing_nested_sdfg_connectors_to_view(state=state,
-                                                                              state_subgraph=state_subgraph,
-                                                                              view_nodes=nodes_list)
+            state_subgraph = self.add_missing_nested_sdfg_connectors_to_view(state=state,
+                                                                             state_subgraph=state_subgraph,
+                                                                             view_nodes=nodes_list)
 
             # Add mapping
             self.states_view_map[state] = state_subgraph
@@ -876,11 +877,11 @@ class BackwardPassGenerator:
                 backward_nodes = ad_utils.reverse_bfs_gradient_nodes(state, state_given_gradients)
 
                 view_nodes = list(backward_nodes)
-                self._remove_maps_without_input_connectors(nodes_list, state)
+                self.remove_maps_without_input_connectors(nodes_list, state)
 
                 loop_state_subgraph = dstate.StateSubgraphView(state, view_nodes)
 
-                loop_state_subgraph = self._add_missing_nested_sdfg_connectors_to_view(
+                loop_state_subgraph = self.add_missing_nested_sdfg_connectors_to_view(
                     state=state, state_subgraph=loop_state_subgraph, view_nodes=view_nodes)
 
                 # If the two views are different
@@ -903,7 +904,7 @@ class BackwardPassGenerator:
 
         return self.array_grad_map[forward_name]
 
-    def _add_gradient_data_descriptor(self, data_name: str) -> dt.Array:
+    def add_gradient_data_descriptor(self, data_name: str) -> dt.Array:
         """Add the data descriptor for the gradient for `data_name`.
 
         :param data_name: The name of the forward descriptor.
@@ -928,7 +929,7 @@ class BackwardPassGenerator:
         self.backward_sdfg.arrays[grad_name] = cloned_datadesc
         return cloned_datadesc
 
-    def _reverse_loop_conditional(self, loop: LoopRegion) -> str:
+    def reverse_loop_conditional(self, loop: LoopRegion) -> str:
         """Given a loop region as a parameter, create the conditional for the reversed version of this loop."""
 
         # Get the loop iterator
@@ -949,7 +950,7 @@ class BackwardPassGenerator:
 
         return reversed_condition
 
-    def _reverse_loop_initial_statement(self, loop: LoopRegion) -> str:
+    def reverse_loop_initial_statement(self, loop: LoopRegion) -> str:
         """Given a loop region as a parameter, create the initialization statement for the reversed version of this loop."""
         # Get the loop iterator
         it = loop.loop_variable
@@ -968,7 +969,7 @@ class BackwardPassGenerator:
 
         return init_expr
 
-    def _reverse_loop_update_statement(self, loop: LoopRegion) -> str:
+    def reverse_loop_update_statement(self, loop: LoopRegion) -> str:
         """Given a loop region as a parameter, create the update statement for the reversed version of this loop."""
 
         # Get the original update statement
@@ -985,12 +986,12 @@ class BackwardPassGenerator:
 
         return update_statement
 
-    def _match_loop_region(self, fwd_loop: LoopRegion) -> LoopRegion:
+    def match_loop_region(self, fwd_loop: LoopRegion) -> LoopRegion:
         """Create the backward LoopRegion and fill it with the reversal of the forward LoopRegion."""
 
-        init_expr = self._reverse_loop_initial_statement(fwd_loop)
-        reversed_condition = self._reverse_loop_conditional(fwd_loop)
-        update_statement = self._reverse_loop_update_statement(fwd_loop)
+        init_expr = self.reverse_loop_initial_statement(fwd_loop)
+        reversed_condition = self.reverse_loop_conditional(fwd_loop)
+        update_statement = self.reverse_loop_update_statement(fwd_loop)
 
         # Create the label
         reversed_label = f"{fwd_loop.label}_reversed"
@@ -1004,15 +1005,15 @@ class BackwardPassGenerator:
 
         return reversed_loop
 
-    def _reverse_loop_region(self, loop: LoopRegion):
+    def reverse_loop_region(self, loop: LoopRegion):
         """Given a LoopRegion as a parameter, reverse it, add the loop states that belong in this region."""
 
         # Create the reversed loop region
-        reversed_loop = self._match_loop_region(fwd_loop=loop)
+        reversed_loop = self.match_loop_region(fwd_loop=loop)
         self.reversed_loops_map[loop] = reversed_loop
 
         # Add the reversed loop directly
-        parent_graph = self._get_reversed_parent_graph(loop)
+        parent_graph = self.get_reversed_parent_graph(loop)
         parent_graph.add_node(reversed_loop)
 
         # Add all the loop nodes to the graph and recursivly reverse child loop regions
@@ -1022,7 +1023,7 @@ class BackwardPassGenerator:
                 # This node shouldn't be reversed already since we're going top-down
                 if node in self.reversed_loops_map:
                     raise AutoDiffException(f"Loop {node} has already been reversed")
-                self._reverse_loop_region(node)
+                self.reverse_loop_region(node)
             elif isinstance(node, SDFGState):
 
                 # Get the backward_node
@@ -1039,8 +1040,8 @@ class BackwardPassGenerator:
                     # Get the backward_node
                     bwd_node = self.reversed_loop_states_map[node]
 
-    def _add_missing_nested_sdfg_connectors_to_view(self, state: SDFGState, state_subgraph: dstate.StateSubgraphView,
-                                                    view_nodes: List[nodes.Node]):
+    def add_missing_nested_sdfg_connectors_to_view(self, state: SDFGState, state_subgraph: dstate.StateSubgraphView,
+                                                   view_nodes: list[nodes.Node]):
         """Add missing NestedSDFG connectors to the view for correctness.
 
         There is a special case for NestedSDFGs that we need to fix
@@ -1083,7 +1084,7 @@ class BackwardPassGenerator:
 
         return dstate.StateSubgraphView(state, view_nodes)
 
-    def _compare_memlet_accesses_to_array_size(self, data_name: str, memlet: Memlet) -> int:
+    def compare_memlet_accesses_to_array_size(self, data_name: str, memlet: Memlet) -> int:
         """Compare the memlet range with the size of the array to see if the array is being overwritten."""
         total_size = self.backward_sdfg.arrays[data_name].total_size
         try:
@@ -1099,7 +1100,7 @@ class BackwardPassGenerator:
         except TypeError:
             return None
 
-    def _get_reversed_parent_graph(self, forward_node: nodes.Node):
+    def get_reversed_parent_graph(self, forward_node: nodes.Node):
         """Given a node in the SDFG, get the reversed parent of this node."""
         fwd_parent_graph = forward_node.parent_graph
 
@@ -1112,7 +1113,7 @@ class BackwardPassGenerator:
 
         return parent_graph
 
-    def _get_backward_loop_state_edge(self, forward_edge: dace.InterstateEdge) -> dace.InterstateEdge:
+    def get_backward_loop_state_edge(self, forward_edge: dace.InterstateEdge) -> dace.InterstateEdge:
         """Given an edge from the forward pass, return the equivalent edge in the backward pass."""
         # Get the source and destination states
         forward_src = forward_edge.src
@@ -1158,7 +1159,7 @@ class BackwardPassGenerator:
 
         return bwd_edge
 
-    def _get_backward_state_edge(self, forward_edge: dace.InterstateEdge) -> dace.InterstateEdge:
+    def get_backward_state_edge(self, forward_edge: dace.InterstateEdge) -> dace.InterstateEdge:
         """Given an edge from the forward pass, return the equivalent edge in the backward pass."""
         # Get the source and destination states
         forward_state_src = forward_edge.src
@@ -1194,7 +1195,7 @@ class BackwardPassGenerator:
 
         return bwd_edge
 
-    def _str_to_access(self, data: str, source: str) -> nodes.AccessNode:
+    def str_to_access(self, data: str, source: str) -> nodes.AccessNode:
         """Given a string containing the name of the accessed array, return the AccessNode in the state.
 
         Given a string containing the name of the accessed array, return the AccessNode in the state
@@ -1239,7 +1240,7 @@ class BackwardPassGenerator:
             raise AutoDiffException(f"There are multiple nodes with data {data} "
                                     f" but the source (inputs or outputs) was not specified correctly")
 
-    def _expand_nodes(self) -> bool:
+    def expand_nodes(self) -> bool:
         """Expand all library nodes in the sdfg to pure implementations.
 
         Returns whether something was expanded.
@@ -1263,7 +1264,7 @@ class BackwardPassGenerator:
                     for impl in impls:
                         if impl.forward_can_be_applied(node, parent_graph, self.sdfg):
                             # Configure the module-level expansion class
-                            ExpansionTemplate.environments = impl.environments if hasattr(impl, "environments") else []
+                            ExpansionTemplate.environments = impl.environments
                             ExpansionTemplate._impl = impl
                             ExpansionTemplate._match_node = xf.PatternNode(type(node))
                             ExpansionTemplate.apply_to(parent_graph.parent, verify=False, _match_node=node)
@@ -1274,17 +1275,10 @@ class BackwardPassGenerator:
                 # on to the next expansion. For now we will just apply the first one that matches, prioritizing ones that
                 # have "pure" in the name
                 if isinstance(node, nodes.LibraryNode) and not (ONNX_AVAILABLE and isinstance(node, ONNXOp)):
-                    # Try to select an expansion
-                    if hasattr(node, "implementations"):
-                        implementations = node.implementations
-
-                        pure_candidates = [name for name, _ in sorted(implementations.items()) if "pure" in name]
-                        if len(pure_candidates) > 0:
-                            expansion = pure_candidates[0]
-                        else:
-                            expansion = node.implementation
-                    else:
-                        expansion = node.implementation
+                    # Try to select an expansion. Every expandable library node declares
+                    # ``implementations``; @dace.library.node refuses to register one that does not.
+                    pure_candidates = [name for name in sorted(node.implementations) if "pure" in name]
+                    expansion = pure_candidates[0] if pure_candidates else node.implementation
 
                     node.implementation = expansion
                     node.expand(parent_graph)
@@ -1292,7 +1286,7 @@ class BackwardPassGenerator:
 
         return expanded_something
 
-    def _get_node_state(self, node: nodes.Node) -> SDFGState:
+    def get_node_state(self, node: nodes.Node) -> SDFGState:
         """Return the SDFG state that contains this node."""
         matches = []
         for state in self.sdfg.states():
@@ -1303,8 +1297,8 @@ class BackwardPassGenerator:
             raise AutoDiffException(f"Expected exactly one match, got {len(matches)}")
         return matches[0]
 
-    def _connect_conditional_map_exist(self, forward_state: SDFGState, backward_state: SDFGState,
-                                       backward_map_exit: nodes.MapExit, fwd_tasklet: nodes.Tasklet):
+    def connect_conditional_map_exist(self, forward_state: SDFGState, backward_state: SDFGState,
+                                      backward_map_exit: nodes.MapExit, fwd_tasklet: nodes.Tasklet):
         """Connect the map exit of a conditional tasklet to a new access node which will zero out the gradient.
         """
 
@@ -1352,7 +1346,7 @@ class BackwardPassGenerator:
 
         # We need to get the map entry that starts the conditional block
         # First get the conditional tasklet
-        conditional_block = self._extract_conditional_array_assignment_block(
+        conditional_block = self.extract_conditional_array_assignment_block(
             forward_state=forward_state, tasklet_node=fwd_tasklet, subgraph=self.states_view_map[forward_state])
         # Get the map entry of the conditional bloc
         map_entries = [n for n in conditional_block if isinstance(n, nodes.MapEntry)]
@@ -1366,7 +1360,7 @@ class BackwardPassGenerator:
         # Add the new access node to a dictionary in case it needs to be connected
         self.conditional_block_entry[map_entry] = replicated_bwd_target_an
 
-    def _conditional_tasklet(self, tasklet_node: nodes.Tasklet):
+    def conditional_tasklet(self, tasklet_node: nodes.Tasklet):
         """Check if this tasklet contains a conditional.
 
         This only happens in conditional array assignments and requires special treatment in reversing the graph.
@@ -1379,7 +1373,7 @@ class BackwardPassGenerator:
         # TODO: How to more accurately check this?
         return "if" in tasklet_node.code.as_string
 
-    def _conditional_nested_sdfg(self, forward_state: SDFGState, node: nodes.NestedSDFG):
+    def conditional_nested_sdfg(self, forward_state: SDFGState, node: nodes.NestedSDFG):
         """Check if this NestedSDFG contains a conditional.
 
         This only happens in conditional array assignments and requires special treatment in reversing the graph.
@@ -1399,8 +1393,8 @@ class BackwardPassGenerator:
         # get the code string and check if there is an if
         return False
 
-    def _extract_conditional_array_assignment_block(self, forward_state: SDFGState, tasklet_node: nodes.Node,
-                                                    subgraph: dstate.SubgraphView):
+    def extract_conditional_array_assignment_block(self, forward_state: SDFGState, tasklet_node: nodes.Node,
+                                                   subgraph: dstate.SubgraphView):
         """Extract a conditional array assignment block.
 
         Given a conditional tasklet, check if this is a conditional array assignment of the type
@@ -1442,7 +1436,7 @@ class BackwardPassGenerator:
             }
 
             # if any of the nodes in the block are required for gradient tracking
-            nodes_to_keep_tracking: set[nodes.Node] = self._get_gradient_nodes_to_track(
+            nodes_to_keep_tracking: set[nodes.Node] = self.get_gradient_nodes_to_track(
                 forward_state=forward_state, block_nodes=conditional_assingement_block_nodes, subgraph=subgraph)
             for node in nodes_to_keep_tracking:
                 # we get the reverse bfs of this node and remove it from block nodes to avoid skipping these nodes
@@ -1459,8 +1453,8 @@ class BackwardPassGenerator:
 
         return conditional_assingement_block_nodes
 
-    def _get_gradient_nodes_to_track(self, forward_state: SDFGState, block_nodes: List[nodes.Node],
-                                     subgraph: dstate.SubgraphView):
+    def get_gradient_nodes_to_track(self, forward_state: SDFGState, block_nodes: list[nodes.Node],
+                                    subgraph: dstate.SubgraphView):
         """Get gradient nodes that need tracking in conditional assignments.
 
         When extracting the block for a conditional assignment, we need to make sure we keep tracking
@@ -1468,7 +1462,7 @@ class BackwardPassGenerator:
         This function checks all the required access nodes that are in the conditional block.
         At the moment this is just the target access node.
         """
-        nodes_to_track: List[nodes.AccessNode] = []
+        nodes_to_track: list[nodes.AccessNode] = []
         gradient_nodes = [n for n in self.required_gradients_data]
         gradient_nodes += [n for n in self.given_gradients_data]
 
@@ -1501,8 +1495,8 @@ class BackwardPassGenerator:
                     nodes_to_track.append(node)
         return nodes_to_track
 
-    def _reverse_subgraph(self, forward_state: SDFGState, backward_state: SDFGState,
-                          subgraph: dstate.StateSubgraphView) -> None:
+    def reverse_subgraph(self, forward_state: SDFGState, backward_state: SDFGState,
+                         subgraph: dstate.StateSubgraphView) -> None:
         """Reverse a given subgraph by reversing all nodes within it.
 
         :param forward_state: The forward state containing the subgraph.
@@ -1511,7 +1505,7 @@ class BackwardPassGenerator:
         """
 
         # Conditional assignment nodes
-        conditional_assignment_nodes: List[nodes.Node] = []
+        conditional_assignment_nodes: list[nodes.Node] = []
 
         # A reversed topological sort is a topological sort on the reverse graph
         for node in reversed(list(dace_utils.dfs_topological_sort(subgraph, subgraph.source_nodes()))):
@@ -1542,18 +1536,18 @@ class BackwardPassGenerator:
                     and self.sdfg.arrays[edge.data.data].dtype != dace.bool
                 ]
 
-                reversed_node, backward_result = self._get_reverse_node(forward_state, backward_state, node,
-                                                                        given_gradients, required_gradients)
+                reversed_node, backward_result = self.get_reverse_node(forward_state, backward_state, node,
+                                                                       given_gradients, required_gradients)
 
                 self.reverse_map[node] = reversed_node
                 self.result_map[node] = backward_result
 
                 # Connect the required inputs of the reverse node:
                 # the gradients ...
-                self._connect_given_gradients(forward_state=forward_state,
-                                              backward_state=backward_state,
-                                              subgraph=subgraph,
-                                              forward_node=node)
+                self.connect_given_gradients(forward_state=forward_state,
+                                             backward_state=backward_state,
+                                             subgraph=subgraph,
+                                             forward_node=node)
 
                 # ... and any required input values from the forward pass
                 ####################################
@@ -1562,17 +1556,17 @@ class BackwardPassGenerator:
                 already_connected = {e.dst_conn for e in backward_state.in_edges(reversed_node)}
                 required_inputs = set(reversed_node.in_connectors).difference(already_connected)
                 required_inputs = {c: c for c in required_inputs}
-                self._connect_forward_inputs(forward_state, backward_state, node, reversed_node, required_inputs)
+                self.connect_forward_inputs(forward_state, backward_state, node, reversed_node, required_inputs)
 
                 if isinstance(node, nodes.AccessNode):
 
                     # this means we are writing out a grad to an array.
                     # initialize the gradient if it hasn't been initialized already (this can also happen in
-                    # _connect_given_gradients
+                    # connect_given_gradients
                     array_grad_name = self.array_grad_name(node.data)
                     if array_grad_name not in self.backward_sdfg.arrays:
                         # this grad hasn't been written before: initialize it
-                        self._add_gradient_data_descriptor(node.data)
+                        self.add_gradient_data_descriptor(node.data)
 
                     # we need to make all incoming gradients sum
                     if backward_state.in_degree(reversed_node) > 1:
@@ -1585,12 +1579,12 @@ class BackwardPassGenerator:
 
                 # If this node is a tasklet with a condition, we add some modification to the backward state
                 elif (isinstance(node, nodes.Tasklet)
-                      and self._conditional_tasklet(node)) or (isinstance(node, nodes.NestedSDFG)
-                                                               and self._conditional_nested_sdfg(forward_state, node)):
+                      and self.conditional_tasklet(node)) or (isinstance(node, nodes.NestedSDFG)
+                                                              and self.conditional_nested_sdfg(forward_state, node)):
                     # extract the conditional assignment block or fail if this is an unexpected structure
-                    conditional_block = self._extract_conditional_array_assignment_block(forward_state=forward_state,
-                                                                                         tasklet_node=node,
-                                                                                         subgraph=subgraph)
+                    conditional_block = self.extract_conditional_array_assignment_block(forward_state=forward_state,
+                                                                                        tasklet_node=node,
+                                                                                        subgraph=subgraph)
 
                     # add these nodes to be skipped in the future
                     conditional_assignment_nodes.extend(conditional_block)
@@ -1626,9 +1620,7 @@ class BackwardPassGenerator:
 
                             # We need to zero out the same memlet accesses in the backward pass
                             if zero_out:
-                                self._zero_out_gradient(forward_state=forward_state,
-                                                        forward_node=node,
-                                                        memlet=edge.data)
+                                self.zero_out_gradient(forward_state=forward_state, forward_node=node, memlet=edge.data)
 
                 # Cleanup of isolated nodes
                 # We will have an isolated node if it is not connected to any other node in the state view
@@ -1642,8 +1634,8 @@ class BackwardPassGenerator:
             except AutoDiffException as e:
                 raise AutoDiffException("Failed at node {}: {}".format(node, str(e))) from e
 
-    def _set_wcr_if_needed(self, backward_state: SDFGState, backward_node: nodes.Node,
-                           edge: dstate.MultiConnectorEdge) -> None:
+    def set_wcr_if_needed(self, backward_state: SDFGState, backward_node: nodes.Node,
+                          edge: dstate.MultiConnectorEdge) -> None:
         """Set write-conflict resolution (WCR) for gradient accumulation if needed.
 
         If this AccessNode represents a gradient that has already been used elsewhere,
@@ -1662,8 +1654,8 @@ class BackwardPassGenerator:
         for tree_edge in backward_state.memlet_tree(edge):
             tree_edge.data.wcr = "lambda x, y: x + y"
 
-    def _connect_given_gradients(self, forward_state: SDFGState, backward_state: SDFGState,
-                                 subgraph: dstate.StateSubgraphView, forward_node: nodes.Node) -> Optional[SDFGState]:
+    def connect_given_gradients(self, forward_state: SDFGState, backward_state: SDFGState,
+                                subgraph: dstate.StateSubgraphView, forward_node: nodes.Node) -> Optional[SDFGState]:
         """Connect output gradients of forward_node as inputs to the corresponding reverse node.
 
         :param forward_state: The forward state containing the node.
@@ -1678,7 +1670,7 @@ class BackwardPassGenerator:
             grad_name = self.array_grad_name(forward_node.data)
             if grad_name not in self.backward_sdfg.arrays:
                 # This grad hasn't been written before: initialize it
-                self._add_gradient_data_descriptor(forward_node.data)
+                self.add_gradient_data_descriptor(forward_node.data)
 
         for edge in subgraph.out_edges(forward_node):
             if not ad_utils.path_src_node_in_subgraph(edge, subgraph) or edge.dst not in self.reverse_map:
@@ -1711,10 +1703,10 @@ class BackwardPassGenerator:
                 assert conn_to_remove in backward_node.in_connectors
                 assert backward_node.remove_in_connector(conn_to_remove)
                 if len(backward_node.in_connectors) == 0:
-                    self._connect_conditional_map_exist(forward_state=forward_state,
-                                                        backward_state=backward_state,
-                                                        backward_map_exit=backward_node,
-                                                        fwd_tasklet=edge.dst)
+                    self.connect_conditional_map_exist(forward_state=forward_state,
+                                                       backward_state=backward_state,
+                                                       backward_map_exit=backward_node,
+                                                       fwd_tasklet=edge.dst)
                 continue
 
             _, output_conn, dest_node, input_conn, fwd_memlet = edge
@@ -1727,7 +1719,7 @@ class BackwardPassGenerator:
             grad_name = self.array_grad_name(memlet.data)
             if grad_name not in self.backward_sdfg.arrays:
                 # This grad hasn't been written before: initialize it
-                self._add_gradient_data_descriptor(memlet.data)
+                self.add_gradient_data_descriptor(memlet.data)
 
             # We should not rely on the memlet data because that depends on the subset and other subset attibutes
             # If this is an access node, and the memlet data is not the same as the AN data
@@ -1786,9 +1778,9 @@ class BackwardPassGenerator:
                 continue
             new_edge = backward_state.add_edge(
                 backward_dst_node,
-                self._lookup_required_grad_name(dest_node, input_conn),
+                self.lookup_required_grad_name(dest_node, input_conn),
                 self.reverse_map[forward_node],
-                self._lookup_given_grad_name(forward_node, output_conn),
+                self.lookup_given_grad_name(forward_node, output_conn),
                 memlet,
             )
 
@@ -1809,13 +1801,13 @@ class BackwardPassGenerator:
                     in_values = any(source_access_node in values for values in self.zeroed_out.values())
                     if source_access_node.data != memlet.data and in_values:
                         memlet.data = source_access_node.data
-            self._set_wcr_if_needed(backward_state=backward_state,
-                                    backward_node=self.reverse_map[forward_node],
-                                    edge=new_edge)
+            self.set_wcr_if_needed(backward_state=backward_state,
+                                   backward_node=self.reverse_map[forward_node],
+                                   edge=new_edge)
 
         return new_backward_state
 
-    def _get_accessnode_to_forward(self, forward_state: SDFGState, forward_node: nodes.AccessNode):
+    def get_accessnode_to_forward(self, forward_state: SDFGState, forward_node: nodes.AccessNode):
         """
         Check if this AccessNode is at the base level of the state. If yes, this is the node we want to connect
         Otherwise, in the case the AN is encolsed by maps, we walk up the maps until we find the source AN.
@@ -1839,8 +1831,8 @@ class BackwardPassGenerator:
             assert forward_state.scope_dict()[original_an] is None
             return original_an
 
-    def _connect_forward_inputs(self, state: SDFGState, backward_state: SDFGState, forward_node: nodes.Node,
-                                backward_node: nodes.Node, required_inputs: Dict[str, str]) -> None:
+    def connect_forward_inputs(self, state: SDFGState, backward_state: SDFGState, forward_node: nodes.Node,
+                               backward_node: nodes.Node, required_inputs: dict[str, str]) -> None:
         """Connect the reversed node to all required non-gradient inputs.
 
         This function handles non-trivial routing scenarios:
@@ -1875,7 +1867,7 @@ class BackwardPassGenerator:
             # This is set to False if the connection has already been established
             connect_replicated_node = True
             edge_src = edge.src
-            next_required_inputs: Dict[Optional[str], Optional[str]]
+            next_required_inputs: dict[Optional[str], Optional[str]]
             replicated_edge_src: nodes.Node
             replicated_edge_src_conn: str
 
@@ -1904,7 +1896,7 @@ class BackwardPassGenerator:
 
             elif isinstance(edge_src, nodes.AccessNode):
                 # Get the AccessNode to connect
-                an_to_connect = self._get_accessnode_to_forward(state, edge_src)
+                an_to_connect = self.get_accessnode_to_forward(state, edge_src)
 
                 # Save the information about the data to be forwarded
                 # to call the function to connect this required AccessNode
@@ -1977,9 +1969,9 @@ class BackwardPassGenerator:
             if next_required_inputs:
                 # If there are any required inputs on the new node, we need to
                 # recursively call
-                self._connect_forward_inputs(state, backward_state, edge.src, replicated_edge_src, next_required_inputs)
+                self.connect_forward_inputs(state, backward_state, edge.src, replicated_edge_src, next_required_inputs)
 
-    def _lookup_required_grad_name(self, node: nodes.Node, connector: str) -> str:
+    def lookup_required_grad_name(self, node: nodes.Node, connector: str) -> str:
         """Look up the required gradient name for a given node and connector.
 
         :param node: The forward pass node.
@@ -1992,7 +1984,7 @@ class BackwardPassGenerator:
                                     f"before the backward node was created")
         return self.result_map[node].required_grad_names[connector]
 
-    def _lookup_given_grad_name(self, node: nodes.Node, connector: str) -> str:
+    def lookup_given_grad_name(self, node: nodes.Node, connector: str) -> str:
         """Look up the given gradient name for a given node and connector.
 
         :param node: The forward pass node.
@@ -2005,8 +1997,8 @@ class BackwardPassGenerator:
                                     f"before the backward node was created")
         return self.result_map[node].given_grad_names[connector]
 
-    def _find_backward_entry_node_for_map_entry(self, backward_state: SDFGState,
-                                                entry_node: nodes.MapEntry) -> nodes.MapEntry:
+    def find_backward_entry_node_for_map_entry(self, backward_state: SDFGState,
+                                               entry_node: nodes.MapEntry) -> nodes.MapEntry:
         """Find the entry node in the backward pass corresponding to a forward pass entry node.
 
         :param backward_state: The backward state to search in.
@@ -2024,9 +2016,9 @@ class BackwardPassGenerator:
 
         return src_candidates[0]
 
-    def _get_reverse_node(self, state: SDFGState, backward_state: SDFGState, node: nodes.Node,
-                          given_gradients: List[str],
-                          required_gradients: List[str]) -> Tuple[nodes.Node, BackwardResult]:
+    def get_reverse_node(self, state: SDFGState, backward_state: SDFGState, node: nodes.Node,
+                         given_gradients: list[str],
+                         required_gradients: list[str]) -> tuple[nodes.Node, BackwardResult]:
         """Add the reverse node for a node from the forward pass to the backward pass.
 
         Resolution order:
@@ -2043,8 +2035,8 @@ class BackwardPassGenerator:
         """
 
         # (1)
-        if hasattr(self.dace_node_impl, "_reverse_" + type(node).__name__):
-            reverse_method = getattr(self.dace_node_impl, f"_reverse_{type(node).__name__}")
+        reverse_method = self.dace_node_impl.reverse_dispatch.get(type(node))
+        if reverse_method is not None:
             return reverse_method(state, backward_state, node, given_gradients, required_gradients)
 
         # (2)
@@ -2060,7 +2052,8 @@ class BackwardPassGenerator:
                                                            ),
                                                            given_gradients=given_gradients,
                                                            required_gradients=required_gradients)
-            if isinstance(backward_node, nodes.LibraryNode) and hasattr(node, 'schedule'):
+            # ``schedule`` is a declared Property, so ask the node's schema rather than the instance.
+            if isinstance(backward_node, nodes.LibraryNode) and 'schedule' in type(node).__properties__:
                 backward_node.schedule = node.schedule
             return backward_node, backward_result
 

--- a/dace/autodiff/base_abc.py
+++ b/dace/autodiff/base_abc.py
@@ -45,13 +45,13 @@ class BackwardResult:
     """
 
     #: Mapping from names of output connectors to the connector name of the gradient for that connector.
-    required_grad_names: typing.Dict[typing.Optional[str], typing.Optional[str]]
+    required_grad_names: dict[typing.Optional[str], typing.Optional[str]]
 
     #: Mapping from names of input connectors to the connector name of the gradient for that connector.
-    given_grad_names: typing.Dict[typing.Optional[str], typing.Optional[str]]
+    given_grad_names: dict[typing.Optional[str], typing.Optional[str]]
 
     #: Mapping from names of gradients to whether they should be zeroed out on initialization.
-    zero_init: typing.Dict[typing.Optional[str], typing.Optional[bool]]
+    zero_init: dict[typing.Optional[str], typing.Optional[bool]]
 
     def __init__(self, required_grad_names, given_grad_names, zero_init=None):
         self.required_grad_names = required_grad_names
@@ -90,8 +90,8 @@ class BackwardImplementation(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: typing.List[typing.Optional[str]],
-                 required_gradients: typing.List[typing.Optional[str]]) -> typing.Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[typing.Optional[str]],
+                 required_gradients: list[typing.Optional[str]]) -> tuple[nd.Node, BackwardResult]:
         """Add the reverse node for a node from the forward pass to the backward pass, and return it.
 
         For each input connector with name ``n`` of the forward in required_gradients, the returned backward node must
@@ -161,7 +161,7 @@ def find_backward_implementation(forward_sdfg: SDFG, forward_state: SDFGState,
 class ExpansionTemplate(xf.ExpandTransformation):
     """Module-level expansion class for operations during autodiff.
 
-    This class is used by BackwardPassGenerator._expand_nodes to expand operations
+    This class is used by BackwardPassGenerator.expand_nodes to expand operations
     that don't have backward implementations. It needs to be at module level for serialization.
 
     The class is dynamically configured before use by setting:

--- a/dace/autodiff/data_forwarding/__init__.py
+++ b/dace/autodiff/data_forwarding/__init__.py
@@ -7,9 +7,9 @@ recomputing them during the backward pass. This is a fundamental memory-time
 tradeoff in automatic differentiation.
 """
 
-from .manager import DataForwardingManager
-from .store import resolve_overwrite_with_store
-from .recompute import get_recomputation_nsdfg, resolve_overwrite_with_recomputation
+from dace.autodiff.data_forwarding.manager import DataForwardingManager
+from dace.autodiff.data_forwarding.store import resolve_overwrite_with_store
+from dace.autodiff.data_forwarding.recompute import get_recomputation_nsdfg, resolve_overwrite_with_recomputation
 
 __all__ = [
     "DataForwardingManager",

--- a/dace/autodiff/data_forwarding/manager.py
+++ b/dace/autodiff/data_forwarding/manager.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import copy
-from typing import List, Tuple, Optional
+from typing import TYPE_CHECKING, Optional
 
 # DaCe imports
 import dace.sdfg.nodes as nodes
@@ -11,6 +11,9 @@ from dace.sdfg import SDFGState, graph as dgraph
 from dace.autodiff.base_abc import AutoDiffException
 import dace.autodiff.utils as ad_utils
 import dace.autodiff.data_forwarding as data_forwarding
+
+if TYPE_CHECKING:
+    from dace.autodiff.backward_pass_generator import BackwardPassGenerator
 
 
 class DataForwardingManager:
@@ -26,22 +29,22 @@ class DataForwardingManager:
         Iterate through all the data that needs to be forwarded to the backward pass states.
         """
         # Get the strategy decision for each data that needs to be forwarded to the backward pass
-        strategy_choice, recomputation_nsdfgs = self._get_overwrite_resolution_strategy()
+        strategy_choice, recomputation_nsdfgs = self.get_overwrite_resolution_strategy()
 
         # Make the connection according to the chosen strategy
         for index, (forward_state, backward_state, access_node, node,
                     edge) in enumerate(self.bwd_generator.data_to_forward):
-            self._connect_forward_accessnode(forward_state, backward_state, access_node, node, edge,
-                                             recomputation_nsdfgs[index], strategy_choice[index])
+            self.connect_forward_accessnode(forward_state, backward_state, access_node, node, edge,
+                                            recomputation_nsdfgs[index], strategy_choice[index])
 
-    def _get_overwrite_resolution_strategy(self) -> Tuple[List[str], List[Optional[nodes.NestedSDFG]]]:
+    def get_overwrite_resolution_strategy(self) -> tuple[list[str], list[Optional[nodes.NestedSDFG]]]:
         """
         Choose a strategy for resolving overwritten data that we need to forward to the backward pass.
         If the user wants a specific strategy, we use it.
         Otherwise, we evaluate what strategy is best for this specific node.
         """
-        strategy_choice: List[str] = []
-        recomputation_nsdfgs: List[Optional[nodes.NestedSDFG]] = []
+        strategy_choice: list[str] = []
+        recomputation_nsdfgs: list[Optional[nodes.NestedSDFG]] = []
 
         # As preprocessing step,
         # We will store all of the global program inputs,
@@ -55,7 +58,7 @@ class DataForwardingManager:
                 continue
 
             # Store the input
-            self._connect_forward_accessnode(forward_state, backward_state, access_node, node, edge, None, "store")
+            self.connect_forward_accessnode(forward_state, backward_state, access_node, node, edge, None, "store")
 
             # Remove this element from the list of the data to forward
             to_remove.append(i)
@@ -106,10 +109,10 @@ class DataForwardingManager:
                                     f"but got {self.bwd_generator.data_forwarding_strategy}")
         return strategy_choice, recomputation_nsdfgs
 
-    def _connect_forward_accessnode(self, forward_state: SDFGState, backward_state: SDFGState,
-                                    forward_node: nodes.AccessNode, target_node: nodes.Node,
-                                    starting_edge: dgraph.MultiConnectorEdge,
-                                    recomputation_nsdfg: Optional[nodes.NestedSDFG], strategy: str):
+    def connect_forward_accessnode(self, forward_state: SDFGState, backward_state: SDFGState,
+                                   forward_node: nodes.AccessNode, target_node: nodes.Node,
+                                   starting_edge: dgraph.MultiConnectorEdge,
+                                   recomputation_nsdfg: Optional[nodes.NestedSDFG], strategy: str):
         """
         We need to forward an array from the forward pass to the backward pass.
         To do this we first check if this array has been overwritten or not.
@@ -125,7 +128,7 @@ class DataForwardingManager:
         """
 
         # First, we check if the node has been overwritten
-        overwritten, recomputable = self._check_node_overwrite(forward_state=forward_state, node=forward_node)
+        overwritten, recomputable = self.check_node_overwrite(forward_state=forward_state, node=forward_node)
 
         # Boolean indicating whether we should fall back to storing
         fallback = False
@@ -156,8 +159,8 @@ class DataForwardingManager:
             # The data has been overwritten
             if not overwritten:
                 # We still have access to this data
-                self._connect_forward_accessnode_not_overwritten(forward_state, backward_state, forward_node,
-                                                                 target_node, starting_edge)
+                self.connect_forward_accessnode_not_overwritten(forward_state, backward_state, forward_node,
+                                                                target_node, starting_edge)
                 return
 
             data_forwarding.resolve_overwrite_with_store(bwd_generator=self.bwd_generator,
@@ -167,7 +170,7 @@ class DataForwardingManager:
                                                          target_node=target_node,
                                                          starting_edge=starting_edge)
 
-    def _check_node_overwrite(self, forward_state: SDFGState, node: nodes.AccessNode) -> Tuple[bool, bool]:
+    def check_node_overwrite(self, forward_state: SDFGState, node: nodes.AccessNode) -> tuple[bool, bool]:
         """
         Given an AccessNode from the forward state, check if the data of this node has changed.
         We look at all the AccessNodes with the same data that occur after the 'node' parameter
@@ -272,13 +275,13 @@ class DataForwardingManager:
                 recomputable = True
         return overwritten, recomputable
 
-    def _connect_forward_accessnode_not_overwritten(self,
-                                                    forward_state: SDFGState,
-                                                    backward_state: SDFGState,
-                                                    forward_node: nodes.AccessNode,
-                                                    target_node: nodes.Node,
-                                                    starting_edge: dgraph.MultiConnectorEdge,
-                                                    replicated_node: Optional[nodes.AccessNode] = None):
+    def connect_forward_accessnode_not_overwritten(self,
+                                                   forward_state: SDFGState,
+                                                   backward_state: SDFGState,
+                                                   forward_node: nodes.AccessNode,
+                                                   target_node: nodes.Node,
+                                                   starting_edge: dgraph.MultiConnectorEdge,
+                                                   replicated_node: Optional[nodes.AccessNode] = None):
         """
         Replicate and connect the forward AccessNode to the requesting node in the backward pass.
         Because the AccessNode has not been overwritten, we just need to create the same connection
@@ -322,8 +325,8 @@ class DataForwardingManager:
             # If the destination is a map entry,
             if isinstance(dst, nodes.MapEntry):
                 # We need to get the corresponding map entry in the backward pass.
-                bwd_dst = self.bwd_generator._find_backward_entry_node_for_map_entry(backward_state=backward_state,
-                                                                                     entry_node=dst)
+                bwd_dst = self.bwd_generator.find_backward_entry_node_for_map_entry(backward_state=backward_state,
+                                                                                    entry_node=dst)
                 # Add the dst connector to the map
                 added = bwd_dst.add_in_connector(bwd_dst_conn)
                 assert added
@@ -331,8 +334,8 @@ class DataForwardingManager:
             # If the destination is a map entry,
             if isinstance(src, nodes.MapEntry):
                 # We need to get the corresponding map entry in the backward pass.
-                bwd_src = self.bwd_generator._find_backward_entry_node_for_map_entry(backward_state=backward_state,
-                                                                                     entry_node=src)
+                bwd_src = self.bwd_generator.find_backward_entry_node_for_map_entry(backward_state=backward_state,
+                                                                                    entry_node=src)
                 # Add the src connector to the map
                 added = bwd_src.add_out_connector(bwd_src_conn)
                 assert added

--- a/dace/autodiff/data_forwarding/recompute.py
+++ b/dace/autodiff/data_forwarding/recompute.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import copy
-from typing import List
+from typing import TYPE_CHECKING
 
 # DaCe imports
 import dace
@@ -11,6 +11,9 @@ from dace.sdfg.state import LoopRegion
 # Autodiff imports
 from dace.autodiff.base_abc import AutoDiffException
 import dace.autodiff.utils as ad_utils
+
+if TYPE_CHECKING:
+    from dace.autodiff.backward_pass_generator import BackwardPassGenerator
 
 
 def resolve_overwrite_with_recomputation(
@@ -26,17 +29,17 @@ def resolve_overwrite_with_recomputation(
     """
 
     # Add the nsdfg where it is required
-    _connect_recomputation_nsdfg(forward_state=forward_state,
-                                 backward_state=backward_state,
-                                 nsdfg=recomputation_nsdfg,
-                                 target_an=target_an,
-                                 target_node=target_node,
-                                 starting_edge=starting_edge)
+    connect_recomputation_nsdfg(forward_state=forward_state,
+                                backward_state=backward_state,
+                                nsdfg=recomputation_nsdfg,
+                                target_an=target_an,
+                                target_node=target_node,
+                                starting_edge=starting_edge)
 
 
-def _connect_recomputation_nsdfg(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState,
-                                 backward_state: SDFGState, target_an: nodes.AccessNode, target_node: nodes.Node,
-                                 nsdfg: nodes.NestedSDFG, starting_edge: dstate.MultiConnectorEdge):
+def connect_recomputation_nsdfg(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState,
+                                backward_state: SDFGState, target_an: nodes.AccessNode, target_node: nodes.Node,
+                                nsdfg: nodes.NestedSDFG, starting_edge: dstate.MultiConnectorEdge):
     """
 
     """
@@ -80,7 +83,7 @@ def _connect_recomputation_nsdfg(bwd_generator: 'BackwardPassGenerator', forward
 
     # Get the new array shape
     # This will be the shape of the current array
-    shape: List[int] = list(bwd_generator.forward_sdfg.arrays[target_an.data].shape)
+    shape: list[int] = list(bwd_generator.forward_sdfg.arrays[target_an.data].shape)
 
     # Add the array descriptor and AccessNode to the forward state
     original_desc = target_an.desc(forward_state)
@@ -104,16 +107,16 @@ def _connect_recomputation_nsdfg(bwd_generator: 'BackwardPassGenerator', forward
     backward_state.add_edge(nsdfg, nsdfg_out_conn, new_recomp_node, None, memlet)
 
     # Connect the new AccessNode to the required computation
-    bwd_generator._connect_forward_accessnode_not_overwritten(forward_state=forward_state,
-                                                              backward_state=backward_state,
-                                                              forward_node=target_an,
-                                                              target_node=target_node,
-                                                              starting_edge=starting_edge,
-                                                              replicated_node=new_recomp_node)
+    bwd_generator.connect_forward_accessnode_not_overwritten(forward_state=forward_state,
+                                                             backward_state=backward_state,
+                                                             forward_node=target_an,
+                                                             target_node=target_node,
+                                                             starting_edge=starting_edge,
+                                                             replicated_node=new_recomp_node)
 
 
-def _prune_descendants_recomputation_nsdfg(forward_state: SDFGState, target_an: nodes.AccessNode,
-                                           nsdfg: nodes.NestedSDFG):
+def prune_descendants_recomputation_nsdfg(forward_state: SDFGState, target_an: nodes.AccessNode,
+                                          nsdfg: nodes.NestedSDFG):
     """
     1: From this Nested-SDFG, we remove everything that will be executed after the target access node to be recomputed
     2: Prune the unnecessary computation inside the forward state
@@ -122,16 +125,16 @@ def _prune_descendants_recomputation_nsdfg(forward_state: SDFGState, target_an: 
 
     # 1
     # Get the states order for the nested_sdfg
-    states_order: List[SDFGState] = ad_utils.get_state_topological_order(nsdfg.sdfg)
+    states_order: list[SDFGState] = ad_utils.get_state_topological_order(nsdfg.sdfg)
     state_index = states_order.index(forward_state)
-    descendant_states: List[SDFGState] = states_order[state_index:]
+    descendant_states: list[SDFGState] = states_order[state_index:]
     assert descendant_states.pop(0) == forward_state
 
     # Check if the target state is within a loop
     target_within_loop, target_loop = ad_utils.state_within_loop(forward_state)
 
     # We will save the states that are within the same loop because they require special treatement
-    same_loop_states: List[SDFGState] = []
+    same_loop_states: list[SDFGState] = []
     for state in descendant_states:
         # We want to avoid removing the descendant states that are inside the same loop region
         if target_within_loop:
@@ -174,7 +177,7 @@ def _prune_descendants_recomputation_nsdfg(forward_state: SDFGState, target_an: 
                 forward_state.remove_node(node)
 
 
-def _prune_recomputation_sdfg(forward_state: SDFGState, target_an: nodes.AccessNode, nsdfg: nodes.NestedSDFG):
+def prune_recomputation_sdfg(forward_state: SDFGState, target_an: nodes.AccessNode, nsdfg: nodes.NestedSDFG):
     """
     1: From this Nested-SDFG, we remove everything that will be executed after the target access node to be recomputed
     2: Prune the unnecessary computation inside the forward state
@@ -183,10 +186,10 @@ def _prune_recomputation_sdfg(forward_state: SDFGState, target_an: nodes.AccessN
     """
 
     # 1 and 2
-    _prune_descendants_recomputation_nsdfg(forward_state=forward_state, target_an=target_an, nsdfg=nsdfg)
+    prune_descendants_recomputation_nsdfg(forward_state=forward_state, target_an=target_an, nsdfg=nsdfg)
 
 
-def _rename_descriptors_for_recomputation_nsdfg(forward_sdfg: SDFG, nsdfg: nodes.NestedSDFG):
+def rename_descriptors_for_recomputation_nsdfg(forward_sdfg: SDFG, nsdfg: nodes.NestedSDFG):
     """
     """
     # Get all the nodes to rename in the NestedSDFG
@@ -291,9 +294,9 @@ def get_recomputation_nsdfg(bwd_generator: 'BackwardPassGenerator', forward_stat
     assert nb_occurrences == 1
     assert nsdfg_target_node
 
-    _prune_recomputation_sdfg(nsdfg=nsdfg, forward_state=nsdfg_forward_state, target_an=nsdfg_target_node)
+    prune_recomputation_sdfg(nsdfg=nsdfg, forward_state=nsdfg_forward_state, target_an=nsdfg_target_node)
 
     # Change descriptors if the inputs are written to
-    _rename_descriptors_for_recomputation_nsdfg(forward_sdfg=bwd_generator.sdfg, nsdfg=nsdfg)
+    rename_descriptors_for_recomputation_nsdfg(forward_sdfg=bwd_generator.sdfg, nsdfg=nsdfg)
 
     return nsdfg

--- a/dace/autodiff/data_forwarding/store.py
+++ b/dace/autodiff/data_forwarding/store.py
@@ -1,6 +1,6 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
 import copy
-from typing import List, Tuple
+from typing import TYPE_CHECKING
 import sympy as sp
 
 # DaCe imports
@@ -14,6 +14,9 @@ from dace.sdfg.state import LoopRegion
 from dace.autodiff.base_abc import AutoDiffException
 import dace.autodiff.utils as ad_utils
 
+if TYPE_CHECKING:
+    from dace.autodiff.backward_pass_generator import BackwardPassGenerator
+
 
 def resolve_overwrite_with_store(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState,
                                  backward_state: SDFGState, forward_node: nodes.AccessNode, target_node: nodes.Node,
@@ -24,12 +27,12 @@ def resolve_overwrite_with_store(bwd_generator: 'BackwardPassGenerator', forward
     """
 
     # Modify the forward pass to save the data in a new array
-    new_stored_array, memlets = _store_data(bwd_generator=bwd_generator,
-                                            forward_state=forward_state,
-                                            backward_state=backward_state,
-                                            forward_an=forward_node,
-                                            target_node=target_node,
-                                            edge=starting_edge)
+    new_stored_array, memlets = store_data(bwd_generator=bwd_generator,
+                                           forward_state=forward_state,
+                                           backward_state=backward_state,
+                                           forward_an=forward_node,
+                                           target_node=target_node,
+                                           edge=starting_edge)
 
     # Check if this data needs to be forwarded through NestedSDFGs
     if bwd_generator.separate_sdfgs or forward_state.sdfg.parent_sdfg is not None:
@@ -42,19 +45,19 @@ def resolve_overwrite_with_store(bwd_generator: 'BackwardPassGenerator', forward
             bwd_generator.backward_input_arrays[new_stored_array.data] = data_desc
 
     # Connect the new array to the target node
-    _connect_stored_data_to_target(bwd_generator=bwd_generator,
-                                   forward_state=forward_state,
-                                   backward_state=backward_state,
-                                   source_node=new_stored_array,
-                                   forward_node=forward_node,
-                                   starting_edge=starting_edge,
-                                   memlets=memlets,
-                                   target_node=target_node)
+    connect_stored_data_to_target(bwd_generator=bwd_generator,
+                                  forward_state=forward_state,
+                                  backward_state=backward_state,
+                                  source_node=new_stored_array,
+                                  forward_node=forward_node,
+                                  starting_edge=starting_edge,
+                                  memlets=memlets,
+                                  target_node=target_node)
 
 
-def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState, backward_state: SDFGState,
-                forward_an: nodes.AccessNode, target_node: nodes.Node,
-                edge: dgraph.MultiConnectorEdge) -> Tuple[nodes.AccessNode, List[Memlet]]:
+def store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState, backward_state: SDFGState,
+               forward_an: nodes.AccessNode, target_node: nodes.Node,
+               edge: dgraph.MultiConnectorEdge) -> tuple[nodes.AccessNode, list[Memlet]]:
     """
     Given an edge leading an AccessNode or a map to the target node in the forward state,
     add a path from the connector for this AccessNode to store its values for all iterations.
@@ -90,7 +93,7 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
 
     # Get the new array shape
     # This will be the shape of the current array
-    shape: List[int] = list(bwd_generator.sdfg.arrays[forward_an.data].shape)
+    shape: list[int] = list(bwd_generator.sdfg.arrays[forward_an.data].shape)
 
     # If the shape is an expression:
     free_symbols_dict = {sym: None for sym in bwd_generator.sdfg.free_symbols}
@@ -98,13 +101,13 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
         # Otherwise, replace all the loop dependent allocations with the max length of the loop
         # For example, an array of size [i+1] in a range(2, 10) loop will be stored in a [10, 10] array (1)
         # Additionally, an array of size [32-i] in the same loop will be stored in a [10, 30]  (2)
-        loops = _get_all_enclosing_loops(forward_state)
+        loops = get_all_enclosing_loops(forward_state)
 
         if len(loops) > 0:
             # Loop over the shape dimensions
             for i, s in enumerate(shape):
                 if ad_utils.shape_has_symbols_to_replace(bwd_generator.sdfg, s):
-                    loop_size, loop_index = _get_symbol_upper_bound_from_loop(bwd_generator, s, loops)
+                    loop_size, loop_index = get_symbol_upper_bound_from_loop(bwd_generator, s, loops)
                     # Replace the symbol with the loop size and evaluate the expression
                     # Check if loop size can be converted to an integer
                     loop_index_sym = symbolic.pystr_to_symbolic(loop_index)
@@ -117,7 +120,7 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
     loop_param_list = []
     if enclosed:
         # Get all enclosing loops
-        all_encolsing_loops = _get_all_enclosing_loops(forward_state=forward_state)
+        all_encolsing_loops = get_all_enclosing_loops(forward_state=forward_state)
         nb_enclosing_loops = len(all_encolsing_loops)
         # Get the size of each loop and add it to the list
         for loop in all_encolsing_loops:
@@ -141,7 +144,7 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
                     new_dim = symbolic.pystr_to_symbolic(new_dim)
 
                 # Try to replace the symbols with the loop size
-                loop_size, loop_index = _get_symbol_upper_bound_from_loop(bwd_generator, new_dim, all_encolsing_loops)
+                loop_size, loop_index = get_symbol_upper_bound_from_loop(bwd_generator, new_dim, all_encolsing_loops)
                 loop_index_sym = symbolic.pystr_to_symbolic(loop_index)
                 loop_size_sym = loop_size if isinstance(loop_size, int) else symbolic.pystr_to_symbolic(loop_size)
                 new_dim = new_dim.subs(loop_index_sym, loop_size_sym)
@@ -206,11 +209,11 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
 
     params_to_add = new_param_dict
     # First, we need to add an assign tasklet
-    assign_tasklet_node, assign_tasklet_node_out_connector = _get_assign_tasklet(forward_state=forward_state,
-                                                                                 node=forward_an,
-                                                                                 stored_node=new_store_node,
-                                                                                 last_edge=edge,
-                                                                                 loop_iterators=loop_access)
+    assign_tasklet_node, assign_tasklet_node_out_connector = get_assign_tasklet(forward_state=forward_state,
+                                                                                node=forward_an,
+                                                                                stored_node=new_store_node,
+                                                                                last_edge=edge,
+                                                                                loop_iterators=loop_access)
 
     # Start iterating
     previous_node = assign_tasklet_node
@@ -219,7 +222,7 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
     for edge in reversed(all_edges):
         if isinstance(edge.src, nodes.MapEntry):
             # Get the corresponding map exit
-            map_exist = _find_map_exist_for_map_entry(map_entry=edge.src, state=forward_state)
+            map_exist = find_map_exist_for_map_entry(map_entry=edge.src, state=forward_state)
 
             # Add the Connectors to the map
             map_exit_in_connector = f"IN_stored_{new_store_node.label}"
@@ -368,10 +371,10 @@ def _store_data(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState
     return new_store_node, memlets_stack
 
 
-def _connect_stored_data_to_target(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState,
-                                   backward_state: SDFGState, source_node: nodes.AccessNode,
-                                   forward_node: nodes.AccessNode, target_node: nodes.Node, memlets: List[Memlet],
-                                   starting_edge: dgraph.MultiConnectorEdge):
+def connect_stored_data_to_target(bwd_generator: 'BackwardPassGenerator', forward_state: SDFGState,
+                                  backward_state: SDFGState, source_node: nodes.AccessNode,
+                                  forward_node: nodes.AccessNode, target_node: nodes.Node, memlets: list[Memlet],
+                                  starting_edge: dgraph.MultiConnectorEdge):
     """
         Connect the source node to the sink target node (both in the backawrd state) through a set of maps using the parameter memelets.
         We use the forward_sink_edge to track which maps to make this connection through.
@@ -402,7 +405,7 @@ def _connect_stored_data_to_target(bwd_generator: 'BackwardPassGenerator', forwa
         edge_src = edge.src
         if isinstance(edge_src, nodes.MapEntry):
             # Get the correponding map exist
-            map_exit = _find_map_exist_for_map_entry(map_entry=edge_src, state=forward_state)
+            map_exit = find_map_exist_for_map_entry(map_entry=edge_src, state=forward_state)
 
             # Use the lookup table to get the map entry in the backward state corresponding to this map exist in the forward state
             # Sanity check: this map entry should already exist in the backward state
@@ -471,12 +474,12 @@ def _connect_stored_data_to_target(bwd_generator: 'BackwardPassGenerator', forwa
     assert len(memlets) == 0
 
 
-def _get_assign_tasklet(forward_state: SDFGState,
-                        node: nodes.AccessNode,
-                        stored_node: nodes.AccessNode,
-                        last_edge: dgraph.MultiConnectorEdge,
-                        loop_iterators: str,
-                        cuda: bool = False):
+def get_assign_tasklet(forward_state: SDFGState,
+                       node: nodes.AccessNode,
+                       stored_node: nodes.AccessNode,
+                       last_edge: dgraph.MultiConnectorEdge,
+                       loop_iterators: str,
+                       cuda: bool = False):
     """
         """
     # Create the assign tasklet
@@ -583,7 +586,7 @@ def _get_assign_tasklet(forward_state: SDFGState,
     return return_node, return_connector
 
 
-def _find_map_exist_for_map_entry(map_entry: nodes.MapEntry, state: SDFGState) -> nodes.MapExit:
+def find_map_exist_for_map_entry(map_entry: nodes.MapEntry, state: SDFGState) -> nodes.MapExit:
     """
     Find the map exist that corresponds to the input map entry
     """
@@ -596,8 +599,8 @@ def _find_map_exist_for_map_entry(map_entry: nodes.MapEntry, state: SDFGState) -
     return src_candidates[0]
 
 
-def _get_symbol_upper_bound_from_loop(bwd_generator: 'DataForwardingbwd_generator', s: sp.Symbol,
-                                      loops: List[LoopRegion]) -> int:
+def get_symbol_upper_bound_from_loop(bwd_generator: 'BackwardPassGenerator', s: sp.Symbol,
+                                     loops: list[LoopRegion]) -> int:
     """
     Given a symbol and a list of loops, get the upper bound of the symbol from the loops.
     Raises an error if the symbol is not a loop index or the upper bound cannot be extracted correctly.
@@ -610,11 +613,12 @@ def _get_symbol_upper_bound_from_loop(bwd_generator: 'DataForwardingbwd_generato
             raise AutoDiffException(f"Symbol dimension {s} couldn't be parsed correctly during storing")
         loop_index = str(list(loop_indices)[0])
     elif isinstance(s, str):
-        # Convert the string to a symbolic expression and extract free symbols
+        # Convert the string to a symbolic expression and extract free symbols. Not sympify: a
+        # subset dimension spells integer division as ``//``, which sympify reads as a rational.
         try:
-            expr = sp.sympify(s)
-        except (sp.SympifyError, TypeError, ValueError) as e:
-            raise AutoDiffException(f"Symbol dimension {s} couldn't be parsed as a symbolic expression: {e}")
+            expr = symbolic.pystr_to_symbolic(s)
+        except (sp.SympifyError, SyntaxError, NameError, TypeError, ValueError) as e:
+            raise AutoDiffException(f"Symbol dimension {s} couldn't be parsed as a symbolic expression: {e}") from e
 
         # We don't want to match global SDFG symbols
         loop_indices = {symb for symb in expr.free_symbols if str(symb) not in bwd_generator.sdfg.free_symbols}
@@ -639,7 +643,7 @@ def _get_symbol_upper_bound_from_loop(bwd_generator: 'DataForwardingbwd_generato
 
                 # Check if the loop variable has a negative coefficient
                 # by extracting the coefficient from the affine expression
-                s_expr = sp.sympify(s) if isinstance(s, str) else s
+                s_expr = symbolic.pystr_to_symbolic(s) if isinstance(s, str) else s
                 # Find the actual symbol in the expression that matches loop_index by name
                 loop_symbol = None
                 for sym in s_expr.free_symbols:
@@ -667,11 +671,11 @@ def _get_symbol_upper_bound_from_loop(bwd_generator: 'DataForwardingbwd_generato
 
     # We will call this function recusrively until loop size is numeric or it is a global SDFG symbol
     if ad_utils.shape_has_symbols_to_replace(bwd_generator.sdfg, loop_size):
-        loop_size, _ = _get_symbol_upper_bound_from_loop(bwd_generator, loop_size, loops)
+        loop_size, _ = get_symbol_upper_bound_from_loop(bwd_generator, loop_size, loops)
     return loop_size, loop_index
 
 
-def _get_all_enclosing_loops(forward_state: SDFGState) -> List[LoopRegion]:
+def get_all_enclosing_loops(forward_state: SDFGState) -> list[LoopRegion]:
     """
         Check if this state will be executed several times within a loop.
         We check if any of the parents of this state is a loop region.

--- a/dace/autodiff/implementations/dace_nodes.py
+++ b/dace/autodiff/implementations/dace_nodes.py
@@ -7,13 +7,14 @@ import ast
 import collections
 import copy
 import numbers
+from typing import TYPE_CHECKING
 import astunparse
 import sympy as sp
-from typing import List, Tuple
 
 # DaCe imports
 import dace
 import dace.sdfg.nodes as nodes
+from ordered_set import OrderedSet
 from dace import dtypes
 from dace.data import Reference, Structure
 from dace.sdfg import SDFGState
@@ -23,21 +24,32 @@ from dace.data import find_new_name
 from dace.autodiff.base_abc import BackwardResult, AutoDiffException
 import dace.autodiff.utils as ad_utils
 
+if TYPE_CHECKING:
+    from dace.autodiff.backward_pass_generator import BackwardPassGenerator
+
 
 class DaceNodeBackwardImplementations:
 
     def __init__(self, backward_pass_generator: 'BackwardPassGenerator'):
         self.bwd_engine = backward_pass_generator
-        pass
+        # Keyed by exact node type, as the getattr-on-a-built-name dispatch it replaces was: a
+        # subclass never resolved to its base's rule either.
+        self.reverse_dispatch = {
+            nodes.NestedSDFG: self.reverse_nested_sdfg,
+            nodes.AccessNode: self.reverse_access_node,
+            nodes.MapEntry: self.reverse_map_entry,
+            nodes.MapExit: self.reverse_map_exit,
+            nodes.Tasklet: self.reverse_tasklet,
+        }
 
-    def _reverse_NestedSDFG(
+    def reverse_nested_sdfg(
         self,
         forward_state: SDFGState,
         backward_state: SDFGState,
         node: nodes.NestedSDFG,
-        given_gradients: List[str],
-        required_gradients: List[str],
-    ) -> Tuple[nodes.Node, BackwardResult]:
+        given_gradients: list[str],
+        required_gradients: list[str],
+    ) -> tuple[nodes.Node, BackwardResult]:
         reverse_nsdfg = dace.SDFG(node.sdfg.name + "_backward")
 
         gen = self.bwd_engine.create_child_generator(
@@ -52,7 +64,7 @@ class DaceNodeBackwardImplementations:
         # sdfg fails otherwise
         deferred_edges = []
 
-        inputs = set(backward_result.given_grad_names[name] for name in sorted(given_gradients))
+        inputs: OrderedSet[str] = OrderedSet(backward_result.given_grad_names[name] for name in sorted(given_gradients))
         # loop through the arrays that we need from the forward pass
         for name, desc in sorted(backward_input_arrays.items()):
             # if the name is not already passed to the reverse SDFG node ...
@@ -105,8 +117,9 @@ class DaceNodeBackwardImplementations:
         # "split" lengths input of an ONNX Split, or other index/shape inputs) and
         # therefore have no gradient produced by the child backward pass. Skip those
         # rather than raising a KeyError.
-        outputs = set(backward_result.required_grad_names[name] for name in required_gradients
-                      if name in backward_result.required_grad_names)
+        outputs: OrderedSet[str] = OrderedSet(backward_result.required_grad_names[name]
+                                              for name in sorted(required_gradients)
+                                              if name in backward_result.required_grad_names)
 
         for inp in inputs:
             if inp in reverse_nsdfg.arrays:
@@ -117,8 +130,11 @@ class DaceNodeBackwardImplementations:
         # Create the sdfg and return it
         nsdfg = backward_state.add_nested_sdfg(
             reverse_nsdfg,
-            inputs=inputs,
-            outputs=outputs,
+            inputs=ad_utils.connector_dict(inputs),
+            outputs=ad_utils.connector_dict(outputs),
+            # Rebound below for every connector that names a symbol; identity is right for the rest,
+            # the backward SDFG being built from this SDFG's own descriptors.
+            symbol_mapping=ad_utils.backward_symbol_mapping(reverse_nsdfg, backward_state),
         )
 
         # If any input connectors point to symbols
@@ -139,14 +155,14 @@ class DaceNodeBackwardImplementations:
         return nsdfg, BackwardResult(required_grad_names=backward_result.required_grad_names,
                                      given_grad_names=backward_result.given_grad_names)
 
-    def _reverse_AccessNode(
+    def reverse_access_node(
         self,
         forward_state: SDFGState,
         backward_state: SDFGState,
         node: nodes.AccessNode,
-        given_gradients: List[str],
-        required_gradients: List[str],
-    ) -> Tuple[nodes.Node, BackwardResult]:
+        given_gradients: list[str],
+        required_gradients: list[str],
+    ) -> tuple[nodes.Node, BackwardResult]:
 
         desc = self.bwd_engine.sdfg.arrays[node.data]
         if isinstance(desc, Reference):
@@ -169,14 +185,14 @@ class DaceNodeBackwardImplementations:
 
         return rev, BackwardResult(required_grad_names=required_grad_names, given_grad_names=given_grad_names)
 
-    def _reverse_MapEntry(
+    def reverse_map_entry(
         self,
         forward_state: SDFGState,
         backward_state: SDFGState,
         node: nodes.MapEntry,
-        given_gradients: List[str],
-        required_gradients: List[str],
-    ) -> Tuple[nodes.Node, BackwardResult]:
+        given_gradients: list[str],
+        required_gradients: list[str],
+    ) -> tuple[nodes.Node, BackwardResult]:
 
         required_grad_names = {n: ad_utils.invert_map_connector(n) for n in required_gradients}
         given_grad_names = {n: ad_utils.invert_map_connector(n) for n in given_gradients}
@@ -194,13 +210,13 @@ class DaceNodeBackwardImplementations:
         backward_state.add_node(rev)
         return rev, result
 
-    def _reverse_MapExit(
+    def reverse_map_exit(
         self,
         forward_state: SDFGState,
         backward_state: SDFGState,
         node: nodes.MapExit,
-        given_gradients: List[str],
-        required_gradients: List[str],
+        given_gradients: list[str],
+        required_gradients: list[str],
     ):
         self.bwd_engine.reverse_map[node.map] = copy.deepcopy(node.map)
 
@@ -228,14 +244,14 @@ class DaceNodeBackwardImplementations:
         )
         # yapf: enable
 
-    def _reverse_Tasklet(
+    def reverse_tasklet(
         self,
         state: SDFGState,
         backward_state: SDFGState,
         tasklet: nodes.Tasklet,
-        given_gradients: List[str],
-        required_gradients: List[str],
-    ) -> Tuple[nodes.Node, BackwardResult]:
+        given_gradients: list[str],
+        required_gradients: list[str],
+    ) -> tuple[nodes.Node, BackwardResult]:
         if tasklet.language is not dtypes.Language.Python:
             raise AutoDiffException("Expected tasklet with language Python, got language {}".format(tasklet.language))
 
@@ -259,15 +275,15 @@ class DaceNodeBackwardImplementations:
         code_str = tasklet.code.as_string
 
         # check if this is a conditional tasklet
-        if self.bwd_engine._conditional_tasklet(tasklet):
+        if self.bwd_engine.conditional_tasklet(tasklet):
             # we want to extract the if and else expressions and pass them to sympy
             if_expression, else_expression, conditional = ad_utils.extract_conditional_expressions(tasklet)
 
-            if_code, if_rev_inputs, if_rev_outputs, if_result = self._differentiate_code_symbolically(
+            if_code, if_rev_inputs, if_rev_outputs, if_result = self.differentiate_code_symbolically(
                 self.bwd_engine.sdfg, if_expression, state, tasklet, given_gradients, required_gradients)
 
             if else_expression:
-                else_code, else_rev_inputs, else_rev_outputs, else_result = self._differentiate_code_symbolically(
+                else_code, else_rev_inputs, else_rev_outputs, else_result = self.differentiate_code_symbolically(
                     self.bwd_engine.sdfg, else_expression, state, tasklet, given_gradients, required_gradients)
                 assert else_rev_inputs == if_rev_inputs
                 assert if_rev_outputs == else_rev_outputs
@@ -302,7 +318,7 @@ class DaceNodeBackwardImplementations:
 
             result = if_result
         else:
-            code, rev_inputs, rev_outputs, result = self._differentiate_code_symbolically(
+            code, rev_inputs, rev_outputs, result = self.differentiate_code_symbolically(
                 self.bwd_engine.sdfg, code_str, state, tasklet, given_gradients, required_gradients)
             rev = nodes.Tasklet("_" + tasklet.label + "_reverse_",
                                 inputs=rev_inputs,
@@ -312,14 +328,14 @@ class DaceNodeBackwardImplementations:
             backward_state.add_node(rev)
         return rev, result
 
-    def _differentiate_code_symbolically(
+    def differentiate_code_symbolically(
         self,
         sdfg: dace.SDFG,
         code_str: str,
         forward_state: SDFGState,
         tasklet: nodes.Tasklet,
-        given_gradients: List[str],
-        required_gradients: List[str],
+        given_gradients: list[str],
+        required_gradients: list[str],
     ):
         """Performs symbolic differentiation on tasklet code to generate the backward-pass tasklet.
 
@@ -354,7 +370,7 @@ class DaceNodeBackwardImplementations:
             Required gradient: dx (∂L/∂x)
             Generated code: ``dx_gradient = dy_gradient * (2*x + 2)``
         """
-        output_exprs, indexed_objects_map = ad_utils.code_to_exprs(code_str, tasklet, list(sdfg.symbols.keys()))
+        output_exprs, indexed_objects_map = ad_utils.code_to_exprs(code_str, tasklet, sdfg.symbols)
 
         # for each output that an input is used in, there will be an entry for the expression of the
         # grad in this list in the final code snippet. When we generate the final code for the
@@ -403,15 +419,10 @@ class DaceNodeBackwardImplementations:
                 if isinstance(output_expr, numbers.Real):
                     output_expr = sp.Float(output_expr)
 
-                # We need to prepare the w.r.t expression
-                if inp in indexed_objects_map:
-                    # if the input is an indexed object, we need to create the sympy expression
-                    indexed_base = sp.IndexedBase(inp)
-                    idx_objects = [sp.Idx(index) for index in indexed_objects_map[inp]]
-                    inp_expr = indexed_base[tuple(idx_objects)]
-                else:
-                    # if the input is not an indexed object, we can just use it as is
-                    inp_expr = sp.symbols(inp)
+                # Differentiate against the instance already inside the expression. A re-minted one
+                # compares unequal to it (dtype and assumptions differ) yet still substitutes, so
+                # diff() returns a silent zero for a symbol and a KroneckerDelta for an Indexed.
+                inp_expr = ad_utils.resolve_differentiation_target(output_expr, inp, indexed_objects_map.get(inp))
 
                 # symbolically differentiate the output w.r.t inp
                 diff_expr = output_expr.diff(inp_expr)

--- a/dace/autodiff/implementations/dace_reduction_nodes.py
+++ b/dace/autodiff/implementations/dace_reduction_nodes.py
@@ -27,6 +27,7 @@ from dace.registry import autoregister_params
 from dace.autodiff.base_abc import BackwardImplementation, BackwardContext, BackwardResult, AutoDiffException
 
 # Utility imports
+import dace.autodiff.utils as ad_utils
 from dace.autodiff.utils import init_grad
 from dace.sdfg.utils import in_desc_with_name, out_desc_with_name
 
@@ -57,8 +58,8 @@ class ReverseReduce(BackwardImplementation):
         return True
 
     @staticmethod
-    def backward(forward_node: Node, context: BackwardContext, given_gradients: typing.List[typing.Optional[str]],
-                 required_gradients: typing.List[typing.Optional[str]]) -> typing.Tuple[Node, BackwardResult]:
+    def backward(forward_node: Node, context: BackwardContext, given_gradients: list[typing.Optional[str]],
+                 required_gradients: list[typing.Optional[str]]) -> tuple[Node, BackwardResult]:
         """Generate the backward pass for a reduction node.
 
         :param forward_node: The forward reduction node.
@@ -84,20 +85,19 @@ class ReverseReduce(BackwardImplementation):
         output_name = next(iter(given_gradients))
         out_desc = out_desc_with_name(forward_node, context.forward_state, context.forward_sdfg, output_name)
 
-        all_axes: typing.List[int] = list(range(len(in_desc.shape)))
-        reduce_axes: typing.List[int] = all_axes if forward_node.axes is None else forward_node.axes
-        non_reduce_axes: typing.List[int] = [i for i in all_axes if i not in reduce_axes]
+        all_axes: list[int] = list(range(len(in_desc.shape)))
+        reduce_axes: list[int] = all_axes if forward_node.axes is None else forward_node.axes
+        non_reduce_axes: list[int] = [i for i in all_axes if i not in reduce_axes]
 
         result = BackwardResult.empty()
 
-        return ReverseReduce._backward_reduction(forward_node, context, result, reduction_type, input_name, output_name,
-                                                 in_desc, out_desc, all_axes, non_reduce_axes)
+        return ReverseReduce.backward_reduction(forward_node, context, result, reduction_type, input_name, output_name,
+                                                in_desc, out_desc, all_axes, non_reduce_axes)
 
     @staticmethod
-    def _backward_reduction(forward_node: Node, context: BackwardContext, result: BackwardResult,
-                            reduction_type: dtypes.ReductionType, input_name: str, output_name: str, in_desc, out_desc,
-                            all_axes: typing.List[int],
-                            non_reduce_axes: typing.List[int]) -> typing.Tuple[Node, BackwardResult]:
+    def backward_reduction(forward_node: Node, context: BackwardContext, result: BackwardResult,
+                           reduction_type: dtypes.ReductionType, input_name: str, output_name: str, in_desc, out_desc,
+                           all_axes: list[int], non_reduce_axes: list[int]) -> tuple[Node, BackwardResult]:
         """Backward pass for Sum/Max/Min reductions.
 
         - Sum: Broadcasts gradients uniformly across reduced dimensions
@@ -134,14 +134,14 @@ class ReverseReduce(BackwardImplementation):
         sdfg.add_array(rev_input_conn_name, shape=out_desc.shape, dtype=out_desc.dtype, strides=out_desc.strides)
         sdfg.add_array(rev_output_conn_name, shape=in_desc.shape, dtype=in_desc.dtype, strides=in_desc.strides)
 
-        nsdfg_inputs = {rev_input_conn_name}
+        nsdfg_inputs = [rev_input_conn_name]
 
         if is_extremal:
             extremal_conn_name = f"input_{type_name}_val"
             extremal_idx_conn_name = f"input_{type_name}_arr"
             sdfg.add_array(extremal_conn_name, shape=out_desc.shape, dtype=out_desc.dtype, strides=out_desc.strides)
             sdfg.add_array(extremal_idx_conn_name, shape=in_desc.shape, dtype=in_desc.dtype, strides=in_desc.strides)
-            nsdfg_inputs.update({extremal_conn_name, extremal_idx_conn_name})
+            nsdfg_inputs += [extremal_conn_name, extremal_idx_conn_name]
 
             # Add transient array to count matching elements per output position
             count_arr_name = f"_{type_name}_count"
@@ -241,7 +241,11 @@ class ReverseReduce(BackwardImplementation):
                                                       tasklet_code, {"__out": reverse_reduction_memlet},
                                                       external_edges=True)
 
-        nsdfg = context.backward_state.add_nested_sdfg(sdfg, nsdfg_inputs, {rev_output_conn_name})
+        nsdfg = context.backward_state.add_nested_sdfg(sdfg,
+                                                       ad_utils.connector_dict(nsdfg_inputs),
+                                                       ad_utils.connector_dict([rev_output_conn_name]),
+                                                       symbol_mapping=ad_utils.backward_symbol_mapping(
+                                                           sdfg, context.backward_state))
 
         out_edges = state.out_edges(exit_map)
         if len(out_edges) != 1:

--- a/dace/autodiff/implementations/onnx_ops.py
+++ b/dace/autodiff/implementations/onnx_ops.py
@@ -15,7 +15,7 @@ The implementations handle various ONNX operations including:
 
 import copy
 import itertools
-from typing import List, Optional, Tuple, Dict, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -39,7 +39,7 @@ from dace.autodiff.base_abc import BackwardImplementation, BackwardContext, Back
 from dace.sdfg.utils import in_desc_with_name
 
 
-def reverse_einsum_wrt_input(forward_node: 'donnx.nodes.onnx_op.ONNXOp', input_name: str) -> Tuple[List[str], str]:
+def reverse_einsum_wrt_input(forward_node: 'donnx.nodes.onnx_op.ONNXOp', input_name: str) -> tuple[list[str], str]:
     """Produce the einsum string that computes the gradient of forward_node w.r.t. input_name.
 
     .. note::
@@ -77,8 +77,8 @@ class DefaultEinsumBackward(BackwardImplementation):
         return PureEinsum.forward_can_be_applied(node, state, sdfg)
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
 
         nsdfg = dace.SDFG(forward_node.label + "_backward")
         nstate = nsdfg.add_state()
@@ -96,7 +96,7 @@ class DefaultEinsumBackward(BackwardImplementation):
 
         # the forward inputs we will require
         # maps the connector name to the accessnode
-        required_forward_inputs: Dict[str, nd.AccessNode] = {}
+        required_forward_inputs: dict[str, nd.AccessNode] = {}
 
         for input_name in sorted(required_gradients):
             # we add an einsum for each required gradient
@@ -132,8 +132,9 @@ class DefaultEinsumBackward(BackwardImplementation):
 
         result_node = context.backward_state.add_nested_sdfg(
             nsdfg,
-            set(result.given_grad_names.values()).union(required_forward_inputs),
-            set(result.required_grad_names.values()))
+            butils.connector_dict([*result.given_grad_names.values(), *required_forward_inputs]),
+            butils.connector_dict(result.required_grad_names.values()),
+            symbol_mapping=butils.backward_symbol_mapping(nsdfg, context.backward_state))
 
         return result_node, result
 
@@ -147,8 +148,8 @@ class DefaultClipBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
 
         result_node, result = butils.add_empty_sdfg_for_node(forward_node, ["input_grad", "output_grad", "input"],
                                                              context)
@@ -196,8 +197,8 @@ class DefaultDropoutBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
 
         data_desc = butils.forward_in_desc_with_name(forward_node, context, "data")
 
@@ -251,8 +252,8 @@ class DefaultSoftmaxBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
 
         dim = forward_node.axis
 
@@ -323,7 +324,7 @@ class DefaultSoftmaxBackward(BackwardImplementation):
         # Setup the axes input for the ReduceSum node
         axes_name, _ = nsdfg.add_array(name="reduce_sum_axes", shape=[1], dtype=dace.int64, transient=True)
         axes_access = nstate.add_access(axes_name)
-        axes_tasklet = nstate.add_tasklet("init_axes", {}, {"out"}, f"out = {dim};", language=dace.Language.CPP)
+        axes_tasklet = nstate.add_tasklet("init_axes", {}, {"out": None}, f"out = {dim};", language=dace.Language.CPP)
         nstate.add_edge(axes_tasklet, "out", axes_access, None, dace.Memlet(f"{axes_name}"))
 
         nstate.add_edge(prod_access, None, reduce_sum_node, "data", nsdfg.make_array_memlet("prod"))
@@ -348,16 +349,17 @@ class DefaultSoftmaxBackward(BackwardImplementation):
         result_node = context.backward_state.add_nested_sdfg(
             nsdfg,
             # Inputs to nested SDFG
-            {"output", "output_grad"},
+            butils.connector_dict(["output", "output_grad"]),
             # Outputs from nested SDFG
-            {"input_grad"})
+            butils.connector_dict(["input_grad"]),
+            symbol_mapping=butils.backward_symbol_mapping(nsdfg, context.backward_state))
 
         butils.connect_output_from_forward(forward_node, result_node, context, "output")
 
         return result_node, result
 
 
-def _find_map_by_param(sdfg: dace.SDFG, pname: str) -> dace.nodes.MapEntry:
+def find_map_by_param(sdfg: dace.SDFG, pname: str) -> dace.nodes.MapEntry:
     """Find the first map entry node by the given parameter name.
 
     :param sdfg: The SDFG to search.
@@ -377,8 +379,8 @@ class DefaultMaxPoolBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
 
         output_shape = butils.forward_out_desc_with_name(forward_node, context, "Y").shape
 
@@ -430,8 +432,8 @@ class DefaultLogSoftmaxBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
 
         dim = forward_node.axis
         output_shape = butils.forward_out_desc_with_name(forward_node, context, "output").shape
@@ -469,8 +471,8 @@ class PureGlobalAveragePoolingBackward(BackwardImplementation):
         return len(in_desc_with_name(node, state, sdfg, "X").shape) == 4
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
         desc = butils.forward_in_desc_with_name(forward_node, context, "X")
         N, C, H, W = desc.shape
         dtype = desc.dtype
@@ -495,8 +497,8 @@ class DefaultTransposeBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
         inv_perm = tuple(np.argsort(forward_node.perm))
 
         node = donnx.ONNXTranspose(forward_node.name + "_backward", perm=inv_perm)
@@ -518,8 +520,8 @@ class WhereBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
         # condition, X, Y -> Output
         # Get condition descriptor for shape information
         _ = butils.forward_in_desc_with_name(forward_node, context, "condition")
@@ -559,8 +561,8 @@ class DefaultLayerNormalizationBackward(BackwardImplementation):
     """
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
         # Create new SDFG
         nsdfg = dace.SDFG(forward_node.label + "_backward")
         nstate = nsdfg.add_state()
@@ -602,9 +604,9 @@ class DefaultLayerNormalizationBackward(BackwardImplementation):
             # Add B to SDFG inputs when needed
             nsdfg.add_datadesc("B", B_desc)
 
-        # Get axis and epsilon
-        axis = forward_node.axis if hasattr(forward_node, 'axis') else -1
-        epsilon = forward_node.epsilon if hasattr(forward_node, 'epsilon') else 1e-5
+        # Get axis and epsilon; the LayerNormalization schema declares both, so they are always set.
+        axis = forward_node.axis
+        epsilon = forward_node.epsilon
 
         rank = len(X_desc.shape)
         if axis < 0:
@@ -696,7 +698,7 @@ class DefaultLayerNormalizationBackward(BackwardImplementation):
         epsilon_tasklet = nstate.add_tasklet(
             "make_epsilon",
             {},
-            {"out"},
+            {"out": None},
             f"out = {epsilon};",
             language=dace.Language.CPP,
         )
@@ -730,7 +732,7 @@ class DefaultLayerNormalizationBackward(BackwardImplementation):
 
         # Create inv_std_dev descriptor
         one_name, _ = nsdfg.add_scalar("one", X_desc.dtype, transient=True)
-        one_tasklet = nstate.add_tasklet("make_one", {}, {"out"}, "out = 1.0;", language=dace.Language.CPP)
+        one_tasklet = nstate.add_tasklet("make_one", {}, {"out": None}, "out = 1.0;", language=dace.Language.CPP)
         one_write = nstate.add_write(one_name)
         nstate.add_edge(one_tasklet, "out", one_write, None, dace.Memlet(f"{one_name}[0]"))
 
@@ -901,12 +903,15 @@ class DefaultLayerNormalizationBackward(BackwardImplementation):
             nstate.add_edge(x_grad_op, "C", nstate.add_write("X_grad"), None, nsdfg.make_array_memlet("X_grad"))
 
         # Set up inputs for nested SDFG
-        inputs = {"X", "Scale", "Y_grad"}
+        inputs = ["X", "Scale", "Y_grad"]
         if "B" in required_gradients:
-            inputs.add("B")
+            inputs.append("B")
 
-        outputs = set(result.required_grad_names.values())
-        bwd_node = context.backward_state.add_nested_sdfg(nsdfg, inputs, outputs)
+        bwd_node = context.backward_state.add_nested_sdfg(nsdfg,
+                                                          butils.connector_dict(inputs),
+                                                          butils.connector_dict(result.required_grad_names.values()),
+                                                          symbol_mapping=butils.backward_symbol_mapping(
+                                                              nsdfg, context.backward_state))
         return bwd_node, result
 
 
@@ -923,8 +928,8 @@ class DefaultReduceSumBackward(BackwardImplementation):
         return True
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
 
         # The backward pass of a reduction is a broadcast.
         # We use ONNXExpand to perform the broadcast.
@@ -955,7 +960,7 @@ class DefaultReduceSumBackward(BackwardImplementation):
         grad_to_expand = "reduced_grad"
         read_grad_to_expand = nstate.add_read(grad_to_expand)
 
-        keepdims = getattr(forward_node, 'keepdims', 1)
+        keepdims = forward_node.keepdims
 
         if not keepdims:
             # When keepdims is False, the rank of the output is reduced. We need to
@@ -1001,7 +1006,7 @@ class DefaultReduceSumBackward(BackwardImplementation):
                 axes_tasklet = nstate.add_tasklet(
                     'init_axes',
                     {},
-                    {'out'},
+                    {'out': None},
                     '\n'.join([f'out[{i}] = {v};' for i, v in enumerate(axes)]),
                     language=dace.Language.CPP,
                 )
@@ -1028,7 +1033,7 @@ class DefaultReduceSumBackward(BackwardImplementation):
         shape_name, shape_desc = nsdfg.add_array("shape_for_expand", [len(input_desc.shape)],
                                                  dace.int64,
                                                  transient=True)
-        shape_tasklet = nstate.add_tasklet("init_shape", {}, {"out"},
+        shape_tasklet = nstate.add_tasklet("init_shape", {}, {"out": None},
                                            '\n'.join([f"out[{i}] = {s};" for i, s in enumerate(input_desc.shape)]))
         shape_access = nstate.add_access(shape_name)
         nstate.add_edge(shape_tasklet, "out", shape_access, None, dace.Memlet.from_array(shape_name, shape_desc))
@@ -1048,10 +1053,14 @@ class DefaultReduceSumBackward(BackwardImplementation):
         write_data_grad = nstate.add_write("data_grad")
         nstate.add_edge(write_data_grad_tmp, None, write_data_grad, None, finale_memlet)
 
-        inputs = {"reduced_grad"}
+        inputs = ["reduced_grad"]
         if not keepdims and 'axes' in forward_node.in_connectors:
-            inputs.add("axes")
+            inputs.append("axes")
 
-        result_node = context.backward_state.add_nested_sdfg(nsdfg, inputs, {"data_grad"})
+        result_node = context.backward_state.add_nested_sdfg(nsdfg,
+                                                             butils.connector_dict(inputs),
+                                                             butils.connector_dict(["data_grad"]),
+                                                             symbol_mapping=butils.backward_symbol_mapping(
+                                                                 nsdfg, context.backward_state))
 
         return result_node, result

--- a/dace/autodiff/implementations/pytorch_ops.py
+++ b/dace/autodiff/implementations/pytorch_ops.py
@@ -2,7 +2,7 @@
 
 import copy
 import itertools
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import dace
 import dace.libraries.torch
@@ -30,8 +30,8 @@ class PyTorchConvBackward(BackwardImplementation):
         return len(X_desc.shape) == 4
 
     @staticmethod
-    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: List[Optional[str]],
-                 required_gradients: List[Optional[str]]) -> Tuple[nd.Node, BackwardResult]:
+    def backward(forward_node: nd.Node, context: BackwardContext, given_gradients: list[Optional[str]],
+                 required_gradients: list[Optional[str]]) -> tuple[nd.Node, BackwardResult]:
 
         nsdfg = dace.SDFG(forward_node.label + "_backward")
         X_desc = butils.forward_in_desc_with_name(forward_node, context, "X")
@@ -121,8 +121,12 @@ class PyTorchConvBackward(BackwardImplementation):
             arr_name = result.required_grad_names[name]
             nstate.add_edge(tasklet, f"_d{name}", nstate.add_write(arr_name), None, nsdfg.make_array_memlet(arr_name))
 
-        inputs = {result.given_grad_names["Y"]}.union(required_forward_inputs)
-        outputs = {result.required_grad_names[n] for n in sorted(required_gradients)}
-        node = context.backward_state.add_nested_sdfg(nsdfg, inputs, outputs)
+        inputs = [result.given_grad_names["Y"], *sorted(required_forward_inputs)]
+        outputs = [result.required_grad_names[n] for n in sorted(required_gradients)]
+        node = context.backward_state.add_nested_sdfg(nsdfg,
+                                                      butils.connector_dict(inputs),
+                                                      butils.connector_dict(outputs),
+                                                      symbol_mapping=butils.backward_symbol_mapping(
+                                                          nsdfg, context.backward_state))
 
         return node, result

--- a/dace/autodiff/library/__init__.py
+++ b/dace/autodiff/library/__init__.py
@@ -9,11 +9,11 @@ library operations and provides hooks for frontend-specific optimizations.
 
 import dace.library
 
-from . import library
+from dace.autodiff.library import library
 
 # PyTorch integrations are optional
 try:
-    from . import torch_integration
+    from dace.autodiff.library import torch_integration
     from dace.frontend.python.replacements import torch_autodiff
     TORCH_INTEGRATION_AVAILABLE = True
 except ImportError:

--- a/dace/autodiff/library/library.py
+++ b/dace/autodiff/library/library.py
@@ -4,7 +4,6 @@ Dace library for autodiff
 
 Includes the BackwardPass library node, and the replacements for the python frontend
 """
-from typing import Dict, Set
 
 import dace
 import dace.library
@@ -144,12 +143,12 @@ class BackwardPass(nodes.LibraryNode):
         " buffer need to be with write-conflict-resolution. Note: this field is automatically populated upon expansion."
     )
 
-    def __init__(self, name, given_gradients: Dict[str, str], *args, **kwargs):
+    def __init__(self, name, given_gradients: dict[str, str], *args, **kwargs):
         super().__init__(name, *args, **kwargs)
         self.given_gradients = given_gradients
         self.required_gradients = {}
 
-    def outer_names_given_gradients(self, state: SDFGState) -> Set[str]:
+    def outer_names_given_gradients(self, state: SDFGState) -> set[str]:
         """
         Returns the names of the arrays that are passed as given gradients.
         """

--- a/dace/autodiff/torch.py
+++ b/dace/autodiff/torch.py
@@ -1,5 +1,4 @@
 # Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
-from typing import Tuple, Dict, List
 
 import dace
 from dace import data as dt
@@ -19,8 +18,8 @@ except ImportError:
 
 def make_backward_function(
     model,  # ONNXModel type hint removed for optional import
-    required_grads: List[str],
-) -> Tuple[dace.SDFG, dace.SDFG, BackwardResult, Dict[str, dt.Data]]:
+    required_grads: list[str],
+) -> tuple[dace.SDFG, dace.SDFG, BackwardResult, dict[str, dt.Data]]:
     """ Convert an ONNXModel to a PyTorch differentiable function. This method should not be used on its own.
         Instead use the ``backward=True`` parameter of :class:`dace.ml.DaceModule`.
 
@@ -56,7 +55,7 @@ def make_backward_function(
     # start/end of the backward (a source to ``add_state_before``, a sink to ``add_state_after``).
     # With a single state these coincide; with multiple states (e.g. GPU copy-in/out) they don't,
     # so pick the correct boundary. Computed lazily -- only needed when a scalar is forwarded.
-    def _boundary(sdfg: dace.SDFG, kind: str) -> dace.SDFGState:
+    def boundary(sdfg: dace.SDFG, kind: str) -> dace.SDFGState:
         states = sdfg.sink_nodes() if kind == "sink" else sdfg.source_nodes()
         if len(states) != 1:
             raise AutoDiffException(f"make_backward_function: expected a single {kind} state in SDFG '{sdfg.name}' to "
@@ -91,9 +90,9 @@ def make_backward_function(
                                                              find_new_name=True)
             backward_sdfg.arrays[name].transient = True
 
-            fwd_copy_state = forward_sdfg.add_state_after(_boundary(forward_sdfg, "sink"),
+            fwd_copy_state = forward_sdfg.add_state_after(boundary(forward_sdfg, "sink"),
                                                           label="copy_out_" + fwd_arr_name)
-            bwd_copy_state = backward_sdfg.add_state_before(_boundary(backward_sdfg, "source"),
+            bwd_copy_state = backward_sdfg.add_state_before(boundary(backward_sdfg, "source"),
                                                             label="copy_in_" + bwd_arr_name)
             fwd_copy_state.add_edge(fwd_copy_state.add_read(name), None, fwd_copy_state.add_write(fwd_arr_name), None,
                                     dace.Memlet(name + "[0]"))
@@ -117,7 +116,7 @@ def make_backward_function(
                                                          storage=desc.storage,
                                                          find_new_name=True)
             desc.transient = True
-            bwd_copy_state = backward_sdfg.add_state_after(_boundary(backward_sdfg, "sink"),
+            bwd_copy_state = backward_sdfg.add_state_after(boundary(backward_sdfg, "sink"),
                                                            label="copy_out_" + bwd_name)
             bwd_copy_state.add_edge(bwd_copy_state.add_read(bwd_name), None, bwd_copy_state.add_write(arr_name), None,
                                     dace.Memlet(bwd_name + "[0]"))

--- a/dace/autodiff/utils.py
+++ b/dace/autodiff/utils.py
@@ -5,7 +5,7 @@ import copy
 import inspect
 import numbers
 import re
-from typing import Dict, List, Set, Tuple, Union
+from typing import Union
 
 import astunparse
 import sympy as sp
@@ -14,7 +14,7 @@ from ordered_set import OrderedSet
 # DaCe imports
 import dace
 import dace.sdfg.utils as utils
-from dace import dtypes
+from dace import dtypes, symbolic
 from dace import data as dt
 from dace.frontend.python.parser import DaceProgram
 from dace.sdfg import SDFG, SDFGState, graph as dgraph, nodes as nd, state as dstate
@@ -22,6 +22,15 @@ from dace.sdfg.state import LoopRegion
 
 # Autodiff imports
 from dace.autodiff.base_abc import AutoDiffException, BackwardContext, BackwardResult
+
+#: Global the generated ``symbolic_execution`` source reads its pre-built symbols from, so that
+#: minting happens here with a dtype instead of inside an exec'd string with a bare name.
+#:
+#: PORTING NOTE: this table is only worth having because the extended branch keeps a symbol's dtype
+#: in its identity, so a dtype-carrying symbol is not interchangeable with a bare one. Main has no
+#: such distinction; porting there can drop the table and mint in the generated source again. The
+#: dependency is confined to ``code_to_exprs`` and to the ``symbols`` argument its one caller passes.
+SYMBOL_TABLE_GLOBAL = "dace_ad_symbol_table"
 
 
 def forward_in_desc_with_name(forward_node: nd.Node, context: BackwardContext, name: str) -> dt.Data:
@@ -87,8 +96,34 @@ def add_backward_desc(backward_sdfg: dace.SDFG, forward_sdfg: dace.SDFG, forward
     return backward_sdfg.add_datadesc(backward_name, new_desc)
 
 
-def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: List[str],
-                            context: BackwardContext) -> Tuple[nd.NestedSDFG, BackwardResult]:
+def backward_symbol_mapping(nested_sdfg: SDFG, parent_state: SDFGState) -> dict[str, sp.Expr]:
+    """Symbol mapping for a backward nested SDFG, resolved against the scope it is placed in.
+
+    Backward SDFGs are assembled from descriptors deep-copied out of the parent, so identity is the
+    right mapping -- but it has to be spelled out. ``add_nested_sdfg`` installs its identity default
+    only *after* its own missing-symbol check, which therefore can never fire, and the default
+    re-mints every symbol from a bare name, dropping the dtype the parent declared for it.
+    """
+    parent_symbols = parent_state.sdfg.symbols
+    # A symbol the parent SDFG does not declare is scope-local (a map parameter, say) and has no
+    # authoritative dtype to carry over.
+    return {
+        name: connector_symbol(name, parent_symbols.get(name))
+        for name in sorted(nested_sdfg.free_symbols - {'NoneSymbol'})
+    }
+
+
+def connector_dict(names) -> dict[str, None]:
+    """Connector set for ``add_nested_sdfg`` as an ordered mapping.
+
+    A plain ``set`` makes connector order -- which reaches codegen -- depend on ``PYTHONHASHSEED``,
+    and ``add_nested_sdfg`` warns about exactly that. ``None`` keeps its type auto-detection.
+    """
+    return {name: None for name in sorted(names)}
+
+
+def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: list[str],
+                            context: BackwardContext) -> tuple[nd.NestedSDFG, BackwardResult]:
     """ Given a node, return an SDFG that can be used as a nested SDFG expansion for that node.
 
         ``required_descriptors`` may contain:
@@ -107,7 +142,7 @@ def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: List[st
 
     nsdfg = dace.SDFG(forward_node.label + "_backward_expansion")
 
-    def _get_fwd_descriptor(name):
+    def get_fwd_descriptor(name):
         """Returns the descriptor and whether it is an input"""
         if name in forward_node.out_connectors:
             return forward_out_desc_with_name(forward_node, context, name), False
@@ -119,13 +154,13 @@ def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: List[st
     outputs_to_connect_from_forward = []
 
     result = BackwardResult.empty()
-    inputs = set()
-    outputs = set()
+    inputs: OrderedSet[str] = OrderedSet()
+    outputs: OrderedSet[str] = OrderedSet()
 
     for name in required_descriptors:
         if name.endswith("_grad"):
             # hook this up as a gradient
-            desc, is_input = _get_fwd_descriptor(name[:-5])
+            desc, is_input = get_fwd_descriptor(name[:-5])
             if is_input:
                 result.required_grad_names[name[:-5]] = name
             else:
@@ -136,7 +171,7 @@ def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: List[st
             else:
                 inputs.add(name)
         else:
-            desc, is_input = _get_fwd_descriptor(name)
+            desc, is_input = get_fwd_descriptor(name)
             if not is_input:
                 outputs_to_connect_from_forward.append(name)
             inputs.add(name)
@@ -144,7 +179,11 @@ def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: List[st
         ndesc.transient = False
         nsdfg.add_datadesc(name, ndesc)
 
-    bwd_node = context.backward_state.add_nested_sdfg(nsdfg, inputs, outputs)
+    bwd_node = context.backward_state.add_nested_sdfg(nsdfg,
+                                                      connector_dict(inputs),
+                                                      connector_dict(outputs),
+                                                      symbol_mapping=backward_symbol_mapping(
+                                                          nsdfg, context.backward_state))
     for output in outputs_to_connect_from_forward:
         connect_output_from_forward(forward_node, bwd_node, context, output)
 
@@ -152,7 +191,7 @@ def add_empty_sdfg_for_node(forward_node: nd.Node, required_descriptors: List[st
 
 
 def backward_program_for_node(program, context: BackwardContext,
-                              forward_node: nd.Node) -> Tuple[nd.Node, BackwardResult]:
+                              forward_node: nd.Node) -> tuple[nd.Node, BackwardResult]:
     """ Expand a function to the backward function for a node.
 
         The dtypes for the arguments will be extracted by matching the parameter names to edges.
@@ -200,7 +239,11 @@ def backward_program_for_node(program, context: BackwardContext,
 
     sdfg = DaceProgram(program, (), {}, False, dace.DeviceType.CPU).to_sdfg()
 
-    result_node = context.backward_state.add_nested_sdfg(sdfg, set(inputs), set(outputs))
+    result_node = context.backward_state.add_nested_sdfg(sdfg,
+                                                         connector_dict(inputs),
+                                                         connector_dict(outputs),
+                                                         symbol_mapping=backward_symbol_mapping(
+                                                             sdfg, context.backward_state))
 
     return result_node, backward_result
 
@@ -342,7 +385,7 @@ def init_grad(data: str, sdfg: SDFG, current_state: SDFGState) -> None:
         raise AutoDiffException("Unsupported data descriptor {}".format(arr))
 
 
-def extract_indices(expression: str) -> Dict[str, List[str]]:
+def extract_indices(expression: str) -> dict[str, list[str]]:
     """Extracts indexed array names and their indices from a given string expression.
 
     This function uses regular expressions to find patterns like "array[i, j, k]"
@@ -372,25 +415,86 @@ def extract_indices(expression: str) -> Dict[str, List[str]]:
     return index_map
 
 
+def connector_symbol(name: str, dtype: dtypes.typeclass | None = None) -> symbolic.symbol:
+    """Mint the DaCe symbol standing for a tasklet connector or an SDFG symbol.
+
+    Always a ``symbolic.symbol``, never a bare ``sympy.Symbol``: a bare one carries neither the
+    dtype nor DaCe's assumptions, so it compares unequal to the same-named DaCe symbol while still
+    substituting for it -- the split that makes ``diff()`` return a silent zero.
+    """
+    return symbolic.symbol(name, dtype if isinstance(dtype, dtypes.typeclass) else None)
+
+
+def index_symbol(name: str, dtype: dtypes.typeclass | None = None) -> sp.Idx:
+    """Index label for an ``IndexedBase`` access, over a DaCe symbol.
+
+    An ``Idx`` label must be integral, so a non-integer declaration cannot supply it and the
+    default integer dtype stands in.
+    """
+    sym = connector_symbol(name, dtype)
+    return sp.Idx(sym if sym.is_integer else connector_symbol(name))
+
+
+def replace_bare_symbols(expr: sp.Expr, known: dict[str, sp.Expr]) -> sp.Expr:
+    """Replace every bare sympy Symbol in ``expr`` with the DaCe symbol of the same name.
+
+    The boundary guarantee for this module: no expression leaves it carrying a symbol that would
+    compare unequal to the SDFG's own. SymPy can still introduce one from inside the executed code.
+    """
+    replacements = {}
+    for sym in expr.free_symbols:
+        if type(sym) is not sp.Symbol:
+            continue
+        declared = known.get(sym.name)
+        replacements[sym] = declared if isinstance(declared, symbolic.symbol) else connector_symbol(sym.name)
+    return expr.xreplace(replacements) if replacements else expr
+
+
+def resolve_differentiation_target(expr: sp.Expr, name: str, indices: list[str] | None) -> sp.Expr:
+    """Find, inside ``expr``, the symbol or indexed access that stands for connector ``name``.
+
+    ``expr.diff(...)`` has to see the very instance the expression was built around; a re-minted
+    equivalent differentiates to zero (or to a KroneckerDelta). A connector absent from ``expr``
+    falls back to a fresh instance, where zero is the right derivative anyway.
+    """
+    if indices is None:
+        # sorted() only to keep the fallback deterministic; at most one symbol carries a given name.
+        candidates = sorted((s for s in expr.free_symbols if str(s) == name), key=str)
+        return candidates[0] if candidates else connector_symbol(name)
+
+    wanted = tuple(indices)
+    candidates = sorted(
+        (a for a in expr.atoms(sp.Indexed) if str(a.base) == name and tuple(str(i) for i in a.indices) == wanted),
+        key=str)
+    if candidates:
+        return candidates[0]
+    return sp.IndexedBase(name)[tuple(index_symbol(index) for index in indices)]
+
+
 def code_to_exprs(code: str, tasklet: nd.Tasklet,
-                  symbols: List[str]) -> Tuple[Dict[str, sp.Expr], Dict[str, List[str]]]:
+                  symbols: dict[str, dtypes.typeclass]) -> tuple[dict[str, sp.Expr], dict[str, list[str]]]:
     """ Convert a python string to a set of (simplified) symbolic sympy expressions. Currently, this
         supports only code consisting of assignment statements.
 
         :param code: the code to convert
-        :param inputs: the inputs (i.e. the defined variables) for the code
-        :param outputs: the outputs to generate simplified expressions for
-        :return: map from outputs to symbolic expressions
+        :param tasklet: the tasklet the code belongs to; its connectors are the defined variables
+        :param symbols: the SDFG symbols visible to the code, mapped to their dtypes
+        :return: map from outputs to symbolic expressions, and the map of indexed objects to indices
     """
 
-    inputs: List[str] = list(tasklet.in_connectors)
-    outputs: List[str] = list(tasklet.out_connectors)
+    inputs: list[str] = list(tasklet.in_connectors)
+    outputs: list[str] = list(tasklet.out_connectors)
+
+    # Symbols reach the generated source through this table instead of being minted inside it from a
+    # bare name: minting here is the only place that still knows their dtypes.
+    symbol_table: dict[str, sp.Expr] = {}
 
     # Add the definition of global constant symbols that are presen in the code
     # Prepare the Symbol declaration code
     symbol_code = ""
-    for symb in symbols:
-        symbol_code += f"    {symb} = sp.symbols('{symb}')\n"
+    for symb, symb_dtype in symbols.items():
+        symbol_table[symb] = connector_symbol(symb, symb_dtype)
+        symbol_code += f"    {symb} = {SYMBOL_TABLE_GLOBAL}['{symb}']\n"
 
     # We prepare a map of indexed objects and their indices
     indexed_objects_map = extract_indices(code)
@@ -409,7 +513,8 @@ def code_to_exprs(code: str, tasklet: nd.Tasklet,
                 raise AutoDiffException(f"Expected connector '{conn}' to be in indexed objects map for pointer type")
             indexed_objects_code += f"    {conn} = sp.IndexedBase('{conn}')\n"
             for idx in indexed_objects_map[conn]:
-                indexed_objects_code += f"    {idx} = sp.symbols('{idx}', cls=sp.Idx)\n"
+                symbol_table[idx] = index_symbol(idx, symbols.get(idx) or tasklet.in_connectors.get(idx))
+                indexed_objects_code += f"    {idx} = {SYMBOL_TABLE_GLOBAL}['{idx}']\n"
 
     code_fn = """
 def symbolic_execution({}):
@@ -445,23 +550,26 @@ def symbolic_execution({}):
 
     try:
         # need to have dace so things like `dace.float32(1)` work
-        temp_globals = {'dace': dace}
+        temp_globals = {'dace': dace, SYMBOL_TABLE_GLOBAL: symbol_table}
         exec(code_fn, temp_globals)
 
         # no idea why, but simply calling symbolic_execution doesn't work
-        results = temp_globals["symbolic_execution"](*[sp.symbols(inp) for inp in inputs])
+        results = temp_globals["symbolic_execution"](
+            *[connector_symbol(inp, tasklet.in_connectors[inp]) for inp in inputs])
 
         if len(outputs) > 1:
-            # make sure that everything is a sympy expression
-            for i, res in enumerate(results):
-                if not isinstance(res, sp.Expr):
-                    results[i] = sp.sympify(res)
-            return dict(zip(outputs, results)), indexed_objects_map
+            # make sure that everything is a sympy expression. A new list, not in place: a
+            # multi-output symbolic_execution returns a tuple.
+            normalized = [
+                replace_bare_symbols(res if isinstance(res, sp.Expr) else symbolic.pystr_to_symbolic(res), symbol_table)
+                for res in results
+            ]
+            return dict(zip(outputs, normalized)), indexed_objects_map
         else:
             # make sure that everything is a sympy expression
             if not isinstance(results, sp.Expr):
-                results = sp.sympify(results)
-            return {outputs[0]: results}, indexed_objects_map
+                results = symbolic.pystr_to_symbolic(results)
+            return {outputs[0]: replace_bare_symbols(results, symbol_table)}, indexed_objects_map
     except Exception as e:
         raise AutoDiffException(
             "Exception occurred while attempting to symbolically execute code:\n{}".format(code)) from e
@@ -499,7 +607,7 @@ def carries_gradient(edge: dgraph.MultiConnectorEdge) -> bool:
     return (not edge.data.is_empty() or isinstance(edge.src, nd.EntryNode) or isinstance(edge.dst, nd.ExitNode))
 
 
-def reverse_bfs_gradient_nodes(state: dstate.StateSubgraphView, sources: List[nd.Node]) -> OrderedSet[nd.Node]:
+def reverse_bfs_gradient_nodes(state: dstate.StateSubgraphView, sources: list[nd.Node]) -> OrderedSet[nd.Node]:
     """Collect the endpoints of every edge a reverse BFS from ``sources`` reaches along gradients.
 
     :param state: The state (or subgraph view) to traverse.
@@ -529,7 +637,7 @@ def path_src_node_in_subgraph(edge: dgraph.MultiConnectorEdge, subgraph: dstate.
     return path_src in subgraph.nodes()
 
 
-def get_read_only_arrays(sdfg: SDFG) -> Set[str]:
+def get_read_only_arrays(sdfg: SDFG) -> set[str]:
     """Get the arrays that are only read in SDFG.
 
     This function identifies arrays that are never written to (only have outgoing
@@ -548,7 +656,7 @@ def get_read_only_arrays(sdfg: SDFG) -> Set[str]:
     return read_only_arrays
 
 
-def get_state_topological_order(graph) -> List[SDFGState]:
+def get_state_topological_order(graph) -> list[SDFGState]:
     """
     Returns the SDFG states in topological order.
     """
@@ -650,7 +758,7 @@ def analyze_loop_change(code: str, loop_variable: str) -> str:
 
 
 def get_map_nest_information(
-        edges_list: List[dstate.MultiConnectorEdge]) -> Tuple[List, List[str], List, Dict[str, Tuple]]:
+        edges_list: list[dstate.MultiConnectorEdge]) -> tuple[list, list[str], list, dict[str, tuple]]:
     """
         """
     # First, get the shape of the new array
@@ -683,7 +791,7 @@ def get_map_nest_information(
 
 
 def get_all_path_edges(state: SDFGState, source: nd.Node,
-                       starting_edge: dgraph.MultiConnectorEdge) -> List[dgraph.MultiConnectorEdge]:
+                       starting_edge: dgraph.MultiConnectorEdge) -> list[dgraph.MultiConnectorEdge]:
     """
     We will start from the target node and go back until we reach the destination.
     Starting edge should be an in node
@@ -707,7 +815,7 @@ def get_all_path_edges(state: SDFGState, source: nd.Node,
     raise AutoDiffException("Can't easily find path. Upgrade function.")
 
 
-def extract_conditional_expressions(tasklet_node: nd.Tasklet) -> Tuple[str, str, str]:
+def extract_conditional_expressions(tasklet_node: nd.Tasklet) -> tuple[str, str, str]:
     """
         Given a conditional tasklet node, extract the if and else expressions and return them with the conditional.
         The else statement could be None in case there is only an if statement. The current supported formats are the following:
@@ -844,7 +952,7 @@ def check_edges_type_in_state(subgraph: dstate.StateSubgraphView) -> None:
                     f" on edge {edge} has type {edge_type}")
 
 
-def state_within_loop(forward_state: SDFGState) -> Tuple[bool, LoopRegion]:
+def state_within_loop(forward_state: SDFGState) -> tuple[bool, LoopRegion]:
     """
     Check if this state will be executed several times within a loop.
     We check if any of the parents of this state is a loop region.
@@ -865,7 +973,7 @@ class SympyCleaner(ast.NodeTransformer):
         return self.generic_visit(node)
 
 
-def extract_loop_region_info(loop: LoopRegion) -> Tuple[str, str]:
+def extract_loop_region_info(loop: LoopRegion) -> tuple[str, str]:
     """
         Use regular expression matching to extract the start and end of the loop region.
         We only treat regular for-loops with incrementation and decrementation updates.

--- a/dace/libraries/onnx/forward_implementation_abc.py
+++ b/dace/libraries/onnx/forward_implementation_abc.py
@@ -54,6 +54,11 @@ class ONNXForward(abc.ABC):
     selection based on applicability criteria.
     """
 
+    #: Library environments the expansion needs. Declared here so consumers can read it off any
+    #: implementation instead of probing for it; a tuple, since the default is shared by every
+    #: subclass that does not override it. Only ever iterated.
+    environments: tuple = ()
+
     @staticmethod
     def forward_can_be_applied(node: ONNXOp, state: SDFGState, sdfg: SDFG) -> bool:
         """Check whether this implementation can be applied to the given node.

--- a/tests/autodiff/test_symbolic_audit.py
+++ b/tests/autodiff/test_symbolic_audit.py
@@ -1,0 +1,199 @@
+# Copyright 2019-2025 ETH Zurich and the DaCe authors. All rights reserved.
+"""Structural regressions for the autodiff symbolic/nested-SDFG audit.
+
+Each test pins an invariant that used to hold only by accident: how a subset dimension is parsed,
+what kind of symbol reaches a differentiated expression, and what a backward nested SDFG node
+declares about its symbols and connectors.
+"""
+import typing
+import warnings
+
+import numpy as np
+import pytest
+import sympy
+
+import dace
+import dace.sdfg.nodes as nd
+from dace import symbolic
+from dace.sdfg.state import LoopRegion
+
+import dace.autodiff.utils as ad_utils
+import dace.autodiff.data_forwarding.store as ad_store
+from dace.autodiff import add_backward_pass
+from dace.autodiff.backward_pass_generator import BackwardPassGenerator
+
+N = dace.symbol("N", dtype=dace.int64)
+
+
+class BoundsGeneratorStub:
+    """The two attributes ``get_symbol_upper_bound_from_loop`` reads off the generator."""
+
+    def __init__(self, sdfg: dace.SDFG):
+        self.sdfg = sdfg
+        self.interstate_symbols: dict[str, str] = {}
+
+
+def counting_loop() -> tuple[dace.SDFG, LoopRegion]:
+    sdfg = dace.SDFG("stored_bounds")
+    loop = LoopRegion("loop", condition_expr="i < 10", loop_var="i", initialize_expr="i = 0", update_expr="i = i + 1")
+    sdfg.add_node(loop)
+    loop.add_state("body", is_start_block=True)
+    return sdfg, loop
+
+
+@dace.program
+def scale_and_sum(X: dace.float64[N], Y: dace.float64[N], S: dace.float64[1]):
+    Y[:] = X * 2.0
+    S[0] = np.sum(Y)
+
+
+def differentiated_sdfg() -> tuple[dace.SDFG, list[warnings.WarningMessage]]:
+    """Backward pass over a symbolically shaped program, with the warnings it raised.
+
+    Only the backward generation is recorded: the Python frontend raises the same set-connector
+    warning while parsing, and that is not this module's business.
+    """
+    sdfg = scale_and_sum.to_sdfg(simplify=True)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        add_backward_pass(sdfg=sdfg, outputs=["S"], inputs=["X"], simplify=False)
+    return sdfg, caught
+
+
+def nested_sdfg_nodes(sdfg: dace.SDFG) -> list[tuple[nd.NestedSDFG, dace.SDFGState]]:
+    return [(node, parent) for node, parent in sdfg.all_nodes_recursive() if isinstance(node, nd.NestedSDFG)]
+
+
+# Issue 1: subset dimensions are parsed with DaCe's parser, not sympy's.
+def test_stored_dimension_parse_keeps_integer_division():
+    sdfg, loop = counting_loop()
+    generator = BoundsGeneratorStub(sdfg)
+
+    # The two parsers disagree on `//`: DaCe builds an int_floor node, sympify a rational division
+    # that folds `i//i` to 1 and loses the loop index entirely.
+    assert isinstance(symbolic.pystr_to_symbolic("i//2"), symbolic.int_floor)
+    assert sympy.sympify("i//2").has(sympy.floor)
+    assert sympy.sympify("i//i").free_symbols == set()
+
+    for dimension in ("i", "i//2", "i//i", "2*i"):
+        bound, loop_index = ad_store.get_symbol_upper_bound_from_loop(generator, dimension, [loop])
+        assert loop_index == "i"
+        assert bound == 10
+
+
+# Issue 2: no bare sympy symbol reaches a caller of the symbolic-differentiation path.
+def test_code_to_exprs_yields_dace_symbols_with_the_sdfg_dtype():
+    sdfg = dace.SDFG("tasklet_symbols")
+    sdfg.add_symbol("N", dace.int64)
+    state = sdfg.add_state()
+    tasklet = state.add_tasklet("t", {"a": dace.float64, "b": dace.float64}, {"c": dace.float64}, "c = a * b + N")
+
+    exprs, indexed = ad_utils.code_to_exprs(tasklet.code.as_string, tasklet, sdfg.symbols)
+
+    assert indexed == {}
+    free = {str(s): s for s in exprs["c"].free_symbols}
+    assert set(free) == {"a", "b", "N"}
+    for sym in free.values():
+        assert isinstance(sym, symbolic.symbol), f"{sym} is a bare sympy symbol"
+    assert free["N"].dtype == dace.int64
+    assert free["a"].dtype == dace.float64
+
+
+def test_differentiation_target_is_the_instance_inside_the_expression():
+    x_in_expr = symbolic.symbol("x", dace.float64)
+    expr = x_in_expr * 3
+
+    resolved = ad_utils.resolve_differentiation_target(expr, "x", None)
+    assert resolved is x_in_expr
+    assert expr.diff(resolved) == 3
+
+    # A re-minted symbol is what the fix removes: it compares unequal and differentiates to zero.
+    assert expr.diff(sympy.Symbol("x")) == 0
+
+    # A connector that does not occur still yields a DaCe symbol, and a zero derivative.
+    missing = ad_utils.resolve_differentiation_target(expr, "y", None)
+    assert isinstance(missing, symbolic.symbol)
+    assert expr.diff(missing) == 0
+
+
+def test_indexed_differentiation_target_is_the_instance_inside_the_expression():
+    base = sympy.IndexedBase("A")
+    expr = base[ad_utils.index_symbol("i", dace.int64)] * 2
+
+    resolved = ad_utils.resolve_differentiation_target(expr, "A", ["i"])
+    assert resolved is next(iter(expr.atoms(sympy.Indexed)))
+    assert expr.diff(resolved) == 2
+
+    # Rebuilding the access from bare names produces a KroneckerDelta rather than the derivative.
+    assert expr.diff(base[sympy.Idx("i")]).has(sympy.KroneckerDelta)
+
+
+# Issue 3: every backward nested SDFG declares its symbols explicitly.
+@pytest.mark.autodiff
+def test_backward_nested_sdfgs_declare_their_symbol_mapping():
+    sdfg, _ = differentiated_sdfg()
+    nested = nested_sdfg_nodes(sdfg)
+    assert nested, "expected the backward pass to build at least one nested SDFG"
+
+    for node, parent in nested:
+        required = node.sdfg.free_symbols - {"NoneSymbol"}
+        assert required, f"nested SDFG {node.label} carries no symbol; the test program lost its symbolic shape"
+        assert required <= set(node.symbol_mapping), (f"nested SDFG {node.label} leaves "
+                                                      f"{sorted(required - set(node.symbol_mapping))} unmapped")
+        for name in required:
+            declared = parent.sdfg.symbols.get(name)
+            if declared is None:
+                continue
+            mapped = node.symbol_mapping[name]
+            assert str(mapped) == name
+            assert isinstance(mapped, symbolic.symbol), f"{node.label}:{name} mapped to a bare {type(mapped)}"
+            assert mapped.dtype == declared, f"{node.label}:{name} mapped as {mapped.dtype}, parent says {declared}"
+
+
+def test_backward_symbol_mapping_carries_the_parent_dtype():
+    parent = dace.SDFG("parent")
+    parent.add_symbol("N", dace.int64)
+    parent_state = parent.add_state()
+
+    child = dace.SDFG("child")
+    child.add_array("data", [dace.symbol("N", dace.int32)], dace.float64)
+    child.add_state().add_access("data")
+
+    mapping = ad_utils.backward_symbol_mapping(child, parent_state)
+    assert set(mapping) == {"N"}
+    assert isinstance(mapping["N"], symbolic.symbol)
+    assert mapping["N"].dtype == dace.int64
+
+
+# Issue 4: connectors are ordered, so codegen does not depend on PYTHONHASHSEED.
+def test_connector_dict_is_ordered_and_type_autodetecting():
+    assert list(ad_utils.connector_dict({"b", "a", "c"})) == ["a", "b", "c"]
+    assert set(ad_utils.connector_dict(["z", "y"]).values()) == {None}
+
+
+@pytest.mark.autodiff
+def test_backward_pass_does_not_build_nested_sdfgs_from_sets():
+    sdfg, caught = differentiated_sdfg()
+
+    offenders = [str(w.message) for w in caught if "sets as inputs" in str(w.message)]
+    assert not offenders, offenders
+
+    nested = nested_sdfg_nodes(sdfg)
+    assert nested
+    for node, _ in nested:
+        assert list(node.in_connectors) == sorted(node.in_connectors)
+        assert list(node.out_connectors) == sorted(node.out_connectors)
+
+
+# Issues 5 and 6: the forward references in annotations name a class that exists.
+def test_backward_pass_generator_forward_references_resolve():
+    annotated = [
+        ad_store.get_symbol_upper_bound_from_loop,
+        ad_store.resolve_overwrite_with_store,
+        ad_store.store_data,
+        ad_store.connect_stored_data_to_target,
+    ]
+    for fn in annotated:
+        # localns stands in for the ``if TYPE_CHECKING:`` import, which is absent at runtime by design.
+        hints = typing.get_type_hints(fn, localns={"BackwardPassGenerator": BackwardPassGenerator})
+        assert hints["bwd_generator"] is BackwardPassGenerator


### PR DESCRIPTION
Symbolic parsing now goes through `symbolic.pystr_to_symbolic` instead of `sp.sympify`, so an index expression's `//` stays `int_floor` rather than becoming sympy's rational division.

Symbol identity: bare `sp.symbols` minting is replaced by DaCe symbols carrying the SDFG's dtype, because a bare sympy symbol is a different object from the SDFG's and differentiates to the wrong answer.

Nested-SDFG symbol maps: all 9 `add_nested_sdfg` sites now pass an explicit mapping carrying the parent's dtype instead of relying on the implicit default.

Determinism: connector dicts are ordered rather than plain `set`s, which reach codegen and would otherwise vary the emitted order between runs.

Type annotations: a mangled forward reference is fixed and `TYPE_CHECKING` blocks are added.

House style: underscore-prefixed defs, `getattr`/`hasattr`, relative imports and `typing.List` generics are removed.
