### PR TITLE
Compose the view subset affinely when removing a slice view

### DIFF
--- a/dace/transformation/dataflow/redundant_array.py
+++ b/dace/transformation/dataflow/redundant_array.py
@@ -1858,17 +1858,20 @@ class RemoveSliceView(pm.SingleStateTransformation):
         state.remove_node(self.view)
 
     def _offset_subset(self, mapping: Dict[int, int], subset: subsets.Range, edge_subset: subsets.Range):
-        # Get offset and size from the space of the view to compose
-        old_subset = edge_subset.min_element()
-        old_size = edge_subset.size()
+        """Compose ``edge_subset`` (view space) into ``subset`` (array space) affinely.
 
-        # Create a new subset in the space of the data container from the offsets and sizes
+        Offset-and-size is not composition. Reading only ``min_element``/``size`` discards the edge
+        subset's own STEP and re-derives the end as ``offset + size - 1``, turning a strided window
+        into a contiguous one holding the same number of elements: ``a[0:N, 0:N][:, 0:N:2]`` folded
+        into ``a[0:N, 0:N//2]``, so the program read the first half of every row instead of its even
+        columns. The step is also missing from the offset, so a strided view of a strided view came
+        out wrong twice over.
+        """
         new_subset: List[Tuple[int, int, int]] = subset.ndrange()
         for vdim, adim in mapping.items():
             rb, re, rs = new_subset[adim]
-            rb += old_subset[vdim]
-            re = rb + old_size[vdim] - 1
-            new_subset[adim] = (rb, re, rs)
+            vb, ve, vs = edge_subset.ranges[vdim]
+            new_subset[adim] = (rb + rs * vb, rb + rs * ve, rs * vs)
 
         return subsets.Range(new_subset)
 

--- a/tests/transformations/redundant_slices_test.py
+++ b/tests/transformations/redundant_slices_test.py
@@ -148,6 +148,32 @@ def test_view_slice_detect_nonslice():
     assert tuple(sq) == (0, )
 
 
+def test_strided_slice_of_a_slice_keeps_its_step():
+    """A strided slice of a slice must keep its step when the intermediate view is removed.
+
+    ``RemoveSliceView`` composed the two subsets from the inner one's offset and SIZE. That drops
+    its step and re-derives the end as ``offset + size - 1``, so ``image[0:N, 0:N][:, 0:2*h:2]``
+    folded into ``image[0:N, 0:h]`` -- the first half of every row instead of its even columns, an
+    access of the right shape over the wrong elements.
+    """
+    N = dace.symbol('N', dtype=dace.int64)
+    H = dace.symbol('H', dtype=dace.int64)
+
+    @dace.program
+    def even_columns_of_a_block(image: dace.float64[N, N], out: dace.float64[N, H]):
+        block = image[0:N, 0:N]
+        out[:] = block[:, 0:2 * H:2]
+
+    sdfg = even_columns_of_a_block.to_sdfg(simplify=True)
+    reads = [
+        e.data.subset for st in sdfg.states() for e in st.edges()
+        if e.data is not None and e.data.data == 'image' and e.data.subset is not None
+    ]
+    assert reads, 'expected at least one read of the viewed array'
+    assert any(r.ranges[1][2] == 2 for r in reads), \
+        f'the composed read must keep step 2, got {[str(r) for r in reads]}'
+
+
 if __name__ == '__main__':
     test_read_slice()
     test_read_slice2()
@@ -158,3 +184,4 @@ if __name__ == '__main__':
     test_view_slice_detect_complex(False)
     test_view_slice_detect_complex(True)
     test_view_slice_detect_nonslice()
+    test_strided_slice_of_a_slice_keeps_its_step()


### PR DESCRIPTION
`RemoveSliceView` built the composed subset from the inner memlet's offset and size, which discards its step and re-derives the end as `offset + size - 1`, so `image[0:N, 0:N][:, 0:2*H:2]` folded into `image[0:N, 0:H]` -- the first half of every row instead of its even columns. This composes the two ranges affinely instead, and adds a regression test that fails on main and passes here.
