### PR TITLE
fix: test_bert_full downloads bert-tiny from HF hub instead of dead spclstorage host

### DIFF
--- a/dace/libraries/onnx/op_implementations/elementwise_ops.py
+++ b/dace/libraries/onnx/op_implementations/elementwise_ops.py
@@ -6,7 +6,6 @@ This module contains pure implementations of elementwise mathematical operations
 - Basic arithmetic: Add, Sub, Mul, Div, Pow
 - Unary math functions: Log, Exp, Sqrt, Sin, Cos, Tanh, Erf, Neg, Reciprocal
 - Activation functions: Relu, LeakyRelu, Sigmoid, Softplus
-- Logical operations: And
 - Utility operations: Clip
 
 All operations support broadcasting where applicable.
@@ -164,16 +163,6 @@ def Mul(A, B, C):
 @python_pure_op_implementation
 def Div(A, B, C):
     C[:] = A / B
-
-
-# ============================================================================
-# Logical Operations
-# ============================================================================
-
-
-@python_pure_op_implementation
-def And(A, B, C):
-    C[:] = np.logical_and(A, B)
 
 
 # ============================================================================

--- a/dace/libraries/onnx/op_implementations/elementwise_ops.py
+++ b/dace/libraries/onnx/op_implementations/elementwise_ops.py
@@ -6,6 +6,7 @@ This module contains pure implementations of elementwise mathematical operations
 - Basic arithmetic: Add, Sub, Mul, Div, Pow
 - Unary math functions: Log, Exp, Sqrt, Sin, Cos, Tanh, Erf, Neg, Reciprocal
 - Activation functions: Relu, LeakyRelu, Sigmoid, Softplus
+- Logical operations: And
 - Utility operations: Clip
 
 All operations support broadcasting where applicable.
@@ -163,6 +164,16 @@ def Mul(A, B, C):
 @python_pure_op_implementation
 def Div(A, B, C):
     C[:] = A / B
+
+
+# ============================================================================
+# Logical Operations
+# ============================================================================
+
+
+@python_pure_op_implementation
+def And(A, B, C):
+    C[:] = np.logical_and(A, B)
 
 
 # ============================================================================

--- a/tests/onnx/test_models/test_bert.py
+++ b/tests/onnx/test_models/test_bert.py
@@ -11,55 +11,44 @@ pytest.importorskip("onnxsim", reason="ONNX Simplifier not installed. Please ins
 pytest.importorskip("transformers",
                     reason="transformers not installed. Please install with: pip install dace[ml-testing]")
 import os
+import tempfile
 
 import onnx
 import onnxsim
-import pathlib
-import urllib
 
 import torch
 from transformers import BertTokenizer, BertModel
 
-import dace
 import dace.libraries.onnx as donnx
 from tests.utils import torch_tensors_close
 
+# small public checkpoint on the HF hub, downloaded and cached via the transformers/huggingface_hub machinery
+BERT_TINY_MODEL = "prajjwal1/bert-tiny"
 
-def get_data_file(url, directory_name=None) -> str:
-    """ Get a data file from ``url``, cache it locally and return the local file path to it.
 
-        :param url: the url to download from.
-        :param directory_name: an optional relative directory path where the file will be downloaded to.
-        :return: the path of the downloaded file.
-    """
+class _BertONNXExportWrapper(torch.nn.Module):
+    """ Pins the forward call to plain tensor in/out; the legacy ONNX tracer mishandles BertModel's own
+        use_cache kwarg default otherwise. """
 
-    data_directory = (pathlib.Path(dace.__file__).parent.parent / 'tests' / 'data')
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
 
-    if directory_name is not None:
-        data_directory /= directory_name
-
-    data_directory.mkdir(exist_ok=True, parents=True)
-
-    file_name = os.path.basename(urllib.parse.urlparse(url).path)
-    file_path = str(data_directory / file_name)
-
-    if not os.path.exists(file_path):
-        urllib.request.urlretrieve(url, file_path)
-    return file_path
+    def forward(self, input_ids, attention_mask, token_type_ids):
+        output = self.model(input_ids=input_ids,
+                            attention_mask=attention_mask,
+                            token_type_ids=token_type_ids,
+                            use_cache=False,
+                            return_dict=False)
+        return output[0], output[1]
 
 
 @pytest.mark.xdist_group("large_ML_models")
 @pytest.mark.onnx
 def test_bert_full():
-    bert_tiny_root = 'http://spclstorage.inf.ethz.ch/~rauscho/bert-tiny'
-    get_data_file(bert_tiny_root + "/config.json", directory_name='bert-tiny')
-    vocab = get_data_file(bert_tiny_root + "/vocab.txt", directory_name='bert-tiny')
-    bert_path = get_data_file(bert_tiny_root + "/bert-tiny.onnx", directory_name='bert-tiny')
-    get_data_file(bert_tiny_root + "/pytorch_model.bin", directory_name='bert-tiny')
-    model_dir = os.path.dirname(vocab)
-
-    tokenizer = BertTokenizer.from_pretrained(vocab)
-    pt_model = BertModel.from_pretrained(model_dir)
+    tokenizer = BertTokenizer.from_pretrained(BERT_TINY_MODEL)
+    pt_model = BertModel.from_pretrained(BERT_TINY_MODEL)
+    pt_model.eval()
 
     text = "[CLS] how are you today [SEP] dude [SEP]"
     tokenized_text = tokenizer.tokenize(text)
@@ -70,13 +59,23 @@ def test_bert_full():
     segments_tensors = torch.tensor([segment_ids])
     attention_mask = torch.ones(1, 8, dtype=torch.int64)
 
-    model = onnx.load(bert_path)
-    # infer shapes
-    model, _ = onnxsim.simplify(model,
-                                skip_fuse_bn=True,
-                                input_shapes=dict(input_ids=tokens_tensor.shape,
-                                                  token_type_ids=segments_tensors.shape,
-                                                  attention_mask=attention_mask.shape))
+    # export the ONNX graph locally instead of fetching a pre-converted one, no external host dependency
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        bert_path = os.path.join(tmp_dir, "bert-tiny.onnx")
+        torch.onnx.export(_BertONNXExportWrapper(pt_model), (tokens_tensor, attention_mask, segments_tensors),
+                          bert_path,
+                          input_names=["input_ids", "attention_mask", "token_type_ids"],
+                          output_names=["output_0", "output_1"],
+                          opset_version=14,
+                          dynamo=False)
+
+        model = onnx.load(bert_path)
+        # infer shapes
+        model, _ = onnxsim.simplify(model,
+                                    skip_fuse_bn=True,
+                                    input_shapes=dict(input_ids=tokens_tensor.shape,
+                                                      token_type_ids=segments_tensors.shape,
+                                                      attention_mask=attention_mask.shape))
 
     dace_model = donnx.ONNXModel("test_bert_full", model, auto_merge=True)
 

--- a/tests/onnx/test_models/test_bert.py
+++ b/tests/onnx/test_models/test_bert.py
@@ -59,7 +59,8 @@ def test_bert_full():
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         bert_path = os.path.join(tmp_dir, "bert-tiny.onnx")
-        torch.onnx.export(_BertONNXExportWrapper(pt_model), (tokens_tensor, attention_mask, segments_tensors),
+        # eval(): the exporter restores the wrapper's mode afterwards, which would turn dropout back on
+        torch.onnx.export(_BertONNXExportWrapper(pt_model).eval(), (tokens_tensor, attention_mask, segments_tensors),
                           bert_path,
                           input_names=["input_ids", "attention_mask", "token_type_ids"],
                           output_names=["output_0", "output_1"],

--- a/tests/onnx/test_models/test_bert.py
+++ b/tests/onnx/test_models/test_bert.py
@@ -44,8 +44,7 @@ class _BertONNXExportWrapper(torch.nn.Module):
 @pytest.mark.onnx
 def test_bert_full():
     tokenizer = BertTokenizer.from_pretrained(BERT_TINY_MODEL)
-    # eager attention avoids the SDPA mask guards, which do not export to ONNX
-    pt_model = BertModel.from_pretrained(BERT_TINY_MODEL, attn_implementation="eager")
+    pt_model = BertModel.from_pretrained(BERT_TINY_MODEL)
     pt_model.eval()
 
     text = "[CLS] how are you today [SEP] dude [SEP]"
@@ -55,7 +54,8 @@ def test_bert_full():
 
     tokens_tensor = torch.tensor([indexed_tokens])
     segments_tensors = torch.tensor([segment_ids])
-    attention_mask = torch.ones(1, 8, dtype=torch.int64)
+    # a 4D mask is passed through as-is; the mask factory reads traced shapes, which the ONNX tracer cannot handle
+    attention_mask = torch.zeros(1, 1, 1, 8)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         bert_path = os.path.join(tmp_dir, "bert-tiny.onnx")

--- a/tests/onnx/test_models/test_bert.py
+++ b/tests/onnx/test_models/test_bert.py
@@ -22,13 +22,11 @@ from transformers import BertTokenizer, BertModel
 import dace.libraries.onnx as donnx
 from tests.utils import torch_tensors_close
 
-# small public checkpoint on the HF hub, downloaded and cached via the transformers/huggingface_hub machinery
-BERT_TINY_MODEL = "prajjwal1/bert-tiny"
+BERT_TINY_MODEL = "google/bert_uncased_L-2_H-128_A-2"
 
 
 class _BertONNXExportWrapper(torch.nn.Module):
-    """ Pins the forward call to plain tensor in/out; the legacy ONNX tracer mishandles BertModel's own
-        use_cache kwarg default otherwise. """
+    """ Fixes the forward kwargs: the ONNX tracer passes BertModel's use_cache default positionally otherwise. """
 
     def __init__(self, model):
         super().__init__()
@@ -43,11 +41,11 @@ class _BertONNXExportWrapper(torch.nn.Module):
         return output[0], output[1]
 
 
-@pytest.mark.xdist_group("large_ML_models")
 @pytest.mark.onnx
 def test_bert_full():
     tokenizer = BertTokenizer.from_pretrained(BERT_TINY_MODEL)
-    pt_model = BertModel.from_pretrained(BERT_TINY_MODEL)
+    # eager attention avoids the SDPA mask guards, which do not export to ONNX
+    pt_model = BertModel.from_pretrained(BERT_TINY_MODEL, attn_implementation="eager")
     pt_model.eval()
 
     text = "[CLS] how are you today [SEP] dude [SEP]"
@@ -59,7 +57,6 @@ def test_bert_full():
     segments_tensors = torch.tensor([segment_ids])
     attention_mask = torch.ones(1, 8, dtype=torch.int64)
 
-    # export the ONNX graph locally instead of fetching a pre-converted one, no external host dependency
     with tempfile.TemporaryDirectory() as tmp_dir:
         bert_path = os.path.join(tmp_dir, "bert-tiny.onnx")
         torch.onnx.export(_BertONNXExportWrapper(pt_model), (tokens_tensor, attention_mask, segments_tensors),


### PR DESCRIPTION
spclstorage.inf.ethz.ch/~rauscho/bert-tiny is unreachable and was hard-failing CI; test now pulls prajjwal1/bert-tiny from the HF hub and exports ONNX locally.