### PR TITLE
[WIP] Compare int_floor against the same extent written with Python's //

### DIFF
--- a/dace/symbolic.py
+++ b/dace/symbolic.py
@@ -1110,6 +1110,18 @@ class int_ceil(sympy.Function):
         return True
 
 
+def relax_int_floor(expr: SymbolicType) -> SymbolicType:
+    """Rewrite ``int_floor``/``int_ceil`` to SymPy's own ``floor``/``ceiling``.
+
+    Both are bare ``Function`` heads to SymPy, which relates neither of them to the ``floor`` that
+    Python's ``//`` operator produces. Normalize both sides through this before comparing them.
+    """
+    if not isinstance(expr, sympy.Basic):
+        return expr
+    expr = expr.replace(int_floor, lambda x, y: sympy.floor(x / y))
+    return expr.replace(int_ceil, lambda x, y: sympy.ceiling(x / y))
+
+
 class OR(sympy.Function):
 
     @classmethod
@@ -2696,7 +2708,7 @@ def inequal_symbols(a: Union[sympy.Expr, Any], b: Union[sympy.Expr, Any]) -> boo
     if not isinstance(a, sympy.Expr) or not isinstance(b, sympy.Expr):
         return a != b
     else:
-        a, b = equalize_symbols(a, b)
+        a, b = (relax_int_floor(x) for x in equalize_symbols(a, b))
         # NOTE: We simplify in an attempt to remove inconvenient methods, such
         # as `ceiling` and `floor`, if the symbol assumptions allow it.
         # We subtract and compare to zero according to the SymPy documentation

--- a/tests/symbolic_test.py
+++ b/tests/symbolic_test.py
@@ -2,6 +2,7 @@
 
 from sympy import Min, Max
 
+from dace import dtypes
 from dace.symbolic import simplify_ext, symbol
 
 
@@ -15,5 +16,28 @@ def test_simplify_ext_min() -> None:
     assert simplify_ext(untouched) == untouched
 
 
+def test_int_floor_compares_equal_to_the_same_extent_written_with_python_floordiv():
+    """One extent, two spellings, and they have to compare equal.
+
+    ``pystr_to_symbolic`` maps ``//`` to ``int_floor``, so everything DaCe parses from a string --
+    a memlet subset, a shape, an interstate assignment -- says ``int_floor``. Python's own ``//``
+    says SymPy ``floor``, and a data-descriptor shape built in Python says it that way. SymPy
+    relates neither head to the other, so ``inequal_symbols`` answered True (not equal) for two
+    spellings of the same number.
+    """
+    from dace.symbolic import inequal_symbols, pystr_to_symbolic, relax_int_floor, symbol
+
+    h = symbol('h', dtype=dtypes.int64, positive=True)
+    assert not inequal_symbols((h - 7) // 2 + 1, pystr_to_symbolic('(h - 7) // 2 + 1'))
+    assert not inequal_symbols(h // 2, pystr_to_symbolic('h // 2'))
+    # int_ceil too, and the rewrite leaves a DaCe head behind in neither case.
+    assert str(relax_int_floor(pystr_to_symbolic('int_ceil(h, 2)'))) == 'ceiling(h/2)'
+    assert str(relax_int_floor(pystr_to_symbolic('(h - 7) // 2 + 1'))) == 'floor(h/2 - 7/2) + 1'
+    # A genuinely different extent must still compare unequal -- the fix must not make everything
+    # equal by relaxing both sides into mush.
+    assert inequal_symbols(pystr_to_symbolic('(h - 7) // 2 + 1'), pystr_to_symbolic('(h - 7) // 3 + 1'))
+
+
 if __name__ == "__main__":
     test_simplify_ext_min()
+    test_int_floor_compares_equal_to_the_same_extent_written_with_python_floordiv()


### PR DESCRIPTION
`pystr_to_symbolic` maps `//` to `int_floor`, so every extent DaCe parses from a string carries that head, while Python's own `//` produces SymPy's `floor` — and SymPy relates neither to the other, so `inequal_symbols` judged two spellings of the same number unequal. `relax_int_floor` normalizes both sides at the comparison, which is the only place it can be fixed: `(h - 7) // 2` dispatches to `Add.__floordiv__`, so making one spelling win is not available.

```python
h = symbol('h', dtype=dace.int64, positive=True)
inequal_symbols((h - 7) // 2 + 1, pystr_to_symbolic('(h - 7) // 2 + 1'))   # True before, False after
```
