### PR TITLE
simplify: rename collection of recursive passes

### DIFF
--- a/dace/transformation/passes/dead_dataflow_elimination.py
+++ b/dace/transformation/passes/dead_dataflow_elimination.py
@@ -24,6 +24,7 @@ PROTECTED_NAMES = {'__pystate'}  #: A set of names that are not allowed to be er
 class DeadDataflowElimination(ppl.ControlFlowRegionPass):
     """
     Removes unused computations from SDFG states.
+
     Traverses the graph backwards, removing any computations that result in transient descriptors
     that are not used again. Removal propagates through scopes (maps), tasklets, and optionally library nodes.
     """

--- a/dace/transformation/passes/simplify.py
+++ b/dace/transformation/passes/simplify.py
@@ -44,7 +44,7 @@ SIMPLIFY_PASSES = [
     EmptyLoopElimination,
 ]
 
-_nonrecursive_passes = [
+_recursive_passes = [
     ScalarToSymbolPromotion,
     DeadDataflowElimination,
     DeadStateElimination,
@@ -128,7 +128,7 @@ class SimplifyPass(ppl.FixedPointPipeline):
                               'for more information.')
                 return None
 
-        if type(p) in _nonrecursive_passes:  # If pass needs to run recursively, do so and modify return value
+        if type(p) in _recursive_passes:  # If pass needs to run recursively, do so and modify return value
             ret: Dict[int, Any] = {}
             for sd in sdfg.all_sdfgs_recursive():
                 subret = p.apply_pass(sd, state)
@@ -142,7 +142,7 @@ class SimplifyPass(ppl.FixedPointPipeline):
 
         if self.verbose:
             if ret is not None:
-                if type(p) not in _nonrecursive_passes:
+                if type(p) not in _recursive_passes:
                     rep = p.report(ret)
                 else:
                     # Create report from recursive application


### PR DESCRIPTION
## Description

This PR renames `_nonrecursive_passes` to `_recursive_passes`  in `dace/transformation/passes/simplify.py` because those are the passes that run recursively.