### PR TITLE
[WIP] Broadcast and Merge library nodes, reachable from NumPy

### DIFF
--- a/dace/frontend/python/replacements/array_manipulation.py
+++ b/dace/frontend/python/replacements/array_manipulation.py
@@ -210,6 +210,38 @@ def _ndarray_transpose(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: st
     return _transpose(pv, sdfg, state, arr, axes)
 
 
+@oprepo.replaces('numpy.broadcast_to')
+def broadcast_to(pv: ProgramVisitor, sdfg: SDFG, state: SDFGState, arr: str,
+                 shape: Union[str, symbolic.SymbolicType, Sequence[Union[str, symbolic.SymbolicType]]]) -> str:
+    """Replicate ``arr`` across ``shape`` by the NumPy broadcasting rule.
+
+    NumPy returns a zero-stride VIEW; DaCe materializes a transient instead, because a
+    stride of 0 makes every write to the result alias and there is no way to tell here
+    whether the caller only reads it.
+    """
+    from dace.libraries.standard.nodes import Broadcast  # Avoid import loop
+
+    if isinstance(arr, (list, tuple)) and len(arr) == 1:
+        arr = arr[0]
+    desc = sdfg.arrays[arr]
+    if isinstance(shape, (str, symbolic.symbol)) or isinstance(shape, Integral):
+        shape = [shape]
+    newshape = [symbolic.pystr_to_symbolic(s) for s in shape]
+    if len(newshape) < len(desc.shape):
+        raise ValueError(f'Cannot broadcast a rank-{len(desc.shape)} array to the '
+                         f'rank-{len(newshape)} shape {tuple(newshape)}')
+
+    out, out_desc = sdfg.add_transient(pv.get_target_name(), newshape, desc.dtype, desc.storage, find_new_name=True)
+    node = Broadcast('broadcast_to', dim=None)
+    state.add_node(node)
+    state.add_edge(state.add_read(arr), None, node, '_src', Memlet.from_array(arr, desc))
+    state.add_edge(node, '_dst', state.add_write(out), None, Memlet.from_array(out, out_desc))
+    # The node's own validate() is what rejects a shape that does not broadcast; run it here
+    # so the error names the numpy call instead of surfacing at expansion time.
+    node.validate(sdfg, state)
+    return out
+
+
 @oprepo.replaces('numpy.reshape')
 def reshape(pv: ProgramVisitor,
             sdfg: SDFG,

--- a/dace/frontend/python/replacements/filtering.py
+++ b/dace/frontend/python/replacements/filtering.py
@@ -57,7 +57,7 @@ def _array_array_where(visitor: ProgramVisitor,
     (out_shape, all_idx_dict, out_idx, left_idx, right_idx) = broadcast_together(left_shape, right_shape)
 
     # Broadcast condition with broadcasted left+right
-    _, _, _, cond_idx, _ = broadcast_together(cond_shape, out_shape)
+    cond_out_shape, _, _, cond_idx, _ = broadcast_together(cond_shape, out_shape)
 
     # Fix for Scalars
     if isinstance(left_arr, data.Scalar):
@@ -104,6 +104,40 @@ def _array_array_where(visitor: ProgramVisitor,
                     generated_nodes.add(n2)
             state.add_edge(n2, None, tasklet, '__in2', Memlet.from_array(right_operand, right_arr))
         state.add_edge(tasklet, '__out', n3, None, Memlet.from_array(out_operand, out_arr))
+    elif (left_arr is not None and right_arr is not None and left_cast is None and right_cast is None
+          and list(cond_out_shape) == list(out_shape)):
+        # A per-element select IS Fortran ``MERGE``, so hand the whole thing to the library node
+        # and let its expansion do the broadcasting -- that keeps one implementation of the select
+        # for both frontends and leaves the choice of lowering (vectorised, GPU, a vendor call) to
+        # whoever picks the node's implementation later.
+        #
+        # Restricted to the case the node can express exactly: three real arrays, no cast to insert
+        # (the node's tasklet assigns straight across and has nowhere to put one), and a condition
+        # that broadcasts into the result rather than widening it.
+        from dace.libraries.standard.nodes import MergeLibraryNode  # Avoid import loop
+
+        node = MergeLibraryNode('_where_')
+        state.add_node(node)
+        n_cond = state.add_read(cond_operand)
+        n_left = left_operand_node if left_operand_node else state.add_read(left_operand)
+        n_right = right_operand_node if right_operand_node else state.add_read(right_operand)
+        n_out = state.add_write(out_operand)
+        state.add_edge(n_left, None, node, MergeLibraryNode.TRUE_CONNECTOR_NAME,
+                       Memlet.from_array(left_operand, left_arr))
+        state.add_edge(n_right, None, node, MergeLibraryNode.FALSE_CONNECTOR_NAME,
+                       Memlet.from_array(right_operand, right_arr))
+        state.add_edge(n_cond, None, node, MergeLibraryNode.MASK_CONNECTOR_NAME,
+                       Memlet.from_array(cond_operand, cond_arr))
+        state.add_edge(node, MergeLibraryNode.OUTPUT_CONNECTOR_NAME, n_out, None,
+                       Memlet.from_array(out_operand, out_arr))
+        if generated_nodes is not None:
+            generated_nodes.add(node)
+            generated_nodes.add(n_cond)
+            generated_nodes.add(n_out)
+            if not left_operand_node:
+                generated_nodes.add(n_left)
+            if not right_operand_node:
+                generated_nodes.add(n_right)
     else:
         inputs = {}
         inputs['__incond'] = Memlet.simple(cond_operand, cond_idx)

--- a/dace/libraries/standard/nodes/__init__.py
+++ b/dace/libraries/standard/nodes/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+from .broadcast import Broadcast
 from .code import CodeLibraryNode
+from .merge_node import MergeLibraryNode
 from .gearbox import Gearbox
 from .reduce import Reduce

--- a/dace/libraries/standard/nodes/broadcast.py
+++ b/dace/libraries/standard/nodes/broadcast.py
@@ -1,0 +1,146 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""``Broadcast`` library node -- Fortran ``SPREAD`` and NumPy ``broadcast_to``.
+
+Two spellings of one replication, picked by ``dim``:
+
+* ``dim`` an integer -- Fortran ``SPREAD(SOURCE, DIM, NCOPIES)``: insert a new axis at
+  position ``DIM`` (1-based) of size ``NCOPIES`` and replicate ``SOURCE`` along it.  The
+  result is rank ``rank(SOURCE) + 1``, and the source uses the other output axes
+  positionally.
+* ``dim`` ``None`` -- NumPy ``broadcast_to``: right-align the source's axes against the
+  result's, stretch every source axis of extent 1 across the result axis it lines up
+  with, and leave the leading result axes to be filled by the source entire.  This is
+  the general case; SPREAD is only the shape it cannot say, because inserting an axis in
+  the MIDDLE is not a right-aligned stretch.
+
+Pure expansion: a single Map writes the broadcasted output in parallel, one tasklet per
+output element reading the source position the rule above gives it.  DaCe's scheduler
+picks the OpenMP / GPU lowering for the Map.
+"""
+import dace
+import dace.library
+import dace.properties
+import dace.sdfg.nodes
+from dace import SDFG, SDFGState, memlet as mm, symbolic
+from dace.frontend.common import op_repository as oprepo
+from dace.transformation.transformation import ExpandTransformation
+
+
+@dace.library.expansion
+class ExpandBroadcastPure(ExpandTransformation):
+    """Pure expansion -- a Map writing each output position from the matching source element."""
+
+    environments = []
+
+    @staticmethod
+    def expansion(node, parent_state, parent_sdfg, **kwargs):
+        desc_src, desc_dst, dim_zero = node.validate(parent_sdfg, parent_state)
+        dtype = desc_src.dtype.base_type
+        src_shape = list(desc_src.shape)
+        dst_shape = list(desc_dst.shape)
+        out_rank = len(dst_shape)
+
+        sdfg = dace.SDFG(node.label + "_sdfg")
+        sdfg.add_array("_src", src_shape, dtype)
+        sdfg.add_array("_dst", dst_shape, dtype)
+
+        state = sdfg.add_state()
+        map_rng = {f"__o{d}": f"0:{dst_shape[d]}" for d in range(out_rank)}
+        if dim_zero is None:
+            # NumPy: right-align, and read a source axis of extent 1 at 0 for every
+            # iteration of the result axis it lines up with.
+            offset = out_rank - len(src_shape)
+            src_subs = ["0" if extent == 1 else f"__o{offset + k}" for k, extent in enumerate(src_shape)]
+        else:
+            # SPREAD: skip the inserted axis -- the source is rank ``out_rank - 1`` and uses
+            # the OTHER output iterators positionally.
+            src_subs = [f"__o{d}" for d in range(out_rank) if d != dim_zero]
+        if not src_subs:  # rank-0 source -> length-1 broadcast over the new axis
+            src_subs = ["0"]
+        src_sub = ", ".join(src_subs)
+        dst_sub = ", ".join([f"__o{d}" for d in range(out_rank)])
+        state.add_mapped_tasklet(
+            name="_broadcast",
+            map_ranges=map_rng,
+            inputs={"__in": dace.Memlet(f"_src[{src_sub}]")},
+            code="__out = __in",
+            outputs={"__out": dace.Memlet(f"_dst[{dst_sub}]")},
+            external_edges=True,
+        )
+        return sdfg
+
+
+@dace.library.node
+class Broadcast(dace.sdfg.nodes.LibraryNode):
+    """Replicate a source array across the destination's shape.
+
+    * ``dim`` an integer  --  Fortran ``SPREAD``: the 1-based axis into which the new
+      replicated dimension is inserted.  ``rank(dst)`` must be ``rank(src) + 1``, and
+      ``NCOPIES`` is read off the destination descriptor, so there is no separate
+      property for it.
+    * ``dim`` ``None``  --  NumPy ``broadcast_to``: right-align and stretch, for any
+      ``rank(dst) >= rank(src)``.
+
+    ``dim`` defaults to ``1`` so an unqualified node keeps meaning SPREAD.
+    """
+
+    implementations = {"pure": ExpandBroadcastPure}
+    default_implementation = "pure"
+
+    dim = dace.properties.Property(dtype=int,
+                                   default=1,
+                                   allow_none=True,
+                                   desc="Fortran 1-based axis position of the new replicated dimension, or "
+                                   "None for a right-aligned NumPy broadcast.")
+
+    def __init__(self, name, *, dim=1, **kwargs):
+        super().__init__(name, inputs={"_src"}, outputs={"_dst"}, **kwargs)
+        self.dim = dim
+
+    def validate(self, sdfg, state):
+        """:returns: ``(desc_src, desc_dst, dim_zero)``, ``dim_zero`` being the 0-based
+            insert position, or ``None`` for the right-aligned NumPy broadcast.
+
+        :raises ValueError: if the shapes cannot broadcast under the selected rule.
+        """
+        in_edges = state.in_edges(self)
+        out_edges = state.out_edges(self)
+        if len(in_edges) != 1 or in_edges[0].dst_conn != "_src":
+            raise ValueError("Broadcast requires a `_src` input")
+        if len(out_edges) != 1 or out_edges[0].src_conn != "_dst":
+            raise ValueError("Broadcast requires a `_dst` output")
+        desc_src = sdfg.arrays[in_edges[0].data.data]
+        desc_dst = sdfg.arrays[out_edges[0].data.data]
+        src_rank = len(desc_src.shape)
+        dst_rank = len(desc_dst.shape)
+        if self.dim is None:
+            if dst_rank < src_rank:
+                raise ValueError(f"Broadcast: dst rank must be at least the src rank; "
+                                 f"got src={src_rank}, dst={dst_rank}")
+            offset = dst_rank - src_rank
+            for k, extent in enumerate(desc_src.shape):
+                if extent == 1:
+                    continue
+                # Tri-state: only an answer of False is a proven mismatch. Symbolic extents that
+                # cannot be decided here are left to the caller, as everywhere else in DaCe.
+                if symbolic.equal(extent, desc_dst.shape[offset + k]) is False:
+                    raise ValueError(f"Broadcast: src axis {k} has extent {extent}, which neither is 1 "
+                                     f"nor matches dst axis {offset + k} ({desc_dst.shape[offset + k]})")
+            return desc_src, desc_dst, None
+        if dst_rank != src_rank + 1:
+            raise ValueError(f"Broadcast: dst rank must be src rank + 1; got src={src_rank}, dst={dst_rank}")
+        if not (1 <= self.dim <= dst_rank):
+            raise ValueError(f"Broadcast: dim={self.dim} out of range for dst rank-{dst_rank}")
+        return desc_src, desc_dst, self.dim - 1
+
+
+@oprepo.replaces('dace.libraries.standard.broadcast')
+@oprepo.replaces('dace.libraries.standard.Broadcast')
+def broadcast_libnode(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, src, dst, *, dim=1):
+    src_in = state.add_read(src)
+    dst_w = state.add_write(dst)
+    node = Broadcast("broadcast", dim=dim)
+    state.add_node(node)
+    state.add_edge(src_in, None, node, '_src', mm.Memlet(src))
+    state.add_edge(node, '_dst', dst_w, None, mm.Memlet(dst))
+    return []

--- a/dace/libraries/standard/nodes/merge_node.py
+++ b/dace/libraries/standard/nodes/merge_node.py
@@ -1,0 +1,144 @@
+"""``MergeLibraryNode`` — Fortran ``MERGE(tsource, fsource, mask)`` intrinsic.
+
+Mirrors the modularity pattern of ``CopyLibraryNode`` /
+``FillLibraryNode``: the bridge / frontend can drop a ``MergeLibraryNode``
+into the SDFG instead of inlining a per-element conditional tasklet, so
+later passes (vectorisation, GPU offload, alternative backends) can pick
+their own expansion without touching the surrounding graph.
+
+Per-element semantics: ``_out[i] = _t[i] if _mask[i] else _f[i]`` -- the
+same operation as a per-element if-then-else (ITE) and as NumPy's
+``np.where(mask, t, f)``, only with the operands named after the Fortran
+intrinsic.  A frontend that has one of those spellings wants this node.
+
+Every operand -- ``_t``, ``_f``, ``_mask`` alike -- is broadcast against the result
+by the NumPy rule: right-align the axes, and read an operand axis of extent 1 at
+index ``0`` for every iteration of the result axis it lines up with.  That covers
+Fortran's all-array and scalar-broadcast ``MERGE`` variants and NumPy's partial
+broadcasts (a ``(N, 1)`` operand against an ``(N, M)`` result) in one rule.  Each
+operand's shape comes from ITS OWN memlet subset, so the caller says which variant it
+means by the memlet it wires, not by a flag.
+
+Today only the ``pure`` expansion is provided (a mapped tasklet); GPU /
+CPU-vectorised expansions slot in the same way ``CopyLibraryNode``'s
+storage-aware variants do.
+"""
+import dace
+from dace import library, nodes
+from dace.transformation.transformation import ExpandTransformation
+
+# Outer connector names this libnode publishes. Republished as
+# ``MergeLibraryNode.{TRUE,FALSE,MASK,OUTPUT}_CONNECTOR_NAME`` so
+# external consumers reference class constants instead of string
+# literals (mirrors ``copy`` / ``fill``).
+_TRUE_CONNECTOR_NAME = "_mrg_t"
+_FALSE_CONNECTOR_NAME = "_mrg_f"
+_MASK_CONNECTOR_NAME = "_mrg_mask"
+_OUTPUT_CONNECTOR_NAME = "_mrg_out"
+
+
+@library.expansion
+class ExpandPure(ExpandTransformation):
+    """Pure SDFG expansion — one mapped tasklet doing the per-element select.
+
+    Each input keeps its OWN shape on the inner SDFG and is indexed by NumPy
+    broadcasting against the iteration space: axes right-align, an operand axis of
+    extent 1 is read at index ``0`` for every iteration of the matching output axis,
+    and any other axis is read at that axis' iterator.  A Fortran scalar dummy is the
+    degenerate rank-1 case of the same rule, so ``MERGE`` broadcast operands and
+    ``np.where`` partial broadcasts go through one code path.
+    """
+    environments = []
+
+    @staticmethod
+    def expansion(node, parent_state: dace.SDFGState, parent_sdfg: dace.SDFG):
+        t_oe, f_oe, m_oe, out_oe = node.validate(parent_sdfg, parent_state)
+        # Iteration shape = the output's subset (the result shape).
+        out_subset = out_oe.data.subset
+        out_arr = parent_sdfg.arrays[out_oe.data.data]
+        iter_shape = [dace.symbolic.int_floor(e + 1 - b, s) for (b, e, s) in out_subset]
+        params = [f"__i{i}" for i in range(len(iter_shape))]
+        rng = {p: f"0:{s}" for p, s in zip(params, iter_shape)}
+        full_idx = ", ".join(params)
+
+        sdfg = dace.SDFG(f"{node.label}_sdfg")
+
+        # Per-input descriptor + access expression.  The connector mirrors the operand's
+        # own subset shape and strides -- it is a view onto the caller's buffer, so
+        # assuming the iteration shape or a packed C layout would read a Fortran-layout,
+        # sliced or broadcast operand at the wrong addresses.  The index expression is
+        # what applies the broadcast, one axis at a time.
+        def add_input(conn: str, edge):
+            arr = parent_sdfg.arrays[edge.data.data]
+            shape = list(edge.data.subset.size())
+            if len(shape) > len(iter_shape):
+                raise ValueError(f"{node.label}: operand on {conn} has rank {len(shape)}, above the "
+                                 f"rank-{len(iter_shape)} result; it cannot broadcast")
+            sdfg.add_array(conn, shape, arr.dtype, arr.storage, strides=arr.strides)
+            # Right-align the operand's axes against the result's, NumPy style.
+            offset = len(iter_shape) - len(shape)
+            idx = ["0" if extent == 1 else params[offset + k] for k, extent in enumerate(shape)]
+            return ", ".join(idx)
+
+        t_idx = add_input(_TRUE_CONNECTOR_NAME, t_oe)
+        f_idx = add_input(_FALSE_CONNECTOR_NAME, f_oe)
+        m_idx = add_input(_MASK_CONNECTOR_NAME, m_oe)
+        sdfg.add_array(_OUTPUT_CONNECTOR_NAME, iter_shape, out_arr.dtype, out_arr.storage, strides=out_arr.strides)
+
+        state = sdfg.add_state(f"{node.label}_state")
+        state.add_mapped_tasklet(
+            f"{node.label}_tasklet",
+            rng,
+            inputs={
+                "_in_t": dace.memlet.Memlet(f"{_TRUE_CONNECTOR_NAME}[{t_idx}]"),
+                "_in_f": dace.memlet.Memlet(f"{_FALSE_CONNECTOR_NAME}[{f_idx}]"),
+                "_in_mask": dace.memlet.Memlet(f"{_MASK_CONNECTOR_NAME}[{m_idx}]"),
+            },
+            code="_out_v = (_in_t if _in_mask else _in_f)",
+            outputs={"_out_v": dace.memlet.Memlet(f"{_OUTPUT_CONNECTOR_NAME}[{full_idx}]")},
+            external_edges=True,
+        )
+        return sdfg
+
+
+@library.node
+class MergeLibraryNode(nodes.LibraryNode):
+    """Library node for the per-element select: Fortran
+    ``MERGE(tsource, fsource, mask)``, NumPy ``where(mask, t, f)``, and the
+    element-wise if-then-else generally.
+
+    Inputs ``_t``, ``_f``, ``_mask``; output ``_out``.  Each input is broadcast
+    against the result shape by the NumPy rule; see :class:`ExpandPure`.
+    """
+
+    implementations = {"pure": ExpandPure}
+    default_implementation = "pure"
+
+    # Connector names this libnode publishes. External consumers (tests,
+    # the Fortran frontend's emitter) must reference these constants
+    # instead of string literals so a future rename is a single-line
+    # change (mirrors ``CopyLibraryNode`` / ``FillLibraryNode``).
+    TRUE_CONNECTOR_NAME = _TRUE_CONNECTOR_NAME
+    FALSE_CONNECTOR_NAME = _FALSE_CONNECTOR_NAME
+    MASK_CONNECTOR_NAME = _MASK_CONNECTOR_NAME
+    OUTPUT_CONNECTOR_NAME = _OUTPUT_CONNECTOR_NAME
+
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(name,
+                         *args,
+                         inputs={_TRUE_CONNECTOR_NAME, _FALSE_CONNECTOR_NAME, _MASK_CONNECTOR_NAME},
+                         outputs={_OUTPUT_CONNECTOR_NAME},
+                         **kwargs)
+
+    def validate(self, sdfg, state):
+        """Return the four edge descriptors after asserting the expected
+        connector layout.  Each connector takes exactly one edge."""
+        t_es = [ie for ie in state.in_edges(self) if ie.dst_conn == _TRUE_CONNECTOR_NAME]
+        f_es = [ie for ie in state.in_edges(self) if ie.dst_conn == _FALSE_CONNECTOR_NAME]
+        m_es = [ie for ie in state.in_edges(self) if ie.dst_conn == _MASK_CONNECTOR_NAME]
+        o_es = [oe for oe in state.out_edges(self) if oe.src_conn == _OUTPUT_CONNECTOR_NAME]
+        if len(t_es) != 1 or len(f_es) != 1 or len(m_es) != 1 or len(o_es) != 1:
+            raise ValueError(f"{type(self).__name__} expects exactly one edge per connector "
+                             f"({_TRUE_CONNECTOR_NAME}, {_FALSE_CONNECTOR_NAME}, "
+                             f"{_MASK_CONNECTOR_NAME}, {_OUTPUT_CONNECTOR_NAME})")
+        return t_es[0], f_es[0], m_es[0], o_es[0]

--- a/tests/library/broadcast_test.py
+++ b/tests/library/broadcast_test.py
@@ -1,0 +1,90 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Correctness tests for the :class:`Broadcast` library node -- Fortran ``SPREAD`` and the
+right-aligned NumPy rule behind ``np.broadcast_to``."""
+import numpy as np
+import pytest
+
+import dace
+from dace.libraries.standard.nodes import Broadcast
+
+
+def _build(src_shape, dst_shape, dim, dtype):
+    sdfg = dace.SDFG(f"broadcast_{dim}")
+    sdfg.add_array("src", list(src_shape), dtype)
+    sdfg.add_array("dst", list(dst_shape), dtype)
+    state = sdfg.add_state()
+    node = Broadcast("broadcast", dim=dim)
+    state.add_node(node)
+    state.add_edge(state.add_read("src"), None, node, '_src', dace.Memlet.from_array("src", sdfg.arrays["src"]))
+    state.add_edge(node, '_dst', state.add_write("dst"), None, dace.Memlet.from_array("dst", sdfg.arrays["dst"]))
+    sdfg.expand_library_nodes()
+    return sdfg
+
+
+def test_broadcast_1d_to_2d_dim1():
+    """SPREAD([1,2,3], DIM=1, NCOPIES=2) -> [[1,2,3], [1,2,3]]."""
+    src = np.array([1.0, 2.0, 3.0])
+    dst = np.zeros((2, 3))
+    sdfg = _build(src.shape, dst.shape, 1, dace.float64)
+    sdfg(src=src, dst=dst)
+    np.testing.assert_array_equal(dst, np.broadcast_to(src, (2, 3)))
+
+
+def test_broadcast_1d_to_2d_dim2():
+    """SPREAD([1,2,3], DIM=2, NCOPIES=4) -> each entry replicated columnwise."""
+    src = np.array([1.0, 2.0, 3.0])
+    dst = np.zeros((3, 4))
+    sdfg = _build(src.shape, dst.shape, 2, dace.float64)
+    sdfg(src=src, dst=dst)
+    expected = np.broadcast_to(src.reshape(3, 1), (3, 4))
+    np.testing.assert_array_equal(dst, expected)
+
+
+@pytest.mark.parametrize('src_shape,dst_shape', [
+    ((3, ), (2, 3)),
+    ((3, 1), (3, 4)),
+    ((1, 4), (3, 4)),
+    ((1, ), (2, 5)),
+    ((2, 3), (4, 2, 3)),
+])
+def test_broadcast_numpy_rule(src_shape, dst_shape):
+    """``dim=None`` must agree with NumPy on every shape NumPy accepts -- including the two
+    SPREAD cannot say: stretching an existing extent-1 axis, and adding more than one axis."""
+    src = np.arange(np.prod(src_shape), dtype=np.float64).reshape(src_shape).copy()
+    dst = np.zeros(dst_shape)
+    sdfg = _build(src_shape, dst_shape, None, dace.float64)
+    sdfg(src=src, dst=dst)
+    np.testing.assert_array_equal(dst, np.broadcast_to(src, dst_shape))
+
+
+def test_broadcast_numpy_rule_rejects_a_mismatch():
+    """A source axis that is neither 1 nor equal to the destination's cannot broadcast; catching
+    it in validate() is what keeps the expansion from emitting an out-of-bounds read."""
+    with pytest.raises(ValueError, match='neither is 1'):
+        _build((3, ), (2, 5), None, dace.float64)
+
+
+def test_broadcast_to_frontend():
+    """``np.broadcast_to`` in a dace.program must reach the library node and match NumPy."""
+
+    @dace.program
+    def bcast(a: dace.float64[3, 1], out: dace.float64[3, 4]):
+        out[:] = np.broadcast_to(a, (3, 4))
+
+    sdfg = bcast.to_sdfg(simplify=False)
+    assert len([n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, Broadcast)]) == 1
+
+    a = np.random.randn(3, 1)
+    out = np.zeros((3, 4))
+    bcast(a=a, out=out)
+    np.testing.assert_array_equal(out, np.broadcast_to(a, (3, 4)))
+
+
+if __name__ == '__main__':
+    test_broadcast_1d_to_2d_dim1()
+    test_broadcast_1d_to_2d_dim2()
+    for shapes in [((3, ), (2, 3)), ((3, 1), (3, 4)), ((1, 4), (3, 4)), ((1, ), (2, 5)), ((2, 3), (4, 2, 3))]:
+        test_broadcast_numpy_rule(*shapes)
+    test_broadcast_numpy_rule_rejects_a_mismatch()
+    test_broadcast_to_frontend()
+    print('Broadcast tests PASS')

--- a/tests/library/merge_node_test.py
+++ b/tests/library/merge_node_test.py
@@ -1,0 +1,278 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""
+Tests for ``MergeLibraryNode`` and its expansion — exercises every
+supported variant in isolation so the library node's contract is pinned
+independently of any frontend wiring.
+
+Variants follow the Fortran ``MERGE(tsource, fsource, mask)`` shapes;
+each test documents one desired-behaviour case.
+
+  * **V1 — all scalar** (``MERGE(t, f, mask_scalar)``):
+    Each operand is a single value → result is a single value.
+    Degenerate, but the node accepts it via length-1 input arrays.
+  * **V2 — all-array** (``MERGE(t_arr, f_arr, mask_arr)``):
+    Per-element select; all four cover the same shape.
+  * **V3 — broadcast both scalars** (``MERGE(t_scalar, f_scalar,
+    mask_arr)``):
+    Each output element picks one of two scalars via the mask array.
+    Both ``_t`` and ``_f`` arrive as length-1 inputs; ``_mask`` and
+    ``_out`` are full arrays.  The expansion broadcasts the scalars
+    by indexing them as ``[0]`` per iteration.
+  * **V4 — t scalar, f array** (``MERGE(t_scalar, f_arr, mask_arr)``):
+    Asymmetric broadcast — ``_t`` is broadcast, ``_f`` per-element.
+  * **V5 — t array, f scalar** (``MERGE(t_arr, f_scalar, mask_arr)``):
+    Mirror of V4 — ``_f`` broadcast, ``_t`` per-element.
+"""
+import ctypes
+
+import dace
+from dace.libraries.standard.nodes import MergeLibraryNode
+
+import numpy as np
+
+try:
+    ctypes.CDLL("libgomp.so.1", ctypes.RTLD_GLOBAL)
+except OSError:
+    pass
+
+
+def _build_merge_sdfg(name_tag: str, t_shape, f_shape, m_shape, out_shape, strides=None):
+    """Build a one-state SDFG that wires a MergeLibraryNode for the
+    given operand shapes.  Each input is wired with a memlet covering
+    its full descriptor; the expansion picks broadcast vs per-element
+    behaviour based on the memlet subset's volume.  ``strides`` gives
+    every operand a non-default layout; ``None`` leaves them packed."""
+    sdfg = dace.SDFG(f"merge_{name_tag}")
+    sdfg.add_array("t", t_shape, dace.float64, transient=False, strides=strides)
+    sdfg.add_array("f", f_shape, dace.float64, transient=False, strides=strides)
+    sdfg.add_array("mask", m_shape, dace.int32, transient=False, strides=strides)
+    sdfg.add_array("out", out_shape, dace.float64, transient=False, strides=strides)
+    state = sdfg.add_state("merge_state")
+
+    node = MergeLibraryNode("merge_main")
+    state.add_node(node)
+    t_in = state.add_access("t")
+    f_in = state.add_access("f")
+    m_in = state.add_access("mask")
+    out_w = state.add_access("out")
+
+    state.add_edge(t_in, None, node, MergeLibraryNode.TRUE_CONNECTOR_NAME,
+                   dace.Memlet(f"t[{', '.join(f'0:{s}' for s in t_shape)}]"))
+    state.add_edge(f_in, None, node, MergeLibraryNode.FALSE_CONNECTOR_NAME,
+                   dace.Memlet(f"f[{', '.join(f'0:{s}' for s in f_shape)}]"))
+    state.add_edge(m_in, None, node, MergeLibraryNode.MASK_CONNECTOR_NAME,
+                   dace.Memlet(f"mask[{', '.join(f'0:{s}' for s in m_shape)}]"))
+    state.add_edge(node, MergeLibraryNode.OUTPUT_CONNECTOR_NAME, out_w, None,
+                   dace.Memlet(f"out[{', '.join(f'0:{s}' for s in out_shape)}]"))
+    sdfg.validate()
+    return sdfg
+
+
+# ---------------------------------------------------------------------------
+# V1 — all scalar
+# ---------------------------------------------------------------------------
+
+
+def test_v1_all_scalar():
+    """``MERGE(t, f, mask)`` with t, f, mask, out each length-1.
+    Degenerate variant; result picks t or f by the single mask bit."""
+    sdfg = _build_merge_sdfg("v1_scalar", [1], [1], [1], [1])
+    for mask_val, expected in [(1, 7.5), (0, -3.25)]:
+        t = np.array([7.5], dtype=np.float64)
+        f = np.array([-3.25], dtype=np.float64)
+        mask = np.array([mask_val], dtype=np.int32)
+        out = np.zeros(1, dtype=np.float64)
+        sdfg(t=t, f=f, mask=mask, out=out)
+        assert float(out[0]) == expected
+
+
+# ---------------------------------------------------------------------------
+# V2 — all-array
+# ---------------------------------------------------------------------------
+
+
+def test_v2_all_array_pointwise():
+    """``MERGE(t_arr, f_arr, mask_arr)`` — pointwise select, all same
+    shape.  The common case.  Result is per-element ``np.where``."""
+    n = 16
+    sdfg = _build_merge_sdfg("v2_array", [n], [n], [n], [n])
+
+    rng = np.random.default_rng(0)
+    t = rng.standard_normal(n, dtype=np.float64)
+    f = rng.standard_normal(n, dtype=np.float64)
+    mask = (rng.random(n) > 0.5).astype(np.int32)
+    out = np.zeros(n, dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    np.testing.assert_array_equal(out, np.where(mask.astype(bool), t, f))
+
+
+def _provenance_report(got, expected, **operands) -> str:
+    """Every wrong cell, and WHERE its value came from.
+
+    A wrong result is either a value the kernel had no business reading -- so the read address is
+    off -- or a write that never happened, leaving the caller's zero. Naming the operand and index
+    each wrong value actually occupies separates those two, which the default
+    ``assert_array_equal`` message cannot: it prints five indices and truncates the arrays.
+    """
+    lines = [f'{np.count_nonzero(got != expected)} / {got.size} cells wrong']
+    for idx in zip(*np.nonzero(got != expected)):
+        value = got[idx]
+        source = 'never written (still the caller zero)' if value == 0 else 'not in any operand'
+        for oname, operand in operands.items():
+            where = np.nonzero(operand == value)
+            if where[0].size:
+                source = f'{oname}{tuple(int(c[0]) for c in where)}'
+                break
+        lines.append(f'  out{tuple(int(i) for i in idx)} = {value!r} <- {source}, wanted {expected[idx]!r}')
+    return '\n'.join(lines)
+
+
+def test_v2_all_array_2d():
+    """``MERGE`` on a 2-D pointwise shape — verifies the iteration
+    domain matches the output's shape across rank > 1."""
+    n, m = 6, 8
+    sdfg = _build_merge_sdfg("v2_2d", [n, m], [n, m], [n, m], [n, m])
+
+    rng = np.random.default_rng(1)
+    t = rng.standard_normal((n, m), dtype=np.float64)
+    f = rng.standard_normal((n, m), dtype=np.float64)
+    mask = (rng.random((n, m)) > 0.5).astype(np.int32)
+    out = np.zeros((n, m), dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    expected = np.where(mask.astype(bool), t, f)
+    assert np.array_equal(out, expected), _provenance_report(out, expected, t=t, f=f)
+
+
+# ---------------------------------------------------------------------------
+# V3 — both sources scalar, mask array (scalar-broadcast)
+# ---------------------------------------------------------------------------
+
+
+def test_v3_both_scalars_array_mask():
+    """``MERGE(t_scalar, f_scalar, mask_arr)`` — both ``_t`` and ``_f``
+    are length-1; the expansion's per-input broadcast detection makes
+    each iteration read element ``[0]`` of the scalar inputs."""
+    n = 10
+    sdfg = _build_merge_sdfg("v3", [1], [1], [n], [n])
+
+    t = np.array([42.0], dtype=np.float64)
+    f = np.array([-1.5], dtype=np.float64)
+    mask = np.array([1, 0, 1, 1, 0, 1, 0, 0, 1, 1], dtype=np.int32)
+    out = np.zeros(n, dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    expected = np.where(mask.astype(bool), 42.0, -1.5)
+    np.testing.assert_array_equal(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# V4 — t scalar, f array, mask array
+# ---------------------------------------------------------------------------
+
+
+def test_v4_t_scalar_f_array():
+    """``MERGE(t_scalar, f_arr, mask_arr)`` — only ``_t`` broadcasts;
+    ``_f`` and ``_mask`` are per-element."""
+    n = 12
+    sdfg = _build_merge_sdfg("v4", [1], [n], [n], [n])
+
+    t = np.array([99.0], dtype=np.float64)
+    rng = np.random.default_rng(2)
+    f = rng.standard_normal(n, dtype=np.float64)
+    mask = (rng.random(n) > 0.5).astype(np.int32)
+    out = np.zeros(n, dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    expected = np.where(mask.astype(bool), 99.0, f)
+    np.testing.assert_array_equal(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# V5 — t array, f scalar, mask array
+# ---------------------------------------------------------------------------
+
+
+def test_v5_t_array_f_scalar():
+    """Mirror of V4 — only ``_f`` broadcasts; ``_t`` and ``_mask`` are
+    per-element."""
+    n = 14
+    sdfg = _build_merge_sdfg("v5", [n], [1], [n], [n])
+
+    rng = np.random.default_rng(3)
+    t = rng.standard_normal(n, dtype=np.float64)
+    f = np.array([-7.0], dtype=np.float64)
+    mask = (rng.random(n) > 0.5).astype(np.int32)
+    out = np.zeros(n, dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    expected = np.where(mask.astype(bool), t, -7.0)
+    np.testing.assert_array_equal(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# Operand layout — descriptors that are not packed C
+# ---------------------------------------------------------------------------
+
+
+def test_fortran_layout_operands():
+    """Every operand is Fortran-strided.  Each connector on the expanded
+    SDFG is a view onto the caller's buffer, so it has to carry that
+    operand's own strides — assuming a packed C layout reads the wrong
+    addresses and the select returns other elements' values."""
+    n, m = 6, 8
+    fstrides = (1, n)
+    sdfg = _build_merge_sdfg("fortran_2d", [n, m], [n, m], [n, m], [n, m], strides=fstrides)
+
+    state = sdfg.states()[0]
+    node = next(nd for nd in state.nodes() if isinstance(nd, MergeLibraryNode))
+    node.expand(state)
+    inner = next(nd.sdfg for nd in state.nodes() if isinstance(nd, dace.nodes.NestedSDFG))
+    for conn in (MergeLibraryNode.TRUE_CONNECTOR_NAME, MergeLibraryNode.FALSE_CONNECTOR_NAME,
+                 MergeLibraryNode.MASK_CONNECTOR_NAME, MergeLibraryNode.OUTPUT_CONNECTOR_NAME):
+        assert tuple(inner.arrays[conn].strides) == fstrides, \
+            f"connector '{conn}' dropped the operand layout: {tuple(inner.arrays[conn].strides)} != {fstrides}"
+
+    rng = np.random.default_rng(1)
+    t = np.asfortranarray(rng.standard_normal((n, m), dtype=np.float64))
+    f = np.asfortranarray(rng.standard_normal((n, m), dtype=np.float64))
+    mask = np.asfortranarray((rng.random((n, m)) > 0.5).astype(np.int32))
+    out = np.zeros((n, m), order="F", dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    np.testing.assert_array_equal(out, np.where(mask.astype(bool), t, f))
+
+
+def test_fortran_layout_scalar_broadcast():
+    """Fortran-strided array operands alongside a length-1 one: the
+    broadcast operand stays a scalar view while the array operands keep
+    their own strides."""
+    n, m = 5, 7
+    fstrides = (1, n)
+    sdfg = dace.SDFG("merge_fortran_bcast")
+    sdfg.add_array("t", [1], dace.float64, transient=False)
+    sdfg.add_array("f", [n, m], dace.float64, transient=False, strides=fstrides)
+    sdfg.add_array("mask", [n, m], dace.int32, transient=False, strides=fstrides)
+    sdfg.add_array("out", [n, m], dace.float64, transient=False, strides=fstrides)
+    state = sdfg.add_state("merge_state")
+    node = MergeLibraryNode("merge_main")
+    state.add_node(node)
+    state.add_edge(state.add_access("t"), None, node, MergeLibraryNode.TRUE_CONNECTOR_NAME, dace.Memlet("t[0:1]"))
+    state.add_edge(state.add_access("f"), None, node, MergeLibraryNode.FALSE_CONNECTOR_NAME,
+                   dace.Memlet(f"f[0:{n}, 0:{m}]"))
+    state.add_edge(state.add_access("mask"), None, node, MergeLibraryNode.MASK_CONNECTOR_NAME,
+                   dace.Memlet(f"mask[0:{n}, 0:{m}]"))
+    state.add_edge(node, MergeLibraryNode.OUTPUT_CONNECTOR_NAME, state.add_access("out"), None,
+                   dace.Memlet(f"out[0:{n}, 0:{m}]"))
+    sdfg.validate()
+
+    node.expand(state)
+    inner = next(nd.sdfg for nd in state.nodes() if isinstance(nd, dace.nodes.NestedSDFG))
+    assert tuple(inner.arrays[MergeLibraryNode.TRUE_CONNECTOR_NAME].shape) == (1, )
+    for conn in (MergeLibraryNode.FALSE_CONNECTOR_NAME, MergeLibraryNode.MASK_CONNECTOR_NAME,
+                 MergeLibraryNode.OUTPUT_CONNECTOR_NAME):
+        assert tuple(inner.arrays[conn].strides) == fstrides, \
+            f"connector '{conn}' dropped the operand layout: {tuple(inner.arrays[conn].strides)} != {fstrides}"
+
+    rng = np.random.default_rng(4)
+    t = np.array([13.5], dtype=np.float64)
+    f = np.asfortranarray(rng.standard_normal((n, m), dtype=np.float64))
+    mask = np.asfortranarray((rng.random((n, m)) > 0.5).astype(np.int32))
+    out = np.zeros((n, m), order="F", dtype=np.float64)
+    sdfg(t=t, f=f, mask=mask, out=out)
+    np.testing.assert_array_equal(out, np.where(mask.astype(bool), 13.5, f))

--- a/tests/numpy/searching_test.py
+++ b/tests/numpy/searching_test.py
@@ -29,6 +29,60 @@ def test_numpy_select():
         assert (np.allclose(numpy_where(A, B, C), np.select([A > 0.5, B > 0.5, C > 0.5], [A, B, C], 0.0)))
 
 
+def test_numpy_where_uses_the_merge_library_node():
+    """ Three real arrays and no cast is exactly what MergeLibraryNode expresses, so the
+        frontend must hand that case to the node rather than inline a tasklet -- otherwise
+        nothing downstream can pick a different lowering for the select. """
+    from dace.libraries.standard.nodes import MergeLibraryNode
+
+    @dace.program
+    def where_arrays(A: dace.float64[N], B: dace.float64[N], C: dace.bool_[N]):
+        return np.where(C, A, B)
+
+    sdfg = where_arrays.to_sdfg(simplify=False)
+    merges = [n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, MergeLibraryNode)]
+    assert len(merges) == 1, f'expected one MergeLibraryNode, found {len(merges)}'
+
+    A, B = np.random.randn(N), np.random.randn(N)
+    C = A > B
+    assert np.allclose(where_arrays(A, B, C), np.where(C, A, B))
+
+
+def test_numpy_where_partial_broadcast():
+    """ A (N, 1) operand against an (N, M) result: the axis of extent 1 must be read at index 0
+        for every column, not indexed by the column iterator. """
+
+    @dace.program
+    def where_partial(A: dace.float64[N, 1], B: dace.float64[N, 4], C: dace.bool_[N, 4]):
+        return np.where(C, A, B)
+
+    A = np.random.randn(N, 1)
+    B = np.random.randn(N, 4)
+    C = B > 0.0
+    assert np.allclose(where_partial(A, B, C), np.where(C, A, B))
+
+
+def test_numpy_where_cast_stays_a_tasklet():
+    """ The library node's tasklet assigns straight across, so an operand needing a cast to the
+        result type has to keep the inlined-tasklet path. """
+    from dace.libraries.standard.nodes import MergeLibraryNode
+
+    @dace.program
+    def where_mixed(A: dace.float64[N], B: dace.int32[N], C: dace.bool_[N]):
+        return np.where(C, A, B)
+
+    sdfg = where_mixed.to_sdfg(simplify=False)
+    assert not [n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, MergeLibraryNode)]
+
+    A = np.random.randn(N)
+    B = np.random.randint(-8, 8, size=N).astype(np.int32)
+    C = A > 0.0
+    assert np.allclose(where_mixed(A, B, C), np.where(C, A, B))
+
+
 if __name__ == "__main__":
     test_numpy_where()
     test_numpy_select()
+    test_numpy_where_uses_the_merge_library_node()
+    test_numpy_where_partial_broadcast()
+    test_numpy_where_cast_stays_a_tasklet()


### PR DESCRIPTION
Adds two standard library nodes -- `Broadcast` (Fortran `SPREAD` with an integer `dim`, the right-aligned NumPy rule with `dim=None`) and `MergeLibraryNode` (the per-element select: Fortran `MERGE`, `np.where`, element-wise if-then-else) -- both describing every operand by the same broadcasting rule instead of a special case. `numpy.where` hands the node the case it expresses exactly (three arrays, no cast, a condition that broadcasts into the result) and keeps the inlined tasklet otherwise, and `numpy.broadcast_to` is new.

```python
@dace.program
def k(a: dace.float64[N, 1], b: dace.float64[N, 4], c: dace.bool_[N, 4]):
    return np.where(c, a, b)     # (N, 1) operand read at column 0 for every column
```