### PR TITLE
docs: add minimal docstring for `ConditionalBlock`

### DIFF
--- a/dace/sdfg/state.py
+++ b/dace/sdfg/state.py
@@ -3832,6 +3832,11 @@ class LoopRegion(ControlFlowRegion):
 
 @make_properties
 class ConditionalBlock(AbstractControlFlowRegion):
+    """
+    A control flow region that represents conditional code exectution (if/elif/else).
+
+    Add branches with `add_branch(condition, region)`, where the condition is optional.
+    """
 
     _branches: List[Tuple[Optional[CodeBlock], ControlFlowRegion]]
 


### PR DESCRIPTION
Adds a minimal docstring to `ConditionalBlock`  explaining how to add branches.