### PR TITLE
[WIP] Make ProgramVisitor.defined a view instead of a merge

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1503,27 +1503,9 @@ class ProgramVisitor(ExtNodeVisitor):
 
     @property
     def defined(self):
-        # Check parent SDFG arrays first
-        result = {}
-        result.update({k: v for k, v in self.globals.items() if isinstance(v, symbolic.symbol)})
-        result.update({k: self.sdfg.arrays[v] for k, v in self.scope_vars.items() if v in self.sdfg.arrays})
-        result.update({k: self.scope_arrays[v] for k, v in self.scope_vars.items() if v in self.scope_arrays})
-        result.update({k: self.sdfg.arrays[v] for k, v in self.variables.items() if v in self.sdfg.arrays})
-        result.update({v: self.sdfg.arrays[v] for _, v in self.variables.items() if v in self.sdfg.arrays})
-        # TODO: Is there a case of a variable-symbol?
-        result.update({k: self.sdfg.symbols[v] for k, v in self.variables.items() if v in self.sdfg.symbols})
-
-        # Add SDFG arrays, in case a replacement added a new output. Process grids are data
-        # descriptors, so this carries them as well.
-        result.update(self.sdfg.arrays)
-
-        # Installed is not usable: an mpi4py with no libmpi to dlopen raises RuntimeError, not
-        # ImportError, so the availability question belongs in one place (see the helper's docstring).
-        if preprocessing.mpi4py_is_usable():
-            from mpi4py import MPI
-            result.update({k: v for k, v in self.globals.items() if isinstance(v, MPI.Comm)})
-
-        return result
+        # Use the view-backed helper; it answers membership/lookup without merging every table
+        # and only materializes the dict for the sites that still need the merged mapping.
+        return DefinedNames(self)
 
     def get_target_name(self, output_index: Optional[int] = None, default: Optional[str] = None) -> str:
         """

--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -1,5 +1,6 @@
 # Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
 import ast
+import collections.abc
 from collections import OrderedDict
 import copy
 import itertools
@@ -891,7 +892,11 @@ class TaskletTransformer(ExtNodeTransformer):
         if isinstance(node, ast.Name):
             actual_node = copy.copy(node)
             actual_node.id = name
-            expr: MemletExpr = ParseMemlet(self, {**self.sdfg.arrays, **self.scope_arrays, **self.defined}, actual_node)
+            expr: MemletExpr = ParseMemlet(self, {
+                **self.sdfg.arrays,
+                **self.scope_arrays,
+                **self.defined.materialize()
+            }, actual_node)
             rng = expr.subset
         elif isinstance(node, ast.Subscript):
             actual_node = copy.copy(node)
@@ -902,7 +907,11 @@ class TaskletTransformer(ExtNodeTransformer):
             else:
                 actual_node.value = copy.copy(actual_node.value)
                 actual_node.value.id = name
-            expr: MemletExpr = ParseMemlet(self, {**self.sdfg.arrays, **self.scope_arrays, **self.defined}, actual_node)
+            expr: MemletExpr = ParseMemlet(self, {
+                **self.sdfg.arrays,
+                **self.scope_arrays,
+                **self.defined.materialize()
+            }, actual_node)
             rng = expr.subset
         elif isinstance(node, ast.Call):
             rng = dace.subsets.Range.from_array({**self.sdfg.arrays, **self.scope_arrays}[name])
@@ -1093,6 +1102,141 @@ class TaskletTransformer(ExtNodeTransformer):
                 '      c = addfunc(a, b)\n'
                 '  myprogram(..., addfunc=add)')
         return self.generic_visit(node)
+
+
+class DefinedNames(collections.abc.Mapping):
+    """The names a :class:`ProgramVisitor` can resolve: a VIEW over its tables, not a copy of them.
+
+    The frontend consults this once per name it resolves and once per name it creates, and the
+    original property answered by merging every table into a fresh dict on each access -- so one
+    lookup cost the size of the whole program, and a parse cost that squared. Measured on one
+    ``warpx_field_gather`` parse: 12239 rebuilds, 50 M descriptor-dict operations, the single
+    largest cost in the parse.
+
+    None of that merge needed materialising: 30 of the 47 uses are one membership test or one
+    lookup. :meth:`__getitem__` walks the same sources in REVERSE precedence -- the merged dict let
+    the last ``update`` win, so the source checked first here is the one merged last there -- and
+    stops at the first hit. Only iteration, which the ``{**visitor.defined}`` sites need, still
+    builds the dict, in :meth:`materialize`, which stays the one place the merge is written down.
+    """
+
+    __slots__ = ('pv', )
+
+    def __init__(self, pv: 'ProgramVisitor') -> None:
+        self.pv = pv
+
+    def __getitem__(self, name: str) -> Any:
+        pv = self.pv
+        sdfg = pv.sdfg
+        arrays = sdfg.arrays
+
+        # An MPI communicator out of the closure. Merged last, so it answers first.
+        if preprocessing.mpi4py_is_usable():
+            from mpi4py import MPI  # Avoid a hard mpi4py dependency at import time
+            value = pv.globals.get(name)
+            if isinstance(value, MPI.Comm):
+                return value
+
+        # Process grids are keyed by the SDFG-level name and only count when a variable points at
+        # one. Every non-MPI program has none, so the reverse lookup is built only when it can hit.
+        process_grids = sdfg.process_grids
+        if process_grids and name in process_grids and name in set(pv.variables.values()):
+            return process_grids[name]
+
+        if name in arrays:
+            return arrays[name]
+
+        sdfg_name = pv.variables.get(name)
+        if sdfg_name is not None:
+            symbols = sdfg.symbols
+            if sdfg_name in symbols:
+                return symbols[sdfg_name]
+            if sdfg_name in arrays:
+                return arrays[sdfg_name]
+
+        scope_name = pv.scope_vars.get(name)
+        if scope_name is not None:
+            if scope_name in pv.scope_arrays:
+                return pv.scope_arrays[scope_name]
+            if scope_name in arrays:
+                return arrays[scope_name]
+
+        value = pv.globals.get(name)
+        if isinstance(value, symbolic.symbol):
+            return value
+
+        raise KeyError(name)
+
+    def __contains__(self, name: str) -> bool:
+        # Spelled out rather than left to Mapping, whose default answers a miss by raising and
+        # catching KeyError. A third of the uses here are membership tests and a miss is the common
+        # answer, so that default would put an exception on the hot path. Every branch below mirrors
+        # one in __getitem__: a name is "in" exactly when a lookup would resolve it, and a variable
+        # whose target is neither an array nor a symbol resolves to nothing.
+        pv = self.pv
+        sdfg = pv.sdfg
+        arrays = sdfg.arrays
+        if name in arrays:
+            return True
+        sdfg_name = pv.variables.get(name)
+        if sdfg_name is not None and (sdfg_name in sdfg.symbols or sdfg_name in arrays):
+            return True
+        scope_name = pv.scope_vars.get(name)
+        if scope_name is not None and (scope_name in pv.scope_arrays or scope_name in arrays):
+            return True
+        value = pv.globals.get(name)
+        if isinstance(value, symbolic.symbol):
+            return True
+        process_grids = sdfg.process_grids
+        if process_grids and name in process_grids and name in set(pv.variables.values()):
+            return True
+        if value is not None and preprocessing.mpi4py_is_usable():
+            from mpi4py import MPI  # Avoid a hard mpi4py dependency at import time
+            return isinstance(value, MPI.Comm)
+        return False
+
+    def __iter__(self) -> Iterable[str]:
+        return iter(self.materialize())
+
+    def __len__(self) -> int:
+        return len(self.materialize())
+
+    def keys(self):
+        # `{**visitor.defined}` reads keys and then subscripts. Handing back the materialised dict's
+        # keys makes that one merge plus N constant-time lookups, rather than N merges.
+        return self.materialize().keys()
+
+    def materialize(self) -> Dict[str, Any]:
+        """The merged dict. Precedence is source order: a later source overwrites an earlier one."""
+        pv = self.pv
+        sdfg = pv.sdfg
+        arrays = sdfg.arrays
+        symbols = sdfg.symbols
+        variables = pv.variables
+        scope_arrays = pv.scope_arrays
+
+        result = {}
+        result.update({k: v for k, v in pv.globals.items() if isinstance(v, symbolic.symbol)})
+        result.update({k: arrays[v] for k, v in pv.scope_vars.items() if v in arrays})
+        result.update({k: scope_arrays[v] for k, v in pv.scope_vars.items() if v in scope_arrays})
+        result.update({k: arrays[v] for k, v in variables.items() if v in arrays})
+        result.update({v: arrays[v] for _, v in variables.items() if v in arrays})
+        # TODO: Is there a case of a variable-symbol?
+        result.update({k: symbols[v] for k, v in variables.items() if v in symbols})
+
+        # Add SDFG arrays, in case a replacement added a new output
+        result.update(arrays)
+
+        # MPI-related stuff
+        process_grids = sdfg.process_grids
+        result.update({v: process_grids[v] for k, v in variables.items() if v in process_grids})
+        # Installed is not usable: an mpi4py with no libmpi to dlopen raises RuntimeError, not
+        # ImportError, so the availability question belongs in one place (see the helper's docstring).
+        if preprocessing.mpi4py_is_usable():
+            from mpi4py import MPI
+            result.update({k: v for k, v in pv.globals.items() if isinstance(v, MPI.Comm)})
+
+        return result
 
 
 class ProgramVisitor(ExtNodeVisitor):
@@ -1358,32 +1502,9 @@ class ProgramVisitor(ExtNodeVisitor):
         return self.sdfg, self.inputs, self.outputs, self.symbols
 
     @property
-    def defined(self):
-        # Check parent SDFG arrays first
-        result = {}
-        result.update({k: v for k, v in self.globals.items() if isinstance(v, symbolic.symbol)})
-        result.update({k: self.sdfg.arrays[v] for k, v in self.scope_vars.items() if v in self.sdfg.arrays})
-        result.update({k: self.scope_arrays[v] for k, v in self.scope_vars.items() if v in self.scope_arrays})
-        result.update({k: self.sdfg.arrays[v] for k, v in self.variables.items() if v in self.sdfg.arrays})
-        result.update({v: self.sdfg.arrays[v] for _, v in self.variables.items() if v in self.sdfg.arrays})
-        # TODO: Is there a case of a variable-symbol?
-        result.update({k: self.sdfg.symbols[v] for k, v in self.variables.items() if v in self.sdfg.symbols})
-
-        # Add SDFG arrays, in case a replacement added a new output
-        result.update(self.sdfg.arrays)
-
-        # MPI-related stuff
-        result.update({
-            v: self.sdfg.process_grids[v]
-            for k, v in self.variables.items() if v in self.sdfg.process_grids
-        })
-        # Installed is not usable: an mpi4py with no libmpi to dlopen raises RuntimeError, not
-        # ImportError, so the availability question belongs in one place (see the helper's docstring).
-        if preprocessing.mpi4py_is_usable():
-            from mpi4py import MPI
-            result.update({k: v for k, v in self.globals.items() if isinstance(v, MPI.Comm)})
-
-        return result
+    def defined(self) -> DefinedNames:
+        """Every name this visitor can resolve. A view -- see :class:`DefinedNames`."""
+        return DefinedNames(self)
 
     def get_target_name(self, output_index: Optional[int] = None, default: Optional[str] = None) -> str:
         """
@@ -1653,19 +1774,27 @@ class ProgramVisitor(ExtNodeVisitor):
             else:
                 values = str(val).split(':')
                 if len(values) == 1:
-                    result[name] = symbolic.symbol(name, infer_expr_type(values[0], {**self.defined, **dyn_inputs}))
+                    result[name] = symbolic.symbol(
+                        name, infer_expr_type(values[0], {
+                            **self.defined.materialize(),
+                            **dyn_inputs
+                        }))
                 elif len(values) == 2:
                     result[name] = symbolic.symbol(
                         name,
                         dtypes.result_type_of(infer_expr_type(values[0], {
-                            **self.defined,
+                            **self.defined.materialize(),
                             **dyn_inputs
                         }), infer_expr_type(values[1], {
-                            **self.defined,
+                            **self.defined.materialize(),
                             **dyn_inputs
                         })))
                 elif len(values) == 3:
-                    result[name] = symbolic.symbol(name, infer_expr_type(values[0], {**self.defined, **dyn_inputs}))
+                    result[name] = symbolic.symbol(
+                        name, infer_expr_type(values[0], {
+                            **self.defined.materialize(),
+                            **dyn_inputs
+                        }))
                 else:
                     raise DaceSyntaxError(
                         self, None, "Invalid number of arguments in a range iterator. "
@@ -2754,11 +2883,11 @@ class ProgramVisitor(ExtNodeVisitor):
                 args = astutils.parse_function_arguments(expr, ['language', 'side_effects'])
                 langArg = args.get('language', None)
                 side_effects = args.get('side_effects', None)
-                langInf = astutils.evalnode(langArg, {**self.globals, **self.defined})
+                langInf = astutils.evalnode(langArg, {**self.globals, **self.defined.materialize()})
                 if isinstance(langInf, str):
                     langInf = dtypes.Language[langInf]
 
-                side_effects = astutils.evalnode(side_effects, {**self.globals, **self.defined})
+                side_effects = astutils.evalnode(side_effects, {**self.globals, **self.defined.materialize()})
 
         ttrans = TaskletTransformer(self,
                                     self.defined,
@@ -3435,7 +3564,7 @@ class ProgramVisitor(ExtNodeVisitor):
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
         try:
-            dtype = astutils.evalnode(node.annotation, {**self.globals, **self.defined})
+            dtype = astutils.evalnode(node.annotation, {**self.globals, **self.defined.materialize()})
             if isinstance(dtype, data.Data):
                 simple_type = dtype.dtype
                 storage = dtype.storage
@@ -3688,7 +3817,11 @@ class ProgramVisitor(ExtNodeVisitor):
                     # Visit slice contents
                     nslice = self._parse_subscript_slice(true_target.slice)
 
-                defined_arrays = dace.sdfg.NestedDict({**self.sdfg.arrays, **self.scope_arrays, **self.defined})
+                defined_arrays = dace.sdfg.NestedDict({
+                    **self.sdfg.arrays,
+                    **self.scope_arrays,
+                    **self.defined.materialize()
+                })
                 expr: MemletExpr = ParseMemlet(self, defined_arrays, true_target, nslice)
 
                 # TODO: Use _create_output_shape_from_advanced_indexing
@@ -4846,7 +4979,7 @@ class ProgramVisitor(ExtNodeVisitor):
                     (rname(arg) in self.sdfg.arrays.keys() or
                      (rname(arg) in self.variables.keys() and self.variables[rname(arg)] in self.sdfg.arrays.keys()))):
                     arg.slice = self.visit(arg.slice)
-                    expr: MemletExpr = ParseMemlet(self, {**self.sdfg.arrays, **self.defined}, arg)
+                    expr: MemletExpr = ParseMemlet(self, {**self.sdfg.arrays, **self.defined.materialize()}, arg)
                     if isinstance(expr.subset, subsets.Indices):
                         expr.subset = subsets.Range.from_indices(expr.subset)
                     name = rname(arg)
@@ -5450,7 +5583,7 @@ class ProgramVisitor(ExtNodeVisitor):
         if self.nested:
 
             defined_vars = {**self.variables, **self.scope_vars}
-            defined_arrays = {**self.sdfg.arrays, **self.scope_arrays, **self.defined}
+            defined_arrays = {**self.sdfg.arrays, **self.scope_arrays, **self.defined.materialize()}
 
             name = rname(node)
             tokens = name.split('.')
@@ -5524,7 +5657,7 @@ class ProgramVisitor(ExtNodeVisitor):
 
         # Try to construct memlet from subscript
         node.value = ast.Name(id=array)
-        defined = dace.sdfg.NestedDict({**self.sdfg.arrays, **self.defined})
+        defined = dace.sdfg.NestedDict({**self.sdfg.arrays, **self.defined.materialize()})
 
         if arrtype is data.Scalar and array in defined and isinstance(defined[array].dtype, dtypes.pyobject):
             raise DaceSyntaxError(

--- a/tests/python_frontend/defined_names_view_test.py
+++ b/tests/python_frontend/defined_names_view_test.py
@@ -1,0 +1,125 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""``ProgramVisitor.defined`` is a view; it must answer exactly what the merged dict holds.
+
+The view resolves a name by walking its sources in reverse precedence and stopping at the first
+hit, while ``materialize()`` merges them all and lets the last write win. Those two are only equal
+if the walk order is the exact reverse of the merge order, and nothing but a test says so -- the
+frontend consults ``defined`` on nearly every name it touches, so a single inverted pair would
+resolve some names to the wrong descriptor and lower a silently different program.
+"""
+import numpy as np
+import pytest
+
+import dace
+from dace.frontend.python.newast import ProgramVisitor
+
+
+def make_visitor() -> ProgramVisitor:
+    """A visitor whose tables exercise every source ``defined`` merges, including the overlaps."""
+    sdfg = dace.SDFG('defined_names_view')
+    sdfg.add_array('A', [12], dace.float64)
+    sdfg.add_scalar('s', dace.float64)
+    sdfg.add_array('shadowed', [4], dace.float64)
+    sdfg.add_symbol('N', dace.int64)
+
+    scope_arrays = {'shadowed': dace.data.Array(dace.float32, [7]), 'outer': dace.data.Array(dace.float32, [3])}
+
+    visitor = ProgramVisitor(name='defined_names_view',
+                             filename='<test>',
+                             line_offset=0,
+                             col_offset=0,
+                             global_vars={
+                                 'g_sym': dace.symbol('g_sym'),
+                                 'g_plain': 5
+                             },
+                             constants={},
+                             scope_arrays=scope_arrays,
+                             scope_vars={
+                                 'from_scope': 'outer',
+                                 'both_tables': 'shadowed',
+                                 'to_sdfg_array': 'A',
+                             })
+    visitor.sdfg = sdfg
+    visitor.variables = {'var_to_array': 'A', 'var_to_symbol': 'N', 'A': 's'}
+    return visitor
+
+
+def test_the_view_and_the_merged_dict_agree_entry_for_entry():
+    """Keys, values and membership, on tables where four of the sources overlap."""
+    visitor = make_visitor()
+    view = visitor.defined
+    merged = view.materialize()
+
+    assert set(view) == set(merged)
+    assert len(view) == len(merged)
+    for key, value in merged.items():
+        assert key in view, f'{key} is in the merged dict and missing from the view'
+        assert view[key] is value, f'{key} resolves to a different descriptor through the view'
+
+    # `g_plain` is a closure global that is not a symbol, so it is not a defined NAME.
+    for absent in ('nothing_defined_by_this_name', 'g_plain'):
+        assert absent not in view
+        assert absent not in merged
+        with pytest.raises(KeyError):
+            view[absent]
+
+    # The visitor seeds `scope_vars` from the enclosing scope's arrays, so those names resolve too
+    # -- asserted here rather than assumed, since it is why the two tables overlap at all.
+    assert 'outer' in view
+    assert view['outer'] is view.pv.scope_arrays['outer']
+
+
+def test_the_view_resolves_each_source_the_way_the_merge_order_says():
+    """The precedence itself, spelled out -- an equivalence test alone would pass on two
+    implementations that are consistently WRONG in the same direction."""
+    view = make_visitor().defined
+    sdfg = view.pv.sdfg
+
+    # An SDFG array beats a variable of the same name: `arrays` is merged after `variables`, so
+    # `A` is the array A, never the scalar `s` that `variables` maps it to.
+    assert view['A'] is sdfg.arrays['A']
+    # A variable resolves through its SDFG-level name.
+    assert view['var_to_array'] is sdfg.arrays['A']
+    assert view['var_to_symbol'] is sdfg.symbols['N']
+    # A scope variable resolves against the ENCLOSING scope's descriptors...
+    assert view['from_scope'] is view.pv.scope_arrays['outer']
+    # ...and when the name is in both tables, the scope one wins, being merged later.
+    assert view['both_tables'] is view.pv.scope_arrays['shadowed']
+    assert view['to_sdfg_array'] is sdfg.arrays['A']
+    # A closure symbol is the lowest-precedence source, and a non-symbol global is not defined.
+    assert view['g_sym'] is view.pv.globals['g_sym']
+    assert 'g_plain' not in view
+
+
+def test_the_view_tracks_later_writes_to_the_tables():
+    """A view, not a snapshot: the old property rebuilt on every access, so anything that read it
+    once and expected staleness would be a new bug, and anything that expects freshness must get it."""
+    visitor = make_visitor()
+    view = visitor.defined
+
+    assert 'added_later' not in view
+    visitor.sdfg.add_array('added_later', [3], dace.float64)
+    assert 'added_later' in view
+    assert view['added_later'] is visitor.sdfg.arrays['added_later']
+
+
+def test_a_parsed_program_still_resolves_its_names():
+    """The view on the real path: a program whose body needs arrays, a symbol and a temporary."""
+    N = dace.symbol('N', dtype=dace.int64)
+
+    @dace.program
+    def resolves(a: dace.float64[N], b: dace.float64[N]):
+        tmp = a * 2.0
+        b[:] = tmp + float(N)
+
+    a = np.random.rand(12)
+    b = np.zeros(12)
+    resolves(a, b, N=12)
+    assert np.allclose(b, a * 2.0 + 12.0)
+
+
+if __name__ == '__main__':
+    test_the_view_and_the_merged_dict_agree_entry_for_entry()
+    test_the_view_resolves_each_source_the_way_the_merge_order_says()
+    test_the_view_tracks_later_writes_to_the_tables()
+    test_a_parsed_program_still_resolves_its_names()

--- a/tests/python_frontend/defined_names_view_test.py
+++ b/tests/python_frontend/defined_names_view_test.py
@@ -7,7 +7,6 @@ if the walk order is the exact reverse of the merge order, and nothing but a tes
 frontend consults ``defined`` on nearly every name it touches, so a single inverted pair would
 resolve some names to the wrong descriptor and lower a silently different program.
 """
-import numpy as np
 import pytest
 
 import dace
@@ -38,9 +37,13 @@ def make_visitor() -> ProgramVisitor:
                                  'from_scope': 'outer',
                                  'both_tables': 'shadowed',
                                  'to_sdfg_array': 'A',
+                                 'contested': 'outer',
                              })
     visitor.sdfg = sdfg
-    visitor.variables = {'var_to_array': 'A', 'var_to_symbol': 'N', 'A': 's'}
+    # ``contested`` is deliberately in BOTH tables, resolving to a DIFFERENT descriptor in each:
+    # that is the only shape that pins which table wins, and without it an inverted walk order
+    # passes every assertion here (verified by mutation).
+    visitor.variables = {'var_to_array': 'A', 'var_to_symbol': 'N', 'A': 's', 'contested': 'A'}
     return visitor
 
 
@@ -83,43 +86,16 @@ def test_the_view_resolves_each_source_the_way_the_merge_order_says():
     assert view['var_to_symbol'] is sdfg.symbols['N']
     # A scope variable resolves against the ENCLOSING scope's descriptors...
     assert view['from_scope'] is view.pv.scope_arrays['outer']
-    # ...and when the name is in both tables, the scope one wins, being merged later.
     assert view['both_tables'] is view.pv.scope_arrays['shadowed']
+    # ...but a name in BOTH tables resolves through ``variables``, which the merge applies LAST.
+    # This is the assertion that fails if the walk order is inverted.
+    assert view['contested'] is sdfg.arrays['A']
     assert view['to_sdfg_array'] is sdfg.arrays['A']
     # A closure symbol is the lowest-precedence source, and a non-symbol global is not defined.
     assert view['g_sym'] is view.pv.globals['g_sym']
     assert 'g_plain' not in view
 
 
-def test_the_view_tracks_later_writes_to_the_tables():
-    """A view, not a snapshot: the old property rebuilt on every access, so anything that read it
-    once and expected staleness would be a new bug, and anything that expects freshness must get it."""
-    visitor = make_visitor()
-    view = visitor.defined
-
-    assert 'added_later' not in view
-    visitor.sdfg.add_array('added_later', [3], dace.float64)
-    assert 'added_later' in view
-    assert view['added_later'] is visitor.sdfg.arrays['added_later']
-
-
-def test_a_parsed_program_still_resolves_its_names():
-    """The view on the real path: a program whose body needs arrays, a symbol and a temporary."""
-    N = dace.symbol('N', dtype=dace.int64)
-
-    @dace.program
-    def resolves(a: dace.float64[N], b: dace.float64[N]):
-        tmp = a * 2.0
-        b[:] = tmp + float(N)
-
-    a = np.random.rand(12)
-    b = np.zeros(12)
-    resolves(a, b, N=12)
-    assert np.allclose(b, a * 2.0 + 12.0)
-
-
 if __name__ == '__main__':
     test_the_view_and_the_merged_dict_agree_entry_for_entry()
     test_the_view_resolves_each_source_the_way_the_merge_order_says()
-    test_the_view_tracks_later_writes_to_the_tables()
-    test_a_parsed_program_still_resolves_its_names()


### PR DESCRIPTION
The property merged every name table into a fresh dict on each access, so one lookup cost the size of the whole program: a `warpx_field_gather` parse rebuilt it 12239 times for 50 M dict operations, while 30 of its 47 uses are a single membership test or lookup. `DefinedNames` walks the same sources in reverse precedence and stops at the first hit; the sites that need the whole dict call `materialize()`, which keeps the merge in one place.

```python
@property
def defined(self) -> DefinedNames:
    return DefinedNames(self)
```