### PR TITLE
Keep both parts when promoting a real and a complex type

### DIFF
--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -538,6 +538,14 @@ def result_type_of(lhs, *rhs):
     if numpy.issubdtype(rhs_, numpy.integer):
         return lhs
     # Both sides are floating point numbers
+    # A complex type is not simply a wider float: half its width is the imaginary part, so its real
+    # component is only ``itemsize // 2``. Comparing byte widths alone therefore ties complex64 with
+    # float64 and lets argument order settle it -- ``result_type_of(complex64, double)`` answered
+    # ``double`` and dropped the imaginary part, while the same two the other way round answered
+    # ``complex64`` and dropped half the real precision. Where exactly one side is complex, take
+    # numpy's rule: the result is complex and wide enough for the other side's precision.
+    if numpy.issubdtype(lhs_, numpy.complexfloating) != numpy.issubdtype(rhs_, numpy.complexfloating):
+        return typeclass(numpy.promote_types(lhs_, rhs_).type)
     if size_lhs > size_rhs:
         return lhs
     return rhs  # RHS is bigger

--- a/tests/result_type_of_test.py
+++ b/tests/result_type_of_test.py
@@ -1,0 +1,55 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Type promotion in :func:`dace.dtypes.result_type_of`."""
+import functools
+import itertools
+
+import numpy as np
+import pytest
+
+import dace
+from dace import dtypes
+
+SCALARS = [
+    dace.bool_, dace.int8, dace.uint8, dace.int16, dace.uint16, dace.int32, dace.uint32, dace.int64, dace.uint64,
+    dace.float16, dace.float32, dace.float64, dace.complex64, dace.complex128
+]
+
+
+def test_result_type_of_is_commutative():
+    """Callers fold this over unordered containers, so an answer that depends on argument order is
+    an answer that depends on iteration order."""
+    for lhs, rhs in itertools.permutations(SCALARS, 2):
+        assert str(dtypes.result_type_of(lhs, rhs)) == str(dtypes.result_type_of(rhs, lhs)), \
+            f'{lhs} and {rhs} promote differently depending on the order'
+
+
+def test_result_type_of_is_order_independent_when_folded():
+    """The commutativity above is not enough on its own: a fold visits the types pairwise, so the
+    property that matters to a caller is that every permutation reaches the same type."""
+    for triple in itertools.combinations(SCALARS, 3):
+        promoted = {str(functools.reduce(dtypes.result_type_of, order)) for order in itertools.permutations(triple)}
+        assert len(promoted) == 1, f'{[str(t) for t in triple]} folds to {sorted(promoted)} depending on the order'
+
+
+@pytest.mark.parametrize('real,complex_', [(dace.float16, dace.complex64), (dace.float32, dace.complex64),
+                                           (dace.float64, dace.complex64), (dace.float64, dace.complex128),
+                                           (dace.float32, dace.complex128)])
+def test_mixing_a_float_and_a_complex_type_keeps_both_parts(real, complex_):
+    """A complex type carries its real part in HALF its width, so a byte-width comparison ties
+    complex64 with float64. That tie used to be settled by argument order: one way round the result
+    was ``double`` and the imaginary part was gone. The result must be complex, and wide enough for
+    the real side -- which is what numpy promotes these to."""
+    expected = np.promote_types(real.as_numpy_dtype(), complex_.as_numpy_dtype())
+    for got in (dtypes.result_type_of(real, complex_), dtypes.result_type_of(complex_, real)):
+        assert got.as_numpy_dtype() == expected, f'{real} with {complex_} promoted to {got}, expected {expected}'
+
+
+def test_float64_with_complex64_is_the_regression():
+    """The reported case, spelled out: neither order may answer ``double`` (imaginary part dropped)
+    nor ``complex64`` (half the real precision dropped)."""
+    assert dtypes.result_type_of(dace.float64, dace.complex64) == dace.complex128
+    assert dtypes.result_type_of(dace.complex64, dace.float64) == dace.complex128
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
`result_type_of` compared floating-point types by byte width alone, so complex64 tied with float64 and argument order settled it: one way the answer dropped the imaginary part, the other dropped half the real precision. Half a complex type's width is its imaginary part, so where exactly one side is complex the result is now complex and wide enough for the other side, matching numpy.

```
result_type_of(complex64, double)  before: double      after: complex128
result_type_of(double, complex64)  before: complex64   after: complex128
```