### PR TITLE
[New GPU Codegen Prep] Carry over library node connectors on expansion

### DIFF
--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -724,6 +724,23 @@ class ExpandTransformation(PatternTransformation):
             elif isinstance(expansion, (nd.EntryNode, nd.LibraryNode)):
                 if expansion.schedule is ScheduleType.Default:
                     expansion.schedule = node.schedule
+
+            # Carry over connectors the expansion did not declare itself (e.g. passthrough
+            # connectors injected by upstream passes), otherwise the redirected edges point at
+            # nonexistent connectors. Only those that still have edges: an expansion may rename
+            # edges in-place, leaving the original names dangling.
+            in_conns_with_edges = {e.dst_conn for e in state.in_edges(node) if e.dst_conn is not None}
+            out_conns_with_edges = {e.src_conn for e in state.out_edges(node) if e.src_conn is not None}
+            for conn_name, conn_type in node.in_connectors.items():
+                if conn_name not in in_conns_with_edges:
+                    continue
+                if conn_name not in expansion.in_connectors and conn_name not in expansion.out_connectors:
+                    expansion.add_in_connector(conn_name, dtype=conn_type)
+            for conn_name, conn_type in node.out_connectors.items():
+                if conn_name not in out_conns_with_edges:
+                    continue
+                if conn_name not in expansion.out_connectors and conn_name not in expansion.in_connectors:
+                    expansion.add_out_connector(conn_name, dtype=conn_type)
         else:
             raise TypeError("Node expansion must be a CodeNode or an SDFG")
 

--- a/dace/transformation/transformation.py
+++ b/dace/transformation/transformation.py
@@ -725,10 +725,9 @@ class ExpandTransformation(PatternTransformation):
                 if expansion.schedule is ScheduleType.Default:
                     expansion.schedule = node.schedule
 
-            # Carry over connectors the expansion did not declare itself (e.g. passthrough
-            # connectors injected by upstream passes), otherwise the redirected edges point at
-            # nonexistent connectors. Only those that still have edges: an expansion may rename
-            # edges in-place, leaving the original names dangling.
+            # Carry over connectors the expansion did not declare (e.g. passthrough connectors
+            # injected by upstream passes), else the redirected edges point at nonexistent ones.
+            # Only connectors that still have edges: an expansion may rename edges in place.
             in_conns_with_edges = {e.dst_conn for e in state.in_edges(node) if e.dst_conn is not None}
             out_conns_with_edges = {e.src_conn for e in state.out_edges(node) if e.src_conn is not None}
             for conn_name, conn_type in node.in_connectors.items():

--- a/tests/library/expansion_connector_carryover_test.py
+++ b/tests/library/expansion_connector_carryover_test.py
@@ -1,0 +1,57 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""An expansion into a ``CodeNode`` keeps connectors a pass added to the library node."""
+import dace
+from dace import library, nodes
+from dace.transformation.transformation import ExpandTransformation
+
+
+@library.expansion
+class ExpandAddOnePure(ExpandTransformation):
+    environments = []
+
+    @staticmethod
+    def expansion(node, parent_state, parent_sdfg):
+        return parent_state.add_tasklet(node.label, {'_inp'}, {'_out'}, '_out = _inp + 1')
+
+
+@library.node
+class AddOne(nodes.LibraryNode):
+    implementations = {'pure': ExpandAddOnePure}
+    default_implementation = 'pure'
+
+    def __init__(self, name):
+        super().__init__(name, inputs={'_inp'}, outputs={'_out'})
+
+
+def _sdfg_with_extra_connector() -> dace.SDFG:
+    """One ``AddOne`` node carrying an extra ``_side`` input wired from a scalar."""
+    sdfg = dace.SDFG('expansion_connector_carryover')
+    sdfg.add_array('A', [1], dace.float64)
+    sdfg.add_array('B', [1], dace.float64)
+    sdfg.add_array('S', [1], dace.float64)
+    state = sdfg.add_state()
+
+    lib = AddOne('addone')
+    state.add_node(lib)
+    state.add_edge(state.add_read('A'), None, lib, '_inp', dace.Memlet('A[0]'))
+    state.add_edge(lib, '_out', state.add_write('B'), None, dace.Memlet('B[0]'))
+
+    lib.add_in_connector('_side', dtype=dace.float64)
+    state.add_edge(state.add_read('S'), None, lib, '_side', dace.Memlet('S[0]'))
+    return sdfg
+
+
+def test_extra_connector_survives_expansion():
+    sdfg = _sdfg_with_extra_connector()
+    sdfg.expand_library_nodes()
+    sdfg.validate()
+
+    state = sdfg.states()[0]
+    tasklets = [n for n in state.nodes() if isinstance(n, nodes.Tasklet)]
+    assert len(tasklets) == 1
+    assert '_side' in tasklets[0].in_connectors
+    assert any(e.dst_conn == '_side' for e in state.in_edges(tasklets[0]))
+
+
+if __name__ == '__main__':
+    test_extra_connector_survives_expansion()


### PR DESCRIPTION
An `ExpandTransformation` returning a `CodeNode` dropped any connector the library node gained after construction, leaving its edges pointing at a connector that no longer exists; this is part of the new GPU codegen PR.

This is a problem because new stream synchronization adds a "__stream" connector to all libnodes that are GPU kernels.