### PR TITLE
stree -> sdfg: add missing nested SDFG connectors

### DIFF
--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -207,7 +207,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         use_nview = self._apply_nview_array_override(memlet.data, sdfg)
                         if not use_nview:
                             sdfg.add_datadesc(memlet.data, parent_sdfg.arrays[memlet.data].clone())
-
                             # Transients passed into a nested SDFG become non-transient inside that nested SDFG
                             if parent_sdfg.arrays[memlet.data].transient:
                                 sdfg.arrays[memlet.data].transient = False
@@ -288,7 +287,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     use_nview = self._apply_nview_array_override(memlet.data, sdfg)
                     if not use_nview:
                         sdfg.add_datadesc(memlet.data, parent_sdfg.arrays[memlet.data].clone())
-
                         # Transients passed into a nested SDFG become non-transient inside that nested SDFG
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
@@ -518,10 +516,13 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     dst_conn=connector,
                     memlet=Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]),
                 )
+                if isinstance(outer_map_entry, SDFG) and memlet_data in outer_to_connect["outputs"]:
+                    # in case of read after write of memory that comes from an "outside" SDFG,
+                    # make sure that we register the read in the nested SDFG.
+                    outer_to_connect["inputs"].add(memlet_data)
                 continue
 
             if isinstance(outer_map_entry, nodes.EntryNode):
-
                 # get it from outside the map
                 connector_name = f"{PREFIX_PASSTHROUGH_OUT}{memlet_data}"
                 if connector_name not in outer_map_entry.out_connectors:
@@ -541,17 +542,17 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                 if isinstance(outer_map_entry, SDFG):
                     # Copy data descriptor from parent SDFG and add input connector
                     if memlet_data not in sdfg.arrays:
-                        parent_sdfg: SDFG = self._parent_sdfg_with_array(memlet_data, sdfg)
+                        parent_sdfg = self._parent_sdfg_with_array(memlet_data, sdfg)
 
                         # Add support for NView nodes
                         use_nview = self._apply_nview_array_override(memlet_data, sdfg)
                         if not use_nview:
                             sdfg.add_datadesc(memlet_data, parent_sdfg.arrays[memlet_data].clone())
-
                             # Transients passed into a nested SDFG become non-transient inside that nested SDFG
                             if parent_sdfg.arrays[memlet_data].transient:
                                 sdfg.arrays[memlet_data].transient = False
 
+                    # Add in_connector in any case if not yet present, e.g. read after write
                     # Dev note: nview.target and memlet_data are identical
                     outer_to_connect["inputs"].add(memlet_data)
                 else:
@@ -620,7 +621,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     use_nview = self._apply_nview_array_override(name, sdfg)
                     if not use_nview:
                         sdfg.add_datadesc(name, parent_sdfg.arrays[name].clone())
-
                         # Transients passed into a nested SDFG become non-transient inside that nested SDFG
                         if parent_sdfg.arrays[name].transient:
                             sdfg.arrays[name].transient = False
@@ -702,7 +702,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     use_nview = self._apply_nview_array_override(memlet.data, sdfg)
                     if not use_nview:
                         sdfg.add_datadesc(memlet.data, parent_sdfg.arrays[memlet.data].clone())
-
                         # Transients passed into a nested SDFG become non-transient inside that nested SDFG
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
@@ -748,7 +747,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     use_nview = self._apply_nview_array_override(memlet.data, sdfg)
                     if not use_nview:
                         sdfg.add_datadesc(memlet.data, parent_sdfg.arrays[memlet.data].clone())
-
                         # Transients passed into a nested SDFG become non-transient inside that nested SDFG
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
@@ -756,7 +754,6 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                 # Add out_connector in any case if not yet present, e.g. write after read
                 # Dev note: memlet.data and nview.target are identical
                 to_connect["outputs"].add(memlet.data)
-
             else:
                 assert scope_node is None
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -214,6 +214,10 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         # Dev note: nview.target and memlet.data are identical
                         assert memlet.data not in to_connect["inputs"]
                         to_connect["inputs"].add(memlet.data)
+
+                    # Add in_connector in case of read after write
+                    if memlet.data in to_connect["outputs"]:
+                        to_connect["inputs"].add(memlet.data)
                 return
 
         for memlet in input_memlets:
@@ -293,6 +297,10 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
                     # Dev note: memlet.data and nview.target are identical
                     assert memlet.data not in to_connect["inputs"]
+                    to_connect["inputs"].add(memlet.data)
+
+                # Add in_connector in case of read after write
+                if memlet.data in to_connect["outputs"]:
                     to_connect["inputs"].add(memlet.data)
 
     def visit_IfScope(self, node: tn.IfScope, sdfg: SDFG) -> None:
@@ -552,9 +560,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                             if parent_sdfg.arrays[memlet_data].transient:
                                 sdfg.arrays[memlet_data].transient = False
 
-                    # Add in_connector in any case if not yet present, e.g. read after write
-                    # Dev note: nview.target and memlet_data are identical
-                    outer_to_connect["inputs"].add(memlet_data)
+                        # Dev note: nview.target and memlet_data are identical
+                        outer_to_connect["inputs"].add(memlet_data)
+
+                    # Add in_connector in case of read after write
+                    if memlet_data in outer_to_connect["outputs"]:
+                        outer_to_connect["inputs"].add(memlet_data)
                 else:
                     assert outer_map_entry is None
 
@@ -625,9 +636,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         if parent_sdfg.arrays[name].transient:
                             sdfg.arrays[name].transient = False
 
-                # Add out_connector in any case if not yet present, e.g. write after read
-                # Dev not: name and nview.target are identical
-                outer_to_connect["outputs"].add(name)
+                    # Dev not: name and nview.target are identical
+                    outer_to_connect["outputs"].add(name)
+
+                # Add out_connector in case of write after read
+                if memlet_data in outer_to_connect["inputs"]:
+                    outer_to_connect["outputs"].add(name)
 
             # connect "outside the map"
             # only re-use cached write-only nodes, e.g. don't create a cycle for
@@ -706,9 +720,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
 
-                # Add in_connector in any case if not yet present, e.g. read after (partial) write
-                # Dev note: memlet.data and nview.target are identical
-                to_connect["inputs"].add(memlet.data)
+                    # Dev note: memlet.data and nview.target are identical
+                    to_connect["inputs"].add(memlet.data)
+
+                # Add in_connector in case of read after (partial) write
+                if memlet.data in to_connect["outputs"]:
+                    to_connect["inputs"].add(memlet.data)
             else:
                 assert scope_node is None
 
@@ -751,9 +768,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
 
-                # Add out_connector in any case if not yet present, e.g. write after read
-                # Dev note: memlet.data and nview.target are identical
-                to_connect["outputs"].add(memlet.data)
+                    # Dev note: memlet.data and nview.target are identical
+                    to_connect["outputs"].add(memlet.data)
+
+                # Add out_connector in case case of write after read
+                if memlet.data in to_connect["inputs"]:
+                    to_connect["outputs"].add(memlet.data)
             else:
                 assert scope_node is None
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -706,9 +706,9 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
 
-                    # Dev note: memlet.data and nview.target are identical
-                    assert memlet.data not in to_connect["inputs"]
-                    to_connect["inputs"].add(memlet.data)
+                # Add in_connector in any case if not yet present, e.g. read after (partial) write
+                # Dev note: memlet.data and nview.target are identical
+                to_connect["inputs"].add(memlet.data)
             else:
                 assert scope_node is None
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -87,6 +87,9 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
         self._current_nestedSDFG: int | None = None
         """Id of the current nested SDFG if we are inside one."""
 
+        self._known_data_outside_nestedSDFG: set[str] | None = None
+        """In case we are inside a nested SDFG, this list previously accessed data (arrays and scalars) outside the nestedSDFG."""
+
         self._interstate_symbols: list[tn.AssignNode] = []
         """Interstate symbol assignments. Will be assigned with the next state transition."""
 
@@ -215,8 +218,8 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         assert memlet.data not in to_connect["inputs"]
                         to_connect["inputs"].add(memlet.data)
 
-                    # Add in_connector in case of read after write
-                    if memlet.data in to_connect["outputs"]:
+                    # Add in_connector in case of read after write of "outside" data
+                    if memlet.data in self._known_data_outside_nestedSDFG:
                         to_connect["inputs"].add(memlet.data)
                 return
 
@@ -299,8 +302,8 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     assert memlet.data not in to_connect["inputs"]
                     to_connect["inputs"].add(memlet.data)
 
-                # Add in_connector in case of read after write
-                if memlet.data in to_connect["outputs"]:
+                # Add in_connector in case of read after write in case of "outside data"
+                if memlet.data in self._known_data_outside_nestedSDFG:
                     to_connect["inputs"].add(memlet.data)
 
     def visit_IfScope(self, node: tn.IfScope, sdfg: SDFG) -> None:
@@ -387,6 +390,12 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
         dataflow_stack_size = len(self._dataflow_stack)
         state_stack_size = len(self._state_stack)
         outer_nestedSDFG = self._current_nestedSDFG
+        outer_known_data = self._known_data_outside_nestedSDFG
+
+        self._known_data_outside_nestedSDFG = set()
+        for access_dict in self._ctx.access_cache.values():
+            for name in access_dict:
+                self._known_data_outside_nestedSDFG.add(name)
 
         # prepare inner SDFG
         inner_sdfg = SDFG("nested_sdfg", parent=self._current_state)
@@ -475,6 +484,7 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
 
         # Restore current nested SDFG
         self._current_nestedSDFG = outer_nestedSDFG
+        self._known_data_outside_nestedSDFG = outer_known_data
 
     def visit_MapScope(self, node: tn.MapScope, sdfg: SDFG) -> None:
         dataflow_stack_size = len(self._dataflow_stack)
@@ -563,8 +573,8 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         # Dev note: nview.target and memlet_data are identical
                         outer_to_connect["inputs"].add(memlet_data)
 
-                    # Add in_connector in case of read after write
-                    if memlet_data in outer_to_connect["outputs"]:
+                    # Add in_connector in case of read after write of "outside data"
+                    if memlet_data in self._known_data_outside_nestedSDFG:
                         outer_to_connect["inputs"].add(memlet_data)
                 else:
                     assert outer_map_entry is None
@@ -721,8 +731,8 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     # Dev note: memlet.data and nview.target are identical
                     to_connect["inputs"].add(memlet.data)
 
-                # Add in_connector in case of read after (partial) write
-                if memlet.data in to_connect["outputs"]:
+                # Add in_connector in case of read after (partial) write of "outside data"
+                if memlet.data in self._known_data_outside_nestedSDFG:
                     to_connect["inputs"].add(memlet.data)
             else:
                 assert scope_node is None

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -636,12 +636,10 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         if parent_sdfg.arrays[name].transient:
                             sdfg.arrays[name].transient = False
 
-                    # Dev not: name and nview.target are identical
-                    outer_to_connect["outputs"].add(name)
-
-                # Add out_connector in case of write after read
-                if name in outer_to_connect["inputs"]:
-                    outer_to_connect["outputs"].add(name)
+                # Add out connector in any case because we don't know who (if anyone)
+                # is gonna read from it down the line.
+                # Dev not: name and nview.target are identical
+                outer_to_connect["outputs"].add(name)
 
             # connect "outside the map"
             # only re-use cached write-only nodes, e.g. don't create a cycle for
@@ -768,12 +766,10 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                         if parent_sdfg.arrays[memlet.data].transient:
                             sdfg.arrays[memlet.data].transient = False
 
-                    # Dev note: memlet.data and nview.target are identical
-                    to_connect["outputs"].add(memlet.data)
-
-                # Add out_connector in case case of write after read
-                if memlet.data in to_connect["inputs"]:
-                    to_connect["outputs"].add(memlet.data)
+                # Add out connector in any case because we don't know who (if anyone)
+                # is gonna read from it down the line.
+                # Dev note: memlet.data and nview.target are identical
+                to_connect["outputs"].add(memlet.data)
             else:
                 assert scope_node is None
 

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -534,7 +534,7 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     dst_conn=connector,
                     memlet=Memlet.from_array(memlet_data, sdfg.arrays[memlet_data]),
                 )
-                if isinstance(outer_map_entry, SDFG) and memlet_data in outer_to_connect["outputs"]:
+                if isinstance(outer_map_entry, SDFG) and memlet_data in self._known_data_outside_nestedSDFG:
                     # in case of read after write of memory that comes from an "outside" SDFG,
                     # make sure that we register the read in the nested SDFG.
                     outer_to_connect["inputs"].add(memlet_data)

--- a/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
+++ b/dace/sdfg/analysis/schedule_tree/tree_to_sdfg.py
@@ -640,7 +640,7 @@ class _StreeToSDFG(tn.ScheduleNodeVisitor):
                     outer_to_connect["outputs"].add(name)
 
                 # Add out_connector in case of write after read
-                if memlet_data in outer_to_connect["inputs"]:
+                if name in outer_to_connect["inputs"]:
                     outer_to_connect["outputs"].add(name)
 
             # connect "outside the map"

--- a/tests/schedule_tree/roundtrip_test.py
+++ b/tests/schedule_tree/roundtrip_test.py
@@ -5,6 +5,8 @@ Tests conversion of schedule trees to SDFGs.
 import dace
 import numpy as np
 
+from dace.sdfg.state import ConditionalBlock
+
 
 def test_implicit_inline_and_constants():
     """
@@ -54,6 +56,130 @@ def test_name_propagation():
     assert sdfg.name == name
 
 
+def test_transients_and_nested_sdfg() -> None:
+
+    def nestedSDFG() -> dace.SDFG:
+
+        def get_start_state(sdfg: dace.SDFG) -> dace.SDFGState:
+            state = sdfg.add_state("my_state", is_start_block=True)
+            read = state.add_read("B")
+            write = state.add_write("tmp_condition")
+            tasklet = state.add_tasklet(
+                "masklet",
+                {"B0"},  # inputs
+                {"out"},  # outputs
+                "out = B0 < 0",
+            )
+            state.add_edge(read, None, tasklet, "B0", dace.Memlet("B[0]"))
+            state.add_edge(tasklet, "out", write, None, dace.Memlet("tmp_condition[0]"))
+            return state
+
+        def get_if_block(sdfg: dace.SDFG) -> dace.sdfg.ControlFlowRegion:
+            if_block = ConditionalBlock('if_region', sdfg=sdfg)
+            then_body = dace.sdfg.ControlFlowRegion('then_body', sdfg=sdfg, parent=if_block)
+            then_state = then_body.add_state('then_state', is_start_block=True)
+            then_write = then_state.add_write('B')
+            then_tasklet = then_state.add_tasklet('write_zero', {}, {'out'}, 'out = 0')
+            then_state.add_edge(then_tasklet, 'out', then_write, None, dace.Memlet('B[0]'))
+            if_block.add_branch("tmp_condition", then_body)
+            return if_block
+
+        def get_map_state(sdfg: dace.SDFG) -> dace.SDFGState:
+            state = sdfg.add_state("map_state")
+            access_A = state.add_access("A")
+            write_B = state.add_write("B")
+            state.add_mapped_tasklet("write_one", {"j": dace.subsets.Range.from_string("0:10")}, {},
+                                     "out = 1.0", {"out": dace.Memlet("A[15*i + 3*j]")},
+                                     external_edges=True,
+                                     output_nodes={"A": access_A})
+            state.add_mapped_tasklet("copy", {"k": dace.subsets.Range.from_string("10:20")},
+                                     {"read": dace.Memlet("A[k]")},
+                                     "write = read", {"write": dace.Memlet("B[k]")},
+                                     external_edges=True,
+                                     input_nodes={"A": access_A},
+                                     output_nodes={"B": write_B})
+            return state
+
+        sdfg = dace.SDFG(name="nested")
+        sdfg.add_scalar("tmp_condition", dace.bool, transient=True)
+        sdfg.add_array("A", [60], dace.float32)
+        sdfg.add_array("B", [60], dace.float32)
+
+        start_state = get_start_state(sdfg)
+
+        if_block = get_if_block(sdfg)
+        sdfg.add_node(if_block)
+        sdfg.add_edge(start_state, if_block, dace.InterstateEdge())
+
+        map_state = get_map_state(sdfg)
+        sdfg.add_edge(if_block, map_state, dace.InterstateEdge())
+
+        return sdfg
+
+    sdfg = dace.SDFG(name="tester")
+    _, A_desc = sdfg.add_array("A", [60], dace.float32, transient=True)
+    _, B_desc = sdfg.add_array("B", [60], dace.float32)
+    state = sdfg.add_state("state")
+    access_A = state.add_access("A")
+    state.add_mapped_tasklet(
+        "fill",
+        {"i": dace.subsets.Range.from_string("0:60")},
+        {},  # inputs
+        "out = 42.42",
+        {"out": dace.Memlet("A[i]")},  # outputs
+        external_edges=True,
+        output_nodes={"A": access_A})
+
+    read_B = state.add_read("B")
+    map_entry, map_exit = state.add_map("second_map", {"i": dace.subsets.Range.from_string("0:2")})
+
+    # map_entry
+    map_entry.add_in_connector("IN_A")
+    map_entry.add_out_connector("OUT_A")
+    map_entry.add_in_connector("IN_B")
+    map_entry.add_out_connector("OUT_B")
+    state.add_edge(access_A, None, map_entry, "IN_A", dace.Memlet.from_array("A", A_desc))
+    state.add_edge(read_B, None, map_entry, "IN_B", dace.Memlet.from_array("B", B_desc))
+
+    # nested SDFG
+    nsdfg = nestedSDFG()
+    nsdfg_node = state.add_nested_sdfg(
+        nsdfg,
+        {
+            "A": None,
+            "B": None
+        },  # inputs
+        {
+            "A": None,
+            "B": None
+        },  # outputs
+        name="nested_sdfg",
+    )
+    state.add_edge(map_entry, "OUT_A", nsdfg_node, "A", dace.Memlet.from_array("A", A_desc))
+    state.add_edge(map_entry, "OUT_B", nsdfg_node, "B", dace.Memlet.from_array("B", B_desc))
+
+    # map_exit
+    map_exit.add_in_connector("IN_A")
+    map_exit.add_out_connector("OUT_A")
+    state.add_edge(nsdfg_node, "A", map_exit, "IN_A", dace.Memlet.from_array("A", A_desc))
+    write_A = state.add_write("A")
+    state.add_edge(map_exit, "OUT_A", write_A, None, dace.Memlet.from_array("A", A_desc))
+
+    map_exit.add_in_connector("IN_B")
+    map_exit.add_out_connector("OUT_B")
+    state.add_edge(nsdfg_node, "B", map_exit, "IN_B", dace.Memlet.from_array("B", B_desc))
+    write_B = state.add_write("B")
+    state.add_edge(map_exit, "OUT_B", write_B, None, dace.Memlet.from_array("B", B_desc))
+
+    sdfg.validate()
+    dace.sdfg.propagation.propagate_memlets_sdfg(sdfg)
+    stree = sdfg.as_schedule_tree()
+    roundtrip_sdfg = stree.as_sdfg(validate=True)
+
+    assert roundtrip_sdfg
+
+
 if __name__ == '__main__':
     test_implicit_inline_and_constants()
     test_name_propagation()
+    test_transients_and_nested_sdfg()

--- a/tests/schedule_tree/roundtrip_test.py
+++ b/tests/schedule_tree/roundtrip_test.py
@@ -64,12 +64,7 @@ def test_transients_and_nested_sdfg() -> None:
             state = sdfg.add_state("my_state", is_start_block=True)
             read = state.add_read("B")
             write = state.add_write("tmp_condition")
-            tasklet = state.add_tasklet(
-                "masklet",
-                {"B0"},  # inputs
-                {"out"},  # outputs
-                "out = B0 < 0",
-            )
+            tasklet = state.add_tasklet("masklet", inputs={"B0"}, outputs={"out"}, code="out = B0 < 0")
             state.add_edge(read, None, tasklet, "B0", dace.Memlet("B[0]"))
             state.add_edge(tasklet, "out", write, None, dace.Memlet("tmp_condition[0]"))
             return state
@@ -121,14 +116,12 @@ def test_transients_and_nested_sdfg() -> None:
     _, B_desc = sdfg.add_array("B", [60], dace.float32)
     state = sdfg.add_state("state")
     access_A = state.add_access("A")
-    state.add_mapped_tasklet(
-        "fill",
-        {"i": dace.subsets.Range.from_string("0:60")},
-        {},  # inputs
-        "out = 42.42",
-        {"out": dace.Memlet("A[i]")},  # outputs
-        external_edges=True,
-        output_nodes={"A": access_A})
+    state.add_mapped_tasklet("fill", {"i": dace.subsets.Range.from_string("0:60")},
+                             inputs={},
+                             code="out = 42.42",
+                             outputs={"out": dace.Memlet("A[i]")},
+                             external_edges=True,
+                             output_nodes={"A": access_A})
 
     read_B = state.add_read("B")
     map_entry, map_exit = state.add_map("second_map", {"i": dace.subsets.Range.from_string("0:2")})
@@ -145,14 +138,14 @@ def test_transients_and_nested_sdfg() -> None:
     nsdfg = nestedSDFG()
     nsdfg_node = state.add_nested_sdfg(
         nsdfg,
-        {
+        inputs={
             "A": None,
             "B": None
-        },  # inputs
-        {
+        },
+        outputs={
             "A": None,
             "B": None
-        },  # outputs
+        },
         name="nested_sdfg",
     )
     state.add_edge(map_entry, "OUT_A", nsdfg_node, "A", dace.Memlet.from_array("A", A_desc))
@@ -176,7 +169,14 @@ def test_transients_and_nested_sdfg() -> None:
     stree = sdfg.as_schedule_tree()
     roundtrip_sdfg = stree.as_sdfg(validate=True)
 
-    assert roundtrip_sdfg
+    assert roundtrip_sdfg.arrays["A"].transient
+    assert not roundtrip_sdfg.arrays["B"].transient
+
+    roundtrip_nested: dace.SDFG = list(filter(lambda node: node.label == "nested_sdfg", roundtrip_sdfg.cfg_list))[0]
+    assert not roundtrip_nested.arrays["A"].transient
+
+    tmp_condition = roundtrip_nested.symbols.get("tmp_condition", None)
+    assert tmp_condition == dace.bool
 
 
 if __name__ == '__main__':

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -13,7 +13,7 @@ from dace.sdfg.state import ConditionalBlock, LoopRegion, SDFGState
 import pytest
 
 
-def test_state_boundaries_none():
+def test_state_boundaries_none() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -31,7 +31,7 @@ def test_state_boundaries_none():
     assert tn.StateBoundaryNode not in [type(n) for n in stree.children]
 
 
-def test_state_boundaries_waw():
+def test_state_boundaries_waw() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -49,7 +49,7 @@ def test_state_boundaries_waw():
 
 
 @pytest.mark.parametrize('overlap', (False, True))
-def test_state_boundaries_waw_ranges(overlap):
+def test_state_boundaries_waw_ranges(overlap: bool) -> None:
     # Manually create a schedule tree
     N = dace.symbol('N')
     stree = tn.ScheduleTreeRoot(
@@ -72,7 +72,7 @@ def test_state_boundaries_waw_ranges(overlap):
         assert [tn.TaskletNode, tn.TaskletNode] == [type(n) for n in stree.children]
 
 
-def test_state_boundaries_war():
+def test_state_boundaries_war() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -91,7 +91,7 @@ def test_state_boundaries_war():
     assert [tn.TaskletNode, tn.StateBoundaryNode, tn.TaskletNode] == [type(n) for n in stree.children]
 
 
-def test_state_boundaries_read_write_chain():
+def test_state_boundaries_read_write_chain() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -113,7 +113,7 @@ def test_state_boundaries_read_write_chain():
     assert [tn.TaskletNode, tn.TaskletNode, tn.TaskletNode] == [type(n) for n in stree.children]
 
 
-def test_state_boundaries_data_race():
+def test_state_boundaries_data_race() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -138,7 +138,7 @@ def test_state_boundaries_data_race():
             tn.TaskletNode] == [type(n) for n in stree.children]
 
 
-def test_state_boundaries_cfg():
+def test_state_boundaries_cfg() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -163,7 +163,7 @@ def test_state_boundaries_cfg():
     assert [tn.TaskletNode, tn.StateBoundaryNode, tn.ForScope] == [type(n) for n in stree.children]
 
 
-def test_state_boundaries_state_transition():
+def test_state_boundaries_state_transition() -> None:
     # Manually create a schedule tree
     stree = tn.ScheduleTreeRoot(
         name='tester',
@@ -188,7 +188,7 @@ def test_state_boundaries_state_transition():
 
 
 @pytest.mark.parametrize('boundary', (False, True))
-def test_state_boundaries_propagation(boundary):
+def test_state_boundaries_propagation(boundary: bool) -> None:
     # Manually create a schedule tree
     N = dace.symbol('N')
     stree = tn.ScheduleTreeRoot(
@@ -220,7 +220,7 @@ def test_state_boundaries_propagation(boundary):
 
 
 @pytest.mark.parametrize("control_flow", (True, False))
-def test_create_state_boundary_state_transition(control_flow: bool):
+def test_create_state_boundary_state_transition(control_flow: bool) -> None:
     sdfg = dace.SDFG("tester")
     state = sdfg.add_state("start", is_start_block=True)
     bnode = tn.StateBoundaryNode(control_flow)
@@ -235,7 +235,7 @@ def test_create_state_boundary_empty_memlet():
     t2s._StreeToSDFG(boundary_behavior=t2s.StateBoundaryBehavior.EMPTY_MEMLET)
 
 
-def test_create_tasklet_raw():
+def test_create_tasklet_raw() -> None:
     stree = tn.ScheduleTreeRoot(
         name='tester',
         containers={
@@ -248,7 +248,7 @@ def test_create_tasklet_raw():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     assert len(sdfg.states()) == 1
     state = sdfg.states()[0]
     first_tasklet, write_read_node, second_tasklet, write_node = state.nodes()
@@ -267,7 +267,7 @@ def test_create_tasklet_raw():
             (second_tasklet, write_node)] == [(edge.src, edge.dst) for edge in state.edges()]
 
 
-def test_create_tasklet_waw():
+def test_create_tasklet_waw() -> None:
     stree = tn.ScheduleTreeRoot(
         name='tester',
         containers={
@@ -279,7 +279,7 @@ def test_create_tasklet_waw():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     assert len(sdfg.states()) == 2
     s1, s2 = sdfg.states()
 
@@ -290,7 +290,7 @@ def test_create_tasklet_waw():
     assert [(s2_tasklet, s2_anode)] == [(edge.src, edge.dst) for edge in s2.edges()]
 
 
-def test_create_tasklet_war():
+def test_create_tasklet_war() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={"A": data.Array(dace.float64, [20])},
@@ -303,7 +303,7 @@ def test_create_tasklet_war():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     sdfg_states = list(sdfg.states())
     assert len(sdfg_states) == 1
@@ -315,7 +315,7 @@ def test_create_tasklet_war():
             if isinstance(node, nodes.AccessNode)] == ["A", "A"], "Expect two AccessNodes for A."
 
 
-def test_create_loop_for():
+def test_create_loop_for() -> None:
     for_scope = tn.ForScope(
         loop=LoopRegion(label="my_for_loop",
                         loop_var="i",
@@ -329,7 +329,7 @@ def test_create_loop_for():
     )
 
     stree = tn.ScheduleTreeRoot(name='tester', containers={'A': data.Array(dace.float64, [20])}, children=[for_scope])
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     loops = list(filter(lambda x: isinstance(x, LoopRegion), sdfg.cfg_list))
     assert len(loops) == 1, "SDFG contains one LoopRegion"
@@ -351,8 +351,9 @@ def test_create_loop_for():
 
 
 def test_create_loop_for_same_name() -> None:
+    label = "same_label"
     loop_1 = tn.ForScope(
-        loop=LoopRegion(label="same_label",
+        loop=LoopRegion(label=label,
                         loop_var="i",
                         initialize_expr=CodeBlock("i = 0 "),
                         condition_expr=CodeBlock("i < 3"),
@@ -362,7 +363,7 @@ def test_create_loop_for_same_name() -> None:
         ],
     )
     loop_2 = tn.ForScope(
-        loop=LoopRegion(label="same_label",
+        loop=LoopRegion(label=label,
                         loop_var="i",
                         initialize_expr=CodeBlock("i = 0 "),
                         condition_expr=CodeBlock("i < 3"),
@@ -376,11 +377,13 @@ def test_create_loop_for_same_name() -> None:
         containers={'A': data.Array(dace.float64, [20])},
         children=[loop_1, loop_2],
     )
-    sdfg = stree.as_sdfg(validate=False, simplify=False)
-    assert sdfg.is_valid()
+    sdfg = stree.as_sdfg(validate=True)
+
+    assert len(list(filter(lambda sdfg: isinstance(sdfg, LoopRegion) and sdfg.label == label, sdfg.sdfg_list))) == 1
+    assert len(list(filter(lambda sdfg: isinstance(sdfg, LoopRegion) and sdfg.label != label, sdfg.sdfg_list))) == 1
 
 
-def test_create_loop_while():
+def test_create_loop_while() -> None:
     while_scope = tn.WhileScope(
         children=[
             tn.TaskletNode(nodes.Tasklet('assign_1', {}, {'out'}, 'out = 1'), {}, {'out': dace.Memlet('A[1]')}),
@@ -394,7 +397,7 @@ def test_create_loop_while():
 
     stree = tn.ScheduleTreeRoot(name='tester', containers={'A': data.Array(dace.float64, [20])}, children=[while_scope])
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     loops = list(filter(lambda x: isinstance(x, LoopRegion), sdfg.cfg_list))
     assert len(loops) == 1, "SDFG contains one LoopRegion"
@@ -431,7 +434,7 @@ def test_create_if_else():
             ]),
         ])
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     blocks = list(filter(lambda x: isinstance(x, ConditionalBlock), sdfg.cfg_list))
     assert len(blocks) == 1, "SDFG contains one ConditionalBlock"
@@ -474,7 +477,7 @@ def test_create_if_elif_else() -> None:
             ])
         ])
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     blocks = list(filter(lambda x: isinstance(x, ConditionalBlock), sdfg.cfg_list))
     assert len(blocks) == 1, "SDFG contains one ConditionalBlock"
@@ -484,7 +487,7 @@ def test_create_if_elif_else() -> None:
     assert len(block.branches) == 3, "Block contains three branches"
 
 
-def test_create_if_without_else():
+def test_create_if_without_else() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [20])},
@@ -498,7 +501,7 @@ def test_create_if_without_else():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     blocks = list(filter(lambda x: isinstance(x, ConditionalBlock), sdfg.cfg_list))
     assert len(blocks) == 1, "SDFG contains one ConditionalBlock"
@@ -513,7 +516,7 @@ def test_create_if_without_else():
     assert tasklets[0].label == "bla", "Branch contains Tasklet('bla')"
 
 
-def test_create_map_scope_write():
+def test_create_map_scope_write() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [20])},
@@ -527,11 +530,15 @@ def test_create_map_scope_write():
         ],
     )
 
-    sdfg = stree.as_sdfg()
-    sdfg.validate()
+    sdfg = stree.as_sdfg(validate=True)
+
+    states = sdfg.states()
+    assert len(states) == 1
+    assert [type(node)
+            for node in states[0].nodes()] == [nodes.MapEntry, nodes.Tasklet, nodes.MapExit, nodes.AccessNode]
 
 
-def test_create_map_scope_read():
+def test_create_map_scope_read() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [20])},
@@ -546,7 +553,7 @@ def test_create_map_scope_read():
         ],
     )
 
-    sdfg = stree.as_sdfg(simplify=False)
+    sdfg = stree.as_sdfg(simplify=False, validate=True)
     sdfg.validate()
 
 
@@ -562,11 +569,11 @@ def test_create_map_scope_hello_world():
         ],
     )
 
-    sdfg = stree.as_sdfg(simplify=False)
+    sdfg = stree.as_sdfg(simplify=False, validate=True)
     sdfg.validate()
 
 
-def test_create_map_scope_read_after_write():
+def test_create_map_scope_read_after_write() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -585,11 +592,11 @@ def test_create_map_scope_read_after_write():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_create_map_scope_write_after_read():
+def test_create_map_scope_write_after_read() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={"A": data.Array(dace.float64, [20])},
@@ -604,11 +611,11 @@ def test_create_map_scope_write_after_read():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_create_map_scope_copy():
+def test_create_map_scope_copy() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -626,11 +633,11 @@ def test_create_map_scope_copy():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_create_map_scope_double_memlet():
+def test_create_map_scope_double_memlet() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -647,11 +654,11 @@ def test_create_map_scope_double_memlet():
                         ])
         ])
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_create_map_scope_write_in_two_tasklets():
+def test_create_map_scope_write_in_two_tasklets() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -669,11 +676,11 @@ def test_create_map_scope_write_in_two_tasklets():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_create_nested_map_scope():
+def test_create_nested_map_scope() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [20])},
@@ -693,11 +700,11 @@ def test_create_nested_map_scope():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_double_map_with_for_loop():
+def test_double_map_with_for_loop() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [60])},
@@ -728,11 +735,11 @@ def test_double_map_with_for_loop():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     assert sdfg.is_valid()
 
 
-def test_triple_map_flat_if():
+def test_triple_map_flat_if() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [60])},
@@ -766,11 +773,11 @@ def test_triple_map_flat_if():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_triple_map_nested_if():
+def test_triple_map_nested_if() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [60])},
@@ -813,11 +820,11 @@ def test_triple_map_nested_if():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_triple_map_if_condition_outside():
+def test_triple_map_if_condition_outside() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -856,12 +863,11 @@ def test_triple_map_if_condition_outside():
         ],
     )
 
-    sdfg = stree.as_sdfg(simplify=False)
-    sdfg.validate()
+    sdfg = stree.as_sdfg(simplify=False, validate=True)
     sdfg.compile()
 
 
-def test_create_nested_map_scope_multi_read():
+def test_create_nested_map_scope_multi_read() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -886,11 +892,11 @@ def test_create_nested_map_scope_multi_read():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_map_with_state_boundary_inside():
+def test_map_with_state_boundary_inside() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={'A': data.Array(dace.float64, [20])},
@@ -905,11 +911,11 @@ def test_map_with_state_boundary_inside():
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
     sdfg.validate()
 
 
-def test_map_calculate_temporary_in_two_loops():
+def test_map_calculate_temporary_in_two_loops() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={
@@ -940,14 +946,13 @@ def test_map_calculate_temporary_in_two_loops():
         ],
     )
 
-    sdfg = stree.as_sdfg(simplify=True)
-    sdfg.validate()
+    sdfg = stree.as_sdfg(simplify=True, validate=True)
 
     assert [node.name for node, _ in sdfg.all_nodes_recursive()
             if isinstance(node, nodes.Tasklet)] == ["beginning", "end", "read_temp"]
 
 
-def test_edge_assignment_read_after_write():
+def test_edge_assignment_read_after_write() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",
         containers={},
@@ -958,13 +963,13 @@ def test_edge_assignment_read_after_write():
         ],
     )
 
-    sdfg = stree.as_sdfg(simplify=False)
+    sdfg = stree.as_sdfg(simplify=False, validate=True)
 
     assert [node.name for node in sdfg.nodes()] == ["tree_root", "state_boundary", "state_boundary_0"]
     assert [edge.data.assignments for edge in sdfg.edges()] == [{"my_condition": "True"}, {"condition": "my_condition"}]
 
 
-def test_assign_nodes_force_state_transition():
+def test_assign_nodes_force_state_transition() -> None:
     stree = tn.ScheduleTreeRoot(
         name='tester',
         containers={
@@ -980,7 +985,7 @@ def test_assign_nodes_force_state_transition():
     assert [type(child) for child in stree.children] == [tn.AssignNode, tn.StateBoundaryNode, tn.TaskletNode]
 
 
-def test_assign_nodes_multiple_force_one_transition():
+def test_assign_nodes_multiple_force_one_transition() -> None:
     stree = tn.ScheduleTreeRoot(
         name='tester',
         containers={
@@ -999,7 +1004,7 @@ def test_assign_nodes_multiple_force_one_transition():
             for child in stree.children] == [tn.AssignNode, tn.AssignNode, tn.StateBoundaryNode, tn.TaskletNode]
 
 
-def test_assign_nodes_avoid_duplicate_boundaries():
+def test_assign_nodes_avoid_duplicate_boundaries() -> None:
     stree = tn.ScheduleTreeRoot(
         name='tester',
         containers={
@@ -1030,7 +1035,7 @@ def test_multiple_copy_nodes() -> None:
         ],
     )
 
-    sdfg = stree.as_sdfg()
+    sdfg = stree.as_sdfg(validate=True)
 
     states = sdfg.states()
     assert len(states) == 1, "expect one state"

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -704,6 +704,59 @@ def test_create_nested_map_scope() -> None:
     sdfg.validate()
 
 
+def test_read_after_write_nested_SDFG() -> None:
+    stree = tn.ScheduleTreeRoot(
+        name="tester",
+        containers={
+            'A': data.Array(dace.float32, [60], transient=True),
+            'B': data.Array(dace.float32, [60]),
+        },
+        children=[
+            tn.MapScope(
+                node=nodes.MapEntry(nodes.Map("map_A", "i", sbs.Range.from_string("0:60"))),
+                children=[
+                    tn.TaskletNode(nodes.Tasklet("fill", {}, {"out"}, "out = 42.42"), {}, {"out": dace.Memlet("A[i]")})
+                ],
+            ),
+            tn.MapScope(
+                node=nodes.MapEntry(nodes.Map("map_i", "i", sbs.Range.from_string("0:2"))),
+                children=[
+                    tn.IfScope(
+                        condition=CodeBlock("B[0] < 0"),
+                        children=[
+                            tn.TaskletNode(nodes.Tasklet("assign", {}, {"out"}, "out = 0"), {},
+                                           {"out": dace.Memlet("B[0]")})
+                        ],
+                    ),
+                    tn.MapScope(
+                        node=nodes.MapEntry(nodes.Map("map_j", "j", sbs.Range.from_string("0:10"))),
+                        children=[
+                            tn.TaskletNode(nodes.Tasklet("assign", {}, {"out"}, "out = 1.0"), {},
+                                           {"out": dace.Memlet("A[i*15+j*3]")})
+                        ],
+                    ),
+                    tn.MapScope(node=nodes.MapEntry(nodes.Map("map_k", "k", sbs.Range.from_string("10:20"))),
+                                children=[
+                                    tn.TaskletNode(nodes.Tasklet("assign", {"read"}, {"out"}, "out = read"),
+                                                   {"read": dace.Memlet("A[k]")}, {"out": dace.Memlet("B[k]")})
+                                ])
+                ],
+            ),
+        ],
+    )
+
+    sdfg = stree.as_sdfg(validate=True)
+
+    # Make sure we keep the initialization of A = 42.42
+    assert len(
+        list(
+            filter(lambda node: isinstance(node, nodes.Tasklet) and node.label == "fill",
+                   [node for node, _ in sdfg.all_nodes_recursive()]))) == 1
+    # Ensure that A isn't transient in the nested SDFG
+    nested_sdfg = list(filter(lambda node: node.label == "nested_sdfg", sdfg.sdfg_list))[0]
+    assert not nested_sdfg.arrays["A"].transient
+
+
 def test_double_map_with_for_loop() -> None:
     stree = tn.ScheduleTreeRoot(
         name="tester",

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -379,8 +379,8 @@ def test_create_loop_for_same_name() -> None:
     )
     sdfg = stree.as_sdfg(validate=True)
 
-    assert len(list(filter(lambda sdfg: isinstance(sdfg, LoopRegion) and sdfg.label == label, sdfg.sdfg_list))) == 1
-    assert len(list(filter(lambda sdfg: isinstance(sdfg, LoopRegion) and sdfg.label != label, sdfg.sdfg_list))) == 1
+    assert len(list(filter(lambda sdfg: isinstance(sdfg, LoopRegion) and sdfg.label == label, sdfg.cfg_list))) == 1
+    assert len(list(filter(lambda sdfg: isinstance(sdfg, LoopRegion) and sdfg.label != label, sdfg.cfg_list))) == 1
 
 
 def test_create_loop_while() -> None:
@@ -753,7 +753,7 @@ def test_read_after_write_nested_SDFG() -> None:
             filter(lambda node: isinstance(node, nodes.Tasklet) and node.label == "fill",
                    [node for node, _ in sdfg.all_nodes_recursive()]))) == 1
     # Ensure that A isn't transient in the nested SDFG
-    nested_sdfg = list(filter(lambda node: node.label == "nested_sdfg", sdfg.sdfg_list))[0]
+    nested_sdfg = list(filter(lambda node: node.label == "nested_sdfg", sdfg.cfg_list))[0]
     assert not nested_sdfg.arrays["A"].transient
 
 

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -760,16 +760,21 @@ def test_read_after_write_nested_SDFG() -> None:
         ],
     )
 
-    sdfg = stree.as_sdfg(validate=True)
+    sdfg = stree.as_sdfg(validate=True, simplify=True)
 
     # Make sure we keep the initialization of A = 42.42
     assert len(
         list(
             filter(lambda node: isinstance(node, nodes.Tasklet) and node.label == "fill",
                    [node for node, _ in sdfg.all_nodes_recursive()]))) == 1
+
     # Ensure that A isn't transient in the nested SDFG
-    nested_sdfg = list(filter(lambda node: node.label == "nested_sdfg", sdfg.cfg_list))[0]
+    nested_sdfg: dace.SDFG = list(filter(lambda node: node.label == "nested_sdfg", sdfg.cfg_list))[0]
     assert not nested_sdfg.arrays["A"].transient
+
+    # Ensure that `tmp_condition` is a boolean symbol inside the nested SDFG
+    tmp_condition = nested_sdfg.symbols.get("tmp_condition", None)
+    assert tmp_condition == dace.bool
 
 
 def test_double_map_with_for_loop() -> None:

--- a/tests/schedule_tree/to_sdfg_test.py
+++ b/tests/schedule_tree/to_sdfg_test.py
@@ -710,6 +710,7 @@ def test_read_after_write_nested_SDFG() -> None:
         containers={
             'A': data.Array(dace.float32, [60], transient=True),
             'B': data.Array(dace.float32, [60]),
+            'tmp_condition': data.Scalar(dace.bool, transient=True)
         },
         children=[
             tn.MapScope(
@@ -721,24 +722,38 @@ def test_read_after_write_nested_SDFG() -> None:
             tn.MapScope(
                 node=nodes.MapEntry(nodes.Map("map_i", "i", sbs.Range.from_string("0:2"))),
                 children=[
+                    tn.TaskletNode(
+                        node=nodes.Tasklet("masklet", {"B0"}, {"out"}, "out = B0 < 0"),
+                        in_memlets={"B0": dace.Memlet("B[0]")},
+                        out_memlets={"out": dace.Memlet("tmp_condition[0]")},
+                    ),
                     tn.IfScope(
-                        condition=CodeBlock("B[0] < 0"),
+                        condition=CodeBlock("tmp_condition"),
                         children=[
-                            tn.TaskletNode(nodes.Tasklet("assign", {}, {"out"}, "out = 0"), {},
-                                           {"out": dace.Memlet("B[0]")})
+                            tn.TaskletNode(
+                                nodes.Tasklet("assign", {}, {"out"}, "out = 0"),
+                                {},
+                                {"out": dace.Memlet("B[0]")},
+                            )
                         ],
                     ),
                     tn.MapScope(
                         node=nodes.MapEntry(nodes.Map("map_j", "j", sbs.Range.from_string("0:10"))),
                         children=[
-                            tn.TaskletNode(nodes.Tasklet("assign", {}, {"out"}, "out = 1.0"), {},
-                                           {"out": dace.Memlet("A[i*15+j*3]")})
+                            tn.TaskletNode(
+                                nodes.Tasklet("assign", {}, {"out"}, "out = 1.0"),
+                                {},
+                                {"out": dace.Memlet("A[i*15+j*3]")},
+                            )
                         ],
                     ),
                     tn.MapScope(node=nodes.MapEntry(nodes.Map("map_k", "k", sbs.Range.from_string("10:20"))),
                                 children=[
-                                    tn.TaskletNode(nodes.Tasklet("assign", {"read"}, {"out"}, "out = read"),
-                                                   {"read": dace.Memlet("A[k]")}, {"out": dace.Memlet("B[k]")})
+                                    tn.TaskletNode(
+                                        nodes.Tasklet("assign", {"read"}, {"out"}, "out = read"),
+                                        {"read": dace.Memlet("A[k]")},
+                                        {"out": dace.Memlet("B[k]")},
+                                    )
                                 ])
                 ],
             ),


### PR DESCRIPTION
## Description

Follow-up from PR https://github.com/spcl/dace/pull/2541: there's one more case of "read after write" where we need to add a connector to the nested SDFG to retain the connection to "outside" memory and not confuse simplify.

Founds as part of our work to port the FV3 dynamical core.

<img width="1309" height="1029" alt="image" src="https://github.com/user-attachments/assets/c54db5a2-d952-49cc-9dac-0d44ae80fc05" />

This is DelnFlux_2, last state. Look at `__g_self__fy2`: it's read after written and thus no input connector for `__g_self__fy2`  is added. That's not good because `__g_self__fy2` is only partially written here. Also, since there's no input connector and since the output connector will be (rightfully) pruned, `__g_self__fy2`  will be "inlined" by `DeadDataflowElimination`, which then breaks stuff down the line (e.g. latest in `D_SW`).

The PR adds a simpler reproducer (in tests) and ensures as part of the unit tests that this won't regress.
