### PR TITLE
Array elimination of scalars

### DIFF
--- a/dace/transformation/passes/array_elimination.py
+++ b/dace/transformation/passes/array_elimination.py
@@ -86,14 +86,13 @@ class ArrayElimination(ppl.Pass):
 
         # If node is completely removed from graph, erase data descriptor
         for aname, desc in list(sdfg.arrays.items()):
-            if isinstance(desc, data.DistributedDescriptor):
+            if not desc.transient:
                 continue
-            if not desc.transient or isinstance(desc, data.Scalar):
+            if isinstance(desc, data.Structure) and len(desc.members) > 0:
+                continue
+            if not isinstance(desc, (data.Array, data.Scalar, data.Structure)):
                 continue
             if aname not in access_sets or not access_sets[aname]:
-                desc = sdfg.arrays[aname]
-                if isinstance(desc, data.Structure) and len(desc.members) > 0:
-                    continue
                 sdfg.remove_data(aname, validate=False)
                 result.add(aname)
 

--- a/tests/passes/array_elimination_test.py
+++ b/tests/passes/array_elimination_test.py
@@ -52,6 +52,26 @@ def test_merge_simple():
     assert len(state.data_nodes()) == 2
 
 
+def test_remove_unused_scalars() -> None:
+    sdfg = dace.SDFG("tester")
+    sdfg.add_array("A", [10], dace.float32)
+    sdfg.add_array("B", [10], dace.float32)
+    sdfg.add_scalar("tmp", dace.int32, transient=True)
+
+    state = sdfg.add_state()
+    state.add_mapped_tasklet("copy", {"i": dace.subsets.Range.from_string("0:10")},
+                             code="a = b; t=1",
+                             inputs={"a": dace.Memlet("A[i]")},
+                             outputs={
+                                 "b": dace.Memlet("B[i]"),
+                                 "t": dace.Memlet("tmp[0]")
+                             },
+                             external_edges=True)
+    sdfg.simplify()
+    assert "tmp" not in sdfg.arrays
+
+
 if __name__ == '__main__':
     test_redundant_simple()
     test_merge_simple()
+    test_remove_unused_scalars()


### PR DESCRIPTION
## Description

`ArrayElimination` removes unused descriptors, but for some reason, `data.Scalar`  are excluded. It is not mentioned why and with `FindAccessStates` tracking all data descriptors in `sdfg.arrays`, I see no reason not to also act on `data.Scalar`.
