### PR TITLE
Fold a repeated symbol name in Range.offset and Range.compose

### DIFF
--- a/dace/libraries/standard/nodes/reduce.py
+++ b/dace/libraries/standard/nodes/reduce.py
@@ -948,8 +948,11 @@ class ExpandReduceGPUAuto(pm.ExpandTransformation):
 
         input_data = dcpy(raw_input_data)
         input_data.transient = False
-        input_data.shape = schedule.in_shape
-        input_data.strides = schedule.in_strides
+        # Through ``set_shape``, because ``offset`` is rank-dependent: assigning ``shape`` alone
+        # leaves it at the source array's rank, and a descriptor whose offset and shape disagree
+        # cannot be read back (``Offset must be the same size as shape``), so the SDFG stops
+        # surviving a serialization round trip.
+        input_data.set_shape(schedule.in_shape, strides=schedule.in_strides, total_size=input_data.total_size)
         nsdfg.add_datadesc('_in', input_data)
 
         output_data = dcpy(raw_output_data)

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -521,8 +521,8 @@ class Range(Subset):
         for i in indices:
             rb, re, rs = self.ranges[i]
             if offset_end:
-                re = re + mult * off[i]
-            self.ranges[i] = (rb + mult * off[i], re, rs)
+                re = symbolic.equalize_symbol(re + mult * off[i])
+            self.ranges[i] = (symbolic.equalize_symbol(rb + mult * off[i]), re, rs)
 
     def offset_new(self, other, negative, indices=None, offset_end=True):
         if other is None:
@@ -536,8 +536,11 @@ class Range(Subset):
         if indices is None:
             indices = set(range(len(self.ranges)))
         off = other.min_element()
-        return Range([(self.ranges[i][0] + mult * off[i], self.ranges[i][1] if not offset_end else
-                       (self.ranges[i][1] + mult * off[i]), self.ranges[i][2]) for i in indices])
+        return Range([
+            (symbolic.equalize_symbol(self.ranges[i][0] + mult * off[i]),
+             self.ranges[i][1] if not offset_end else symbolic.equalize_symbol(self.ranges[i][1] + mult * off[i]),
+             self.ranges[i][2]) for i in indices
+        ])
 
     def dims(self):
         return len(self.ranges)

--- a/dace/subsets.py
+++ b/dace/subsets.py
@@ -842,7 +842,15 @@ class Range(Subset):
                              "or be not stripped of latter at all.")
 
         if isinstance(other, Range):
-            return Range(new_subset)
+            # Through ``equalize_symbol`` for the same reason ``offset`` does: composition adds a
+            # bound of this subset to one of ``other``, and the two can carry different mints of one
+            # name -- a map parameter's and a string-parsed memlet's. SymPy compares assumptions, so
+            # ``i + (M - i - 1)`` keeps both atoms instead of folding to ``M - 1``.
+            return Range([
+                tuple(symbolic.equalize_symbol(entry)
+                      for entry in bounds) if isinstance(bounds, tuple) else symbolic.equalize_symbol(bounds)
+                for bounds in new_subset
+            ])
         else:
             raise NotImplementedError
 

--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -2655,9 +2655,31 @@ def equalize_symbol(sym: sympy.Expr) -> sympy.Expr:
     name, it substitutes them with the last symbol (as they appear in
     s.free_symbols).
     """
+    if not has_duplicate_symbol_names(sym):
+        return sym
     symdict = {s.name: s for s in sym.free_symbols}
     repldict = {s: symdict[s.name] for s in sym.free_symbols}
     return sym.subs(repldict)
+
+
+def has_duplicate_symbol_names(sym: Any) -> bool:
+    """
+    Whether ``sym`` holds two symbols that share a name but not their dtype or assumptions.
+
+    Symbol identity in DaCe is the name, so such a pair always denotes one value -- but SymPy
+    compares assumptions too, keeps both atoms, and then ``k - k`` does not fold to zero.
+
+    :param sym: expression to check; anything that is not symbolic answers False.
+    :return: True if some name occurs on more than one symbol.
+    """
+    if not isinstance(sym, sympy.Basic):
+        return False
+    symbols = sym.free_symbols
+    if len(symbols) < 2:
+        return False
+    # A dict rather than a set: insertion order is defined, so the answer cannot depend on the
+    # hash seed the way a set's iteration would.
+    return len({symbol_atom.name: None for symbol_atom in symbols}) != len(symbols)
 
 
 def equalize_symbols(a: sympy.Expr, b: sympy.Expr) -> Tuple[sympy.Expr, sympy.Expr]:

--- a/tests/reduce_gpu_auto_descriptor_test.py
+++ b/tests/reduce_gpu_auto_descriptor_test.py
@@ -1,0 +1,76 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""The GPUAuto reduce expansion must leave its ``_in`` descriptor in a readable state.
+
+The expansion reshapes the input descriptor to the shape the reduction schedule wants. ``offset``
+is rank-dependent, so assigning ``shape`` alone leaves it at the source array's rank: the
+descriptor then fails its own ``validate`` with ``Offset must be the same size as shape``, and
+deserialization answers with an unregistered placeholder instead of an ``Array``, which is how the
+SDFG stops surviving a serialization round trip (``testing.serialization``, on in CI).
+
+Expanding a library node needs neither a GPU nor a compiler, so this runs anywhere.
+"""
+
+import pytest
+
+import dace
+from dace import dtypes
+from dace.sdfg import nodes
+from dace.libraries.standard.nodes import Reduce
+
+
+def gpu_auto_reduce_sdfg() -> dace.SDFG:
+    """A rank-4 reduction over the last axis, which is where the reshape changes the rank."""
+    sdfg = dace.SDFG('gpu_auto_reduce')
+    sdfg.add_array('A', [2, 3, 4, 5], dace.float32, storage=dtypes.StorageType.GPU_Global)
+    sdfg.add_array('B', [2, 3, 4], dace.float32, storage=dtypes.StorageType.GPU_Global)
+
+    state = sdfg.add_state()
+    reduce_node = Reduce('reduce', wcr='lambda a, b: a + b', axes=[3], identity=0)
+    reduce_node.implementation = 'GPUAuto'
+    reduce_node.add_in_connector('_in')
+    reduce_node.add_out_connector('_out')
+    state.add_node(reduce_node)
+    state.add_edge(state.add_read('A'), None, reduce_node, '_in', dace.Memlet('A[0:2, 0:3, 0:4, 0:5]'))
+    state.add_edge(reduce_node, '_out', state.add_write('B'), None, dace.Memlet('B[0:2, 0:3, 0:4]'))
+
+    sdfg.validate()
+    return sdfg
+
+
+def all_descriptors(sdfg: dace.SDFG):
+    """Every data descriptor in ``sdfg``, including the ones the expansion nested inside it."""
+    for name, desc in sdfg.arrays.items():
+        yield sdfg.label, name, desc
+    for state in sdfg.states():
+        for node in state.nodes():
+            if isinstance(node, nodes.NestedSDFG):
+                yield from all_descriptors(node.sdfg)
+
+
+def test_the_expansion_leaves_every_descriptor_valid():
+    sdfg = gpu_auto_reduce_sdfg()
+    sdfg.expand_library_nodes()
+
+    invalid = []
+    for owner, name, desc in all_descriptors(sdfg):
+        try:
+            desc.validate()
+        except TypeError as exc:
+            invalid.append(f'{owner}.{name}: {exc}')
+    assert not invalid, 'the expansion produced descriptors that cannot be read back: ' + '; '.join(invalid)
+
+
+def test_the_reshaped_input_keeps_its_offset_at_the_new_rank():
+    """The specific pairing the bug broke, named so a regression says what it broke."""
+    sdfg = gpu_auto_reduce_sdfg()
+    sdfg.expand_library_nodes()
+
+    reshaped = [desc for _, name, desc in all_descriptors(sdfg) if name == '_in']
+    assert reshaped, 'the GPUAuto expansion did not run, so this test is anchored on nothing'
+    for desc in reshaped:
+        assert len(desc.offset) == len(desc.shape), f'offset {desc.offset} does not match shape {desc.shape}'
+        assert len(desc.strides) == len(desc.shape), f'strides {desc.strides} do not match shape {desc.shape}'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/subsets_symbol_name_collapse_test.py
+++ b/tests/subsets_symbol_name_collapse_test.py
@@ -51,5 +51,14 @@ def test_the_guard_reports_a_duplicated_name():
     assert not symbolic.has_duplicate_symbol_names(5)
 
 
+def test_compose_folds_it_too():
+    """``Range.compose`` adds a bound of one subset to a bound of the other, same as ``offset``."""
+    from_map, _ = differently_minted_pair()
+    outer = subsets.Range([(from_map, from_map, 1)])
+    composed = outer.compose(dace.Memlet('A[0:M - k]').subset)
+    assert not symbolic.has_duplicate_symbol_names(composed.min_element()[0]), \
+        f'composition kept one name on two symbols: {composed}'
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/subsets_symbol_name_collapse_test.py
+++ b/tests/subsets_symbol_name_collapse_test.py
@@ -1,0 +1,55 @@
+# Copyright 2019-2026 ETH Zurich and the DaCe authors. All rights reserved.
+"""Offsetting a subset must fold a symbol against itself, whatever minted the two instances.
+
+A memlet parsed from a string mints its symbols with the default dtype and no assumptions, while
+a map parameter carries the frontend's -- ``int64``, ``nonnegative``. SymPy compares assumptions,
+so the two ``k`` atoms are different objects and ``k - k`` stays in the subset instead of folding
+to ``0``. In DaCe a symbol IS its name, so both denote the same value and the difference is zero;
+left in the graph it also stops the SDFG from surviving a serialization round trip, because only
+one of the two atoms is written with its dtype and the other comes back as a third symbol.
+"""
+
+import pytest
+
+import dace
+from dace import subsets, symbolic
+
+
+def differently_minted_pair():
+    """The same name from the two paths that disagree: a map parameter and a parsed memlet."""
+    from_map = symbolic.symbol('k', dace.int64, nonnegative=True)
+    from_string = dace.Memlet('A[k]').subset.min_element()[0]
+    assert from_map - from_string != 0, 'the two paths agree now, so this test guards nothing'
+    return from_map, from_string
+
+
+def test_offset_folds_a_symbol_against_its_differently_minted_twin():
+    from_map, _ = differently_minted_pair()
+    rng = subsets.Range([(from_map, from_map, 1)])
+    rng.offset(dace.Memlet('A[k]').subset, negative=True)
+    assert rng == subsets.Range([(0, 0, 1)]), f'k - k did not fold: {rng}'
+
+
+def test_offset_new_folds_it_too():
+    from_map, _ = differently_minted_pair()
+    rng = subsets.Range([(from_map, from_map, 1)]).offset_new(dace.Memlet('A[k]').subset, negative=True)
+    assert rng == subsets.Range([(0, 0, 1)]), f'k - k did not fold: {rng}'
+
+
+def test_an_offset_by_another_symbol_is_left_alone():
+    """The fold is only for one name on two atoms -- a real difference must survive."""
+    rng = subsets.Range([(symbolic.symbol('k', dace.int64, nonnegative=True), ) * 2 + (1, )])
+    rng.offset(dace.Memlet('A[j]').subset, negative=True)
+    assert rng != subsets.Range([(0, 0, 1)]), 'k - j was folded away'
+    assert {str(s) for s in rng.free_symbols} == {'k', 'j'}, f'unexpected symbols in {rng}'
+
+
+def test_the_guard_reports_a_duplicated_name():
+    from_map, from_string = differently_minted_pair()
+    assert symbolic.has_duplicate_symbol_names(from_map - from_string)
+    assert not symbolic.has_duplicate_symbol_names(from_map - symbolic.symbol('j'))
+    assert not symbolic.has_duplicate_symbol_names(5)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
Adding a bound of one subset to a bound of another brings together two mints of the same name — a map parameter's symbol is int64 and nonnegative, a string-parsed memlet's is neither — and SymPy compares assumptions, so `Range.offset` left `k - k` and `Range.compose` left `i + (M - i - 1)` standing where both mean something simpler; the expression then does not survive a serialization round trip, since only one of the two atoms is written with its dtype. Both now fold through `equalize_symbol`, guarded by a name count so the substitution only runs when a name really is repeated, and the GPUAuto reduce expansion reshapes its `_in` descriptor through `set_shape` so `offset` no longer keeps the source array's rank.