### PR TITLE
Scale a strided tile's over-approximation by the map step

### DIFF
--- a/dace/transformation/dataflow/strip_mining.py
+++ b/dace/transformation/dataflow/strip_mining.py
@@ -215,8 +215,13 @@ class StripMining(transformation.SingleStateTransformation):
         else:
             if isinstance(td_to, dace.symbolic.SymExpr):
                 td_to = td_to.expr
+            # The approximation must span the same INDEX extent as the exact bound: ``tile_size``
+            # iterations of a step-``td_step`` map cover ``tile_size * td_step`` indices. Dropping
+            # the step under-approximated a strided tile by a factor of ``td_step``, so
+            # ``InferGPUGridAndBlockSize`` read half the threads a step-2 thread-block map holds
+            # and rejected it as conflicting with the kernel's declared ``gpu_block_size``.
             td_to_new = dace.symbolic.SymExpr(sympy.Min(dimsym + tile_size * td_step - 1, td_to),
-                                              dimsym + tile_size - 1)
+                                              dimsym + tile_size * td_step - 1)
         td_step_new = td_step
 
         return new_dim, new_map, (td_from_new, td_to_new, td_step_new)

--- a/dace/transformation/dataflow/strip_mining.py
+++ b/dace/transformation/dataflow/strip_mining.py
@@ -215,11 +215,8 @@ class StripMining(transformation.SingleStateTransformation):
         else:
             if isinstance(td_to, dace.symbolic.SymExpr):
                 td_to = td_to.expr
-            # The approximation must span the same INDEX extent as the exact bound: ``tile_size``
-            # iterations of a step-``td_step`` map cover ``tile_size * td_step`` indices. Dropping
-            # the step under-approximated a strided tile by a factor of ``td_step``, so
-            # ``InferGPUGridAndBlockSize`` read half the threads a step-2 thread-block map holds
-            # and rejected it as conflicting with the kernel's declared ``gpu_block_size``.
+            # Exact and approximate bounds must span the same index extent: ``tile_size``
+            # iterations of a step-``td_step`` map cover ``tile_size * td_step`` indices.
             td_to_new = dace.symbolic.SymExpr(sympy.Min(dimsym + tile_size * td_step - 1, td_to),
                                               dimsym + tile_size * td_step - 1)
         td_step_new = td_step

--- a/tests/transformations/strip_mining_test.py
+++ b/tests/transformations/strip_mining_test.py
@@ -53,8 +53,8 @@ def test_strip_mining():
     assert np.all(A_np == 1), f"A should be all ones. but got {A_np}"
 
 
-def _strided_assign_sdfg(step: int):
-    """``A[i] = 1`` over ``0:64:step``, built so ``StripMining`` sees a strided map."""
+def strided_tiled_sdfg(step: int, tile_size: int):
+    """``A[i] = 1`` over ``0:64:step``, strip-mined by ``tile_size`` iterations."""
     sdfg = dace.SDFG(f"strided_assign_{step}")
     sdfg.add_array("A", (64, ), dtype=dace.uint32)
     state = sdfg.add_state("main")
@@ -66,51 +66,36 @@ def _strided_assign_sdfg(step: int):
     state.add_edge(map_exit, "OUT_A", A, None, dace.Memlet("A[0:64]"))
     map_exit.add_in_connector("IN_A")
     map_exit.add_out_connector("OUT_A")
-    return sdfg, state, map_entry
 
-
-def test_strided_tile_extent_is_scaled_by_the_map_step():
-    """A tile of ``tile_size`` ITERATIONS spans ``tile_size * step`` INDICES.
-
-    ``Range.size()`` reads the ``SymExpr`` over-approximation, so an approximation that omits the
-    step reports ``tile_size / step`` iterations for the tile -- half the threads a step-2
-    thread-block map actually holds. ``InferGPUGridAndBlockSize`` then read that undercount and
-    rejected the map as conflicting with the kernel's declared ``gpu_block_size``.
-    """
-    tile_size = 8
-    for step in (1, 2, 4):
-        sdfg, state, map_entry = _strided_assign_sdfg(step)
-        stripmine = StripMining()
-        stripmine.map_entry = map_entry
-        stripmine.dim_idx = 0
-        stripmine.new_dim_prefix = "block"
-        stripmine.tile_size = tile_size
-        stripmine.tile_stride = tile_size
-        stripmine.apply(state, sdfg)
-
-        # ``map_entry`` is the inner (tile) map after strip-mining; its parent is the tile-number map.
-        assert map_entry.map.range.size() == [tile_size], \
-            f"step={step}: tile holds {map_entry.map.range.size()} iterations, expected {tile_size}"
-        outer = state.entry_node(map_entry)
-        assert outer.map.range[0][2] == tile_size * step, \
-            f"step={step}: tile-number map strides {outer.map.range[0][2]}, expected {tile_size * step}"
-        # The exact bound (the one that lands in the generated guard) spans the same index extent.
-        begin, end, _ = map_entry.map.range[0]
-        assert (end.approx - begin) + 1 == tile_size * step, \
-            f"step={step}: approximated tile spans {(end.approx - begin) + 1} indices, expected {tile_size * step}"
-
-
-def test_strided_tile_assigns_every_visited_element():
-    """The corrected approximation must not change which elements the strip-mined map writes."""
-    sdfg, state, map_entry = _strided_assign_sdfg(2)
     stripmine = StripMining()
     stripmine.map_entry = map_entry
     stripmine.dim_idx = 0
     stripmine.new_dim_prefix = "block"
-    stripmine.tile_size = 8
-    stripmine.tile_stride = 8
+    stripmine.tile_size = tile_size
+    stripmine.tile_stride = tile_size
     stripmine.apply(state, sdfg)
+    return sdfg, state, map_entry
 
+
+def test_strided_tile_extent_is_scaled_by_the_map_step():
+    """A tile of ``tile_size`` iterations spans ``tile_size * step`` indices.
+
+    ``Range.size()`` reads the ``SymExpr`` over-approximation, so an approximation that omits the
+    step reports ``tile_size / step`` iterations per tile.
+    """
+    tile_size = 8
+    for step in (1, 2, 4):
+        _, state, map_entry = strided_tiled_sdfg(step, tile_size)
+        # ``map_entry`` is the inner (tile) map after strip-mining; its parent is the tile-number map.
+        assert map_entry.map.range.size() == [tile_size], \
+            f"step={step}: tile holds {map_entry.map.range.size()} iterations, expected {tile_size}"
+        assert state.entry_node(map_entry).map.range[0][2] == tile_size * step, \
+            f"step={step}: tile-number map strides {state.entry_node(map_entry).map.range[0][2]}"
+
+
+def test_strided_tile_assigns_every_visited_element():
+    """The corrected approximation must not change which elements the strip-mined map writes."""
+    sdfg, _, _ = strided_tiled_sdfg(2, 8)
     A_np = np.zeros([64], dtype=np.uint32)
     sdfg(A=A_np)
     expected = np.zeros([64], dtype=np.uint32)

--- a/tests/transformations/strip_mining_test.py
+++ b/tests/transformations/strip_mining_test.py
@@ -53,5 +53,72 @@ def test_strip_mining():
     assert np.all(A_np == 1), f"A should be all ones. but got {A_np}"
 
 
+def _strided_assign_sdfg(step: int):
+    """``A[i] = 1`` over ``0:64:step``, built so ``StripMining`` sees a strided map."""
+    sdfg = dace.SDFG(f"strided_assign_{step}")
+    sdfg.add_array("A", (64, ), dtype=dace.uint32)
+    state = sdfg.add_state("main")
+    A = state.add_access("A")
+    map_entry, map_exit = state.add_map("map", dict(i=f"0:64:{step}"))
+    tasklet = state.add_tasklet("assign", inputs=dict(), outputs={"_out"}, code="_out = 1")
+    state.add_edge(map_entry, None, tasklet, None, dace.Memlet())
+    state.add_edge(tasklet, "_out", map_exit, "IN_A", dace.Memlet("A[i]"))
+    state.add_edge(map_exit, "OUT_A", A, None, dace.Memlet("A[0:64]"))
+    map_exit.add_in_connector("IN_A")
+    map_exit.add_out_connector("OUT_A")
+    return sdfg, state, map_entry
+
+
+def test_strided_tile_extent_is_scaled_by_the_map_step():
+    """A tile of ``tile_size`` ITERATIONS spans ``tile_size * step`` INDICES.
+
+    ``Range.size()`` reads the ``SymExpr`` over-approximation, so an approximation that omits the
+    step reports ``tile_size / step`` iterations for the tile -- half the threads a step-2
+    thread-block map actually holds. ``InferGPUGridAndBlockSize`` then read that undercount and
+    rejected the map as conflicting with the kernel's declared ``gpu_block_size``.
+    """
+    tile_size = 8
+    for step in (1, 2, 4):
+        sdfg, state, map_entry = _strided_assign_sdfg(step)
+        stripmine = StripMining()
+        stripmine.map_entry = map_entry
+        stripmine.dim_idx = 0
+        stripmine.new_dim_prefix = "block"
+        stripmine.tile_size = tile_size
+        stripmine.tile_stride = tile_size
+        stripmine.apply(state, sdfg)
+
+        # ``map_entry`` is the inner (tile) map after strip-mining; its parent is the tile-number map.
+        assert map_entry.map.range.size() == [tile_size], \
+            f"step={step}: tile holds {map_entry.map.range.size()} iterations, expected {tile_size}"
+        outer = state.entry_node(map_entry)
+        assert outer.map.range[0][2] == tile_size * step, \
+            f"step={step}: tile-number map strides {outer.map.range[0][2]}, expected {tile_size * step}"
+        # The exact bound (the one that lands in the generated guard) spans the same index extent.
+        begin, end, _ = map_entry.map.range[0]
+        assert (end.approx - begin) + 1 == tile_size * step, \
+            f"step={step}: approximated tile spans {(end.approx - begin) + 1} indices, expected {tile_size * step}"
+
+
+def test_strided_tile_assigns_every_visited_element():
+    """The corrected approximation must not change which elements the strip-mined map writes."""
+    sdfg, state, map_entry = _strided_assign_sdfg(2)
+    stripmine = StripMining()
+    stripmine.map_entry = map_entry
+    stripmine.dim_idx = 0
+    stripmine.new_dim_prefix = "block"
+    stripmine.tile_size = 8
+    stripmine.tile_stride = 8
+    stripmine.apply(state, sdfg)
+
+    A_np = np.zeros([64], dtype=np.uint32)
+    sdfg(A=A_np)
+    expected = np.zeros([64], dtype=np.uint32)
+    expected[0:64:2] = 1
+    assert np.array_equal(A_np, expected), f"strided tiling wrote {np.flatnonzero(A_np)}"
+
+
 if __name__ == '__main__':
     test_strip_mining()
+    test_strided_tile_extent_is_scaled_by_the_map_step()
+    test_strided_tile_assigns_every_visited_element()


### PR DESCRIPTION
`StripMining._create_strided_range` over-approximated a non-divides-evenly tile as `tile_size` indices wide while its exact bound spans `tile_size * td_step`, so `Range.size()` reported a strided map's tile as `tile_size / td_step` iterations -- tiling a step-2 map by 128 produced a thread-block map that `InferGPUGridAndBlockSize` measured at 64 threads and rejected against the kernel's declared `gpu_block_size`. The approximation now carries the step, matching the exact bound and the `divides_evenly` branch one line above, and is identical for `td_step == 1` so no existing caller changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)