### PR TITLE
Avoid GHA warnings: unexpected inputs(s) 'pyproject-file'

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           python-version: '3.11'
           enable-cache: true
-          pyproject-file: pyproject.toml
-          cache-dependency-glob: pyproject.toml
 
       - name: Set up C++ compiler
         run: |

--- a/.github/workflows/general-ci.yml
+++ b/.github/workflows/general-ci.yml
@@ -35,8 +35,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
-        pyproject-file: pyproject.toml
-        cache-dependency-glob: pyproject.toml
     - name: Install dependencies
       run: |
         # Make dependency setup faster

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -33,8 +33,6 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-        pyproject-file: pyproject.toml
-        cache-dependency-glob: pyproject.toml
     - name: Install dependencies
       run: |
         rm -f ~/.dace.conf

--- a/.github/workflows/heterogeneous-ci.yml
+++ b/.github/workflows/heterogeneous-ci.yml
@@ -33,8 +33,6 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-        pyproject-file: pyproject.toml
-        cache-dependency-glob: pyproject.toml
     - name: Install dependencies
       run: |
         rm -f ~/.dace.conf

--- a/.github/workflows/integration-tests-ci.yml
+++ b/.github/workflows/integration-tests-ci.yml
@@ -40,8 +40,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
-        pyproject-file: pyproject.toml
-        cache-dependency-glob: pyproject.toml
     - name: Install dependencies
       run: |
         # Make dependency setup faster

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,8 +26,6 @@ jobs:
       with:
         python-version: '3.10'
         enable-cache: true
-        pyproject-file: pyproject.toml
-        cache-dependency-glob: pyproject.toml
 
     # In one place we should check that `pyproject.toml` and `uv.lock` are up-to-date.
     # This place is as good any other. We un-freeze to lock file to do so.

--- a/.github/workflows/ml-ci.yml
+++ b/.github/workflows/ml-ci.yml
@@ -35,8 +35,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
-        pyproject-file: pyproject.toml
-        cache-dependency-glob: pyproject.toml
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/pyFV3-ci.yml
+++ b/.github/workflows/pyFV3-ci.yml
@@ -35,8 +35,6 @@ jobs:
        uses: astral-sh/setup-uv@v7
        with:
          enable-cache: true
-         pyproject-file: pyproject.toml
-         cache-dependency-glob: pyproject.toml
      - name: Set matrix data
        id: set-matrix
        run: echo "matrix={\"include\":$(jq -c . < .github/workflows/pyFV3-regression-matrix.json)}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The action `astral-ash/setup-uv@v7` is complaining about an unexpected input `pyproject-file`, which is true: according to their documentation, there's no such configuration option. I thus removed that option from all the places that is was used.

<img width="3200" height="396" alt="image" src="https://github.com/user-attachments/assets/ab6db76b-37ba-46fe-a515-42b7b4bbabd3" />

I've also removed the `cache-dependency-glob`  configuration because the default includes not only `pyproject.toml`, but also `uv.lock`, see [1] for reference. Since the `uv.lock` file can change while the `pyproject.toml` remains untouched, that glob is better because a changed `uv.lock` file will match exatly what versions need to be installed.

[1]: https://github.com/astral-sh/setup-uv/tree/v7/#inputs