### PR TITLE
[WIP] Derive a scope's symbol table once per scope

### DIFF
--- a/dace/data/core.py
+++ b/dace/data/core.py
@@ -129,6 +129,11 @@ class Data:
         """Returns a string for a Data-Centric Python function signature (e.g., `A: dace.int32[M]`). """
         raise NotImplementedError
 
+    #: Sources of ``free_symbols``, all tuples or sympy expressions: reassigning one is the only way
+    #: any can change, so that is what drops the memo. Structure overrides and computes fresh.
+    SYMBOL_SOURCE_ATTRIBUTES = frozenset({'_shape', '_strides', '_offset', '_total_size', '_transient', '_dtype'})
+    _free_symbols_memo = None
+
     def used_symbols(self, all_symbols: bool) -> Set[symbolic.SymbolicType]:
         """
         Returns a set of symbols that are used by this data descriptor.
@@ -148,7 +153,15 @@ class Data:
     @property
     def free_symbols(self) -> Set[symbolic.SymbolicType]:
         """ Returns a set of undefined symbols in this data descriptor. """
-        return self.used_symbols(all_symbols=True)
+        if self._free_symbols_memo is None:
+            # Frozen: the answer is shared, so one caller's edit would be every later caller's.
+            self._free_symbols_memo = frozenset(self.used_symbols(all_symbols=True))
+        return self._free_symbols_memo
+
+    def __setattr__(self, name, value):
+        if name in Data.SYMBOL_SOURCE_ATTRIBUTES:
+            object.__setattr__(self, '_free_symbols_memo', None)
+        object.__setattr__(self, name, value)
 
     def __repr__(self):
         return 'Abstract Data Container, DO NOT USE'
@@ -635,10 +648,6 @@ class Array(Data):
                 result |= set(self.total_size.free_symbols)
         return result
 
-    @property
-    def free_symbols(self):
-        return self.used_symbols(all_symbols=True)
-
     def _set_shape_dependent_properties(self, shape, strides, total_size, offset):
         """
         Used to set properties which depend on the shape of the array
@@ -928,10 +937,6 @@ class Stream(Data):
                 result |= set(o.free_symbols)
 
         return result
-
-    @property
-    def free_symbols(self):
-        return self.used_symbols(all_symbols=True)
 
 
 @make_properties

--- a/dace/sdfg/propagation.py
+++ b/dace/sdfg/propagation.py
@@ -9,7 +9,7 @@ import functools
 import itertools
 import warnings
 from collections import deque
-from typing import TYPE_CHECKING, List, Set
+from typing import TYPE_CHECKING, List, Optional, Set
 
 import sympy
 from sympy import Symbol, ceiling
@@ -1518,25 +1518,37 @@ def propagate_memlets_map_scope(sdfg: 'SDFG', state: 'SDFGState', map_entry: nod
 
 def _propagate_node(dfg_state, node):
     if isinstance(node, nodes.EntryNode):
+        entry_node = node
         internal_edges = [e for e in dfg_state.out_edges(node) if e.src_conn and e.src_conn.startswith('OUT_')]
         external_edges = [e for e in dfg_state.in_edges(node) if e.dst_conn and e.dst_conn.startswith('IN_')]
         geticonn = lambda e: e.src_conn[4:]
         geteconn = lambda e: e.dst_conn[3:]
         use_dst = False
     else:
+        entry_node = dfg_state.entry_node(node)
         internal_edges = [e for e in dfg_state.in_edges(node) if e.dst_conn and e.dst_conn.startswith('IN_')]
         external_edges = [e for e in dfg_state.out_edges(node) if e.src_conn and e.src_conn.startswith('OUT_')]
         geticonn = lambda e: e.dst_conn[3:]
         geteconn = lambda e: e.src_conn[4:]
         use_dst = True
 
+    # One table for every edge through this node -- it is one scope, and empty memlets need none.
+    defined_variables = None
+
     for edge in external_edges:
         if edge.data.is_empty():
             new_memlet = Memlet()
         else:
+            if defined_variables is None:
+                defined_variables = dfg_state.symbols_defined_at(entry_node).keys() | dfg_state.parent.constants.keys()
             internal_edge = next(e for e in internal_edges if geticonn(e) == geteconn(edge))
             aligned_memlet = align_memlet(dfg_state, internal_edge, dst=use_dst)
-            new_memlet = propagate_memlet(dfg_state, aligned_memlet, node, True, connector=geteconn(edge))
+            new_memlet = propagate_memlet(dfg_state,
+                                          aligned_memlet,
+                                          node,
+                                          True,
+                                          connector=geteconn(edge),
+                                          defined_variables=defined_variables)
         edge.data = new_memlet
 
 
@@ -1574,7 +1586,8 @@ def propagate_memlet(dfg_state,
                      scope_node: nodes.EntryNode,
                      union_inner_edges: bool,
                      arr=None,
-                     connector=None):
+                     connector=None,
+                     defined_variables: Optional[Set[str]] = None):
     """ Tries to propagate a memlet through a scope (computes the image of
         the memlet function applied on an integer set of, e.g., a map range)
         and returns a new memlet object.
@@ -1585,6 +1598,9 @@ def propagate_memlet(dfg_state,
         :param union_inner_edges: True if the propagation should take other
                                   neighboring internal memlets within the same
                                   scope into account.
+        :param defined_variables: The symbols defined at ``scope_node`` plus the SDFG's constants,
+                                  when the caller already has them. Deriving them here walks every
+                                  descriptor in the SDFG, once per memlet.
     """
     if memlet.is_empty():
         return Memlet()
@@ -1607,10 +1623,9 @@ def propagate_memlet(dfg_state,
 
     sdfg = dfg_state.parent
     scope_node_symbols = set(conn for conn in entry_node.in_connectors if not conn.startswith('IN_'))
-    defined_vars = [
-        symbolic.pystr_to_symbolic(s) for s in (dfg_state.symbols_defined_at(entry_node).keys()
-                                                | sdfg.constants.keys()) if s not in scope_node_symbols
-    ]
+    if defined_variables is None:
+        defined_variables = dfg_state.symbols_defined_at(entry_node).keys() | sdfg.constants.keys()
+    defined_vars = [symbolic.pystr_to_symbolic(s) for s in defined_variables if s not in scope_node_symbols]
 
     # Find other adjacent edges within the connected to the scope node
     # and union their subsets

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1635,7 +1635,8 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         # Start with global symbols
         symbols = collections.OrderedDict(sdfg.symbols)
         for desc in sdfg.arrays.values():
-            symbols.update([(str(s), s.dtype) for s in desc.free_symbols])
+            # ``s.name``, not ``str(s)``: printing a symbol runs sympy's printer for a string it holds.
+            symbols.update([(s.name, s.dtype) for s in desc.free_symbols])
 
         # Add symbols from inter-state edges along the path to the state
         try:
@@ -2019,11 +2020,19 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
         if len(inputs) == 0:
             self.add_edge(map_entry, None, tasklet, None, mm.Memlet())
 
+        # Every edge below propagates through one scope, so its symbols are derived once.
+        defined_variables = (self.symbols_defined_at(map_entry).keys()
+                             | self.sdfg.constants.keys()) if external_edges and propagate else None
+
         if external_edges:
             for inp, inpnode in sorted(inpdict.items()):
                 # Add external edge
                 if propagate:
-                    outer_memlet = sdprop.propagate_memlet(self, tomemlet[inp], map_entry, True)
+                    outer_memlet = sdprop.propagate_memlet(self,
+                                                           tomemlet[inp],
+                                                           map_entry,
+                                                           True,
+                                                           defined_variables=defined_variables)
                 else:
                     outer_memlet = tomemlet[inp]
                 edges.append(self.add_edge(inpnode, None, map_entry, "IN_" + inp, outer_memlet))
@@ -2054,7 +2063,11 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             for out, outnode in sorted(outdict.items()):
                 # Add external edge
                 if propagate:
-                    outer_memlet = sdprop.propagate_memlet(self, tomemlet[out], map_exit, True)
+                    outer_memlet = sdprop.propagate_memlet(self,
+                                                           tomemlet[out],
+                                                           map_exit,
+                                                           True,
+                                                           defined_variables=defined_variables)
                 else:
                     outer_memlet = tomemlet[out]
                 edges.append(self.add_edge(map_exit, "OUT_" + out, outnode, None, outer_memlet))


### PR DESCRIPTION
`symbols_defined_at` walks every descriptor in the SDFG, and `propagate_memlet` derived it once per
memlet, so building a program cost O(scopes x descriptors) sympy work -- on a 2000-line generated
kernel, 8845 walks over 2082 descriptors, 81% of a 183 s parse. Callers propagating several memlets
through one scope node now derive it once, `Data.free_symbols` is memoized behind the property
setter that is the only way its sources can change, and the descriptor scan reads `s.name` instead
of printing the symbol.

```
tests/corpus/cloudsc, build_cloudsc_sdfg(simplify=False)   -- this branch vs main
  before  872.6 s      after  800.3 s      (6342 blocks, 2687 descriptors)

warpx_field_gather (hpcagent_bench, 2000 lines), to_sdfg(simplify=False)
  before  182.6 s      after   38.4 s      (7269 blocks, 2948 descriptors)
```

The second kernel is measured on the `extended` branch: it needs a data-dependent shape main's
frontend refuses, so main cannot parse it either way.
