### PR TITLE
[New GPU Codegen Prep] LoopToMap: a symbol read in a block's own dataflow is read before assignment

### DIFF
--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -113,9 +113,8 @@ class LoopToMap(xf.MultiStateTransformation):
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
         for block in in_order_loop_blocks:
-            # A symbol read in the block's own dataflow (e.g. a memlet subset ``b[im]``) is read
-            # before anything the block assigns on its out-edges, so a later reassignment makes it
-            # loop-carried. ``read_symbols()`` below only sees interstate-edge reads.
+            # ``read_symbols()`` below sees only interstate-edge reads, but a symbol read in the
+            # block's own dataflow (``b[im]``) is read before assignment too, hence loop-carried.
             used_before_assignment |= ({str(s) for s in block.free_symbols} - symbols_that_may_be_used)
             for e in block.parent_graph.out_edges(block):
                 # Collect read-before-assigned symbols (this works because the states are always in order,

--- a/dace/transformation/interstate/loop_to_map.py
+++ b/dace/transformation/interstate/loop_to_map.py
@@ -113,6 +113,10 @@ class LoopToMap(xf.MultiStateTransformation):
         symbols_that_may_be_used: Set[str] = {itervar}
         used_before_assignment: Set[str] = set()
         for block in in_order_loop_blocks:
+            # A symbol read in the block's own dataflow (e.g. a memlet subset ``b[im]``) is read
+            # before anything the block assigns on its out-edges, so a later reassignment makes it
+            # loop-carried. ``read_symbols()`` below only sees interstate-edge reads.
+            used_before_assignment |= ({str(s) for s in block.free_symbols} - symbols_that_may_be_used)
             for e in block.parent_graph.out_edges(block):
                 # Collect read-before-assigned symbols (this works because the states are always in order,
                 # see above call to `blockorder_topological_sort`)

--- a/tests/transformations/interstate/loop_to_map_test.py
+++ b/tests/transformations/interstate/loop_to_map_test.py
@@ -452,7 +452,44 @@ def test_symbol_array_mix_2(parallel):
     body_start.add_edge(t, 'o', body_start.add_write('B'), None, dace.Memlet('B[i]'))
 
     sdfg.apply_transformations_repeated([LoopLifting])
-    assert sdfg.apply_transformations(LoopToMap) == (1 if parallel else 0)
+    # Both variants carry ``sym``: it is read in ``B[i]`` before the body edge reassigns it to
+    # ``A[i-1]``, so a Map would pin it to 0.0 and compute ``B[i] = 0``.
+    assert sdfg.apply_transformations(LoopToMap) == 0
+
+
+_CN = dace.symbol('_CN')
+
+
+@dace.program
+def _carried_symbol_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
+    im = _CN - 1
+    for i in range(_CN):
+        a[i] = b[i] + b[im]
+        im = i
+
+
+@dace.program
+def _peeled_affine_loop(a: dace.float64[_CN], b: dace.float64[_CN]):
+    a[0] = b[0] + b[_CN - 1]  # wrapping first iteration, peeled off
+    for i in range(1, _CN):
+        a[i] = b[i] + b[i - 1]  # induction substituted -> affine
+
+
+def _only_loop(sdfg: dace.SDFG) -> LoopRegion:
+    return next(n for n, _ in sdfg.all_nodes_recursive() if isinstance(n, LoopRegion))
+
+
+def test_loop2map_rejects_unpeeled_carried_symbol():
+    """``im = N-1; a[i] = b[i] + b[im]; im = i`` (TSVC s291): ``im`` is read before it is
+    reassigned, so it is loop-carried and LoopToMap must refuse."""
+    sdfg = _carried_symbol_loop.to_sdfg(simplify=True)
+    assert not LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
+
+
+def test_loop2map_accepts_peeled_affine_form():
+    """Peeled and induction-substituted, ``a[i] = b[i] + b[i-1]`` is affine and still accepted."""
+    sdfg = _peeled_affine_loop.to_sdfg(simplify=True)
+    assert LoopToMap.can_be_applied_to(sdfg, loop=_only_loop(sdfg))
 
 
 @pytest.mark.parametrize('overwrite', (False, True))


### PR DESCRIPTION
Folds each loop block's own free symbols into LoopToMap's read-before-assigned set, so a wrap-around induction such as TSVC s291 (`im = N-1; a[i] = b[i] + b[im]; im = i`) is correctly refused instead of pinning `im` to `N-1`. Split out of the new GPU codegen PR (#2259) as a prerequisite.