### PR TITLE
[WIP] Allocate a view after the container it points into

### DIFF
--- a/dace/codegen/targets/framecode.py
+++ b/dace/codegen/targets/framecode.py
@@ -844,6 +844,40 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
             else:
                 self.where_allocated[(sdfg, name)] = cursdfg
 
+    def order_views_after_their_sources(self, entries: list[tuple[Any, ...]]) -> list[int]:
+        """Order allocations so a view is bound only once the container it points into exists."""
+        allocated_at: dict[str, int] = {}
+        for index, (_, _, node, _, allocate, _) in enumerate(entries):
+            # A scope entry also lands here, and it names no data.
+            if allocate and isinstance(node, nodes.AccessNode) and node.data not in allocated_at:
+                allocated_at[node.data] = index
+
+        def source_of(index: int) -> int | None:
+            tsdfg, state, node, _, allocate, _ = entries[index]
+            if not allocate or state is None or not isinstance(node, nodes.AccessNode):
+                return None
+            if not isinstance(node.desc(tsdfg), data.View):
+                return None
+            # A view bound through a scope resolves to the scope node, which names no data.
+            viewed = utils.get_view_node(state, node)
+            if not isinstance(viewed, nodes.AccessNode) or viewed.data == node.data:
+                return None
+            source = allocated_at.get(viewed.data)
+            return None if source == index else source
+
+        # Depth in the view chain, so a stable sort leaves every unrelated allocation where it was.
+        depth: dict[int, int] = {}
+        for start in range(len(entries)):
+            chain: list[int] = []
+            index: int | None = start
+            while index is not None and index not in depth and index not in chain:
+                chain.append(index)
+                index = source_of(index)
+            base = 0 if index is None or index in chain else depth[index]
+            for offset, member in enumerate(reversed(chain)):
+                depth[member] = base + offset + 1
+        return sorted(range(len(entries)), key=lambda index: depth[index])
+
     def allocate_arrays_in_scope(self, sdfg: SDFG, cfg: ControlFlowRegion, scope: Union[nodes.EntryNode, SDFGState,
                                                                                         SDFG],
                                  function_stream: CodeIOStream, callsite_stream: CodeIOStream) -> None:
@@ -853,7 +887,9 @@ DACE_EXPORTED void __dace_set_external_memory_{storage.name}({mangle_dace_state_
             if instr is not None:
                 instr.on_allocation_begin(sdfg, scope, callsite_stream)
         """ Dispatches allocation of all arrays in the given scope. """
-        for tsdfg, state, node, declare, allocate, _ in self.to_allocate[scope]:
+        entries = self.to_allocate[scope]
+        for index in self.order_views_after_their_sources(entries):
+            tsdfg, state, node, declare, allocate, _ = entries[index]
             if state is not None:
                 state_id = state.block_id
             else:


### PR DESCRIPTION
`allocate_arrays_in_scope` dispatched `to_allocate` in append order, so a view could be bound to its container's pointer before that container was allocated -- null on the first entry, the previous iteration's freed buffer on later ones -- making the read through it wild. Draft because the only reproducer I have needs frontend support that is not on main, so this carries no test yet.