### PR TITLE
Keep the floor and ceiling of an expression that has no denominator

### DIFF
--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1341,7 +1341,7 @@ def sympy_intdiv_fix(expr):
     # The properties avoid matching the silly case "ceiling(N/32)" as
     # ceiling of 1/N and 1/32
     a = sympy.Wild('a', properties=[lambda k: k.is_Symbol or k.is_Integer])
-    b = sympy.Wild('b', properties=[lambda k: k.is_Symbol or k.is_Integer])
+    b = sympy.Wild('b', properties=[lambda k: (k.is_Symbol or k.is_Integer) and k != 1])
     c = sympy.Wild('c')
     d = sympy.Wild('d')
     e = sympy.Wild('e', properties=[lambda k: isinstance(k, sympy.Basic) and not isinstance(k, sympy.Atom)])
@@ -2419,6 +2419,11 @@ class DaceSympyPrinter(sympy.printing.str.StrPrinter):
                 return '((%s) ? (%s) : (%s))' % (cond, tval, fval)
             return '((%s) if (%s) else (%s))' % (tval, cond, fval)
         return super()._print_Function(expr)
+
+    def _print_ceiling(self, expr):
+        if not self.cpp_mode:
+            return super()._print_Function(expr)
+        return 'ceil(%s)' % self._print(expr.args[0])
 
     def _print_Mod(self, expr):
         return '((%s) %% (%s))' % (self._print(expr.args[0]), self._print(expr.args[1]))

--- a/tests/symbolic/test_int_div_rewrites.py
+++ b/tests/symbolic/test_int_div_rewrites.py
@@ -7,8 +7,9 @@ folded a unit denominator. That asymmetry leaked: ``strides_from_layout`` pads w
 folded back to ``N``. Both functions now share the unit-denominator and exact-division rules.
 """
 import pytest
+import sympy
 
-from dace.symbolic import int_ceil, int_floor, pystr_to_symbolic
+from dace.symbolic import int_ceil, int_floor, pystr_to_symbolic, symstr, sympy_intdiv_fix
 
 N = pystr_to_symbolic('N')
 M = pystr_to_symbolic('M')
@@ -40,6 +41,27 @@ def test_inexact_division_is_left_symbolic(fn):
     assert fn(4 * N + 2, 4).func is fn
     # A symbolic denominator cannot be shown to divide, so it is left alone too.
     assert fn(N, M).func is fn
+
+
+@pytest.mark.parametrize('rounding', [sympy.floor, sympy.ceiling])
+def test_rounding_of_a_non_integer_expression_is_kept(rounding):
+    """A rounding call with nothing to divide by must survive the rewrite."""
+    x = sympy.Symbol('x')
+    expr = rounding(sympy.sin(x))
+    assert sympy_intdiv_fix(expr) == expr
+
+
+@pytest.mark.parametrize('rounding,call', [(sympy.floor, 'floor'), (sympy.ceiling, 'ceil')])
+def test_rounding_of_a_non_integer_expression_lowers_to_the_math_call(rounding, call):
+    """The kept rounding must reach C++ as the matching math-library call."""
+    x = pystr_to_symbolic('x')
+    assert symstr(rounding(sympy.sin(x)), cpp_mode=True) == '(%s(sin(x)))' % call
+
+
+@pytest.mark.parametrize('rounding,name', [(sympy.floor, 'int_floor'), (sympy.ceiling, 'int_ceil')])
+def test_division_by_an_integer_still_rewrites(rounding, name):
+    """The integer-division rewrite is unchanged where a real denominator is present."""
+    assert sympy_intdiv_fix(rounding(N / 8)).func.__name__ == name
 
 
 @pytest.mark.parametrize('x,y,expected', [(17, 8, 3), (16, 8, 2), (1, 8, 1), (0, 8, 0)])


### PR DESCRIPTION
`sympy_intdiv_fix` matched `floor(e/b)` with `b = 1` for any non-atomic argument, so `floor(sin(x))` was rewritten to `int_floor(sin(x), 1)` and printed as `((sin(x)) / (1))` -- the rounding silently dropped.