### PR TITLE
Remove RTLTasklet class from nodes.py

### DIFF
--- a/dace/sdfg/nodes.py
+++ b/dace/sdfg/nodes.py
@@ -561,25 +561,6 @@ class Tasklet(CodeNode):
             return self.label
 
 
-@make_properties
-class RTLTasklet(Tasklet):
-    """ A specialized tasklet, which is a functional computation procedure
-        that can only access external data specified using connectors.
-
-        This tasklet is specialized for tasklets implemented in System Verilog
-        in that it adds support for adding metadata about the IP cores in use.
-    """
-    # TODO to be replaced when enums have embedded properties
-    ip_cores = DictProperty(key_type=str, value_type=dict, desc="A set of IP cores used by the tasklet.")
-
-    @property
-    def __jsontype__(self):
-        return 'Tasklet'
-
-    def add_ip_core(self, module_name, name, vendor, version, params):
-        self.ip_cores[module_name] = {'name': name, 'vendor': vendor, 'version': version, 'params': params}
-
-
 # ------------------------------------------------------------------------------
 
 

--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -1737,19 +1737,6 @@ class SDFGState(OrderedMultiDiConnectorGraph[nd.Node, mm.Memlet], ControlFlowBlo
             location=location,
             side_effects=side_effects,
             debuginfo=debuginfo,
-        ) if language != dtypes.Language.SystemVerilog else nd.RTLTasklet(
-            name,
-            inputs,
-            outputs,
-            code,
-            language,
-            state_fields=state_fields,
-            code_global=code_global,
-            code_init=code_init,
-            code_exit=code_exit,
-            location=location,
-            side_effects=side_effects,
-            debuginfo=debuginfo,
         )
         self.add_node(tasklet)
         return tasklet


### PR DESCRIPTION
Removed the RTLTasklet class, which is a leftover of the FPGA codegen migration.