### PR TITLE
fix: rescale nested SDFG subsets by the outer memlet step

### DIFF
--- a/dace/frontend/python/newast.py
+++ b/dace/frontend/python/newast.py
@@ -319,6 +319,14 @@ def _disallow_stmt(visitor, node):
 ###############################################################
 
 
+def _rescale_by_outer_steps(irng: subsets.Range, orng: subsets.Range):
+    for n, ostep in enumerate(orng.strides()):
+        if ostep == 1:
+            continue
+        rb, re, rs = irng.ranges[n]
+        irng.ranges[n] = (symbolic.int_floor(rb, ostep), symbolic.int_floor(re, ostep), symbolic.int_floor(rs, ostep))
+
+
 def _subset_has_indirection(subset, pvisitor: 'ProgramVisitor' = None):
     for dim in subset:
         if not isinstance(dim, tuple):
@@ -2204,6 +2212,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         irng.pop(outer_indices)
                         orng.pop(outer_indices)
                         irng.offset(orng, True)
+                        _rescale_by_outer_steps(irng, orng)
                     if (memlet.data, scope_memlet.subset, 'w') in self.accesses:
                         vname = self.accesses[(memlet.data, scope_memlet.subset, 'w')][0]
                         memlet = Memlet.simple(vname, str(irng))
@@ -2223,6 +2232,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         orig_shape = orng.size()
                         shape = [d for i, d in enumerate(orig_shape) if d != 1 or i in inner_indices]
                         strides = [i for j, i in enumerate(arr.strides) if j not in outer_indices]
+                        strides = [s * st for s, st in zip(strides, orng.strides())]
                         strides = [
                             s for i, (d, s) in enumerate(zip(orig_shape, strides)) if d != 1 or i in inner_indices
                         ]
@@ -2295,6 +2305,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         irng.pop(outer_indices)
                         orng.pop(outer_indices)
                         irng.offset(orng, True)
+                        _rescale_by_outer_steps(irng, orng)
                     if self._find_access(memlet.data, scope_memlet.subset, 'w'):
                         vname = self.accesses[(memlet.data, scope_memlet.subset, 'w')][0]
                         inner_memlet = Memlet.simple(vname, str(irng))
@@ -2314,6 +2325,7 @@ class ProgramVisitor(ExtNodeVisitor):
                         shape = [d for d in orig_shape if d != 1]
                         shape = [d for i, d in enumerate(orig_shape) if d != 1 or i in inner_indices]
                         strides = [i for j, i in enumerate(arr.strides) if j not in outer_indices]
+                        strides = [s * st for s, st in zip(strides, orng.strides())]
                         strides = [
                             s for i, (d, s) in enumerate(zip(orig_shape, strides)) if d != 1 or i in inner_indices
                         ]

--- a/tests/python_frontend/transients_test.py
+++ b/tests/python_frontend/transients_test.py
@@ -30,5 +30,31 @@ def test_transients():
     assert (arr[scal[0]:] == 0).all()
 
 
+def test_transients_array():
+
+    @dace.program
+    def tester(
+            A: dace.data.Array(dace.float32, [60], transient=True),
+            B: dace.data.Array(dace.float32, [60]),
+    ) -> None:
+        A[:] = 42.42
+
+        for i in dace.map[0:2]:
+            tmp_condition = B[0] < 0
+            if tmp_condition:
+                B[0] = 0
+
+            for j in dace.map[0:10]:
+                A[15 * i + 3 * j] = 1.0
+
+            for k in dace.map[10:20]:
+                B[k] = A[k]
+
+    sdfg = tester.to_sdfg(simplify=False)
+    assert sdfg.is_valid()
+    assert not sdfg.arrays["B"].transient
+
+
 if __name__ == "__main__":
     test_transients()
+    test_transients_array()


### PR DESCRIPTION
A map body carried into a nested SDFG got a local descriptor sized from the number of elements of the outer subset, while the inner memlet was only shifted by the outer start. For a strided outer subset such as A[15*i:15*i+28:3] this left an inner range of 0:28:3 against a shape-(10,) array, and parsing failed with "Memlet subset out-of-bounds".

