### PR TITLE
fix deprecation warnings in schedule tree tests

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -710,8 +710,8 @@ class TaskletTransformer(ExtNodeTransformer):
             self.lang = dtypes.Language.Python
 
         t = self.state.add_tasklet(name,
-                                   set(self.inputs.keys()),
-                                   set(self.outputs.keys()),
+                                   self.inputs.keys(),
+                                   self.outputs.keys(),
                                    self.extcode or tasklet_ast.body,
                                    language=self.lang,
                                    code_global=self.globalcode,

--- a/dace/frontend/python/replacements/operators.py
+++ b/dace/frontend/python/replacements/operators.py
@@ -389,8 +389,10 @@ def _array_array_binop(visitor: ProgramVisitor, sdfg: SDFG, state: SDFGState, le
     out_operand, out_arr = visitor.add_temp_transient(out_shape, restype, left_arr.storage)
 
     if list(out_shape) == [1]:
-        tasklet = state.add_tasklet('_%s_' % operator, {'__in1', '__in2'}, {'__out'},
-                                    '__out = {i1} {op} {i2}'.format(i1=tasklet_args[0], op=opcode, i2=tasklet_args[1]))
+        tasklet = state.add_tasklet('_%s_' % operator, {
+            '__in1': None,
+            '__in2': None
+        }, {'__out'}, '__out = {i1} {op} {i2}'.format(i1=tasklet_args[0], op=opcode, i2=tasklet_args[1]))
         n1 = state.add_read(left_operand)
         n2 = state.add_read(right_operand)
         n3 = state.add_write(out_operand)
@@ -581,8 +583,10 @@ def _scalar_scalar_binop(visitor: ProgramVisitor, sdfg: SDFG, state: SDFGState, 
                                             storage=left_scal.storage,
                                             find_new_name=True)
 
-    tasklet = state.add_tasklet('_%s_' % operator, {'__in1', '__in2'}, {'__out'},
-                                '__out = {i1} {op} {i2}'.format(i1=tasklet_args[0], op=opcode, i2=tasklet_args[1]))
+    tasklet = state.add_tasklet('_%s_' % operator, {
+        '__in1': None,
+        '__in2': None
+    }, {'__out'}, '__out = {i1} {op} {i2}'.format(i1=tasklet_args[0], op=opcode, i2=tasklet_args[1]))
     n1 = state.add_read(left_operand)
     n2 = state.add_read(right_operand)
     n3 = state.add_write(out_operand)

--- a/tests/schedule_tree/nesting_test.py
+++ b/tests/schedule_tree/nesting_test.py
@@ -209,7 +209,7 @@ def test_dealias_interstate_edge():
 
     # Connect to nested SDFG both with renaming and offset memlets
     state = sdfg.add_state()
-    nsdfg_node = state.add_nested_sdfg(nsdfg, {'A', 'B'}, {})
+    nsdfg_node = state.add_nested_sdfg(nsdfg, {'A': None, 'B': None}, {})
     ra = state.add_read('A')
     rb = state.add_read('B')
     state.add_edge(ra, None, nsdfg_node, 'B', dace.Memlet('A[1:20]'))


### PR DESCRIPTION
## Description

Using a `set` as data type for inputs / outputs of `NestedSDFG`s or `Tasklet`s is deprecated because sets are not ordered and thus generated SDFGs might not be deterministic.

Replacing all inputs/outputs with `Set`  type is an ongoing effort. This PR updates what is needed to get no warnings when running all tests under `tests/schedule_tree/`.