### PR TITLE
Sync a persistent kernel's stream reset against the pushes of its state

### DIFF
--- a/dace/codegen/targets/cuda.py
+++ b/dace/codegen/targets/cuda.py
@@ -1582,9 +1582,26 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
                 node for node in state.data_nodes() if isinstance(node.desc(sdfg), dace.data.Stream)
                 and node.desc(sdfg).lifetime == dtypes.AllocationLifetime.Scope
             ]
+
+            # A state machine needs a barrier between its states wherever it runs: a nested SDFG
+            # with several states (or control flow) below the kernel still synchronizes between
+            # them. An SDFG that is one lone state has no state transition to order, so below the
+            # kernel's own SDFG it emits no barrier -- it may run inside a single-thread-guarded
+            # component, where a barrier is reached by one thread and never releases. Its writes
+            # are ordered by the enclosing state's own barrier instead.
+            lone_state = sdfg.number_of_nodes() == 1 and isinstance(sdfg.nodes()[0], SDFGState)
+            can_sync = not (self._below_toplevel_sdfg and lone_state)
+
             for stream in streams_to_reset:
                 ptrname = self.ptr(stream.data, stream.desc(sdfg), sdfg)
                 callsite_stream.write("{}.reset();".format(ptrname), cfg, state.block_id)
+
+            # The reset rewinds the queue head for the whole grid, and every block runs it. The
+            # barrier ending the previous state releases the blocks, it does not hold them in step,
+            # so a block entering late rewinds the head under a block that already pushed -- those
+            # slots are handed out twice, while the consumer's count keeps counting every push.
+            if streams_to_reset and can_sync:
+                callsite_stream.write('__gbar.Sync();', cfg, state.block_id)
 
             components = dace.sdfg.concurrent_subgraphs(state)
             for c in components:
@@ -1636,14 +1653,7 @@ void __dace_alloc_{location}(uint32_t {size}, dace::GPUStream<{type}, {is_pow2}>
 
                 callsite_stream.write("}  // subgraph end", cfg, state.block_id)
 
-            # A state machine needs a barrier between its states wherever it runs: a nested SDFG
-            # with several states (or control flow) below the kernel still synchronizes between
-            # them. An SDFG that is one lone state has no state transition to order, so below the
-            # kernel's own SDFG it emits no barrier -- it may run inside a single-thread-guarded
-            # component, where a barrier is reached by one thread and never releases. Its writes
-            # are ordered by the enclosing state's own barrier instead.
-            lone_state = sdfg.number_of_nodes() == 1 and isinstance(sdfg.nodes()[0], SDFGState)
-            if not (self._below_toplevel_sdfg and lone_state):
+            if can_sync:
                 callsite_stream.write('__gbar.Sync();', cfg, state.block_id)
 
             # done here, code is generated

--- a/tests/codegen/gpu_persistent_stream_reset_test.py
+++ b/tests/codegen/gpu_persistent_stream_reset_test.py
@@ -1,0 +1,80 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""A stream reset inside a persistent kernel has to be ordered against the pushes of that state.
+
+``reset()`` rewinds the queue head for the whole grid and every block runs it. The barrier that
+ends the previous state releases the blocks, it does not keep them in step, so a block still on
+its way into the state can rewind the head after another block has already pushed. The pushed
+slots are then handed out a second time, while the consumer's count -- a separate atomic -- still
+counts every push, so it reads slots that were never written. On the first level of a search those
+slots are whatever ``Malloc`` returned, and the index taken from them faults the kernel.
+
+These assert on emitted code, so they need a GPU for neither compilation nor a run.
+"""
+import re
+
+import dace
+from dace.sdfg.graph import SubgraphView
+from dace.transformation.subgraph import GPUPersistentKernel
+
+N = dace.symbol('N')
+
+
+def push_and_drain() -> dace.SDFG:
+    """Persistent kernel that fills a stream in one state and reads the array behind it in the next."""
+    sdfg = dace.SDFG('persistent_stream_reset')
+    sdfg.add_array('src', [N], dace.int32)
+    sdfg.add_array('dst', [N], dace.int32)
+    sdfg.add_transient('buf', [N], dace.int32, may_alias=True)
+    sdfg.add_stream('q', dace.int32, transient=True, buffer_size=N)
+
+    produce = sdfg.add_state('produce', is_start_block=True)
+    consume = sdfg.add_state('consume')
+    sdfg.add_edge(produce, consume, dace.InterstateEdge())
+
+    src = produce.add_read('src')
+    queue = produce.add_access('q')
+    buf = produce.add_write('buf')
+    entry, exit_ = produce.add_map('select', dict(i='0:N'))
+    keep = produce.add_tasklet('keep', {'v'}, {'out'}, 'if v > 0:\n  out = i')
+    produce.add_memlet_path(src, entry, keep, dst_conn='v', memlet=dace.Memlet.simple('src', 'i'))
+    produce.add_memlet_path(keep, exit_, queue, src_conn='out', memlet=dace.Memlet.simple('q', '0', num_accesses=-1))
+    produce.add_memlet_path(queue, buf, memlet=dace.Memlet.simple('buf', '0'))
+
+    kept = consume.add_read('buf')
+    dst = consume.add_write('dst')
+    entry, exit_ = consume.add_map('copy', dict(i='0:N'))
+    copy = consume.add_tasklet('cp', {'v'}, {'out'}, 'out = v')
+    consume.add_memlet_path(kept, entry, copy, dst_conn='v', memlet=dace.Memlet.simple('buf', 'i'))
+    consume.add_memlet_path(copy, exit_, dst, src_conn='out', memlet=dace.Memlet.simple('dst', 'i'))
+
+    sdfg.fill_scope_connectors()
+    sdfg.validate()
+
+    sdfg.apply_gpu_transformations(validate=False, simplify=False)
+    kernel_states = set(sdfg.nodes()) - {sdfg.start_state, sdfg.sink_nodes()[0]}
+    transform = GPUPersistentKernel()
+    transform.setup_match(SubgraphView(sdfg, kernel_states))
+    transform.kernel_prefix = 'search'
+    transform.apply(sdfg)
+    sdfg.validate()
+    return sdfg
+
+
+def test_a_stream_reset_is_ordered_against_the_pushes_of_its_state():
+    code = '\n'.join(obj.clean_code for obj in push_and_drain().generate_code())
+
+    resets = list(re.finditer(r'(\w+)\.reset\(\);', code))
+    assert resets, 'no stream reset was emitted, so this test would pass vacuously'
+
+    for reset in resets:
+        after = code[reset.end():]
+        push = after.find(f'{reset.group(1)}.push(')
+        assert push != -1, f'stream {reset.group(1)} is reset but never pushed to'
+        barrier = after.find('__gbar.Sync();')
+        assert barrier != -1 and barrier < push, (
+            f'stream {reset.group(1)} is pushed to without a grid barrier after its reset: a block '
+            'that enters the state late rewinds the queue head under a block that already pushed')
+
+
+if __name__ == '__main__':
+    test_a_stream_reset_is_ordered_against_the_pushes_of_its_state()


### PR DESCRIPTION
A `GPU_Persistent` state resets its streams from every block and only synchronizes at the end of the state, so a block entering late rewinds the queue head under a block that already pushed and the consumer -- whose count is a separate atomic -- then indexes slots that were never written, which is the `CUDA_ERROR_ILLEGAL_ADDRESS` `tests/persistent_fusion_cudatest.py` hits on GH200 (264 blocks) and which poisons the CUDA context for every later GPU test on that xdist worker.

```c
__1_stream2.reset();
__gbar.Sync();          // new
for (int x = ...) { ... __1_stream2.push(neighbor); ... }
__gbar.Sync();
```