### PR TITLE
Do not treat an empty memlet as a read or a write

### DIFF
--- a/dace/transformation/passes/analysis/analysis.py
+++ b/dace/transformation/passes/analysis/analysis.py
@@ -453,9 +453,14 @@ class FindAccessNodes(ppl.Pass):
                                        lambda: defaultdict(lambda: [OrderedSet(), OrderedSet()]))
             for state in sdfg.states():
                 for anode in state.data_nodes():
-                    if state.in_degree(anode) > 0:
+                    # An EMPTY memlet is an ordering edge, not a transfer: it moves no data, so a node
+                    # reached only by such edges is neither read nor written. Classifying by raw degree
+                    # reports it as a write, and ``ScalarWriteShadowScopes`` then lists it both as a read
+                    # of the real write and as a write scope of its own -- ``ScalarFission`` renames it
+                    # twice and versions a later read onto a container nothing ever writes.
+                    if any(not e.data.is_empty() for e in state.in_edges(anode)):
                         result[anode.data][state][1].add(anode)
-                    if state.out_degree(anode) > 0:
+                    if any(not e.data.is_empty() for e in state.out_edges(anode)):
                         result[anode.data][state][0].add(anode)
             top_result[sdfg.cfg_id] = result
         return top_result

--- a/dace/transformation/passes/scalar_fission.py
+++ b/dace/transformation/passes/scalar_fission.py
@@ -57,16 +57,20 @@ class ScalarFission(ppl.Pass):
             for write, shadowed_reads in write_scope_dict.items():
                 if write is not None and len(shadowed_reads) > 0:
                     newdesc = desc.clone()
+                    # Versions already minted for ``name`` count as the container too: a node renamed
+                    # twice in one pass no longer carries the ORIGINAL name on its memlets, and a guard
+                    # comparing only against that name leaves them naming neither endpoint.
+                    aliases = {name} | set(results[name])
                     newname = sdfg.add_datadesc(name, newdesc, find_new_name=True)
 
                     # Replace the write and any connected memlets with writes to the new data container.
                     write_node = write[1]
                     write_node.data = newname
                     for iedge in write[0].in_edges(write_node):
-                        if iedge.data.data == name:
+                        if iedge.data.data in aliases:
                             iedge.data.data = newname
                     for oeade in write[0].out_edges(write_node):
-                        if oeade.data.data == name:
+                        if oeade.data.data in aliases:
                             oeade.data.data = newname
 
                     # Replace all dominated reads and connected memlets.
@@ -75,10 +79,10 @@ class ScalarFission(ppl.Pass):
                             read_node = read[1]
                             read_node.data = newname
                             for iedge in read[0].in_edges(read_node):
-                                if iedge.data.data == name:
+                                if iedge.data.data in aliases:
                                     iedge.data.data = newname
                             for oeade in read[0].out_edges(read_node):
-                                if oeade.data.data == name:
+                                if oeade.data.data in aliases:
                                     oeade.data.data = newname
                         elif isinstance(read[1], InterstateEdge):
                             read[1].replace_dict({name: newname})

--- a/tests/passes/analysis/find_access_nodes_empty_memlet_test.py
+++ b/tests/passes/analysis/find_access_nodes_empty_memlet_test.py
@@ -1,0 +1,53 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Tests that :class:`FindAccessNodes` classifies by DATA, not by degree.
+
+An empty memlet is an ordering edge -- it transfers nothing -- so an access node reached only by
+such edges is neither read nor written. Counting raw degree made one an apparent write, and
+``ScalarWriteShadowScopes`` then reported it both as a read of the real write and as a write scope
+of its own; ``ScalarFission`` renamed the node twice and versioned a later read onto a container
+that nothing ever writes.
+"""
+import dace
+from dace.transformation.passes.analysis import FindAccessNodes
+
+
+def ordering_edge_sdfg() -> dace.SDFG:
+    """One real write to ``s``, then a second ``s`` node reached only by an ordering edge."""
+    sdfg = dace.SDFG('ordering_edge_access')
+    sdfg.add_array('A', [1], dace.float64)
+    sdfg.add_array('out', [1], dace.float64)
+    sdfg.add_scalar('s', dace.float64, transient=True)
+
+    state = sdfg.add_state('main', is_start_block=True)
+    a_read = state.add_read('A')
+    written = state.add_access('s')
+    ordered = state.add_access('s')
+    out_write = state.add_write('out')
+
+    producer = state.add_tasklet('producer', {'i'}, {'o'}, 'o = i * 2.0')
+    consumer = state.add_tasklet('consumer', {'i'}, {'o'}, 'o = i + 1.0')
+
+    state.add_edge(a_read, None, producer, 'i', dace.Memlet('A[0]'))
+    state.add_edge(producer, 'o', written, None, dace.Memlet('s[0]'))
+    state.add_edge(written, None, ordered, None, dace.Memlet())
+    state.add_edge(ordered, None, consumer, 'i', dace.Memlet('s[0]'))
+    state.add_edge(consumer, 'o', out_write, None, dace.Memlet('out[0]'))
+    return sdfg
+
+
+def test_ordering_edge_is_neither_a_read_nor_a_write():
+    sdfg = ordering_edge_sdfg()
+    sdfg.validate()
+    state = sdfg.states()[0]
+    written, ordered = [n for n in state.data_nodes() if n.data == 's']
+
+    reads, writes = FindAccessNodes().apply_pass(sdfg, {})[sdfg.cfg_id]['s'][state]
+
+    assert ordered not in writes, 'a node reached only by an empty memlet is not written'
+    assert ordered in reads, 'the ordering-only node still READS -- its outgoing memlet carries data'
+    assert written in writes, 'the real write must stay a write'
+    assert written not in reads, 'an empty OUTgoing memlet does not make the writer a read'
+
+
+if __name__ == '__main__':
+    test_ordering_edge_is_neither_a_read_nor_a_write()

--- a/tests/passes/scalar_fission_test.py
+++ b/tests/passes/scalar_fission_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2024 ETH Zurich and the DaCe authors. All rights reserved.
 """ Tests the scalar fission pass. """
 
+import numpy as np
 import pytest
 
 import dace
@@ -305,3 +306,71 @@ if __name__ == '__main__':
     test_scalar_fission(True)
     test_branch_subscopes_nofission(True)
     test_branch_subscopes_fission(True)
+
+
+def ordering_edge_between_writes_sdfg() -> dace.SDFG:
+    """One real write to ``s``, then a second ``s`` node reached only by ordering edges.
+
+    The empty memlets transfer nothing, so that node is a READ of the preceding write, not a
+    dominating write of its own.
+    """
+    sdfg = dace.SDFG('ordering_edge_between_writes')
+    sdfg.add_array('A', [1], dace.float64)
+    sdfg.add_array('out', [1], dace.float64)
+    sdfg.add_scalar('s', dace.float64, transient=True)
+    sdfg.add_scalar('order', dace.float64, transient=True)
+
+    state = sdfg.add_state('main', is_start_block=True)
+    a_read = state.add_read('A')
+    written = state.add_access('s')
+    ordered = state.add_access('s')
+    order_src = state.add_access('order')
+
+    init = state.add_tasklet('init', {'i'}, {'o'}, 'o = i * 2.0')
+    side = state.add_tasklet('side', {'i'}, {'o'}, 'o = i')
+    consumer = state.add_tasklet('consumer', {'i'}, {'o'}, 'o = i + 1.0')
+
+    state.add_edge(a_read, None, init, 'i', dace.Memlet('A[0]'))
+    state.add_edge(init, 'o', written, None, dace.Memlet('s[0]'))
+    state.add_edge(a_read, None, side, 'i', dace.Memlet('A[0]'))
+    state.add_edge(side, 'o', order_src, None, dace.Memlet('order[0]'))
+    state.add_edge(written, None, ordered, None, dace.Memlet())
+    state.add_edge(order_src, None, ordered, None, dace.Memlet())
+    state.add_edge(ordered, None, consumer, 'i', dace.Memlet('s[0]'))
+    state.add_edge(consumer, 'o', state.add_write('out'), None, dace.Memlet('out[0]'))
+
+    second = sdfg.add_state_after(state, 'second')
+    tail = second.add_tasklet('tail', {'i'}, {'o'}, 'o = i')
+    second.add_edge(second.add_read('s'), None, tail, 'i', dace.Memlet('s[0]'))
+    second.add_edge(tail, 'o', second.add_write('out'), None, dace.Memlet('out[0]'))
+    return sdfg
+
+
+def test_ordering_edge_does_not_start_a_version():
+    """An access node reached only by empty memlets is not a dominating write.
+
+    Treating it as one split ``s`` into two versions, left a memlet naming the first while its node
+    carried the second, and versioned the later read onto a container nothing writes.
+    """
+    sdfg = ordering_edge_between_writes_sdfg()
+    sdfg.validate()
+    before = set(sdfg.arrays.keys())
+
+    Pipeline([ScalarFission()]).apply_pass(sdfg, {})
+    sdfg.validate()
+
+    for state in sdfg.states():
+        for edge in state.edges():
+            if edge.data.data is None:
+                continue
+            endpoints = [n.data for n in (edge.src, edge.dst) if isinstance(n, dace.nodes.AccessNode)]
+            assert not endpoints or edge.data.data in endpoints, (
+                f'{state.label}: memlet {edge.data.data} on {edge.src} -> {edge.dst} names no endpoint')
+
+    minted = set(sdfg.arrays.keys()) - before
+    assert not minted, f'the ordering edge is not a write, so nothing may be versioned: {sorted(minted)}'
+
+    A = np.array([3.0], dtype=np.float64)
+    out = np.zeros(1, dtype=np.float64)
+    sdfg(A=A, out=out)
+    assert out[0] == 6.0, f'got {out[0]}'


### PR DESCRIPTION
`FindAccessNodes` classified access nodes by raw degree, so a node reached only by empty memlets -- ordering edges that transfer no data -- was reported as a write, and `ScalarFission` then renamed it twice: the edge was left naming a container that is neither of its endpoints, and the reads it dominated were versioned onto a container nothing ever writes. Classify by the memlet instead, and let the rename guard also accept a version already minted for the same container.