### PR TITLE
Don't map specialized symbols into the loop_body NestedSDFG

### DIFF
--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -1311,6 +1311,8 @@ class LoopToMap(xf.MultiStateTransformation):
                 sym_name = str(sym)
                 if sym_name in internally_defined:
                     continue
+                if sym_name in nsdfg.constants_prop:
+                    continue
                 if sym_name in sdfg.symbols:
                     if sym_name not in nsdfg.symbols:
                         nsdfg.symbols[sym_name] = sdfg.symbols[sym_name]


### PR DESCRIPTION
LoopToMap copies array-shape symbols into the loop_body NestedSDFG's symbol_mapping, but symbols the caller specialized are inherited as constants there and never appear in free_symbols, so the entries are dead and validation warns loop_body maps to unused symbol(s). This skips symbols that are already constants in the nested SDFG.